### PR TITLE
Add method Aggregation.runTasksWithResult commit (same as #442 but for 0.11.3)

### DIFF
--- a/main/Aggregation.scala
+++ b/main/Aggregation.scala
@@ -72,7 +72,7 @@ final object Aggregation
 		Command.applyEffect(seqParser(ps)) { ts =>
 			runTasks(s, structure, ts, Dummies(KNil, HNil), show)
 		}
-	def runTasks[HL <: HList, T](s: State, structure: Load.BuildStructure, ts: Values[Task[T]], extra: Dummies[HL], show: Boolean)(implicit display: Show[ScopedKey[_]]): State =
+	def runTasksWithResult[HL <: HList, T](s: State, structure: Load.BuildStructure, ts: Values[Task[T]], extra: Dummies[HL], show: Boolean)(implicit display: Show[ScopedKey[_]]): (State, Result[Seq[KeyValue[T]]]) =
 	{
 			import EvaluateTask._
 			import std.TaskExtra._
@@ -93,10 +93,15 @@ final object Aggregation
 		try { onResult(result, log) { results => if(show) printSettings(results, log) } }
 		finally { printSuccess(start, stop, extracted, success, log) }
 
-		newS
+		(newS, result)
 	}
 
-	def printSuccess(start: Long, stop: Long, extracted: Extracted, success: Boolean, log: Logger)
+  def runTasks[HL <: HList, T](s: State, structure: Load.BuildStructure, ts: Values[Task[T]], extra: Dummies[HL], show: Boolean)(implicit display: Show[ScopedKey[_]]): State = {
+    runTasksWithResult(s, structure, ts, extra, show)._1
+  }
+
+
+  def printSuccess(start: Long, stop: Long, extracted: Extracted, success: Boolean, log: Logger)
 	{
 		import extracted._
 		lazy val enabled = showSuccess in extracted.currentRef get extracted.structure.data getOrElse true


### PR DESCRIPTION
In addition to the new State, this method also returns the results of the tasks that were run.
