### PR TITLE
Basic support for exclusions in inline dependencies

### DIFF
--- a/ivy/Ivy.scala
+++ b/ivy/Ivy.scala
@@ -419,6 +419,13 @@ private object IvySbt
 				for(conf <- dependencyDescriptor.getModuleConfigurations)
 					dependencyDescriptor.addDependencyArtifact(conf, ivyArtifact)
 			}
+			for(excls <- dependency.exclusions)
+			{
+				for(conf <- dependencyDescriptor.getModuleConfigurations)
+				{
+					dependencyDescriptor.addExcludeRule(conf, IvyScala.excludeRule(excls.organization, excls.name, excls.configurations))
+				}
+			}
 			moduleID.addDependency(dependencyDescriptor)
 		}
 	}

--- a/ivy/IvyInterface.scala
+++ b/ivy/IvyInterface.scala
@@ -9,7 +9,7 @@ import scala.xml.NodeSeq
 import org.apache.ivy.plugins.resolver.{DependencyResolver, IBiblioResolver}
 import org.apache.ivy.util.url.CredentialsStore
 
-final case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, explicitArtifacts: Seq[Artifact] = Nil, extraAttributes: Map[String,String] = Map.empty, crossVersion: Boolean = false)
+final case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, explicitArtifacts: Seq[Artifact] = Nil, exclusions: Seq[ExclusionRule] = Nil, extraAttributes: Map[String,String] = Map.empty, crossVersion: Boolean = false)
 {
 	override def toString =
 		organization + ":" + name + ":" + revision +
@@ -24,6 +24,8 @@ final case class ModuleID(organization: String, name: String, revision: String, 
 	def from(url: String) = artifacts(Artifact(name, new URL(url)))
 	def classifier(c: String) = artifacts(Artifact(name, c))
 	def artifacts(newArtifacts: Artifact*) = copy(explicitArtifacts = newArtifacts ++ this.explicitArtifacts)
+	def excludeAll(rules: ExclusionRule*) = copy(exclusions = this.exclusions ++ rules)
+	def exclude(org: String, name: String) = excludeAll(ExclusionRule(org, name))
 	def extra(attributes: (String,String)*) = copy(extraAttributes = this.extraAttributes ++ ModuleID.checkE(attributes))
 	def sources() = artifacts(Artifact.sources(name))
 	def javadoc() = artifacts(Artifact.javadoc(name))
@@ -46,6 +48,8 @@ case class ModuleInfo(nameFormal: String, description: String = "", homepage: Op
 	def licensed(lics: (String, URL)*) = copy(licenses = lics)
 	def organization(name: String, home: Option[URL]) = copy(organizationName = name, organizationHomepage = home)
 }
+/** Rule to exclude unwanted dependencies pulled in transitively by a module. */
+case class ExclusionRule(organization: String = "*", name: String = "*", artifact: String = "*", configurations: Seq[String] = Nil)
 sealed trait Resolver
 {
 	def name: String

--- a/ivy/IvyScala.scala
+++ b/ivy/IvyScala.scala
@@ -86,7 +86,7 @@ private object IvyScala
 	}
 	/** Creates an ExcludeRule that excludes artifacts with the given module organization and name for
 	* the given configurations. */
-	private def excludeRule(organization: String, name: String, configurationNames: Iterable[String]): ExcludeRule =
+	private[sbt] def excludeRule(organization: String, name: String, configurationNames: Iterable[String]): ExcludeRule =
 	{
 		val artifact = new ArtifactId(ModuleId.newInstance(organization, name), "*", "jar", "*")
 		val rule = new DefaultExcludeRule(artifact, ExactPatternMatcher.INSTANCE, emptyMap[AnyRef,AnyRef])

--- a/main/actions/CacheIvy.scala
+++ b/main/actions/CacheIvy.scala
@@ -78,10 +78,12 @@ object CacheIvy
 			a => (a.name, a.`type`, a.extension, a.classifier, a.configurations.toSeq, a.url, a.extraAttributes),
 			{ case (n,t,x,c,cs,u,e) => Artifact(n,t,x,c,cs,u,e) }
 		)
-	implicit def moduleIDFormat(implicit sf: Format[String], af: Format[Artifact], bf: Format[Boolean]): Format[ModuleID] =
-		wrap[ModuleID, (String,String,String,Option[String],Boolean,Boolean,Seq[Artifact],Map[String,String],Boolean)](
-			m => (m.organization,m.name,m.revision,m.configurations, m.isChanging, m.isTransitive, m.explicitArtifacts, m.extraAttributes, m.crossVersion),
-			{ case (o,n,r,cs,ch,t,as,x,cv) => ModuleID(o,n,r,cs,ch,t,as,x,cv) }
+	implicit def exclusionRuleFormat(implicit sf: Format[String]): Format[ExclusionRule] =
+		wrap[ExclusionRule, (String, String, String, Seq[String])]( e => (e.organization, e.name, e.artifact, e.configurations), { case (o,n,a,cs) => ExclusionRule(o,n,a,cs) })
+	implicit def moduleIDFormat(implicit sf: Format[String], af: Format[Artifact], bf: Format[Boolean], ef: Format[ExclusionRule]): Format[ModuleID] =
+		wrap[ModuleID, ((String,String,String,Option[String]),(Boolean,Boolean,Seq[Artifact],Seq[ExclusionRule],Map[String,String],Boolean))](
+			m => ((m.organization,m.name,m.revision,m.configurations), (m.isChanging, m.isTransitive, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion)),
+			{ case ((o,n,r,cs),(ch,t,as,excl,x,cv)) => ModuleID(o,n,r,cs,ch,t,as,excl,x,cv) }
 		)
 
 	implicit def configurationFormat(implicit sf: Format[String]): Format[Configuration] =
@@ -124,7 +126,7 @@ object CacheIvy
 		implicit def sftpRToHL = (s: SftpRepository) => s.name :+: s.connection :+: s.patterns :+: HNil
 		implicit def rawRToHL = (r: RawRepository) => r.name :+: r.resolver.getClass.getName :+: HNil
 		implicit def chainRToHL = (c: ChainedResolver) => c.name :+: c.resolvers :+: HNil
-		implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.extraAttributes :+: m.crossVersion :+: HNil
+		implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.exclusions :+: m.extraAttributes :+: m.crossVersion :+: HNil
 	}
 	import L3._
 
@@ -141,6 +143,7 @@ object CacheIvy
 		implicit def sshConnectionToHL = (s: SshConnection) => s.authentication :+: s.hostname :+: s.port :+: HNil
 
 		implicit def artifactToHL = (a: Artifact) => a.name :+: a.`type` :+: a.extension :+: a.classifier :+: names(a.configurations) :+: a.url :+: a.extraAttributes :+: HNil
+		implicit def exclusionToHL = (e: ExclusionRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: HNil
 
 /*		implicit def deliverConfToHL = (p: DeliverConfiguration) => p.deliverIvyPattern :+: p.status :+: p.configurations :+: HNil
 		implicit def publishConfToHL = (p: PublishConfiguration) => p.ivyFile :+: p.resolverName :+: p.artifacts :+: HNil*/
@@ -152,6 +155,7 @@ object CacheIvy
 	implicit def ivyFileIC: InputCache[IvyFileConfiguration] = wrapIn
 	implicit def connectionIC: InputCache[SshConnection] = wrapIn
 	implicit def artifactIC: InputCache[Artifact] = wrapIn
+	implicit def exclusionIC: InputCache[ExclusionRule] = wrapIn
 /*	implicit def publishConfIC: InputCache[PublishConfiguration] = wrapIn
 	implicit def deliverConfIC: InputCache[DeliverConfiguration] = wrapIn*/
 


### PR DESCRIPTION
Hey Mark,

This is bit of a _roughcut_ and not meant to be merged right away. It's more to solicit feedback and polish more. But let's see if we can converge on this _long outstanding_ issue. I am suddenly finding this important, so thought of scratching the itch :)

The goal is to support the basic case of excluding a library from the dependency tree given it's `organization` and `name`, no more. This, I imagine, meets _most_ use-cases barring a few esoteric ones (for all such things there is full blown `ivyXML` setting anyway).

So these should work now:

``` scala
val dhttp = "net.databinder" %% "dispatch-http" % "0.7.8" excluding("commons-logging" % "commons-logging")
val dhttp = "net.databinder" %% "dispatch-http" % "0.7.8" excluding("commons-logging" % "commons-logging", "org.apache.httpcomponents" % "httpclient")
```

However, [`CacheIvy.moduleIDFormat`](https://github.com/harrah/xsbt/blob/0.11/main/actions/CacheIvy.scala#L84) is broken. It's not apparent because  `exclusions` is the last parameter in `ModuleID` constructor. But I couldn't figure a nice fix because of the "nine parameters" limitation.

Let me know what you think about it and a suggestion to get around the problem in `moduleIDFormat`.
