### PR TITLE
Add the standard main manifest attributes with packageOptions

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -310,7 +310,9 @@ object Defaults extends BuildCommon
 		artifactName in GlobalScope :== ( Artifact.artifactName _ )
 	)
 	lazy val packageConfig: Seq[Setting[_]] = Seq(
-		packageOptions in packageBin <<= (packageOptions, mainClass in packageBin) map { _ ++ _.map(Package.MainClass.apply).toList }
+		packageOptions in packageBin <<= (packageOptions, mainClass in packageBin, name, version, homepage, organization, organizationName) map { (p, main, name, ver, h, org, orgName) =>
+			p ++ main.map(Package.MainClass.apply) :+ Package.addSpecManifestAttributes(name, ver, orgName) :+ Package.addImplManifestAttributes(name, ver, h, org, orgName) },
+		packageOptions in packageSrc <<= (packageOptions, name, version, organizationName) map { _ :+ Package.addSpecManifestAttributes(_, _, _) }
 	) ++
 	packageTasks(packageBin, packageBinTask) ++
 	packageTasks(packageSrc, packageSrcTask) ++

--- a/main/actions/Package.scala
+++ b/main/actions/Package.scala
@@ -51,10 +51,9 @@ object Package
 	final class Configuration(val sources: Seq[(File, String)], val jar: File, val options: Seq[PackageOption])
 	def apply(conf: Configuration, cacheFile: File, log: Logger)
 	{
-		import conf._
 		val manifest = new Manifest
 		val main = manifest.getMainAttributes
-		for(option <- options)
+		for(option <- conf.options)
 		{
 			option match
 			{
@@ -85,6 +84,20 @@ object Package
 		val version = Attributes.Name.MANIFEST_VERSION
 		if(main.getValue(version) eq null)
 			main.put(version, "1.0")
+	}
+	def addSpecManifestAttributes(name: String, version: String, orgName: String): PackageOption =
+	{
+		import Attributes.Name._
+		val attribKeys = Seq(SPECIFICATION_TITLE, SPECIFICATION_VERSION, SPECIFICATION_VENDOR)
+		val attribVals = Seq(name, version, orgName)
+		ManifestAttributes(attribKeys zip attribVals : _*)
+	}
+	def addImplManifestAttributes(name: String, version: String, homepage: Option[java.net.URL], org: String, orgName: String): PackageOption =
+	{
+		import Attributes.Name._
+		val attribKeys = Seq(IMPLEMENTATION_TITLE, IMPLEMENTATION_VERSION, IMPLEMENTATION_VENDOR, IMPLEMENTATION_VENDOR_ID)
+		val attribVals = Seq(name, version, orgName, org)
+		ManifestAttributes((attribKeys zip attribVals) ++ { homepage map(h => (IMPLEMENTATION_URL, h.toString)) } : _*)
 	}
 	def makeJar(sources: Seq[(File, String)], jar: File, manifest: Manifest, log: Logger)
 	{


### PR DESCRIPTION
As followup to #140, this adds the commonly used [main attributes](http://download.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Main_Attributes) to jar manifest by default. One can override packageOptions as usual to modify this.

Other build tools also injects the tool and JVM details in the jar manifest as so.
`Ant-Version: Apache Ant 1.8.1
Created-By: 1.5.0_22-b03 (Sun Microsystems Inc.).`
I have skipped them as I am not sure about their practicality apart from
cosmetic 'fingerprinting' the jar. I can put them in if Mark opines in favor.
