### PR TITLE
Fixed scripted plugin descriptor to reside in sbt package

### DIFF
--- a/scripted/plugin/src/main/resources/sbt/sbt.plugins
+++ b/scripted/plugin/src/main/resources/sbt/sbt.plugins
@@ -1,1 +1,1 @@
-ScriptedPlugin
+sbt.ScriptedPlugin


### PR DESCRIPTION
Mark, please update the resource. The scripted plugin is broken now with error message:

[error] java.lang.ClassNotFoundException: ScriptedPlugin$
