### PR TITLE
Adding parsing of a credentials file to add Ivy Credentials to the keyring

### DIFF
--- a/launch/ResolveValues.scala
+++ b/launch/ResolveValues.scala
@@ -12,7 +12,7 @@ object ResolveValues
 	def apply(conf: LaunchConfiguration): LaunchConfiguration = (new ResolveValues(conf))()
 	private def trim(s: String) = if(s eq null) None else notEmpty(s.trim)
 	private def notEmpty(s: String) = if(isEmpty(s)) None else Some(s)
-	private def readProperties(propertiesFile: File) =
+	private[boot] def readProperties(propertiesFile: File) =
 	{
 		val properties = new Properties
 		if(propertiesFile.exists)

--- a/launch/Update.scala
+++ b/launch/Update.scala
@@ -7,6 +7,7 @@ import Pre._
 import java.io.{File, FileWriter, PrintWriter, Writer}
 import java.util.concurrent.Callable
 import java.util.regex.Pattern
+import java.util.Properties
 
 import org.apache.ivy.{core, plugins, util, Ivy}
 import core.LogOptions
@@ -45,10 +46,19 @@ final class Update(config: UpdateConfiguration)
 
 	private def addCredentials()
 	{
-		val List(realm, host, user, password) = List("sbt.boot.realm", "sbt.boot.host", "sbt.boot.user", "sbt.boot.password") map System.getProperty
-		if(realm != null && host != null && user != null && password != null)
-			CredentialsStore.INSTANCE.addCredentials(realm, host, user, password)
+		val optionProps = 
+			Option(System.getProperty("sbt.boot.credentials")) orElse 
+			Option(System.getenv("SBT_CREDENTIALS")) map ( path =>
+				ResolveValues.readProperties(new File(path)) 
+			)
+		optionProps foreach extractCredentials("realm","host","user","password")
+		extractCredentials("sbt.boot.realm","sbt.boot.host","sbt.boot.user","sbt.boot.password")(System.getProperties)
 	}
+	private def extractCredentials(keys: (String,String,String,String))(props: Properties) {
+		val List(realm, host, user, password) = keys.productIterator.map(key => props.getProperty(key.toString)).toList
+		if (realm != null && host != null && user != null && password != null)
+			CredentialsStore.INSTANCE.addCredentials(realm, host, user, password)
+        }
 	private lazy val settings =
 	{
 		addCredentials()


### PR DESCRIPTION
If the user sets the _sbt.boot.credentials_ system property or the _SBT_CREDENTIALS_ environment variable, then that file gets parsed for a realm, hostname, username and password which is added to the CredentialsStore static instance.
