### PR TITLE
add support for a masked readline

### DIFF
--- a/util/complete/LineReader.scala
+++ b/util/complete/LineReader.scala
@@ -5,14 +5,18 @@ package sbt
 
 	import jline.{Completor, ConsoleReader}
 	import java.io.File
+	import java.lang.{Character => JCharacter}
 	import complete.Parser
 	
 abstract class JLine extends LineReader
 {
 	protected[this] val reader: ConsoleReader
-	def readLine(prompt: String) = JLine.withJLine { unsynchronizedReadLine(prompt) }
-	private[this] def unsynchronizedReadLine(prompt: String) =
-		reader.readLine(prompt) match
+	def readLine(prompt: String, mask: Option[JCharacter] = None) = JLine.withJLine { unsynchronizedReadLine(prompt, mask) }
+	private[this] def unsynchronizedReadLine(prompt: String, mask: Option[JCharacter]) =
+		(mask match {
+			case Some(m) => reader.readLine(prompt, m)
+			case None => reader.readLine(prompt)
+		}) match
 		{
 			case null => None
 			case x => Some(x.trim)
@@ -59,7 +63,7 @@ private object JLine
 
 trait LineReader
 {
-	def readLine(prompt: String): Option[String]
+	def readLine(prompt: String, mask: Option[JCharacter] = None): Option[String]
 }
 final class FullReader(historyPath: Option[File], complete: Parser[_]) extends JLine
 {

--- a/util/complete/LineReader.scala
+++ b/util/complete/LineReader.scala
@@ -5,14 +5,13 @@ package sbt
 
 	import jline.{Completor, ConsoleReader}
 	import java.io.File
-	import java.lang.{Character => JCharacter}
 	import complete.Parser
 	
 abstract class JLine extends LineReader
 {
 	protected[this] val reader: ConsoleReader
-	def readLine(prompt: String, mask: Option[JCharacter] = None) = JLine.withJLine { unsynchronizedReadLine(prompt, mask) }
-	private[this] def unsynchronizedReadLine(prompt: String, mask: Option[JCharacter]) =
+	def readLine(prompt: String, mask: Option[Char] = None) = JLine.withJLine { unsynchronizedReadLine(prompt, mask) }
+	private[this] def unsynchronizedReadLine(prompt: String, mask: Option[Char]) =
 		(mask match {
 			case Some(m) => reader.readLine(prompt, m)
 			case None => reader.readLine(prompt)
@@ -63,7 +62,7 @@ private object JLine
 
 trait LineReader
 {
-	def readLine(prompt: String, mask: Option[JCharacter] = None): Option[String]
+	def readLine(prompt: String, mask: Option[Char] = None): Option[String]
 }
 final class FullReader(historyPath: Option[File], complete: Parser[_]) extends JLine
 {


### PR DESCRIPTION
Hey. I had the need in the heroku plugin to use jlines masked readline support so I added it to your JLine interface's `readLine` method as an optional char defaulting to None so it requires no code changes.

Example usage in a build file

```
TaskKey[Unit]("prompt-in-plain-sight") <<= (streams) map {
  (out) => out.log.info(
    SimpleReader.readLine("What is your fav color? ").get
  )
}

TaskKey[Unit]("prompt-discreetly") <<= (streams) map {
   (out) => out.log.info(
    SimpleReader.readLine("What is your bank account number? ", Some('*')).get
  )
}
```

Session

```
> sbt-version
[info] 0.11.1-SNAPSHOT
> prompt-in-plain-sight
What is your fav color? green
[info] green
[success] Total time: 13 s, completed Oct 13, 2011 2:10:36 AM
> prompt-discreetly
What is your bank account number? **********
[info] ican'tsay!
[success] Total time: 28 s, completed Oct 13, 2011 2:11:12 AM
```

People can continue using it as it was, but can add a masking char if they are paranoid about the guy looking over their shoulder as they type.

What do you think?
