### PR TITLE
Parser for escaped and verbatim string literals

### DIFF
--- a/util/complete/Parsers.scala
+++ b/util/complete/Parsers.scala
@@ -17,10 +17,8 @@ trait Parsers
 
 	lazy val DigitSet = Set("0","1","2","3","4","5","6","7","8","9")
 	lazy val Digit = charClass(_.isDigit, "digit") examples DigitSet
-	lazy val OctalDigitSet = Set("0","1","2","3","4","5","6","7")
-	lazy val OctalDigit = charClass(c => OctalDigitSet(c.toString), "octal") examples OctalDigitSet
-	lazy val HexDigitSet = Set("0","1","2","3","4","5","6","7","8","9", "A", "B", "C", "D", "E", "F")
-	lazy val HexDigit = charClass(c => HexDigitSet(c.toString.toUpperCase), "hex") examples HexDigitSet
+	lazy val HexDigitSet = Set('0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F')
+	lazy val HexDigit = charClass(HexDigitSet, "hex") examples HexDigitSet.map(_.toString)
 	lazy val Letter = charClass(_.isLetter, "letter")
 	def IDStart = Letter
 	lazy val IDChar = charClass(isIDChar, "ID character")
@@ -90,11 +88,7 @@ trait Parsers
 	}
 	lazy val EscapeSequence: Parser[String] =
 	  "\\" ~> ("b" ^^^ "\b" | "t" ^^^ "\t" | "n" ^^^ "\n" | "f" ^^^ "\f" | "r" ^^^ "\r" |
-	  "\"" ^^^ "\"" | "'" ^^^ "\'" | "\\" ^^^ "\\" | OctalEscape | UnicodeEscape)
-	lazy val OctalEscape: Parser[String] =
-	  repeat(OctalDigit, 1, 3) map { seq =>
-	  	Integer.parseInt(seq.mkString, 8).asInstanceOf[Char].toString
-	  }
+	  "\"" ^^^ "\"" | "'" ^^^ "\'" | "\\" ^^^ "\\" | UnicodeEscape)
 	lazy val UnicodeEscape: Parser[String] =
 	  ("u" ~> repeat(HexDigit, 4, 4)) map { seq =>
 	  	Integer.parseInt(seq.mkString, 16).asInstanceOf[Char].toString

--- a/util/complete/Parsers.scala
+++ b/util/complete/Parsers.scala
@@ -17,6 +17,10 @@ trait Parsers
 
 	lazy val DigitSet = Set("0","1","2","3","4","5","6","7","8","9")
 	lazy val Digit = charClass(_.isDigit, "digit") examples DigitSet
+	lazy val OctalDigitSet = Set("0","1","2","3","4","5","6","7")
+	lazy val OctalDigit = charClass(c => OctalDigitSet(c.toString), "octal") examples OctalDigitSet
+	lazy val HexDigitSet = Set("0","1","2","3","4","5","6","7","8","9", "A", "B", "C", "D", "E", "F")
+	lazy val HexDigit = charClass(c => HexDigitSet(c.toString.toUpperCase), "hex") examples HexDigitSet
 	lazy val Letter = charClass(_.isLetter, "letter")
 	def IDStart = Letter
 	lazy val IDChar = charClass(isIDChar, "ID character")
@@ -44,6 +48,12 @@ trait Parsers
 	lazy val Space = SpaceClass.+.examples(" ")
 	lazy val OptSpace = SpaceClass.*.examples(" ")
 	lazy val URIClass = URIChar.+.string !!! "Invalid URI"
+	lazy val VerbatimDQuotes = "\"\"\""
+	lazy val DQuoteChar = '\"'
+	lazy val DQuoteClass = charClass(_ == DQuoteChar, "double-quote character")
+	lazy val NotDQuoteClass = charClass(_ != DQuoteChar, "non-double-quote character")
+	lazy val NotDQuoteBackslashClass = charClass({ c: Char =>
+		c != DQuoteChar && c != '\\' }, "non-double-quote character")
 
 	lazy val URIChar = charClass(alphanum) | chars("_-!.~'()*,;:$&+=?/[]@%#")
 	def alphanum(c: Char) = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
@@ -57,6 +67,39 @@ trait Parsers
 	private[this] def toInt(neg: Option[Char], digits: Seq[Char]): Int =
 		(neg.toSeq ++ digits).mkString.toInt
 	lazy val Bool = ("true" ^^^ true) | ("false" ^^^ false)
+	lazy val StringBasic = StringVerbatim | StringEscapable | NotQuoted
+	def StringVerbatim: Parser[String] = {
+		var dqcount = 0
+		val p = VerbatimDQuotes ~
+			charClass(_ match {
+				case DQuoteChar =>
+				  dqcount += 1
+				  dqcount < 3
+				case _ =>
+					dqcount = 0
+					true
+			}).*.string ~ DQuoteChar
+		p map { case ((s, p), c) => s + p + c.toString } filter(
+			{ _.endsWith(VerbatimDQuotes) }, _ => "Expected '%s'" format VerbatimDQuotes) map { s =>
+			s.substring(3, s.length - 3) }
+	}
+	lazy val StringEscapable: Parser[String] = {
+		val p = DQuoteChar ~>
+		  (EscapeSequence | NotDQuoteBackslashClass map {_.toString}).* <~ DQuoteChar
+		p map { _.mkString }
+	}
+	lazy val EscapeSequence: Parser[String] =
+	  "\\" ~> ("b" ^^^ "\b" | "t" ^^^ "\t" | "n" ^^^ "\n" | "f" ^^^ "\f" | "r" ^^^ "\r" |
+	  "\"" ^^^ "\"" | "'" ^^^ "\'" | "\\" ^^^ "\\" | OctalEscape | UnicodeEscape)
+	lazy val OctalEscape: Parser[String] =
+	  repeat(OctalDigit, 1, 3) map { seq =>
+	  	Integer.parseInt(seq.mkString, 8).asInstanceOf[Char].toString
+	  }
+	lazy val UnicodeEscape: Parser[String] =
+	  ("u" ~> repeat(HexDigit, 4, 4)) map { seq =>
+	  	Integer.parseInt(seq.mkString, 16).asInstanceOf[Char].toString
+	  }
+	lazy val NotQuoted = (NotDQuoteClass ~ NotSpace) map { case (c, s) => c.toString + s }
 
 	def repsep[T](rep: Parser[T], sep: Parser[_]): Parser[Seq[T]] =
 		rep1sep(rep, sep) ?? Nil
@@ -67,7 +110,7 @@ trait Parsers
 	def mapOrFail[S,T](p: Parser[S])(f: S => T): Parser[T] =
 		p flatMap { s => try { success(f(s)) } catch { case e: Exception => failure(e.toString) } }
 
-	def spaceDelimited(display: String): Parser[Seq[String]] = (token(Space) ~> token(NotSpace, display)).* <~ SpaceClass.*
+	def spaceDelimited(display: String): Parser[Seq[String]] = (token(Space) ~> token(StringBasic, display)).* <~ SpaceClass.*
 
 	def flag[T](p: Parser[T]): Parser[Boolean] = (p ^^^ true) ?? false
 

--- a/util/complete/Parsers.scala
+++ b/util/complete/Parsers.scala
@@ -66,21 +66,9 @@ trait Parsers
 		(neg.toSeq ++ digits).mkString.toInt
 	lazy val Bool = ("true" ^^^ true) | ("false" ^^^ false)
 	lazy val StringBasic = StringVerbatim | StringEscapable | NotQuoted
-	def StringVerbatim: Parser[String] = {
-		var dqcount = 0
-		val p = VerbatimDQuotes ~
-			charClass(_ match {
-				case DQuoteChar =>
-				  dqcount += 1
-				  dqcount < 3
-				case _ =>
-					dqcount = 0
-					true
-			}).*.string ~ DQuoteChar
-		p map { case ((s, p), c) => s + p + c.toString } filter(
-			{ _.endsWith(VerbatimDQuotes) }, _ => "Expected '%s'" format VerbatimDQuotes) map { s =>
-			s.substring(3, s.length - 3) }
-	}
+  lazy val StringVerbatim: Parser[String] = VerbatimDQuotes ~>
+  	any.+.string.filter(!_.contains(VerbatimDQuotes), _ => "Invalid verbatim string") <~ 
+  	VerbatimDQuotes
 	lazy val StringEscapable: Parser[String] = {
 		val p = DQuoteChar ~>
 		  (EscapeSequence | NotDQuoteBackslashClass map {_.toString}).* <~ DQuoteChar


### PR DESCRIPTION
## background

see [Arguments with whitespace](https://groups.google.com/forum/#!topic/simple-build-tool/el5c3oaSgsw/discussion). Heiko wrote:

> How can I pass arguments to the run method that contain a whitespace, e.g.
> 
> ```
> run "Mark Harrah" 
> ```
## what's here

I've changed the `spaceDelimited` parser as follows:

``` scala
def spaceDelimited(display: String): Parser[Seq[String]] = (token(Space) ~> token(StringBasic, display)).* <~ SpaceClass.*
```

Instead of simple `NotSpace`, it uses `StringBasic`, which parses three different kinds of strings:

``` scala
lazy val StringBasic = StringVerbatim | StringEscapable | NotQuoted
```
### verbatim string

Verbatim string uses the same style as Scala:

```
run """foo bar C:\""" """x"""
```

Arguments are passed into the app as two arguments.
### escaped string

Escaped string uses the same style as Scala/Java. See [String Literals](http://docs.oracle.com/javase/specs/jls/se5.0/html/lexical.html#101083) for Java spec.

``` scala
run "baz\u0398\t\""
```

This passes in `bazΘ   "`.
### unquoted string

Finally, for backward compat, we have unquoted string, which begins with non-double-quotation character and ends with a space.

``` scala
run quux
```
## note

All escape sequence evaluations are done at the parser-level, so the underlying settings system does not see any escaping. Thus most of the existing tasks should be able get the benefits without changing them.
The exceptions are InputTasks and Command that currently uses `"` and `\`.
