### PR TITLE
Fixes for generated pom

### DIFF
--- a/ivy/IvyInterface.scala
+++ b/ivy/IvyInterface.scala
@@ -159,6 +159,7 @@ import Resolver._
 object ScalaToolsReleases extends MavenRepository(ScalaToolsReleasesName, ScalaToolsReleasesRoot)
 object ScalaToolsSnapshots extends MavenRepository(ScalaToolsSnapshotsName, ScalaToolsSnapshotsRoot)
 object DefaultMavenRepository extends MavenRepository("public", IBiblioResolver.DEFAULT_M2_ROOT)
+object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository
 sealed trait JavaNet1Repository extends Resolver
 {
@@ -171,6 +172,8 @@ object Resolver
 	val ScalaToolsSnapshotsName = "Scala-Tools Maven2 Snapshots Repository"
 	val ScalaToolsReleasesRoot = "http://scala-tools.org/repo-releases"
 	val ScalaToolsSnapshotsRoot = "http://scala-tools.org/repo-snapshots"
+	val JavaNet2RepositoryName = "java.net Maven2 Repository"
+	val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
 
 	/** Add the local, Maven Central, and Scala Tools releases repositories to the user repositories.  */
 	def withDefaultResolvers(userResolvers: Seq[Resolver]): Seq[Resolver] =

--- a/ivy/MakePom.scala
+++ b/ivy/MakePom.scala
@@ -173,6 +173,7 @@ class MakePom
 			<id>{id}</id>
 			<name>{name}</name>
 			<url>{root}</url>
+			<layout>{ if(name == JavaNet1Repository.name) "legacy" else "default" }</layout>
 		</repository>
 
 	/** Retain dependencies only with the configurations given, or all public configurations of `module` if `configurations` is None.

--- a/ivy/MakePom.scala
+++ b/ivy/MakePom.scala
@@ -78,7 +78,7 @@ class MakePom
 		<license>
 			<name>{l.getName}</name>
 			<url>{l.getUrl}</url>
-			<distribution>jar</distribution>
+			<distribution>repo</distribution>
 		</license>
 	def homePage(homePage: String) = if(homePage eq null) NodeSeq.Empty else <url>{homePage}</url>
 	def revision(version: String) = if(version ne null) <version>{version}</version> else NodeSeq.Empty


### PR DESCRIPTION
Two simple fixes and an enhancements:
- Per http://maven.apache.org/pom.html#Licenses, the distribution text should be repo (not jar)
- Per http://maven.apache.org/pom.html#Repository, JavaNet1Repository should have legacy layout. To me, string comparison seemed the only way as all other speciality about this resolver has been discarded before arriving here (mostly to appease Ivy) :)
- Add java.net Maven2 repository definition for convenience. Newer jars (e.g., javamail, activation) are unlikely to be available in Maven Central going forward. This could likely happen for other javax.\* jars as well. Since java.net M1 repo is already defined, adding java.net M2 would be nice for completeness. This doesn't need to be present in the the default list of resolvers though.
