### PR TITLE
Full path in launch config results to "URI is not hierarchical" error on Windows (0.7) 

### DIFF
--- a/launch/Find.scala
+++ b/launch/Find.scala
@@ -49,9 +49,11 @@ object ResolvePaths
 	def apply(config: LaunchConfiguration, baseDirectory: File): LaunchConfiguration =
 		config.map(f => apply(baseDirectory, f))
 	def apply(baseDirectory: File, f: File): File =
-	{
-		assert(baseDirectory.isDirectory) // if base directory is not a directory, URI.resolve will not work properly
-		val uri = new URI(null, null, f.getPath, null)
-		new File(baseDirectory.toURI.resolve(uri))
-	}
+		if (f.isAbsolute) f
+		else
+		{
+			assert(baseDirectory.isDirectory) // if base directory is not a directory, URI.resolve will not work properly
+			val uri = new URI(null, null, f.getPath, null)
+			new File(baseDirectory.toURI.resolve(uri))
+		}
 }


### PR DESCRIPTION
## steps
1. find a Windows machine
2. run the following:
   
   ```
   C:\>java -jar C:/conscript/.conscript/sbt-launch.jar "@/C:/conscript/.conscript/n8han/conscript/cs/launchconfig"
   ```

where `launchconfig`'s `[boot] directory` is set to `C:/conscript/.conscript/boot`.
## problem

The full path in 

```
java.lang.IllegalArgumentException: URI is not hierarchical
        at java.io.File.<init>(Unknown Source)
        at xsbt.boot.ResolvePaths$.apply(Find.scala:55)
        at xsbt.boot.ResolvePaths$$anonfun$apply$1.apply(Find.scala:50)
        at xsbt.boot.ResolvePaths$$anonfun$apply$1.apply(Find.scala:50)
        at xsbt.boot.BootSetup.map(LaunchConfiguration.scala:92)
        at xsbt.boot.LaunchConfiguration.map(LaunchConfiguration.scala:17)
        at xsbt.boot.ResolvePaths$.apply(Find.scala:50)
        at xsbt.boot.Find.apply(Find.scala:42)
        at xsbt.boot.Find$.apply(Find.scala:10)
        at xsbt.boot.Launch$.configured(Launch.scala:21)
        at xsbt.boot.Launch$.apply(Launch.scala:16)
        at xsbt.boot.Launch$.apply(Launch.scala:13)
        at xsbt.boot.Boot$.runImpl(Boot.scala:24)
        at xsbt.boot.Boot$.run(Boot.scala:19)
        at xsbt.boot.Boot$.main(Boot.scala:15)
        at xsbt.boot.Boot.main(Boot.scala)
Error during sbt execution: java.lang.IllegalArgumentException: URI is not hierarchical
```
## debugging

This is caused by [line 54-55 of Find.scala](https://github.com/harrah/xsbt/blob/0.7/launch/Find.scala#L54):

```
val uri = new URI(null, null, f.getPath, null)
new File(baseDirectory.toURI.resolve(uri))
```

Here's a smaller repro of the bug in REPL:

```
scala> import java.net.URI
import java.net.URI

scala> import java.io.File
import java.io.File

scala> val uri = new URI(null, null, """C:\foo\""", null)
uri: java.net.URI = C:%5Cfoo%5C

scala> val resolved = new File("").toURI.resolve(uri)
resolved: java.net.URI = C:%5Cfoo%5C

scala> new File(resolved)
java.lang.IllegalArgumentException: URI is not hierarchical
```

The above works for relative paths, I worked around it by returning `f` when it's absolute.

```
if (f.isAbsolute) f 
else
{
  assert(baseDirectory.isDirectory) // if base directory is not a directory, URI.resolve will not work properly
  val uri = new URI(null, null, f.getPath, null)
  new File(baseDirectory.toURI.resolve(uri))  
}
```
