### PR TITLE
Adding `scalaOrg` setting key for scala clones.

### DIFF
--- a/launch/BootConfiguration.scala
+++ b/launch/BootConfiguration.scala
@@ -53,11 +53,22 @@ private object BootConfiguration
 
 	val DefaultIvyConfiguration = "default"
 
-	/** The name of the directory within the boot directory to retrieve scala to. */
-	val ScalaDirectoryName = "lib"
+	private val ScalaDirectoryName = "lib"
+	
+	/** The name of the directory within the boot directory to retrieve scala to. 
+	 * scalaOrg is appended if non-standard scala is used. 
+	 * 
+	 * The reason for this inconsistency is backward compatiblity and
+	 * relatively infrequent use of non-standard scalaOrg */
+	def scalaDirectoryName(scalaOrg: String) = scalaOrg match {
+	  case ScalaOrg => ScalaDirectoryName
+	  case _ => ScalaDirectoryName + "-" + scalaOrg
+	}
+	
 	/** The Ivy pattern to use for retrieving the scala compiler and library.  It is relative to the directory
-	* containing all jars for the requested version of scala. */
-	val scalaRetrievePattern = ScalaDirectoryName + "/[artifact](-[classifier]).[ext]"
+	* containing all jars for the requested version of scala.
+	*/
+	def scalaRetrievePattern(scalaOrg: String) = scalaDirectoryName(scalaOrg) + "/[artifact](-[classifier]).[ext]"
 	
 	def artifactType(classifier: String) =
 		classifier match
@@ -80,6 +91,7 @@ private object BootConfiguration
 		case None => "other"
 		case Some(sv) => ScalaDirPrefix + sv
 	}
+	
 	def extractScalaVersion(dir: File): Option[String] =
 	{
 		val name = dir.getName

--- a/launch/BootConfiguration.scala
+++ b/launch/BootConfiguration.scala
@@ -72,23 +72,23 @@ private object BootConfiguration
 	* containing all jars for the requested version of scala. */
 	def appRetrievePattern(appID: xsbti.ApplicationID) = appDirectoryName(appID, "/") + "(/[component])/[artifact]-[revision](-[classifier]).[ext]"
 
-	val ScalaVersionPrefix = ".scala-"
+	val ScalaVersionPrefix = "scala-"
 
 	/** The name of the directory to retrieve the application and its dependencies to.*/
 	def appDirectoryName(appID: xsbti.ApplicationID, sep: String) = appID.groupID + sep + appID.name + sep + appID.version
 	/** The name of the directory in the boot directory to put all jars for the given version of scala in.*/
 	def baseDirectoryName(scalaOrg: String, scalaVersion: Option[String]) = scalaVersion match {
 		case None => "other"
-		case Some(sv) => scalaOrg + ScalaVersionPrefix + sv
+		case Some(sv) => (if (scalaOrg == ScalaOrg) "" else scalaOrg + ".") + ScalaVersionPrefix + sv
 	}
 	
 	def extractScalaVersion(dir: File): Option[String] =
 	{
 		val name = dir.getName
 		if(name.contains(ScalaVersionPrefix))
-		   Some(name.substring(name.lastIndexOf(ScalaVersionPrefix) + ScalaVersionPrefix.length))
+			Some(name.substring(name.lastIndexOf(ScalaVersionPrefix) + ScalaVersionPrefix.length))
 		else
-		   None
+			None
 	}
 }
 private object ProxyProperties

--- a/launch/BootConfiguration.scala
+++ b/launch/BootConfiguration.scala
@@ -53,22 +53,12 @@ private object BootConfiguration
 
 	val DefaultIvyConfiguration = "default"
 
-	private val ScalaDirectoryName = "lib"
-	
-	/** The name of the directory within the boot directory to retrieve scala to. 
-	 * scalaOrg is appended if non-standard scala is used. 
-	 * 
-	 * The reason for this inconsistency is backward compatiblity and
-	 * relatively infrequent use of non-standard scalaOrg */
-	def scalaDirectoryName(scalaOrg: String) = scalaOrg match {
-	  case ScalaOrg => ScalaDirectoryName
-	  case _ => ScalaDirectoryName + "-" + scalaOrg
-	}
+	val ScalaDirectoryName = "lib"
 	
 	/** The Ivy pattern to use for retrieving the scala compiler and library.  It is relative to the directory
 	* containing all jars for the requested version of scala.
 	*/
-	def scalaRetrievePattern(scalaOrg: String) = scalaDirectoryName(scalaOrg) + "/[artifact](-[classifier]).[ext]"
+	val scalaRetrievePattern = ScalaDirectoryName + "/[artifact](-[classifier]).[ext]"
 	
 	def artifactType(classifier: String) =
 		classifier match
@@ -82,20 +72,23 @@ private object BootConfiguration
 	* containing all jars for the requested version of scala. */
 	def appRetrievePattern(appID: xsbti.ApplicationID) = appDirectoryName(appID, "/") + "(/[component])/[artifact]-[revision](-[classifier]).[ext]"
 
-	val ScalaDirPrefix = "scala-"
+	val ScalaVersionPrefix = ".scala-"
 
 	/** The name of the directory to retrieve the application and its dependencies to.*/
 	def appDirectoryName(appID: xsbti.ApplicationID, sep: String) = appID.groupID + sep + appID.name + sep + appID.version
 	/** The name of the directory in the boot directory to put all jars for the given version of scala in.*/
-	def baseDirectoryName(scalaVersion: Option[String]) = scalaVersion match {
+	def baseDirectoryName(scalaOrg: String, scalaVersion: Option[String]) = scalaVersion match {
 		case None => "other"
-		case Some(sv) => ScalaDirPrefix + sv
+		case Some(sv) => scalaOrg + ScalaVersionPrefix + sv
 	}
 	
 	def extractScalaVersion(dir: File): Option[String] =
 	{
 		val name = dir.getName
-		if(name.startsWith(ScalaDirPrefix)) Some(name.substring(ScalaDirPrefix.length)) else None
+		if(name.contains(ScalaVersionPrefix))
+		   Some(name.substring(name.lastIndexOf(ScalaVersionPrefix) + ScalaVersionPrefix.length))
+		else
+		   None
 	}
 }
 private object ProxyProperties

--- a/launch/Launch.scala
+++ b/launch/Launch.scala
@@ -84,10 +84,12 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 	bootDirectory.mkdirs
 	private val scalaProviders = new Cache[(String, String), String, xsbti.ScalaProvider]((x, y) => getScalaProvider(x._1, x._2, y))
 	def getScala(version: String): xsbti.ScalaProvider = getScala(version, "")
-	def getScala(version: String, reason: String): xsbti.ScalaProvider = getScala(BootConfiguration.ScalaOrg, version, reason)
-	def getScala(scalaOrg: String, version: String, reason: String) = scalaProviders((scalaOrg, version), reason)
+	def getScala(version: String, reason: String): xsbti.ScalaProvider = getScala(version, reason, BootConfiguration.ScalaOrg)
+	def getScala(version: String, reason: String, scalaOrg: String) = scalaProviders((scalaOrg, version), reason)
 	def app(id: xsbti.ApplicationID, version: String): xsbti.AppProvider = app(id, Option(version))
-    def app(id: xsbti.ApplicationID, scalaVersion: Option[String]): xsbti.AppProvider = getAppProvider(id, scalaVersion, false)
+    def app(id: xsbti.ApplicationID, scalaVersion: Option[String]): xsbti.AppProvider = 
+      getAppProvider(id, scalaVersion, false)
+
 	val bootLoader = new BootFilteredLoader(getClass.getClassLoader)
 	val topLoader = jnaLoader(bootLoader)
 

--- a/launch/LaunchConfiguration.scala
+++ b/launch/LaunchConfiguration.scala
@@ -15,12 +15,14 @@ final case class LaunchConfiguration(scalaVersion: Value[String], ivyConfigurati
 		val sv = Value.get(scalaVersion)
 		if(sv == "auto") None else Some(sv)
 	}
+	
 	def withScalaVersion(newScalaVersion: String) = LaunchConfiguration(new Explicit(newScalaVersion), ivyConfiguration, app, boot, logging, appProperties)
 	def withApp(app: Application) = LaunchConfiguration(scalaVersion, ivyConfiguration, app, boot, logging, appProperties)
 	def withAppVersion(newAppVersion: String) = LaunchConfiguration(scalaVersion, ivyConfiguration, app.withVersion(new Explicit(newAppVersion)), boot, logging, appProperties)
 	// TODO: withExplicit
 	def withVersions(newScalaVersion: String, newAppVersion: String, classifiers0: Classifiers) =
 		LaunchConfiguration(new Explicit(newScalaVersion), ivyConfiguration.copy(classifiers = classifiers0), app.withVersion(new Explicit(newAppVersion)), boot, logging, appProperties)
+	
 	def map(f: File => File) = LaunchConfiguration(scalaVersion, ivyConfiguration, app.map(f), boot.map(f), logging, appProperties)
 }
 final case class IvyOptions(ivyHome: Option[File], classifiers: Classifiers, repositories: List[xsbti.Repository], checksums: List[String])

--- a/launch/Update.scala
+++ b/launch/Update.scala
@@ -134,7 +134,8 @@ final class Update(config: UpdateConfiguration)
 				addDependency(moduleID, scalaOrg, CompilerModuleName, scalaVersion, "default;optional(default)", u.classifiers)
 				addDependency(moduleID, scalaOrg, LibraryModuleName, scalaVersion, "default", u.classifiers)
 				excludeJUnit(moduleID)
-				System.out.println("Getting " + scalaOrg + " Scala " + scalaVersion + " " + reason + "...")
+				val scalaOrgString = if (scalaOrg != ScalaOrg) " " + scalaOrg else ""
+				System.out.println("Getting" + scalaOrgString + " Scala " + scalaVersion + " " + reason + "...")
 			case u: UpdateApp =>
 				val app = u.id
 				val resolvedName = (app.crossVersioned, scalaVersion) match {

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -7,6 +7,7 @@ public interface Launcher
 	public static final int InterfaceVersion = 1;
 	public ScalaProvider getScala(String version);
 	public ScalaProvider getScala(String version, String reason);
+	public ScalaProvider getScala(String scalaOrg, String version, String reason);
 	public AppProvider app(ApplicationID id, String version);
 	public ClassLoader topLoader();
 	public GlobalLock globalLock();

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -7,7 +7,7 @@ public interface Launcher
 	public static final int InterfaceVersion = 1;
 	public ScalaProvider getScala(String version);
 	public ScalaProvider getScala(String version, String reason);
-	public ScalaProvider getScala(String scalaOrg, String version, String reason);
+	public ScalaProvider getScala(String version, String reason, String scalaOrg);
 	public AppProvider app(ApplicationID id, String version);
 	public ClassLoader topLoader();
 	public GlobalLock globalLock();

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -52,6 +52,7 @@ object Defaults extends BuildCommon
 	))
 	def globalCore: Seq[Setting[_]] = inScope(GlobalScope)(defaultTestTasks(test) ++ defaultTestTasks(testOnly) ++ defaultTestTasks(testQuick) ++ Seq(
 		crossVersion :== CrossVersion.Disabled,
+		scalaOrg :== "org.scala-lang",
 		buildDependencies <<= buildDependencies or Classpaths.constructBuildDependencies,
 		taskTemporaryDirectory := IO.createTemporaryDirectory,
 		onComplete <<= taskTemporaryDirectory { dir => () => IO.delete(dir); IO.createDirectory(dir) },
@@ -264,10 +265,10 @@ object Defaults extends BuildCommon
 			}
 		}
 	}
-	def scalaInstanceSetting = (appConfiguration, scalaVersion, scalaHome) map { (app, version, home) =>
+	def scalaInstanceSetting = (appConfiguration, scalaOrg, scalaVersion, scalaHome) map { (app, scalaOrg, version, home) =>
 		val launcher = app.provider.scalaProvider.launcher
 		home match {
-			case None => ScalaInstance(version, launcher)
+			case None => ScalaInstance(scalaOrg, version, launcher)
 			case Some(h) => ScalaInstance(h, launcher)
 		}
 	}

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -52,7 +52,7 @@ object Defaults extends BuildCommon
 	))
 	def globalCore: Seq[Setting[_]] = inScope(GlobalScope)(defaultTestTasks(test) ++ defaultTestTasks(testOnly) ++ defaultTestTasks(testQuick) ++ Seq(
 		crossVersion :== CrossVersion.Disabled,
-		scalaOrg :== "org.scala-lang",
+		scalaOrganization :== ScalaArtifacts.Organization,
 		buildDependencies <<= buildDependencies or Classpaths.constructBuildDependencies,
 		taskTemporaryDirectory := IO.createTemporaryDirectory,
 		onComplete <<= taskTemporaryDirectory { dir => () => IO.delete(dir); IO.createDirectory(dir) },
@@ -265,10 +265,10 @@ object Defaults extends BuildCommon
 			}
 		}
 	}
-	def scalaInstanceSetting = (appConfiguration, scalaOrg, scalaVersion, scalaHome) map { (app, scalaOrg, version, home) =>
+	def scalaInstanceSetting = (appConfiguration, scalaOrganization, scalaVersion, scalaHome) map { (app, org, version, home) =>
 		val launcher = app.provider.scalaProvider.launcher
 		home match {
-			case None => ScalaInstance(scalaOrg, version, launcher)
+			case None => ScalaInstance(org, version, launcher)
 			case Some(h) => ScalaInstance(h, launcher)
 		}
 	}

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -135,7 +135,7 @@ object Keys
 	val compileInputs = TaskKey[Compiler.Inputs]("compile-inputs", "Collects all inputs needed for compilation.", DTask)
 	val scalaHome = SettingKey[Option[File]]("scala-home", "If Some, defines the local Scala installation to use for compilation, running, and testing.", ASetting)
 	val scalaInstance = TaskKey[ScalaInstance]("scala-instance", "Defines the Scala instance to use for compilation, running, and testing.", DTask)
-	val scalaOrganization = SettingKey[String]("scala-organization", "Organization/group ID of the Scala used in the project. Default value is 'org.scala-lang'.", CSetting)
+	val scalaOrganization = SettingKey[String]("scala-organization", "Organization/group ID of the Scala used in the project. Default value is 'org.scala-lang'. This is an advanced setting used for clones of the Scala Language. It should be disregarded in standard use cases.", CSetting)
 	val scalaVersion = SettingKey[String]("scala-version", "The version of Scala used for building.", APlusSetting)
 	val scalaBinaryVersion = SettingKey[String]("scala-binary-version", "The Scala version substring describing binary compatibility.", BPlusSetting)
 	val crossScalaVersions = SettingKey[Seq[String]]("cross-scala-versions", "The versions of Scala used when cross-building.", BPlusSetting)

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -135,6 +135,7 @@ object Keys
 	val compileInputs = TaskKey[Compiler.Inputs]("compile-inputs", "Collects all inputs needed for compilation.", DTask)
 	val scalaHome = SettingKey[Option[File]]("scala-home", "If Some, defines the local Scala installation to use for compilation, running, and testing.", ASetting)
 	val scalaInstance = TaskKey[ScalaInstance]("scala-instance", "Defines the Scala instance to use for compilation, running, and testing.", DTask)
+	val scalaOrg = SettingKey[String]("scala-org", "Artifact id of Scala scala used in the project.", CSetting)
 	val scalaVersion = SettingKey[String]("scala-version", "The version of Scala used for building.", APlusSetting)
 	val scalaBinaryVersion = SettingKey[String]("scala-binary-version", "The Scala version substring describing binary compatibility.", BPlusSetting)
 	val crossScalaVersions = SettingKey[Seq[String]]("cross-scala-versions", "The versions of Scala used when cross-building.", BPlusSetting)

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -135,7 +135,7 @@ object Keys
 	val compileInputs = TaskKey[Compiler.Inputs]("compile-inputs", "Collects all inputs needed for compilation.", DTask)
 	val scalaHome = SettingKey[Option[File]]("scala-home", "If Some, defines the local Scala installation to use for compilation, running, and testing.", ASetting)
 	val scalaInstance = TaskKey[ScalaInstance]("scala-instance", "Defines the Scala instance to use for compilation, running, and testing.", DTask)
-	val scalaOrg = SettingKey[String]("scala-org", "Artifact id of Scala scala used in the project.", CSetting)
+	val scalaOrganization = SettingKey[String]("scala-organization", "Organization/group ID of the Scala used in the project. Default value is 'org.scala-lang'.", CSetting)
 	val scalaVersion = SettingKey[String]("scala-version", "The version of Scala used for building.", APlusSetting)
 	val scalaBinaryVersion = SettingKey[String]("scala-binary-version", "The Scala version substring describing binary compatibility.", BPlusSetting)
 	val crossScalaVersions = SettingKey[Seq[String]]("cross-scala-versions", "The versions of Scala used when cross-building.", BPlusSetting)

--- a/util/classpath/ScalaInstance.scala
+++ b/util/classpath/ScalaInstance.scala
@@ -23,8 +23,16 @@ object ScalaInstance
 {
 	val VersionPrefix = "version "
 	
-	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance =
+	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance = {
+	  // launcher compatibility check	  
+	  val strClass = "".getClass
+	  if (launcher.getClass.getMethods.exists(m => 
+	    m.getName == "getScala" &&
+	    m.getParameterTypes.toSeq == Seq(strClass, strClass, strClass)))
 		apply(version, launcher.getScala(version, "", org))
+	  else
+	    error("Incompatible version of the xsbti.Launcher interface. Use sbt-0.12.x launcher instead.")
+	}
 	/** Creates a ScalaInstance using the given provider to obtain the jars and loader.*/
 	def apply(version: String, launcher: xsbti.Launcher): ScalaInstance =
 		apply(version, launcher.getScala(version))

--- a/util/classpath/ScalaInstance.scala
+++ b/util/classpath/ScalaInstance.scala
@@ -22,6 +22,9 @@ final class ScalaInstance(val version: String, val loader: ClassLoader, val libr
 object ScalaInstance
 {
 	val VersionPrefix = "version "
+	
+	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance =
+		apply(version, launcher.getScala(org, version, ""))
 	/** Creates a ScalaInstance using the given provider to obtain the jars and loader.*/
 	def apply(version: String, launcher: xsbti.Launcher): ScalaInstance =
 		apply(version, launcher.getScala(version))

--- a/util/classpath/ScalaInstance.scala
+++ b/util/classpath/ScalaInstance.scala
@@ -24,7 +24,7 @@ object ScalaInstance
 	val VersionPrefix = "version "
 	
 	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance =
-		apply(version, launcher.getScala(org, version, ""))
+		apply(version, launcher.getScala(version, "", org))
 	/** Creates a ScalaInstance using the given provider to obtain the jars and loader.*/
 	def apply(version: String, launcher: xsbti.Launcher): ScalaInstance =
 		apply(version, launcher.getScala(version))

--- a/util/classpath/ScalaInstance.scala
+++ b/util/classpath/ScalaInstance.scala
@@ -21,18 +21,19 @@ final class ScalaInstance(val version: String, val loader: ClassLoader, val libr
 }
 object ScalaInstance
 {
+	val ScalaOrg = "org.scala-lang"
 	val VersionPrefix = "version "
 	
-	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance = {
-	  // launcher compatibility check	  
-	  val strClass = "".getClass
-	  if (launcher.getClass.getMethods.exists(m => 
-	    m.getName == "getScala" &&
-	    m.getParameterTypes.toSeq == Seq(strClass, strClass, strClass)))
-		apply(version, launcher.getScala(version, "", org))
-	  else
-	    error("Incompatible version of the xsbti.Launcher interface. Use sbt-0.12.x launcher instead.")
-	}
+	def apply(org: String, version: String, launcher: xsbti.Launcher): ScalaInstance =
+	  // Due to incompatibility with previous launchers if scalaOrg has default value revert to an existing method
+		if (org == ScalaOrg)
+			apply(version, launcher)
+		else try {
+			apply(version, launcher.getScala(version, "", org))
+		} catch {
+			case x: NoSuchMethodError => error("Incompatible version of the xsbti.Launcher interface. Use sbt-0.12.x launcher instead.")
+		}
+
 	/** Creates a ScalaInstance using the given provider to obtain the jars and loader.*/
 	def apply(version: String, launcher: xsbti.Launcher): ScalaInstance =
 		apply(version, launcher.getScala(version))


### PR DESCRIPTION
Adding scalaOrg key that specifies organization (artifactId) of scala used in the project. The change does not affect version checks for dependecies and LauncherConfiguration.

Modified scalaProvider cache in Launcher to use (scalaOrg, version) as a key.

Downloaded jars are stored in the folder scala-.../lig-<scalaOrg> if scalaOrg is not default.

scala-org is an advanced setting so it can not be used in build.sbt.
