### PR TITLE
Add start-year to ProjectInfo

### DIFF
--- a/ivy/IvyInterface.scala
+++ b/ivy/IvyInterface.scala
@@ -39,7 +39,7 @@ object ModuleID
 			if(key.startsWith("e:")) (key, value) else ("e:" + key, value)
 }
 /** Additional information about a project module */
-case class ModuleInfo(nameFormal: String, description: String = "", homepage: Option[URL] = None, licenses: Seq[(String, URL)] = Nil, organizationName: String = "", organizationHomepage: Option[URL] = None)
+case class ModuleInfo(nameFormal: String, description: String = "", homepage: Option[URL] = None, startYear: Option[Int] = None, licenses: Seq[(String, URL)] = Nil, organizationName: String = "", organizationHomepage: Option[URL] = None)
 {
 	def formally(name: String) = copy(nameFormal = name)
 	def describing(desc: String, home: Option[URL]) = copy(description = desc, homepage = home)

--- a/ivy/MakePom.scala
+++ b/ivy/MakePom.scala
@@ -43,6 +43,7 @@ class MakePom
 			<modelVersion>4.0.0</modelVersion>
 			{ makeModuleID(module) }
 			<name>{moduleInfo.nameFormal}</name>
+			{ makeStartYear(moduleInfo) }
 			{ makeOrganization(moduleInfo) }
 			{ extra }
 			{ makeProperties(module) }
@@ -64,6 +65,8 @@ class MakePom
 			licenses(module.getLicenses)) : NodeSeq )
 		a ++ b
 	}
+
+	def makeStartYear(moduleInfo: ModuleInfo): NodeSeq = moduleInfo.startYear map { y => <inceptionYear>{y}</inceptionYear> } getOrElse NodeSeq.Empty
 	def makeOrganization(moduleInfo: ModuleInfo): NodeSeq =
 	{
 		<organization>

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -624,11 +624,12 @@ object Classpaths
 		normalizedName <<= name(StringUtilities.normalize),
 		description <<= description or name.identity,
 		homepage in GlobalScope :== None,
+		startYear in GlobalScope :== None,
 		licenses in GlobalScope :== Nil,
 		organization <<= organization or normalizedName.identity,
 		organizationName <<= organizationName or organization.identity,
 		organizationHomepage <<= organizationHomepage or homepage.identity,
-		projectInfo <<= (name, description, homepage, licenses, organizationName, organizationHomepage) apply ModuleInfo,
+		projectInfo <<= (name, description, homepage, startYear, licenses, organizationName, organizationHomepage) apply ModuleInfo,
 		classpathFilter in GlobalScope :== "*.jar" | "*.so" | "*.dll",
 		externalResolvers <<= (externalResolvers.task.?, resolvers) {
 			case (Some(delegated), Seq()) => delegated

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -184,6 +184,7 @@ object Keys
 	val normalizedName = SettingKey[String]("normalized-name", "Project name transformed from mixed case and spaces to lowercase and dash-separated.")
 	val description = SettingKey[String]("description", "Project description.")
 	val homepage = SettingKey[Option[URL]]("homepage", "Project homepage.")
+	val startYear = SettingKey[Option[Int]]("start-year", "Year in which the project started.")
 	val licenses = SettingKey[Seq[(String, URL)]]("licenses", "Project licenses as (name, url) pairs.")
 	val organization = SettingKey[String]("organization", "Organization/group ID.")
 	val organizationName = SettingKey[String]("organization-name", "Organization full/formal name.")


### PR DESCRIPTION
This isn't used by Ivy and doesn't have any effect in the build chain. But apparently there is a need for this in the pom for compliance. Most OSS project make use of this too.
