### PR TITLE
Parsing of a credentials file to add Ivy Credentials to the launcher

### DIFF
--- a/launch/ResolveValues.scala
+++ b/launch/ResolveValues.scala
@@ -12,7 +12,7 @@ object ResolveValues
 	def apply(conf: LaunchConfiguration): LaunchConfiguration = (new ResolveValues(conf))()
 	private def trim(s: String) = if(s eq null) None else notEmpty(s.trim)
 	private def notEmpty(s: String) = if(isEmpty(s)) None else Some(s)
-	private def readProperties(propertiesFile: File) =
+	private[boot] def readProperties(propertiesFile: File) =
 	{
 		val properties = new Properties
 		if(propertiesFile.exists)


### PR DESCRIPTION
Hi Mark -
I've patched the launcher code a bit to add support for specifying a file using the sbt.boot.credentials system property which is parsed and any credentials are added to the CredentialsStore static instance.  The location defaults to ~/.ivy2/.credentials currently.

Let me know if there's any way that we could get this into xsbt as it's pretty handy, especially with the newly added support for private repositories in Nathan's Conscript utility.

Thanks,
- Aaron 
