### PR TITLE
Scripted launcher opts

### DIFF
--- a/scripted/sbt/SbtHandler.scala
+++ b/scripted/sbt/SbtHandler.scala
@@ -10,9 +10,9 @@ package test
 
 	import Logger._
 
-final class SbtHandler(directory: File, launcher: File, log: Logger, server: IPC.Server) extends StatementHandler
+final class SbtHandler(directory: File, launcher: File, log: Logger, server: IPC.Server, launchOpts: Seq[String] = Seq()) extends StatementHandler
 {
-	def this(directory: File, launcher: File, log: xsbti.Logger, server: IPC.Server) = this(directory, launcher, log: Logger, server)
+	def this(directory: File, launcher: File, log: xsbti.Logger, server: IPC.Server, launchOpts: Seq[String]) = this(directory, launcher, log: Logger, server, launchOpts)
 	type State = Process
 	def initialState = newRemote
 	def apply(command: String, arguments: List[String], p: Process): Process =
@@ -38,7 +38,7 @@ final class SbtHandler(directory: File, launcher: File, log: Logger, server: IPC
 	{
 		val launcherJar = launcher.getAbsolutePath
 		val globalBase = "-Dsbt.global.base=" + (new File(directory, "global")).getAbsolutePath
-		val args = "java" :: globalBase :: "-jar" :: launcherJar :: ( "<" + server.port) :: Nil
+		val args = "java" :: (launchOpts.toList ++ (globalBase :: "-jar" :: launcherJar :: ( "<" + server.port) :: Nil))
 		val io = BasicIO(log, false).withInput(_.close())
 		val p = Process(args, directory) run( io )
 		Spawn { p.exitValue(); server.close() }

--- a/scripted/sbt/ScriptedTests.scala
+++ b/scripted/sbt/ScriptedTests.scala
@@ -12,7 +12,7 @@ import xsbt.IPC
 import xsbt.test.{CommentHandler, FileCommands, ScriptRunner, TestScriptParser}
 import IO.wrapNull
 
-final class ScriptedTests(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, launcher: File)
+final class ScriptedTests(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, launcher: File, launchOpts: Seq[String])
 {
 	private val testResources = new Resources(resourceBaseDirectory)
 	
@@ -46,7 +46,7 @@ final class ScriptedTests(resourceBaseDirectory: File, bufferLog: Boolean, sbtVe
 		def createParser() =
 		{
 			val fileHandler = new FileCommands(testDirectory)
-			val sbtHandler = new SbtHandler(testDirectory, launcher, buffered, server)
+			val sbtHandler = new SbtHandler(testDirectory, launcher, buffered, server, launchOpts)
 			new TestScriptParser(Map('$' -> fileHandler, '>' -> sbtHandler, '#' -> CommentHandler))
 		}
 		def runTest() =
@@ -92,14 +92,14 @@ object ScriptedTests
 		val bootProperties = new File(args(5))
 		val tests = args.drop(6)
 		val logger = ConsoleLogger()
-		run(directory, buffer, sbtVersion, defScalaVersion, buildScalaVersions, tests, logger, bootProperties)
+		run(directory, buffer, sbtVersion, defScalaVersion, buildScalaVersions, tests, logger, bootProperties, Seq())
 	}
-	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], bootProperties: File): Unit =
-		run(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, tests, ConsoleLogger(), bootProperties)//new FullLogger(Logger.xlog2Log(log)))
+	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], bootProperties: File, launchOpts: Seq[String]): Unit =
+		run(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, tests, ConsoleLogger(), bootProperties, launchOpts)//new FullLogger(Logger.xlog2Log(log)))
 
-	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], logger: AbstractLogger, bootProperties: File)
+	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], logger: AbstractLogger, bootProperties: File, launchOpts: Seq[String])
 	{
-		val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, bootProperties)	
+		val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, bootProperties, launchOpts)
 		for( ScriptedTest(group, name) <- get(tests, resourceBaseDirectory, logger) )
 			runner.scriptedTest(group, name, logger)
 	}


### PR DESCRIPTION
When working on the sbt-scrooge plugin, I ran into issues with scripted tests running out of permgen space. While digging through code I found that there was no way to pass arguments to the java process that ran scripted tests. This pull request adds such a setting, and threads launchOpts through the various plugin components.
