### PR TITLE
Fix stack overflow when use Build.projects in a Project's settings.

### DIFF
--- a/main/Project.scala
+++ b/main/Project.scala
@@ -34,7 +34,7 @@ sealed trait ProjectDefinition[PR <: ProjectReference]
 sealed trait Project extends ProjectDefinition[ProjectReference]
 {
 	def copy(id: String = id, base: File = base, aggregate: => Seq[ProjectReference] = aggregate, dependencies: => Seq[ClasspathDep[ProjectReference]] = dependencies, delegates: => Seq[ProjectReference] = delegates,
-		settings: Seq[Project.Setting[_]] = settings, configurations: Seq[Configuration] = configurations): Project =
+		settings: => Seq[Project.Setting[_]] = settings, configurations: Seq[Configuration] = configurations): Project =
 			Project(id, base, aggregate = aggregate, dependencies = dependencies, delegates = delegates, settings, configurations)
 
 	def resolve(resolveRef: ProjectReference => ProjectRef): ResolvedProject =


### PR DESCRIPTION
This code cause stack overflow:

``` scala
import sbt._
import Keys._

object MyBuild extends Build {

  private def addAllBuildDependency(p: Project) =
    buildDependencies <<= (buildDependencies,
                           thisProjectRef,
                           thisProjectRef in p) {
      (origin, self, matchingProject) =>
      if (self == matchingProject)
        origin
      else
        origin.addClasspath(
          self,
          ResolvedClasspathDependency(matchingProject, None))
    }

  // Cause stack overflow without patch.
  private def newProject(path: String) =
    Project(id = path, base = file(path),
            settings = Project.defaultSettings ++
                       (projects map addAllBuildDependency))

  lazy val foo = newProject("foo").dependsOn(bar)

  lazy val bar= Project(id = "bar", base = file("bar"))

}
```

I change `settings` parameter as call-by-name parameter in `Project.copy()` to fix it.
