### PR TITLE
Allow `ModuleID % Configuration`

### DIFF
--- a/ivy/DependencyBuilders.scala
+++ b/ivy/DependencyBuilders.scala
@@ -46,6 +46,8 @@ final class GroupArtifactID private[sbt] (groupID: String, artifactID: String, c
 }
 final class ModuleIDConfigurable private[sbt] (moduleID: ModuleID)
 {
+	def % (configuration: Configuration): ModuleID = %(configuration.name)
+
 	def % (configurations: String): ModuleID =
 	{
 		nonEmpty(configurations, "Configurations")

--- a/main/Project.scala
+++ b/main/Project.scala
@@ -149,6 +149,8 @@ object Project extends Init[Scope] with ProjectExtra
 	def defaultSettings: Seq[Setting[_]] = Defaults.defaultSettings
 
 	final class Constructor(p: ProjectReference) {
+		def %(conf: Configuration): ClasspathDependency = %(conf.name)
+
 		def %(conf: String): ClasspathDependency = new ClasspathDependency(p, Some(conf))
 	}
 


### PR DESCRIPTION
Please accept this patch so we can type `libraryDependencies += "org.foo" % "bar" % "1.0" % Test`
