### PR TITLE
Proxy repo config

### DIFF
--- a/launch/ConfigurationParser.scala
+++ b/launch/ConfigurationParser.scala
@@ -47,7 +47,7 @@ object ConfigurationParser
 }
 class ConfigurationParser
 {
-	def apply(file: File): LaunchConfiguration = Using(new InputStreamReader(new FileInputStream(file), "UTF-8"))(apply)
+	def apply(file: File): LaunchConfiguration = Using(newReader(file))(apply)
 	def apply(s: String): LaunchConfiguration = Using(new StringReader(s))(apply)
 	def apply(reader: Reader): LaunchConfiguration = Using(new BufferedReader(reader))(apply)
 	private def apply(in: BufferedReader): LaunchConfiguration =
@@ -57,16 +57,15 @@ class ConfigurationParser
 			case null => accum.reverse
 			case line => readLine(in, ParseLine(line,index) ::: accum, index+1)
 		}
+	private def newReader(file: File) = new InputStreamReader(new FileInputStream(file), "UTF-8")
 	def readRepositoriesConfig(file: File): List[xsbti.Repository] =
-		Using(new InputStreamReader(new FileInputStream(file), "UTF-8"))(readRepositoriesConfig)
+		Using(newReader(file))(readRepositoriesConfig)
 	def readRepositoriesConfig(reader: Reader): List[xsbti.Repository] = 
 		Using(new BufferedReader(reader))(readRepositoriesConfig)
 	private def readRepositoriesConfig(in: BufferedReader): List[xsbti.Repository] =
 		processRepositoriesConfig(processLines(readLine(in, Nil, 0)))
 	def processRepositoriesConfig(sections: SectionMap): List[xsbti.Repository] =
-		processSection(sections, "repositories", getRepositories) match {
-			case (repositories, _) => repositories
-		}
+		processSection(sections, "repositories", getRepositories)._1
 	// section -> configuration instance  processing
 	def processSections(sections: SectionMap): LaunchConfiguration =
 	{
@@ -135,8 +134,8 @@ class ConfigurationParser
 	{
 		val (ivyHome, m1) = optfile(m, "ivy-home")
 		val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
-    val (overrideRepos, m3) = bool(m2, "override-build", false)
-		val (repoConfig, m4) = optfile(m3, "resolver-config")
+    val (overrideRepos, m3) = bool(m2, "override-build-repos", false)
+		val (repoConfig, m4) = optfile(m3, "repository-config")
 		check(m4, "label")
 		(ivyHome, checksums, overrideRepos, repoConfig filter (_.exists))
 	}

--- a/launch/ConfigurationParser.scala
+++ b/launch/ConfigurationParser.scala
@@ -68,10 +68,10 @@ class ConfigurationParser
 		val (boot, m4) = processSection(m3, "boot", getBoot)
 		val (logging, m5) = processSection(m4, "log", getLogging)
 		val (properties, m6) = processSection(m5, "app-properties", getAppProperties)
-		val ((ivyHome, checksums), m7) = processSection(m6, "ivy", getIvy)
+		val ((ivyHome, checksums, isOverrideRepos), m7) = processSection(m6, "ivy", getIvy)
 		check(m7, "section")
 		val classifiers = Classifiers(scalaClassifiers, appClassifiers)
-		val ivyOptions = IvyOptions(ivyHome, classifiers, repositories, checksums)
+		val ivyOptions = IvyOptions(ivyHome, classifiers, repositories, checksums, isOverrideRepos)
 		new LaunchConfiguration(scalaVersion, ivyOptions, app, boot, logging, properties)
 	}
 	def getScala(m: LabelMap) =
@@ -121,13 +121,14 @@ class ConfigurationParser
 	def file(map: LabelMap, name: String, default: File): (File, LabelMap) =
 		(orElse(getOrNone(map, name).map(toFile), default), map - name)
 
-	def getIvy(m: LabelMap): (Option[File], List[String]) =
+	def getIvy(m: LabelMap): (Option[File], List[String], Boolean) =
 	{
 		val (ivyHome, m1) = file(m, "ivy-home", null) // fix this later
 		val (checksums, m2) = ids(m1, "checksums", BootConfiguration.DefaultChecksums)
-		check(m2, "label")
+    val (overrideRepos, m3) = bool(m2, "override-build", false)
+		check(m3, "label")
 		val home = if(ivyHome eq null) None else Some(ivyHome)
-		(home, checksums)
+		(home, checksums, overrideRepos)
 	}
 	def getBoot(m: LabelMap): BootSetup =
 	{

--- a/launch/Launch.scala
+++ b/launch/Launch.scala
@@ -98,6 +98,7 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 	def globalLock: xsbti.GlobalLock = Locks
 	def ivyHome = orNull(ivyOptions.ivyHome)
 	def ivyRepositories = repositories.toArray
+	def isOverrideRepositories: Boolean = ivyOptions.isOverrideRepositories
 	def checksums = checksumsList.toArray[String]
 
 	def jnaLoader(parent: ClassLoader): ClassLoader =
@@ -278,7 +279,7 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 object Launcher
 {
 	def apply(bootDirectory: File, repositories: List[xsbti.Repository]): xsbti.Launcher =
-		apply(bootDirectory, IvyOptions(None, Classifiers(Nil, Nil), repositories, BootConfiguration.DefaultChecksums))
+		apply(bootDirectory, IvyOptions(None, Classifiers(Nil, Nil), repositories, BootConfiguration.DefaultChecksums, false))
 	def apply(bootDirectory: File, ivyOptions: IvyOptions): xsbti.Launcher =
 		apply(bootDirectory, ivyOptions, GetLocks.find)
 	def apply(bootDirectory: File, ivyOptions: IvyOptions, locks: xsbti.GlobalLock): xsbti.Launcher =

--- a/launch/LaunchConfiguration.scala
+++ b/launch/LaunchConfiguration.scala
@@ -25,8 +25,7 @@ final case class LaunchConfiguration(scalaVersion: Value[String], ivyConfigurati
 
 	def map(f: File => File) = LaunchConfiguration(scalaVersion, ivyConfiguration, app.map(f), boot.map(f), logging, appProperties)
 }
-final case class IvyOptions(ivyHome: Option[File], classifiers: Classifiers, repositories: List[xsbti.Repository], checksums: List[String])
-
+final case class IvyOptions(ivyHome: Option[File], classifiers: Classifiers, repositories: List[xsbti.Repository], checksums: List[String], isOverrideRepositories: Boolean)
 sealed trait Value[T]
 final class Explicit[T](val value: T) extends Value[T] {
 	override def toString = value.toString

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -12,7 +12,10 @@ public interface Launcher
 	public ClassLoader topLoader();
 	public GlobalLock globalLock();
 	public File bootDirectory();
+  /** Configured launcher repositories. */
 	public xsbti.Repository[] ivyRepositories();
+	/** The user has configured the launcher with the only repositories it wants to use for this applciation. */
+	public boolean isOverrideRepositories();
 	// null if none set
 	public File ivyHome();
 	public String[] checksums();

--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -21,3 +21,5 @@ ${{repositories}}
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
+  override-build: ${sbt.override.build.repos-false}
+  resolver-config: ${sbt.resolver.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -21,5 +21,5 @@ ${{repositories}}
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
-  override-build: ${sbt.override.build.repos-false}
-  resolver-config: ${sbt.resolver.config-${sbt.global.base-${user.home}/.sbt}/repositories}
+  override-build-repos: ${sbt.override.build.repos-false}
+  repository-config: ${sbt.resolver.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -779,13 +779,18 @@ object Classpaths
 		organizationHomepage <<= organizationHomepage or homepage,
 		scmInfo in GlobalScope :== None,
 		projectInfo <<= (name, description, homepage, startYear, licenses, organizationName, organizationHomepage, scmInfo) apply ModuleInfo,
+		overrideBuildResolvers <<= appConfiguration(isOverrideRepositories),
 		externalResolvers <<= (externalResolvers.task.?, resolvers) {
 			case (Some(delegated), Seq()) => delegated
 			case (_, rs) => task { Resolver.withDefaultResolvers(rs) }
 		},
-		fullResolvers <<= (projectResolver,externalResolvers,sbtPlugin,sbtResolver) map { (proj,rs,isPlugin,sbtr) =>
-			val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
-			proj +: base
+		bootResolvers <<= appConfiguration map bootRepositories,
+		fullResolvers <<= (projectResolver,externalResolvers,sbtPlugin,sbtResolver,bootResolvers,overrideBuildResolvers) map { (proj,rs,isPlugin,sbtr, boot, overrideFlag) =>
+			if(overrideFlag && boot.isDefined) boot.get
+      else {
+				val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
+				proj +: base
+			}
 		},
 		offline in GlobalScope :== false,
 		moduleName <<= normalizedName,
@@ -1187,6 +1192,10 @@ object Classpaths
 	def bootChecksums(app: xsbti.AppConfiguration): Seq[String] =
 		try { app.provider.scalaProvider.launcher.checksums.toSeq }
 		catch { case _: NoSuchMethodError => IvySbt.DefaultChecksums }
+
+	def isOverrideRepositories(app: xsbti.AppConfiguration): Boolean =
+		try app.provider.scalaProvider.launcher.isOverrideRepositories
+		catch { case _: NoSuchMethodError => false }
 
 	def bootRepositories(app: xsbti.AppConfiguration): Option[Seq[Resolver]] =
 		try { Some(app.provider.scalaProvider.launcher.ivyRepositories.toSeq map bootRepository) }

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -786,10 +786,11 @@ object Classpaths
 		},
 		bootResolvers <<= appConfiguration map bootRepositories,
 		fullResolvers <<= (projectResolver,externalResolvers,sbtPlugin,sbtResolver,bootResolvers,overrideBuildResolvers) map { (proj,rs,isPlugin,sbtr, boot, overrideFlag) =>
-			if(overrideFlag && boot.isDefined) boot.get
-      else {
-				val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
-				proj +: base
+			boot match {
+				case Some(repos) if overrideFlag => repos
+				case _ => 
+					val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
+					proj +: base
 			}
 		},
 		offline in GlobalScope :== false,

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -273,6 +273,8 @@ object Keys
 	val isSnapshot = SettingKey[Boolean]("is-snapshot", "True if the the version of the project is a snapshot version.", BPlusSetting)
 	val moduleID = SettingKey[ModuleID]("module-id", "A dependency management descriptor.  This is currently used for associating a ModuleID with a classpath entry.", BPlusSetting)
 	val projectID = SettingKey[ModuleID]("project-id", "The dependency management descriptor for the current module.", BMinusSetting)
+	val overrideBuildResolvers = SettingKey[Boolean]("override-build-resolvers", "Whether or not all the build resolvers should be overriden with what's defined from the launcher.", BMinusSetting)
+	val bootResolvers = TaskKey[Option[Seq[Resolver]]]("boot-resolvers", "The resolvers used by the sbt launcher.", BMinusSetting)
 	val externalResolvers = TaskKey[Seq[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.", BMinusSetting)
 	val resolvers = SettingKey[Seq[Resolver]]("resolvers", "The user-defined additional resolvers for automatically managed dependencies.", BMinusTask)
 	val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)


### PR DESCRIPTION
With this patch it's now possible to force builds to use only boot resolvers with
the following:  `-Dsbt.override.build.repos=true`

Also, you can configure a `/.sbt/repositories` file such that only proxy repositories show up.   Here's what mine looks like:

```
[repositories]
  local
  ivy-proxy: http://localhost:8081/artifactory/repo/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext] 
  maven-proxy: http://localhost:8081/artifactory/repo/
```

Closes #414 (For me at least.  Some testing from more complicated builds would be ideal.)
