### PR TITLE
Added JavacLogger, fixes #68

### DIFF
--- a/compile/JavaCompiler.scala
+++ b/compile/JavaCompiler.scala
@@ -21,7 +21,7 @@ object JavaCompiler
 				val javaCp = ClasspathOptions.javac(cp.compiler)
 				val arguments = (new CompilerArguments(scalaInstance, javaCp))(sources, augmentedClasspath, outputDirectory, options)
 				log.debug("running javac with arguments:\n\t" + arguments.mkString("\n\t"))
-				val code: Int = f(arguments, JavacLogger(log))
+				val code: Int = f(arguments, log)
 				log.debug("javac returned exit code: " + code)
 				if( code != 0 ) throw new CompileFailed(arguments.toArray, "javac returned nonzero exit code")
 			}
@@ -72,28 +72,4 @@ object JavaCompiler
 	// javac's argument file seems to allow naive space escaping with quotes.  escaping a quote with a backslash does not work
 	def escapeSpaces(s: String): String = '\"' + normalizeSlash(s) + '\"'
 	def normalizeSlash(s: String) = s.replace(File.separatorChar, '/')
-}
-
-case class JavacLogger(log: Logger) extends Logger {
-
-  private var msgs: Seq[String] = Seq()
-
-  def trace(t: => Throwable) = log.trace(t)
-
-  def success(s: => String) = log.success(s)
-
-  def log(level: Level.Value, msg: => String) = {
-    level match {
-      case Level.Debug => log.debug(msg)
-      case Level.Info => log.info(msg)
-      case Level.Warn => msgs = msgs :+ msg
-      case Level.Error => msgs = msgs :+ msg
-    }
-  }
-
-  def flush(exitCode: Int): Unit =
-    if (exitCode == 0)
-      msgs foreach { msg => log.warn(msg) }
-    else
-      msgs foreach { msg => log.error(msg) }
 }

--- a/compile/JavaCompiler.scala
+++ b/compile/JavaCompiler.scala
@@ -21,7 +21,7 @@ object JavaCompiler
 				val javaCp = ClasspathOptions.javac(cp.compiler)
 				val arguments = (new CompilerArguments(scalaInstance, javaCp))(sources, augmentedClasspath, outputDirectory, options)
 				log.debug("running javac with arguments:\n\t" + arguments.mkString("\n\t"))
-				val code: Int = f(arguments, log)
+				val code: Int = f(arguments, JavacLogger(log))
 				log.debug("javac returned exit code: " + code)
 				if( code != 0 ) throw new CompileFailed(arguments.toArray, "javac returned nonzero exit code")
 			}
@@ -72,4 +72,28 @@ object JavaCompiler
 	// javac's argument file seems to allow naive space escaping with quotes.  escaping a quote with a backslash does not work
 	def escapeSpaces(s: String): String = '\"' + normalizeSlash(s) + '\"'
 	def normalizeSlash(s: String) = s.replace(File.separatorChar, '/')
+}
+
+case class JavacLogger(log: Logger) extends Logger {
+
+  private var msgs: Seq[String] = Seq()
+
+  def trace(t: => Throwable) = log.trace(t)
+
+  def success(s: => String) = log.success(s)
+
+  def log(level: Level.Value, msg: => String) = {
+    level match {
+      case Level.Debug => log.debug(msg)
+      case Level.Info => log.info(msg)
+      case Level.Warn => msgs = msgs :+ msg
+      case Level.Error => msgs = msgs :+ msg
+    }
+  }
+
+  def flush(exitCode: Int): Unit =
+    if (exitCode == 0)
+      msgs foreach { msg => log.warn(msg) }
+    else
+      msgs foreach { msg => log.error(msg) }
 }

--- a/main/actions/Compiler.scala
+++ b/main/actions/Compiler.scala
@@ -84,7 +84,14 @@ object Compiler
 		val exec = javaHome match { case None => "javac"; case Some(jh) => (jh / "bin" / "javac").absolutePath }
 		(args: Seq[String], log: Logger) => {
 			log.debug("Forking javac: " + exec + " " + args.mkString(" "))
-			Process(exec, args) ! log
+			val exitCode = Process(exec, args) ! log
+      log match {
+        case javacLogger: JavacLogger => {
+          javacLogger.flush(exitCode)
+        }
+        case _ =>
+      }
+      exitCode
 		}
 	}
 

--- a/main/actions/Compiler.scala
+++ b/main/actions/Compiler.scala
@@ -110,7 +110,7 @@ private[sbt] class JavacLogger(log: Logger) extends ProcessLogger {
   import scala.collection.mutable.ListBuffer
   import Level.{Info, Warn, Error, Value => LogLevel}
 
-  private var msgs: ListBuffer[(LogLevel, String)] = new ListBuffer()
+  private val msgs: ListBuffer[(LogLevel, String)] = new ListBuffer()
 
   def info(s: => String): Unit =
     synchronized { msgs += ((Info, s)) }
@@ -128,5 +128,6 @@ private[sbt] class JavacLogger(log: Logger) extends ProcessLogger {
   def flush(exitCode: Int): Unit = {
     val level = if (exitCode == 0) Warn else Error
     msgs foreach print(level)
+    msgs.clear()
   }
 }


### PR DESCRIPTION
This class extends Logger and buffers all the [warn] and [error]
messages. Once javac is done, you call the flush method so that
it logs all the buffered messages either to [warn] or [error]
depending on the exit code.
