### PR TITLE
Changed skip to be a Task so we can dynamically compute it's value based 

### DIFF
--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -274,7 +274,7 @@ object Keys
 	val sbtResolver = SettingKey[Resolver]("sbt-resolver", "Provides a resolver for obtaining sbt as a dependency.")
 	val sbtDependency = SettingKey[ModuleID]("sbt-dependency", "Provides a definition for declaring the current version of sbt.")
 	val sbtVersion = SettingKey[String]("sbt-version", "Provides the version of sbt.  This setting should be not be modified.")
-	val skip = SettingKey[Boolean]("skip")
+	val skip = TaskKey[Boolean]("skip")
 
 	// special
 	val parallelExecution = SettingKey[Boolean]("parallel-execution", "Enables (true) or disables (false) parallel execution of tasks.")


### PR DESCRIPTION
Hey Mark,

This change was necessary so the locker-lock command in the Scala build will actually take effect immediately.  This appears to be an innocuous change.

Changed skip to be a Task so we can dynamically compute it's value based on a file
