### PR TITLE
Default set of opt-ins for convenience

### DIFF
--- a/main/Opts.scala
+++ b/main/Opts.scala
@@ -1,0 +1,32 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2011 Mark Harrah, Indrajit Raychaudhuri
+ */
+package sbt
+
+/** Options for well-known tasks. */
+object Opts {
+	object compile {
+		val deprecation = "-deprecation"
+		def encoding(enc: String) = Seq("-encoding", enc)
+		val explaintypes = "-explaintypes"
+		val nowarn = "-nowarn"
+		val optimise = "-optimise"
+		val unchecked = "-unchecked"
+		val verbose = "-verbose"
+	}
+	object doc {
+		def generator(g: String) = Seq("-doc-generator", g)
+		def sourceUrl(u: String) = Seq("-doc-source-url", u)
+		def title(t: String) = Seq("-doc-title", t)
+		def version(v: String) = Seq("-doc-version", v)
+	}
+}
+
+object DefaultOptions {
+	import Opts._
+	import Path._
+	def javac: Seq[String] = compile.encoding("UTF-8")
+	def scalac: Seq[String] = compile.encoding("UTF-8")
+	def scaladoc(name: String, version: String): Seq[String] = doc.title(name) ++ doc.version(version)
+	def credentials: Credentials = Credentials(Path.userHome / ".ivy2" / ".credentials")
+}


### PR DESCRIPTION
This is a followup of the proposal [here](https://github.com/harrah/xsbt/pull/179#issuecomment-2071661)

Default set of _well-known_ opt-ins to be used together other deduced Task or Setting values.

Example usages:

``` scala
javacOptions  ++= DefaultOptions.encoding
scalacOptions ++= DefaultOptions.encoding :+ DefaultOptions.deprecation
scalacOptions in doc <++= (name in doc, version in doc) map DefaultOptions.scaladoc
credentials    += DefaultOptions.credentials
```
