### PR TITLE
Support for enhanced cross build suffix in dependencies

### DIFF
--- a/ivy/DependencyBuilders.scala
+++ b/ivy/DependencyBuilders.scala
@@ -4,7 +4,7 @@
 package sbt
 package impl
 
-	import StringUtilities.{appendable,nonEmpty}
+import StringUtilities.nonEmpty
 
 trait DependencyBuilders
 {
@@ -27,20 +27,21 @@ trait DependencyBuilders
 
 final class GroupID private[sbt] (groupID: String)
 {
-	def % (artifactID: String) = groupArtifact(artifactID, false)
-	def %% (artifactID: String) = groupArtifact(artifactID, true)
-	private def groupArtifact(artifactID: String, cross: Boolean) =
+	def % (artifactID: String) = groupArtifact(artifactID, None)
+	def %% (artifactID: String, crossVersion: String => String = identity) = groupArtifact(artifactID, Some(crossVersion))
+	def %% (artifactID: String, alternatives: (String, String)*) = groupArtifact(artifactID, Some(Map(alternatives: _*).orElse[String, String]({ case s => s })))
+	private def groupArtifact(artifactID: String, cross: Option[String => String]) =
 	{
 		nonEmpty(artifactID, "Artifact ID")
 		new GroupArtifactID(groupID, artifactID, cross)
 	}
 }
-final class GroupArtifactID private[sbt] (groupID: String, artifactID: String, crossVersion: Boolean)
+final class GroupArtifactID private[sbt] (groupID: String, artifactID: String, crossVersion: Option[String => String])
 {	
 	def % (revision: String): ModuleID =
 	{
 		nonEmpty(revision, "Revision")
-		ModuleID(groupID, artifactID, revision).cross(crossVersion)
+		ModuleID(groupID, artifactID, revision).cross(!crossVersion.isEmpty, crossVersion.getOrElse(identity))
 	}
 }
 final class ModuleIDConfigurable private[sbt] (moduleID: ModuleID)

--- a/ivy/Ivy.scala
+++ b/ivy/Ivy.scala
@@ -314,7 +314,7 @@ private object IvySbt
 		as.map(art => substituteCross(art, cross))
 	def substituteCross(m: ModuleID, cross: String): ModuleID =
 		if(m.crossVersion)
-			m.copy(name = crossName(m.name, cross), explicitArtifacts = substituteCrossA(m.explicitArtifacts, cross))
+			m.copy(name = crossName(m.name, m.crossVersionRemap(cross)), explicitArtifacts = substituteCrossA(m.explicitArtifacts, cross))
 		else
 			m
 		

--- a/ivy/IvyActions.scala
+++ b/ivy/IvyActions.scala
@@ -205,7 +205,7 @@ object IvyActions
 		report.allMissing flatMap { case (_, mod, art) => art.classifier.map { c => (restrictedCopy(mod, false), c) } } groupBy(_._1) map { case (mod, pairs) => (mod, pairs.map(_._2).toSet) }
 
 	private[this] def restrictedCopy(m: ModuleID, confs: Boolean) =
-		ModuleID(m.organization, m.name, m.revision, crossVersion = m.crossVersion, extraAttributes = m.extraAttributes, configurations = if(confs) m.configurations else None)
+		ModuleID(m.organization, m.name, m.revision, crossVersion = m.crossVersion, crossVersionRemap = m.crossVersionRemap, extraAttributes = m.extraAttributes, configurations = if(confs) m.configurations else None)
 	private[this] def resolve(logging: UpdateLogging.Value)(ivy: Ivy, module: DefaultModuleDescriptor, defaultConf: String): (ResolveReport, Option[ResolveException]) =
 	{
 		val resolveOptions = new ResolveOptions


### PR DESCRIPTION
Although `%%` is very handy in having the cross build suffix appended to the artifact name, oftentimes it gets less useful because the `scalaVersion` used for the build might not be the same as that one to be appended. This is more of compulsion than violation in two prevalent cases:
- Building app on a version of scala which has a library dependency that isn't available for the same version (many of the libraries never came out with a build for scala 2.8.2, although the 2.8.1 build exists, ditto was the case for 2.9.0-1)
- Trying out snapshot builds of scala (building on scala 2.10.0-SNAPSHOT would still require a stable library dependency built for 2.9.1)

In these cases, library dependencies are not guaranteed to be binary compatible (but the developer hopes that they are).

This patch is a _proof of concept_ that allows appending a `Function1` or a var arg of `Pairs` as so:

``` scala
def crossSuffix(s: String) = s match {
  case "2.10-SNAPSHOT" => "2.9.1"
  case "2.8.2"         => "2.8.1"
  case x               => x
}

 // the default status quo, nothing changes for regular users
lazy val myLib = "org.foo" %% "mylib" % "1.2"

// power users can append a `Function1[String,String]`
lazy val myLib = "org.foo" %% ("mylib", crossSuffix _) % "1.2"

// power users can also append a set of `(String,String)` pairs
lazy val myLib = "org.foo" %% ("mylib", "2.10-SNAPSHOT" -> "2.9.1", "2.8.2" -> "2.8.1") % "1.2"
```

A few points:
- Would you be okay with modifying the `%%` signature, or do you think this could be done in other ways?
- I am tempted to feel that just having `(String,String)*` should be sufficient in most cases, and in fact, simpler. But just kept `String=>String` for more complicated cases. I can remove the `String=>String` if to avoid bloat if you want
- Should we handle this for ModuleID in `CacheIvy` too? I suspect we should. How can I have `Format[Function1]`?

Thoughts?
