### PR TITLE
set status according to the isSnapshot setting

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -718,7 +718,7 @@ object Classpaths
 		makePomConfiguration <<= (artifactPath in makePom, projectInfo, pomExtra, pomPostProcess, pomIncludeRepository, pomAllRepositories) {
 			(file, minfo, extra, process, include, all) => new MakePomConfiguration(file, minfo, None, extra, process, include, all)
 		},
-		deliverLocalConfiguration <<= (crossTarget, ivyLoggingLevel) map { (outDir, level) => deliverConfig( outDir, logging = level ) },
+		deliverLocalConfiguration <<= (crossTarget, isSnapshot, ivyLoggingLevel) map { (outDir, snapshot, level) => deliverConfig( outDir, status = if (snapshot) "integration" else "release", logging = level ) },
 		deliverConfiguration <<= deliverLocalConfiguration,
 		publishConfiguration <<= (packagedArtifacts, publishTo, publishMavenStyle, deliver, checksums in publish, ivyLoggingLevel) map { (arts, publishTo, mavenStyle, ivyFile, checks, level) =>
 			publishConfig(arts, if(mavenStyle) None else Some(ivyFile), resolverName = getPublishTo(publishTo).name, checksums = checks, logging = level)


### PR DESCRIPTION
sbt is currently publishing all artifacts as status `"release"`, which is undesirable for `-SNAPSHOT` artifacts.

I changed a line in `Defaults.scala` to look at the state of `isSnapshot` and set the status accordingly.
