### PR TITLE
Always use full form of `-classpath` option

### DIFF
--- a/compile/CompilerArguments.scala
+++ b/compile/CompilerArguments.scala
@@ -18,7 +18,7 @@ final class CompilerArguments(scalaInstance: ScalaInstance, cp: ClasspathOptions
 	{
 		checkScalaHomeUnset()
 		val cpWithCompiler = finishClasspath(classpath)
-		val classpathOption = Seq("-cp", if(cpWithCompiler.isEmpty) "" else absString(cpWithCompiler) )
+		val classpathOption = Seq("-classpath", if(cpWithCompiler.isEmpty) "" else absString(cpWithCompiler) )
 		val outputOption = Seq("-d", outputDirectory.getAbsolutePath)
 		options ++ outputOption ++ bootClasspathOption ++ classpathOption ++ abs(sources)
 	}

--- a/run/Run.scala
+++ b/run/Run.scala
@@ -28,7 +28,7 @@ class ForkRun(config: ForkScalaRun) extends ScalaRun
 		val exitCode = try process.exitValue() catch { case e: InterruptedException => cancel() }
 		processExitCode(exitCode, "runner")
 	}
-	private def classpathOption(classpath: Seq[File]) = "-cp" :: Path.makeString(classpath) :: Nil
+	private def classpathOption(classpath: Seq[File]) = "-classpath" :: Path.makeString(classpath) :: Nil
 	private def processExitCode(exitCode: Int, label: String) =
 	{
 		if(exitCode == 0)


### PR DESCRIPTION
Short form `-cp` isn't always honored (e.g., javadoc — upcoming)
