### PR TITLE
Evict cleaned files from the AggressiveCompile cache

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -387,6 +387,7 @@ object Defaults extends BuildCommon
 		IO.withTemporaryDirectory { temp =>
 			val mappings = preserve.filter(_.exists).zipWithIndex map { case (f, i) => (f, new File(temp, i.toHexString)) }
 			IO.move(mappings)
+			clean.foreach(AggressiveCompile.evictCache)
 			IO.delete(clean)
 			IO.move(mappings.map(_.swap))
 		}

--- a/main/actions/AggressiveCompile.scala
+++ b/main/actions/AggressiveCompile.scala
@@ -112,7 +112,8 @@ class AggressiveCompile(cacheDirectory: File)
 	import AnalysisFormats._
 	val store = AggressiveCompile.staticCache(cacheDirectory, AnalysisStore.sync(AnalysisStore.cached(FileBasedStore(cacheDirectory))))
 }
-private object AggressiveCompile
+
+object AggressiveCompile
 {
 		import collection.mutable
 		import java.lang.ref.{Reference,SoftReference}
@@ -125,4 +126,12 @@ private object AggressiveCompile
 				b
 			}
 		}
+
+	def evictCache(file: File): Unit = synchronized {
+	  if(file.isDirectory) {
+	    IO.listFiles(file).foreach(evictCache)
+		}
+
+	  cache.remove(file)
+	}
 }


### PR DESCRIPTION
AggressiveCompile keeps a cache of AnalysisStores for files that have already been compiled.

This cache is kept with SoftReferences, which means the garbage collector is guaranteed to clear them before throwing an OutOfMemoryError. However, they need not be cleared if there is still memory available. In long-running sbt sessions, I've noticed that the heap keeps growing and growing with objects from this cache. This will trigger GCs, which make progress (garbage collect a small number of objects) and so don't feel pressured to collect SoftReferences. Because so little memory is reclaimed on each GC, eventually GCs are happening very frequently, and SoftReferences don't ever get collected. These very frequent collections hurt the performance of the entire VM (including compiles, etc).

In general, using SoftReferences as a caching mechanism is a bad idea, but until there's a better caching mechanism, this patch (admittedly an ugly hack) will clear entries from the cache when their file is cleaned. The evicted values can then be marked as unreachable by the garbage collector and collected even if the VM is not about to OOM.
