### PR TITLE
Honor <exclusions/> in <dependency/> when available

### DIFF
--- a/ivy/IvyActions.scala
+++ b/ivy/IvyActions.scala
@@ -68,7 +68,7 @@ object IvyActions
 	{
 		import configuration.{allRepositories, moduleInfo, configurations, extra, file, filterRepositories, process}
 		module.withModule(log) { (ivy, md, default) =>
-			(new MakePom).write(ivy, md, moduleInfo, configurations, extra, process, filterRepositories, allRepositories, file)
+			(new MakePom(log)).write(ivy, md, moduleInfo, configurations, extra, process, filterRepositories, allRepositories, file)
 			log.info("Wrote " + file.getAbsolutePath)
 		}
 	}


### PR DESCRIPTION
When we add exclusions via `ivyXML` setting, the generated pom should also honor the exclusions in the `<dependency/>` block.

Thus, the following ivyXML block would generate the right `<exclusion/>` under dependency.

``` xml
<dependency org="net.databinder" name="..." rev="...">
  <exclude org="commons-logging" module="commons-logging" />
</dependency>
```

Further, it's worth noting that although Ivy allows you to skip `org="..."` in `<exclude/>` element (legacy stuff), Maven enforces **both** `<artifactId/>` and `<groupId/>` to avoid resolution ambiguities (which is a good thing).

I think, in SBT we should also actively persuade users to provide both the atributes for completeness and better interoperability.

In the current implementation, I have blindly assumed that both `org` and `module` are provided. There is no good default if they aren't, and the `<exclusion/>` block in pom ends up being a defective one. We can take two position here: 
- Keep the current implementation (your `<exclusion/>` is _broken_ because of incomplete info)
- Modify the implementation _not to_ add exclusion element unless both `org` and `module` are available (your `<exclusion/>` is _unavailable_ because of incomplete info).

Thoughts?
