### PR TITLE
Remove trailing whitespace from entries in credentials file

### DIFF
--- a/ivy/Credentials.scala
+++ b/ivy/Credentials.scala
@@ -64,7 +64,7 @@ object Credentials
 	{
 		val properties = new java.util.Properties
 		IO.load(properties, from)
-		properties map { case (k,v) => (k.toString, v.toString) } toMap;
+		properties map { case (k,v) => (k.toString, v.toString.trim) } toMap;
 	}
 }
 


### PR DESCRIPTION
I fixed the issue that I reported here:

http://groups.google.com/group/simple-build-tool/browse_thread/thread/2cf51db06ff9d6f5
