### PR TITLE
Proxy repo settings

### DIFF
--- a/launch/ConfigurationParser.scala
+++ b/launch/ConfigurationParser.scala
@@ -68,10 +68,10 @@ class ConfigurationParser
 		val (boot, m4) = processSection(m3, "boot", getBoot)
 		val (logging, m5) = processSection(m4, "log", getLogging)
 		val (properties, m6) = processSection(m5, "app-properties", getAppProperties)
-		val ((ivyHome, checksums), m7) = processSection(m6, "ivy", getIvy)
+		val ((ivyHome, checksums, overrideRepos), m7) = processSection(m6, "ivy", getIvy)
 		check(m7, "section")
 		val classifiers = Classifiers(scalaClassifiers, appClassifiers)
-		val ivyOptions = IvyOptions(ivyHome, classifiers, repositories, checksums)
+		val ivyOptions = IvyOptions(ivyHome, classifiers, repositories, checksums, overrideRepos)
 		new LaunchConfiguration(scalaVersion, ivyOptions, app, boot, logging, properties)
 	}
 	def getScala(m: LabelMap) =
@@ -121,13 +121,14 @@ class ConfigurationParser
 	def file(map: LabelMap, name: String, default: File): (File, LabelMap) =
 		(orElse(getOrNone(map, name).map(toFile), default), map - name)
 
-	def getIvy(m: LabelMap): (Option[File], List[String]) =
+	def getIvy(m: LabelMap): (Option[File], List[String], Boolean) =
 	{
 		val (ivyHome, m1) = file(m, "ivy-home", null) // fix this later
 		val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
-		check(m2, "label")
+    val (overrideRepos, m3) = bool(m2, "override-build", false)
+		check(m3, "label")
 		val home = if(ivyHome eq null) None else Some(ivyHome)
-		(home, checksums)
+		(home, checksums, overrideRepos)
 	}
 	def getBoot(m: LabelMap): BootSetup =
 	{

--- a/launch/Launch.scala
+++ b/launch/Launch.scala
@@ -97,6 +97,7 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 
 	def globalLock: xsbti.GlobalLock = Locks
 	def ivyHome = orNull(ivyOptions.ivyHome)
+	def isOverrideRepositories: Boolean = ivyOptions.isOverrideRepositories
 	def ivyRepositories = repositories.toArray
 	def checksums = checksumsList.toArray[String]
 

--- a/launch/LaunchConfiguration.scala
+++ b/launch/LaunchConfiguration.scala
@@ -31,11 +31,12 @@ final case class LaunchConfiguration(scalaVersion: Value[String], ivyConfigurati
 		copy(ivyConfiguration = ivyConfiguration.withIvyProxyRepository(url, ivyPattern, artifactPattern))
 	def map(f: File => File) = LaunchConfiguration(scalaVersion, ivyConfiguration, app.map(f), boot.map(f), logging, appProperties)
 }
-final case class IvyOptions(ivyHome: Option[File], classifiers: Classifiers, repositories: List[xsbti.Repository], checksums: List[String]) {
+final case class IvyOptions(ivyHome: Option[File], classifiers: Classifiers, repositories: List[xsbti.Repository], checksums: List[String], isOverrideRepositories: Boolean = false) {
   def withMavenProxyRepository(url: URL): IvyOptions =
     copy(repositories = Repository.Maven("proxy-maven", url) :: (repositories filterNot Repository.isMavenRemote))
   def withIvyProxyRepository(url: URL, ivyPattern: String, artifactPattern: String): IvyOptions =
     copy(repositories = Repository.Ivy("proxy-ivy", url, ivyPattern, artifactPattern) :: (repositories filterNot Repository.isIvyRemote))
+	def withOverrideRepositories(value: Boolean): IvyOptions = copy(isOverrideRepositories = value)
 }
 
 sealed trait Value[T]

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -4,7 +4,7 @@ package xsbti;
 
 public interface Launcher
 {
-	public static final int InterfaceVersion = 1;
+	public static final int InterfaceVersion = 2;
 	public ScalaProvider getScala(String version);
 	public ScalaProvider getScala(String version, String reason);
 	public ScalaProvider getScala(String version, String reason, String scalaOrg);
@@ -12,7 +12,10 @@ public interface Launcher
 	public ClassLoader topLoader();
 	public GlobalLock globalLock();
 	public File bootDirectory();
+	/** The configured ivy repositories used by the launcher to resolve an application. */
 	public xsbti.Repository[] ivyRepositories();
+	/** The user has configured the launcher with the only repositories it wants to use for this applciation. */
+	public boolean isOverrideRepositories();
 	// null if none set
 	public File ivyHome();
 	public String[] checksums();

--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -21,3 +21,4 @@ ${{repositories}}
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
+  override-build: ${sbt.override.build.repos-false}

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -273,6 +273,7 @@ object Keys
 	val isSnapshot = SettingKey[Boolean]("is-snapshot", "True if the the version of the project is a snapshot version.", BPlusSetting)
 	val moduleID = SettingKey[ModuleID]("module-id", "A dependency management descriptor.  This is currently used for associating a ModuleID with a classpath entry.", BPlusSetting)
 	val projectID = SettingKey[ModuleID]("project-id", "The dependency management descriptor for the current module.", BMinusSetting)
+	val overrideBuildResovlers = SettingKey[Boolean]("override-build-resolvers", "Whether or not all the build resolvers should be overriden with what's defined from sbt.boot.properties.  Useful when using a proxy.")
 	val externalResolvers = TaskKey[Seq[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.", BMinusSetting)
 	val resolvers = SettingKey[Seq[Resolver]]("resolvers", "The user-defined additional resolvers for automatically managed dependencies.", BMinusTask)
 	val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)


### PR DESCRIPTION
With this commit it's now possible to force builds to use _only_ proxy/local resovlers with
the following:

`-Dsbt.override.build.repos=true -Dsbt.repo.proxy.url=http://localhost:8081/artifactory/repo/`

Assuming you have a local proxy artifactory repo that works for both ivy + maven dependencies.

Closes #414 (I think, some testing from more complicated builds would be ideal.)
