### PR TITLE
"inspect tree <key>" command

### DIFF
--- a/main/Command.scala
+++ b/main/Command.scala
@@ -142,6 +142,13 @@ object Command
 		( (c & opOrIDSpaced(name)) ~ c.+) map { case (f, rem) => (f +: rem).mkString }
 }
 
+sealed trait InspectOption
+object InspectOption
+{
+	final case class Details(actual: Boolean) extends InspectOption
+	case object DependencyTree extends InspectOption
+}
+
 trait Help
 {
 	def detail: Map[String, String]

--- a/main/CommandSupport.scala
+++ b/main/CommandSupport.scala
@@ -84,14 +84,17 @@ LastCommand + """ <key>
 	See also '""" + LastGrepCommand + "'."
 
 	val InspectCommand = "inspect"
-	val inspectBrief = (InspectCommand + " <key>", "Prints the value for 'key', the defining scope, delegates, related definitions, and dependencies.")
+	val inspectBrief = (InspectCommand + " [tree] <key>", "Prints the value for 'key', the defining scope, delegates, related definitions, and dependencies.")
 	val inspectDetailed =
-InspectCommand + """ <key>
+InspectCommand + """ [tree] <key>
 
 	For a plain setting, the value bound to the key argument is displayed using its toString method.
 	Otherwise, the type of task ("Task" or "Input task") is displayed.
 
 	"Dependencies" shows the settings that this setting depends on.
+	If 'tree' is specified, the bound value as well as the settings that this setting depends on
+	(and their bound values) are displayed as a tree structure.
+	
 	"Reverse dependencies" shows the settings that depend on this setting.
 
 	When a key is resolved to a value, it may not actually be defined in the requested scope.

--- a/main/Project.scala
+++ b/main/Project.scala
@@ -291,6 +291,8 @@ object Project extends Init[Scope] with ProjectExtra
 			printScopes("Delegates", delegates(structure, scope, key)) +
 			printScopes("Related", related)
 	}
+	def settingGraph(structure: BuildStructure, basedir: File, scoped: ScopedKey[_])(implicit display: Show[ScopedKey[_]]): SettingGraph =
+		SettingGraph(structure, basedir, scoped, 0)
 	def graphSettings(structure: BuildStructure, basedir: File)(implicit display: Show[ScopedKey[_]])
 	{
 		def graph(actual: Boolean, name: String) = graphSettings(structure, actual, name, new File(basedir, name + ".dot"))

--- a/main/SettingGraph.scala
+++ b/main/SettingGraph.scala
@@ -1,0 +1,96 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2011 Mark Harrah, Eugene Yokota
+ */
+package sbt
+
+	import java.net.URI
+	import java.io.File
+	import Project.{ScopedKey, flattenLocals, compiled}
+	import Load.BuildStructure
+	import Predef.{any2stringadd => _, _}
+
+object SettingGraph
+{
+	def apply(structure: BuildStructure, basedir: File, scoped: ScopedKey[_], generation: Int)
+					(implicit display: Show[ScopedKey[_]]): SettingGraph =
+	{
+		val key = scoped.key
+		val scope = scoped.scope
+		
+		lazy val clazz = key.manifest.erasure
+		lazy val firstType = key.manifest.typeArguments.head
+		val (typeName: String, value: Option[_]) =
+			structure.data.get(scope, key) match {
+				case None => ("", None)
+				case Some(v) =>
+					if(clazz == classOf[Task[_]]) ("Task[" + firstType.toString + "]", None)
+					else if(clazz == classOf[InputTask[_]]) ("InputTask[" + firstType.toString + "]", None)
+					else (key.manifest.toString, Some(v))
+			}
+		
+		val definedIn = structure.data.definingScope(scope, key) map { sc => display(ScopedKey(sc, key)) }
+		val cMap = flattenLocals(compiled(structure.settings, false)(structure.delegates, structure.scopeLocal, display))
+		// val related = cMap.keys.filter(k => k.key == key && k.scope != scope)
+		val depends = cMap.get(scoped) match { case Some(c) => c.dependencies.toSet; case None => Set.empty }
+		// val reverse = reverseDependencies(cMap, scoped)
+	
+		SettingGraph(display(scoped), definedIn, typeName, value, key.description, basedir,
+			depends map { apply(structure, basedir, _, generation + 1) })
+	}
+}
+
+case class SettingGraph(name: String,
+	definedIn: Option[String],
+	typeName: String,
+	value: Option[Any],
+	description: Option[String],
+	basedir: File,
+	depends: Set[SettingGraph])
+{
+	def valueString: String =
+		value map {
+			case f: File => IO.relativize(basedir, f) getOrElse {f.toString}
+			case x => x.toString
+		} getOrElse {typeName}
+	
+	def dependsAscii: String = Graph.toAscii(this,
+		(x: SettingGraph) => x.depends.toSeq,
+	  (x: SettingGraph) => "%s = %s" format(x.definedIn getOrElse {""}, x.valueString))
+}
+
+object Graph
+{
+	// [info] foo
+	// [info]   +-bar
+	// [info]   | +-baz
+	// [info]   |
+	// [info]   +-quux
+	def toAscii[A](top: A, children: A => Seq[A], display: A => String): String = {
+		val maxColumn = jline.Terminal.getTerminal.getTerminalWidth - 8
+		val twoSpaces = " " + " " // prevent accidentally being converted into a tab
+		def limitLine(s: String): String =
+			if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."
+			else s
+		def insertBar(s: String, at: Int): String =
+			s.slice(0, at) +
+			(s(at).toString match {
+				case " " => "|"
+				case x => x
+			}) +
+			s.slice(at + 1, s.length)
+		def toAsciiLines(node: A, level: Int): Vector[String] = {
+			val line = limitLine((twoSpaces * level) + (if (level == 0) "" else "+-") + display(node))
+			val cs = Vector(children(node): _*)
+			val childLines = cs map {toAsciiLines(_, level + 1)}
+			val withBar = childLines.zipWithIndex flatMap {
+				case (lines, pos) if pos < (cs.size - 1) => lines map {insertBar(_, 2 * (level + 1))}
+				case (lines, pos) =>
+					if (lines.last.trim != "") lines ++ Vector(twoSpaces * (level + 1))
+					else lines
+			}
+			line +: withBar
+		}
+		
+		toAsciiLines(top, 0).mkString("\n")
+	}
+}


### PR DESCRIPTION
## overview

This is a slightly cleaned up version of [sbt-inspectr](https://github.com/eed3si9n/sbt-inspectr).
When `inspect tree <key>` is called, `SettingGraph` case class is created recursively
along the dependencies, calling the similar code as `inspect` command's `Project.details`.
`SettingGraph` extends `Graph` trait, which is able to render itself as an ascii tree.
## sample usage

```
> inspect 
Display all 217 possibilities? (y or n) 
> inspect tree pa
package                 package-bin             package-configuration
package-doc             package-options         package-src
packaged-artifact       packaged-artifacts      parallel-execution
> inspect tree package
[info] compile:package = Task[java.io.File]
[info]   +-compile:package-bin = Task[java.io.File]
[info]     +-compile:package-configuration(for package-bin) = Task[sbt.Packag..
[info]     | +-compile:mappings(for package-bin) = Task[scala.collection.Seq[..
[info]     | | +-compile:products = Task[scala.collection.Seq[java.io.File]]
[info]     | | 
[info]     | +-compile:artifact-path(for package-bin) = target/scala-2.9.1/he..
[info]     | | +-*:cross-target = target/scala-2.9.1
[info]     | | +-compile:artifact(for package-bin) = Artifact(helloworld,jar,..
[info]     | | | +-*/*:artifact-classifier = None
[info]     | | | +-compile:configuration = compile
[info]     | | | 
[info]     | | +-*/*:scala-version = 2.9.1
[info]     | | +-*:project-id = production:helloworld:0.1-SNAPSHOT
[info]     | | +-*/*:artifact-name = <function3>
[info]     | | 
[info]     | +-compile:package-options(for package-bin) = Task[scala.collecti..
[info]     |   +-*:organization = production
[info]     |   +-*:name = helloworld
[info]     |   +-compile:main-class = Task[scala.Option[java.lang.String]]
[info]     |   +-*/*:version = 0.1-SNAPSHOT
[info]     |   +-*/*:homepage = None
[info]     |   +-*:organization-name = production
[info]     |   +-*/*:package-options = Task[scala.collection.Seq[sbt.PackageO..
[info]     |   
[info]     +-compile:cache-directory(for package-bin) = target/scala-2.9.1/ca..
[info]     +-compile:streams(for package-bin) = Task[sbt.std.TaskStreams[sbt...
[info]       +-*/*:streams-manager = Task[sbt.std.Streams[sbt.Init$ScopedKey[..
[info]       
> inspect package
[info] Task: java.io.File
[info] Description:
[info]  Produces the main artifact, such as a binary jar.  This is typically an alias for the task that actually does the packaging.
[info] Provided by:
[info]  {file:/Users/eed3si9n/work/helloworld/}default-b65acd/compile:package
[info] Dependencies:
[info]  compile:package-bin
[info] Delegates:
[info]  compile:package
[info]  *:package
[info]  {.}/compile:package
[info]  {.}/*:package
[info]  */compile:package
[info]  */*:package
[info] Related:
[info]  test:package
> inspect actual package
[info] Task: java.io.File
[info] Description:
[info]  Produces the main artifact, such as a binary jar.  This is typically an alias for the task that actually does the packaging.
[info] Provided by:
[info]  {file:/Users/eed3si9n/work/helloworld/}default-b65acd/compile:package
[info] Dependencies:
[info]  compile:package-bin
[info] Delegates:
[info]  compile:package
[info]  *:package
[info]  {.}/compile:package
[info]  {.}/*:package
[info]  */compile:package
[info]  */*:package
[info] Related:
[info]  test:package
> help inspect

inspect [tree] <key>

    For a plain setting, the value bound to the key argument is displayed using its toString method.
    Otherwise, the type of task ("Task" or "Input task") is displayed.

    "Dependencies" shows the settings that this setting depends on.
    If 'tree' is specified, the bound value as well as the settings that this setting depends on
    (and their bound values) are displayed as a tree structure.

    "Reverse dependencies" shows the settings that depend on this setting.

    When a key is resolved to a value, it may not actually be defined in the requested scope.
    In this case, there is a defined search sequence.
    "Delegates" shows the scopes that are searched for the key.
    "Provided by" shows the scope that contained the value returned for the key.

    "Related" shows all of the scopes in which the key is defined.


> 
```
