### PR TITLE
use the same logic for selecting extra attributes in addSbtPlugin as in pluginProjectId

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -1228,9 +1228,13 @@ trait BuildExtra extends BuildCommon
 	def addSbtPlugin(dependency: ModuleID, sbtVersion: String, scalaVersion: String): Setting[Seq[ModuleID]] =
 		libraryDependencies += sbtPluginExtra(dependency, sbtVersion, scalaVersion)
 	def addSbtPlugin(dependency: ModuleID, sbtVersion: String): Setting[Seq[ModuleID]] =
-		libraryDependencies <+= (scalaBinaryVersion in update) { scalaV => sbtPluginExtra(dependency, sbtVersion, scalaV) }
+		libraryDependencies <+= (scalaVersion in update, scalaBinaryVersion in update) { (scalaV, scalaBV) =>
+			sbtPluginExtra(dependency, sbtVersion, selectVersion(scalaV, scalaBV))
+		}
 	def addSbtPlugin(dependency: ModuleID): Setting[Seq[ModuleID]] =
-		libraryDependencies <+= (sbtBinaryVersion in update,scalaBinaryVersion in update) { (sbtV, scalaV) => sbtPluginExtra(dependency, sbtV, scalaV) }
+		libraryDependencies <+= (sbtVersion in update, sbtBinaryVersion in update, scalaVersion in update, scalaBinaryVersion in update) { (sbtV, sbtBV, scalaV, scalaBV) =>
+			sbtPluginExtra(dependency, selectVersion(sbtV, sbtBV), selectVersion(scalaV, scalaBV))
+		}
 
 	def compilerPlugin(dependency: ModuleID): ModuleID =
 		dependency.copy(configurations = Some("plugin->default(compile)"))


### PR DESCRIPTION
This enables us to use the same plugins.sbt in projects for release and
pre-release versions of sbt. Right now you have to use

```
addSbtPlugin(org % name % version, sbtVersion = "0.12.0-Beta2")
```

to support add a plugin for the beta version of sbt. This, however, means you have to update your scripted tests for each (pre-) release version of sbt to find the plugin you are testing. 

With this change the declaration stays

```
 addSbtPlugin(org % name % version)
```

regardless of the sbt version you are using.

This is a follow-up to https://groups.google.com/d/msg/simple-build-tool/hIcElXd38xw/nn1muiC6yfEJ
