### PR TITLE
Fixed scripted-plugin's reflection call

### DIFF
--- a/scripted/plugin/ScriptedPlugin.scala
+++ b/scripted/plugin/ScriptedPlugin.scala
@@ -34,13 +34,13 @@ object ScriptedPlugin extends Plugin {
 
 	def scriptedRunTask: Initialize[Task[Method]] = (scriptedTests) map {
 		(m) =>
-		m.getClass.getMethod("run", classOf[File], classOf[Boolean], classOf[String], classOf[String], classOf[String], classOf[Array[String]], classOf[File], classOf[Seq[String]])
+		m.getClass.getMethod("run", classOf[File], classOf[Boolean], classOf[String], classOf[String], classOf[String], classOf[Array[String]], classOf[File], classOf[Array[String]])
 	}
 
 	def scriptedTask: Initialize[InputTask[Unit]] = InputTask(_ => complete.Parsers.spaceDelimited("<arg>")) { result =>
 		(scriptedDependencies, scriptedTests, scriptedRun, sbtTestDirectory, scriptedBufferLog, scriptedSbt, scriptedScalas, sbtLauncher, scriptedLaunchOpts, result) map {
 			(deps, m, r, testdir, bufferlog, version, scriptedScalas, launcher, launchOpts, args) =>
-			try { r.invoke(m, testdir, bufferlog: java.lang.Boolean, version.toString, scriptedScalas.build, scriptedScalas.versions, args.toArray, launcher, launchOpts) }
+			try { r.invoke(m, testdir, bufferlog: java.lang.Boolean, version.toString, scriptedScalas.build, scriptedScalas.versions, args.toArray, launcher, launchOpts.toArray) }
 			catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
 		}
 	}


### PR DESCRIPTION
## steps
1. set up scripted test on 0.12.0-M2 (see [sbt-assembly](https://github.com/sbt/sbt-assembly/)):
   
   ``` scala
   libraryDependencies <+= (sbtVersion) { sv =>
     "org.scala-sbt" % "scripted-plugin" % sv
   }
   ```
2. run `scripted`.
## problem

```
[error] {file:/foo/sbt-assembly/}default-373f46/*:scripted-run: java.lang.NoSuchMethodException: sbt.test.ScriptedTests$.run(java.io.File, boolean, java.lang.String, java.lang.String, java.lang.String, [Ljava.lang.String;, java.io.File, scala.collection.Seq)
```
## note

[30cca3](https://github.com/harrah/xsbt/commit/30cca3a6d0013b192c96eab250f7ea2f1cb7d62b) changes the signature of `run` method. scripted-plugin was calling it via reflection using the old sig.
