### PR TITLE
Expose snapshot flag via standard `SettingKey`

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -632,6 +632,7 @@ object Classpaths
 		conflictWarning <<= (thisProjectRef, conflictWarning) { (ref, cw) => cw.copy(label = Project.display(ref)) },
 		unmanagedBase <<= baseDirectory / "lib",
 		normalizedName <<= name(StringUtilities.normalize),
+		isSnapshot <<= isSnapshot or version(_ endsWith "-SNAPSHOT"),
 		description <<= description or name.identity,
 		homepage in GlobalScope :== None,
 		startYear in GlobalScope :== None,

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -248,6 +248,7 @@ object Keys
 
 	val moduleName = SettingKey[String]("module-name", "The name of the current module, used for dependency management.")
 	val version = SettingKey[String]("version", "The version/revision of the current module.")
+	val isSnapshot = SettingKey[Boolean]("is-snapshot", "True if the the version of the project is a snapshot version.")
 	val moduleID = SettingKey[ModuleID]("module-id", "A dependency management descriptor.  This is currently used for associating a ModuleID with a classpath entry.")
 	val projectID = SettingKey[ModuleID]("project-id", "The dependency management descriptor for the current module.")
 	val externalResolvers = TaskKey[Seq[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.")


### PR DESCRIPTION
It's a common pattern to adjust other settings or tasks based on whether `version` of the project is a snapshot.

Also, `-SNAPSHOT` is a standard way of denoting snapshot version (some build tools, Maven including, has this built-in).

This setting just introduces the flag. Making use of this is up to the build config author. Few known use cases would be:
- Add snapshot repo if this is a snapshot project, remove otherwise
- Switch to a different `publishTo` resolver depending on `isSnapshot` flag
- Perform additional release task automatically if `isSnapshot` isn't true etc.
