### PR TITLE
Jansi init

### DIFF
--- a/launch/Boot.scala
+++ b/launch/Boot.scala
@@ -12,6 +12,7 @@ object Boot
 	{
 		System.clearProperty("scala.home") // avoid errors from mixing Scala versions in the same JVM
 		CheckProxy()
+    initJansi()
 		run(args)
 	}
 	// this arrangement is because Scala 2.7.7 does not properly optimize away
@@ -40,4 +41,16 @@ object Boot
 	}
 	private def exit(code: Int): Nothing = 
 		System.exit(code).asInstanceOf[Nothing]
+
+  private def initJansi() {
+    try {
+      val c = Class.forName("org.fusesource.jansi.AnsiConsole")
+      c.getMethod("systemInstall").invoke(null)
+      if(System.getProperty("sbt.log.format") eq null)
+        System.setProperty("sbt.log.format", "true")
+    } catch {
+      case ignore: ClassNotFoundException =>
+      case ex => println("Jansi found on class path but initialization failed: "+ex)
+    }
+  }
 }


### PR DESCRIPTION
[Jansi](http://jansi.fusesource.org/) can be used to get colorized output from sbt on Windows. This patch for the sbt launcher initializes Jansi and enables ANSI output for sbt if Jansi is found on the classpath, thus removing the need for a separate launcher class for bootstrapping.

Here's the sbt.bat I'm using with this launcher:

```
@set SCRIPT_DIR=%~dp0\
@java -version:1.6.0 -server -XX:ReservedCodeCacheSize=128m -XX:+UseCompressedOops -XX:+UseParallelGC -XX:+DoEscapeAnalysis -Xmx3076M -XX:MaxPermSize=1024M -Xss2M -cp "%SCRIPT_DIR%jansi-1.7.jar;%SCRIPT_DIR%sbt-launch-0.11.2-ansi.jar" xsbt.boot.Boot %*
```

And for MSYS:

```
UDIR=`dirname $0`
WDIR=`cmd //c echo $UDIR`
java -version:1.6.0 -server -XX:ReservedCodeCacheSize=128m -XX:+UseCompressedOops -XX:+UseParallelGC -XX:+DoEscapeAnalysis -Xmx3076M -XX:MaxPermSize=1024M -Xss2M -cp "$WDIR/jansi-1.7.jar;$WDIR/sbt-launch-0.11.2-ansi.jar" xsbt.boot.Boot $@
```

This could be done in more elegant ways (e,g, having the main sbt JAR depend on Jansi and initializing it there, so that the launcher wouldn't need the separate Jansi JAR. OTOH, doing it in the launcher makes it work retroactively for all sbt versions.
