### PR TITLE
Initialize project version to SNAPSHOT

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -80,7 +80,7 @@ object Defaults extends BuildCommon
 		extraLoggers :== { _ => Nil },
 		skip :== false,
 		watchSources :== Nil,
-		version :== "0.1",
+		version :== "0.1-SNAPSHOT",
 		outputStrategy :== None,
 		exportJars :== false,
 		fork :== false,


### PR DESCRIPTION
Under most practical circumstance initializing a project to SNAPSHOT makes sense. This also ensures that snapshot related workflows kick-in instead of release related workflows by default (since isSnapshot would be true).
