### PR TITLE
Escape path in Proguard in order to build xsbt under windows (with spaces in path)

### DIFF
--- a/project/build/InstallExtractProject.scala
+++ b/project/build/InstallExtractProject.scala
@@ -6,63 +6,57 @@ import sbt._
 import java.io.File
 
 // TODO: use ProguardProject
-protected class InstallExtractProject(info: ProjectInfo, pluginProject: => InstallPluginProject) extends DefaultProject(info) with NoPublish
+protected class InstallExtractProject(info: ProjectInfo, pluginProject: => InstallPluginProject) extends DefaultProject(info) with NoPublish with ProguardProject
 {
-	override def unmanagedClasspath = super.unmanagedClasspath +++ info.sbtClasspath
-	private lazy val plugin = pluginProject
-	val mainClassName = "sbt.extract.Main"
-	val proguardConfigurationPath: Path = outputPath / "proguard.pro"
-	val toolsConfig = config("tools")
-	val defaultConfig = Configurations.Default
-	val proguardJar = "net.sf.proguard" % "proguard" % "4.3" % "tools"
-	def rootProjectDirectory = rootProject.info.projectPath
-	def outputJar = (plugin.outputPath ##) / defaultJarName
-	
-	/******** Proguard  *******/
-	lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
-	lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
-	lazy val cleanProguard = cleanTask(outputJar)
-	private def proguardTask =
-		task
-		{
-			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get)
-			val configFile = proguardConfigurationPath.asFile.getAbsolutePath
-			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "@" + configFile)) ! log
-			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
-		}
-	private def writeProguardConfigurationTask =
-		task
-		{
-			// the template for the proguard configuration file
-			val outTemplate = """
-				|-dontoptimize
-				|-dontobfuscate
-				|-dontnote
-				|-dontwarn
-				|-libraryjars %s
-				|%s
-				|-outjars %s
-				|-ignorewarnings
-				|-keep public class %s {
-				|    public static void main(java.lang.String[]);
-				|}"""
-			
-			val defaultJar = jarPath.absolutePath
-			log.debug("proguard configuration using main jar " + defaultJar)
-			val externalDependencies = (mainCompileConditional.analysis.allExternals).map(_.getAbsoluteFile).filter(_.getName.endsWith(".jar"))
-			debugJars("external dependencies", externalDependencies)
-			// partition jars from the external jar dependencies of this project by whether they are located in the project directory
-			// if they are, they are specified with -injars, otherwise they are specified with -libraryjars
-			val (externalJars, libraryJars) = externalDependencies.toList.partition{jar => Path.relativize(rootProjectDirectory, jar).isDefined}
-			debugJars("library jars", libraryJars)
-			val externalJarStrings = externalJars.map( _ + "(!META-INF/**,!*.properties)")
-			// exclude properties files and manifests from scala-library jar
-			val inJars = (defaultJar :: externalJarStrings).map("-injars " + _).mkString("\n")
-			
-			val proguardConfiguration = outTemplate.stripMargin.format(libraryJars.mkString(File.pathSeparator), inJars, outputJar.absolutePath, mainClassName)
-			log.debug("Proguard configuration written to " + proguardConfigurationPath)
-			FileUtilities.write(proguardConfigurationPath.asFile, proguardConfiguration, log)
-		}
-	private def debugJars[T](label: String, jars: Iterable[T]): Unit =
-		log.debug("proguard configuration " + label + ": \n\t" + jars.mkString("\n\t"))
+  override def unmanagedClasspath = super.unmanagedClasspath +++ info.sbtClasspath
+  override def rawPackage = `package`
+  override def rawJarPath = jarPath
+
+  private lazy val plugin = pluginProject
+  val mainClassName = "sbt.extract.Main"
+  val defaultConfig = Configurations.Default
+  def outputJar = (plugin.outputPath ##) / defaultJarName
+  override val proguardConfigurationPath: Path = outputPath / "proguard.pro"
+
+  /******** Proguard  *******/
+  override lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
+  override lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
+  lazy val cleanProguard = cleanTask(outputJar)
+
+  override protected def writeProguardConfigurationTask =
+    task
+    {
+      // the template for the proguard configuration file
+      val outTemplate = """
+        |-dontoptimize
+        |-dontobfuscate
+        |-dontnote
+        |-dontwarn
+        |-libraryjars "%s"
+        |%s
+        |-outjars "%s"
+        |-ignorewarnings
+        |-keep public class %s {
+        |    public static void main(java.lang.String[]);
+        |}"""
+
+      val defaultJar = mkpath(jarPath.absolutePath, '\"')
+      log.debug("proguard configuration using main jar " + defaultJar)
+      val externalDependencies = (mainCompileConditional.analysis.allExternals).map(_.getAbsoluteFile).filter(_.getName.endsWith(".jar"))
+      debugJars("external dependencies", externalDependencies)
+      // partition jars from the external jar dependencies of this project by whether they are located in the project directory
+      // if they are, they are specified with -injars, otherwise they are specified with -libraryjars
+      val (externalJars, libraryJars) = externalDependencies.toList.partition{jar => Path.relativize(rootProjectDirectory, jar).isDefined}
+      debugJars("library jars", libraryJars)
+      val externalJarStrings = externalJars.map( mkpath(_) + "(!META-INF/**,!*.properties)")
+      // exclude properties files and manifests from scala-library jar
+      val inJars = (defaultJar :: externalJarStrings).map("-injars " + _).mkString("\n")
+
+      val proguardConfiguration = outTemplate.stripMargin.format(libraryJars.mkString(File.pathSeparator), inJars, outputJar.absolutePath, mainClassName)
+      log.debug("Proguard configuration written to " + proguardConfigurationPath)
+      FileUtilities.write(proguardConfigurationPath.asFile, proguardConfiguration, log)
+    }
+  
+  private def debugJars[T](label: String, jars: Iterable[T]): Unit =
+    log.debug("proguard configuration " + label + ": \n\t" + jars.mkString("\n\t"))
 }

--- a/project/build/InstallExtractProject.scala
+++ b/project/build/InstallExtractProject.scala
@@ -6,31 +6,24 @@ import sbt._
 import java.io.File
 
 // TODO: use ProguardProject
-protected class InstallExtractProject(info: ProjectInfo, pluginProject: => InstallPluginProject) extends DefaultProject(info) with NoPublish
+protected class InstallExtractProject(info: ProjectInfo, pluginProject: => InstallPluginProject) extends DefaultProject(info) with NoPublish with ProguardProject
 {
 	override def unmanagedClasspath = super.unmanagedClasspath +++ info.sbtClasspath
+	override def rawPackage = `package`
+	override def rawJarPath = jarPath
+
 	private lazy val plugin = pluginProject
 	val mainClassName = "sbt.extract.Main"
-	val proguardConfigurationPath: Path = outputPath / "proguard.pro"
-	val toolsConfig = config("tools")
 	val defaultConfig = Configurations.Default
-	val proguardJar = "net.sf.proguard" % "proguard" % "4.3" % "tools"
-	def rootProjectDirectory = rootProject.info.projectPath
 	def outputJar = (plugin.outputPath ##) / defaultJarName
-	
+	override val proguardConfigurationPath: Path = outputPath / "proguard.pro"
+
 	/******** Proguard  *******/
-	lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
-	lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
+	override lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
+	override lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
 	lazy val cleanProguard = cleanTask(outputJar)
-	private def proguardTask =
-		task
-		{
-			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get)
-			val configFile = proguardConfigurationPath.asFile.getAbsolutePath
-			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "@" + configFile)) ! log
-			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
-		}
-	private def writeProguardConfigurationTask =
+
+	override protected def writeProguardConfigurationTask =
 		task
 		{
 			// the template for the proguard configuration file
@@ -39,15 +32,15 @@ protected class InstallExtractProject(info: ProjectInfo, pluginProject: => Insta
 				|-dontobfuscate
 				|-dontnote
 				|-dontwarn
-				|-libraryjars %s
+				|-libraryjars "%s"
 				|%s
-				|-outjars %s
+				|-outjars "%s"
 				|-ignorewarnings
 				|-keep public class %s {
 				|    public static void main(java.lang.String[]);
 				|}"""
-			
-			val defaultJar = jarPath.absolutePath
+
+			val defaultJar = mkpath(jarPath.absolutePath, '\"')
 			log.debug("proguard configuration using main jar " + defaultJar)
 			val externalDependencies = (mainCompileConditional.analysis.allExternals).map(_.getAbsoluteFile).filter(_.getName.endsWith(".jar"))
 			debugJars("external dependencies", externalDependencies)
@@ -55,14 +48,15 @@ protected class InstallExtractProject(info: ProjectInfo, pluginProject: => Insta
 			// if they are, they are specified with -injars, otherwise they are specified with -libraryjars
 			val (externalJars, libraryJars) = externalDependencies.toList.partition{jar => Path.relativize(rootProjectDirectory, jar).isDefined}
 			debugJars("library jars", libraryJars)
-			val externalJarStrings = externalJars.map( _ + "(!META-INF/**,!*.properties)")
+			val externalJarStrings = externalJars.map( mkpath(_) + "(!META-INF/**,!*.properties)")
 			// exclude properties files and manifests from scala-library jar
 			val inJars = (defaultJar :: externalJarStrings).map("-injars " + _).mkString("\n")
-			
+
 			val proguardConfiguration = outTemplate.stripMargin.format(libraryJars.mkString(File.pathSeparator), inJars, outputJar.absolutePath, mainClassName)
 			log.debug("Proguard configuration written to " + proguardConfigurationPath)
 			FileUtilities.write(proguardConfigurationPath.asFile, proguardConfiguration, log)
 		}
+	
 	private def debugJars[T](label: String, jars: Iterable[T]): Unit =
 		log.debug("proguard configuration " + label + ": \n\t" + jars.mkString("\n\t"))
 }

--- a/project/build/InstallExtractProject.scala
+++ b/project/build/InstallExtractProject.scala
@@ -8,55 +8,55 @@ import java.io.File
 // TODO: use ProguardProject
 protected class InstallExtractProject(info: ProjectInfo, pluginProject: => InstallPluginProject) extends DefaultProject(info) with NoPublish with ProguardProject
 {
-  override def unmanagedClasspath = super.unmanagedClasspath +++ info.sbtClasspath
-  override def rawPackage = `package`
-  override def rawJarPath = jarPath
+	override def unmanagedClasspath = super.unmanagedClasspath +++ info.sbtClasspath
+	override def rawPackage = `package`
+	override def rawJarPath = jarPath
 
-  private lazy val plugin = pluginProject
-  val mainClassName = "sbt.extract.Main"
-  val defaultConfig = Configurations.Default
-  def outputJar = (plugin.outputPath ##) / defaultJarName
-  override val proguardConfigurationPath: Path = outputPath / "proguard.pro"
+	private lazy val plugin = pluginProject
+	val mainClassName = "sbt.extract.Main"
+	val defaultConfig = Configurations.Default
+	def outputJar = (plugin.outputPath ##) / defaultJarName
+	override val proguardConfigurationPath: Path = outputPath / "proguard.pro"
 
-  /******** Proguard  *******/
-  override lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
-  override lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
-  lazy val cleanProguard = cleanTask(outputJar)
+	/******** Proguard  *******/
+	override lazy val proguard = proguardTask dependsOn(`package`, writeProguardConfiguration, cleanProguard)
+	override lazy val writeProguardConfiguration = writeProguardConfigurationTask dependsOn `package`
+	lazy val cleanProguard = cleanTask(outputJar)
 
-  override protected def writeProguardConfigurationTask =
-    task
-    {
-      // the template for the proguard configuration file
-      val outTemplate = """
-        |-dontoptimize
-        |-dontobfuscate
-        |-dontnote
-        |-dontwarn
-        |-libraryjars "%s"
-        |%s
-        |-outjars "%s"
-        |-ignorewarnings
-        |-keep public class %s {
-        |    public static void main(java.lang.String[]);
-        |}"""
+	override protected def writeProguardConfigurationTask =
+		task
+		{
+			// the template for the proguard configuration file
+			val outTemplate = """
+				|-dontoptimize
+				|-dontobfuscate
+				|-dontnote
+				|-dontwarn
+				|-libraryjars "%s"
+				|%s
+				|-outjars "%s"
+				|-ignorewarnings
+				|-keep public class %s {
+				|    public static void main(java.lang.String[]);
+				|}"""
 
-      val defaultJar = mkpath(jarPath.absolutePath, '\"')
-      log.debug("proguard configuration using main jar " + defaultJar)
-      val externalDependencies = (mainCompileConditional.analysis.allExternals).map(_.getAbsoluteFile).filter(_.getName.endsWith(".jar"))
-      debugJars("external dependencies", externalDependencies)
-      // partition jars from the external jar dependencies of this project by whether they are located in the project directory
-      // if they are, they are specified with -injars, otherwise they are specified with -libraryjars
-      val (externalJars, libraryJars) = externalDependencies.toList.partition{jar => Path.relativize(rootProjectDirectory, jar).isDefined}
-      debugJars("library jars", libraryJars)
-      val externalJarStrings = externalJars.map( mkpath(_) + "(!META-INF/**,!*.properties)")
-      // exclude properties files and manifests from scala-library jar
-      val inJars = (defaultJar :: externalJarStrings).map("-injars " + _).mkString("\n")
+			val defaultJar = mkpath(jarPath.absolutePath, '\"')
+			log.debug("proguard configuration using main jar " + defaultJar)
+			val externalDependencies = (mainCompileConditional.analysis.allExternals).map(_.getAbsoluteFile).filter(_.getName.endsWith(".jar"))
+			debugJars("external dependencies", externalDependencies)
+			// partition jars from the external jar dependencies of this project by whether they are located in the project directory
+			// if they are, they are specified with -injars, otherwise they are specified with -libraryjars
+			val (externalJars, libraryJars) = externalDependencies.toList.partition{jar => Path.relativize(rootProjectDirectory, jar).isDefined}
+			debugJars("library jars", libraryJars)
+			val externalJarStrings = externalJars.map( mkpath(_) + "(!META-INF/**,!*.properties)")
+			// exclude properties files and manifests from scala-library jar
+			val inJars = (defaultJar :: externalJarStrings).map("-injars " + _).mkString("\n")
 
-      val proguardConfiguration = outTemplate.stripMargin.format(libraryJars.mkString(File.pathSeparator), inJars, outputJar.absolutePath, mainClassName)
-      log.debug("Proguard configuration written to " + proguardConfigurationPath)
-      FileUtilities.write(proguardConfigurationPath.asFile, proguardConfiguration, log)
-    }
-  
-  private def debugJars[T](label: String, jars: Iterable[T]): Unit =
-    log.debug("proguard configuration " + label + ": \n\t" + jars.mkString("\n\t"))
+			val proguardConfiguration = outTemplate.stripMargin.format(libraryJars.mkString(File.pathSeparator), inJars, outputJar.absolutePath, mainClassName)
+			log.debug("Proguard configuration written to " + proguardConfigurationPath)
+			FileUtilities.write(proguardConfigurationPath.asFile, proguardConfiguration, log)
+		}
+	
+	private def debugJars[T](label: String, jars: Iterable[T]): Unit =
+		log.debug("proguard configuration " + label + ": \n\t" + jars.mkString("\n\t"))
 }

--- a/project/build/ProguardProject.scala
+++ b/project/build/ProguardProject.scala
@@ -62,8 +62,10 @@ trait ProguardProject extends BasicScalaProject
 		task
 		{
 			FileUtilities.clean(outputJar :: Nil, log)
-			val proguardClasspathString = mkpath( Path.makeString(managedClasspath(toolsConfig).get) , '\"' )
+			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get) 
 			val configFile = mkpath(proguardConfigurationPath.asFile.getAbsolutePath, '\'')
+			log.error(proguardClasspathString)
+			log.error(configFile)
 			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "-include " + configFile)) ! log
 			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
 		}

--- a/project/build/ProguardProject.scala
+++ b/project/build/ProguardProject.scala
@@ -56,17 +56,18 @@ trait ProguardProject extends BasicScalaProject
 		lines.mkString("\n")
 	}
 
-	def mkpath(f: File) = '\"' + f.getAbsolutePath + '\"'
-	private def proguardTask =
+	def mkpath(f: File) : String = mkpath(f.getAbsolutePath, '\"')
+	def mkpath(path: String, delimiter : Char) : String = delimiter + path + delimiter
+	protected def proguardTask =
 		task
 		{
 			FileUtilities.clean(outputJar :: Nil, log)
-			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get)
-			val configFile = proguardConfigurationPath.asFile.getAbsolutePath
-			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "@" + configFile)) ! log
+			val proguardClasspathString = mkpath( Path.makeString(managedClasspath(toolsConfig).get) , '\"' )
+			val configFile = mkpath(proguardConfigurationPath.asFile.getAbsolutePath, '\'')
+			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "-include " + configFile)) ! log
 			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
 		}
-	private def writeProguardConfigurationTask =
+	protected def writeProguardConfigurationTask =
 		task
 		{
 			val dependencies = mainDependencies.snapshot

--- a/project/build/ProguardProject.scala
+++ b/project/build/ProguardProject.scala
@@ -56,17 +56,18 @@ trait ProguardProject extends BasicScalaProject
 		lines.mkString("\n")
 	}
 
-	def mkpath(f: File) = '\"' + f.getAbsolutePath + '\"'
-	private def proguardTask =
+	def mkpath(f: File) : String = mkpath(f.getAbsolutePath, '\"')
+	def mkpath(path: String, delimiter : Char) : String = delimiter + path + delimiter
+	protected def proguardTask =
 		task
 		{
 			FileUtilities.clean(outputJar :: Nil, log)
-			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get)
-			val configFile = proguardConfigurationPath.asFile.getAbsolutePath
-			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "@" + configFile)) ! log
+			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get) 
+			val configFile = mkpath(proguardConfigurationPath.asFile.getAbsolutePath, '\'')
+			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "-include " + configFile)) ! log
 			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
 		}
-	private def writeProguardConfigurationTask =
+	protected def writeProguardConfigurationTask =
 		task
 		{
 			val dependencies = mainDependencies.snapshot

--- a/project/build/ProguardProject.scala
+++ b/project/build/ProguardProject.scala
@@ -64,8 +64,6 @@ trait ProguardProject extends BasicScalaProject
 			FileUtilities.clean(outputJar :: Nil, log)
 			val proguardClasspathString = Path.makeString(managedClasspath(toolsConfig).get) 
 			val configFile = mkpath(proguardConfigurationPath.asFile.getAbsolutePath, '\'')
-			log.error(proguardClasspathString)
-			log.error(configFile)
 			val exitValue = Process("java", List("-Xmx256M", "-cp", proguardClasspathString, "proguard.ProGuard", "-include " + configFile)) ! log
 			if(exitValue == 0) None else Some("Proguard failed with nonzero exit code (" + exitValue + ")")
 		}


### PR DESCRIPTION
Hi Mark,

I've found a problem when trying to build the master branch of xsbt on Windows (especially because I use paths with spaces).
There was some paths used by proguard in InstallExtractProject that was not properly escaped.

When trying to fixed this, I've found that they was a trait ProguardProject where all the proguard stuffs was defined. I've refactored InstallExtractProject to mix this trait, I've not see any problem with that, can you confirm that this fix is correct ?

Thanks,
Steve Gury
