### PR TITLE
Enable Javadoc generation in `doc` task

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -131,7 +131,7 @@ object Defaults extends BuildCommon
 
 	lazy val configPaths = sourceConfigPaths ++ resourceConfigPaths ++ outputConfigPaths
 	lazy val sourceConfigPaths = Seq(
-		sourceDirectory <<= configSrcSub( sourceDirectory),
+		sourceDirectory <<= configSrcSub(sourceDirectory),
 		sourceManaged <<= configSrcSub(sourceManaged),
 		scalaSource <<= sourceDirectory / "scala",
 		javaSource <<= sourceDirectory / "java",
@@ -445,14 +445,21 @@ object Defaults extends BuildCommon
 	def docSetting(key: TaskKey[File]): Seq[Setting[_]] = inTask(key)(Seq(
 		cacheDirectory ~= (_ / key.key.label),
 		target <<= docDirectory, // deprecate docDirectory in favor of 'target in doc'; remove when docDirectory is removed
-		scaladocOptions <<= scalacOptions, // deprecate scaladocOptions in favor of 'scalacOptions in doc'; remove when scaladocOptions is removed
-		fullClasspath <<= dependencyClasspath,
-		key in TaskGlobal <<= (sources, cacheDirectory, maxErrors, compilers, target, configuration, scaladocOptions, fullClasspath, streams) map { (srcs, cache, maxE, cs, out, config, options, cp, s) =>
-			(new Scaladoc(maxE, cs.scalac)).cached(cache, nameForSrc(config.name), srcs, cp.files, out, options, s.log)
+		scalacOptions <<= scaladocOptions or scalacOptions, // deprecate scaladocOptions in favor of 'scalacOptions in doc'; remove when scaladocOptions is removed
+		compileInputs <<= compileInputsTask,
+		key in TaskGlobal <<= (cacheDirectory, compileInputs, target, configuration, streams) map { (cache, in, out, config, s) =>
+			// For Scala/Java hybrid projects, the output docs are rebased to `scala` or `java` sub-directory accordingly. We do hybrid 
+			// mode iff both *.scala and *.java files exist -- other doc resources (package.html, *.jpg etc.) don't influence the decision.
+			val srcs = in.config.sources
+			val hybrid = srcs.exists(_.name.endsWith(".scala")) && srcs.exists(_.name.endsWith(".java"))
+			val (scalaOut, javaOut) = if (hybrid) (out / "scala", out / "java") else (out, out)
+			val cp = in.config.classpath.toList - in.config.classesDirectory
+			Doc(in.config.maxErrors, in.compilers.scalac).cached(cache / "scala", nameForSrc(config.name), srcs, cp, scalaOut, in.config.options, s.log)
+			Doc(in.config.maxErrors, in.compilers.javac).cached(cache / "java", nameForSrc(config.name), srcs, cp, javaOut, in.config.javacOptions, s.log)
 			out
 		}
 	))
-		
+
 	@deprecated("Use `docSetting` instead", "0.11.0") def docTask: Initialize[Task[File]] =
 		(cacheDirectory, compileInputs, streams, docDirectory, configuration, scaladocOptions) map { (cache, in, s, target, config, options) =>
 			val d = new Scaladoc(in.config.maxErrors, in.compilers.scalac)

--- a/sbt/src/sbt-test/actions/doc/src/main/java/pkg/J.java
+++ b/sbt/src/sbt-test/actions/doc/src/main/java/pkg/J.java
@@ -1,0 +1,4 @@
+package pkg;
+/** This is class J */
+public class J {
+}

--- a/sbt/src/sbt-test/actions/doc/src/main/java/pkg/K.java
+++ b/sbt/src/sbt-test/actions/doc/src/main/java/pkg/K.java
@@ -1,0 +1,4 @@
+package pkg;
+/** This is class K */
+public class K {
+}

--- a/sbt/src/sbt-test/actions/doc/test
+++ b/sbt/src/sbt-test/actions/doc/test
@@ -1,7 +1,34 @@
+> 'set crossPaths := false'
+
 > 'set scalacOptions in (Compile, doc) += "-Xfatal-warnings"'
 
 -> doc
 
-> 'set sources in (Compile, doc) <<= sources in Compile map { _.filter(_.getName contains "A") }'
+> 'set sources in (Compile, doc) <<= sources in Compile map { _.filterNot(_.getName contains "B") }'
 
+# hybrid project, scaladoc and javadoc in respective directories
 > doc
+$ exists "target/api/scala"
+$ exists "target/api/java"
+
+> 'set sources in (Compile, doc) <<= sources in (Compile, doc) map { _.filterNot(_.getName endsWith ".java") }'
+
+> clean
+> doc
+
+# pure scala project, only scaladoc at top level
+$ exists "target/api/index.js"
+$ absent "target/api/package-list"
+$ absent "target/api/scala"
+$ absent "target/api/java"
+
+> 'set sources in (Compile, doc) <<= sources in Compile map { _.filter(_.getName endsWith ".java") }'
+
+> clean
+> doc
+
+# pure java project, only javadoc at top level
+$ exists "target/api/package-list"
+$ absent "target/api/index.js"
+$ absent "target/api/scala"
+$ absent "target/api/java"


### PR DESCRIPTION
- `docSetting` is now updated to do `Javadoc` in addition to `Scaladoc`. In hybrid project, the outputs are rebased to `scala` or `java` sub-directory but for pure scala or pure java projects, the subdirectory isn't added. This helps retain compatibility as much as possible. I would have liked to tuck them behind some sort of `Doc.apply(...)(...)` but kept it as-is to avoid breaking change (at least at this level).
- Taking cue from `compileInputsTask`, the maxErrors is currently set to 100 to avert the 9 argument cap. Going forward, I wonder if we can re-use `compileInputs` instead - similar to the way it was in (now deprecated)
  docTask. We can then simplify `docSetting` by reusing `compileInputs in (Compile, doc)`
- Related to that, what would be your recommendation to deal with the 9 argument cap? Bringing in intermediate keys might be against the overall intention of reusing existing keys in right scope as much as possible. For consistency, I wanted to find and apply the approach from another `Setting` or `Task` where this was needed – but couldn't find one by casual 'eyeballing'.
- Is it necessary to have `fullClasspath <<= dependencyClasspath`? Can't we just use `dependencyClasspath` instead?
- Also maxErrors isn't used currently for javadoc since it is along the lines of javac (which doesn't use `xsbti.Reporter` either. I have kept is there just in case it's put to use later on.
- Doc.scala has some duplicated currently. This is mostly to preserve the signature of `Scaladoc`. At some later major version (maybe 0.12) this can be restructred a bit. Unless, of course, if you have other
  thing in mind.

This is a draft version to start the conversation. As usual, looking forward to suggestions and feedback (and modifying the patch accordingly).

NB: You get to see three commits for this pull request. I suspect, you'll have to apply #248 and #249 to remove the other commits from showing up here.
