### PR TITLE
Simplify and correct rich uri

### DIFF
--- a/util/io/RichURI.scala
+++ b/util/io/RichURI.scala
@@ -21,7 +21,7 @@ class RichURI(uri: URI)
 		else
 			uri
 
-	def hasMarkerScheme = new URI(uri.getSchemeSpecificPart).getScheme ne null
+	def hasMarkerScheme = new URI(uri.getRawSchemeSpecificPart).getScheme ne null
 
 	def withoutMarkerScheme =
 	{

--- a/util/io/RichURI.scala
+++ b/util/io/RichURI.scala
@@ -15,24 +15,9 @@ class RichURI(uri: URI)
 
 	def hasFragment = uri.getFragment ne null
 
-	def withoutFragment =
-		if (hasFragment)
-			new URI(uri.getScheme, uri.getSchemeSpecificPart, null)
-		else
-			uri
+	def withoutFragment = copy(fragment = null)
 
-	def hasMarkerScheme = new URI(uri.getRawSchemeSpecificPart).getScheme ne null
-
-	def withoutMarkerScheme =
-	{
-		if (hasMarkerScheme)
-			if (hasFragment)
-				new URI(uri.getSchemeSpecificPart + "#" + uri.getFragment)
-			else
-				new URI(uri.getSchemeSpecificPart)
-		else
-			uri
-	}
+	def withoutMarkerScheme = copy(scheme = null)
 }
 
 object RichURI

--- a/util/io/src/test/scala/RichURISpecification.scala
+++ b/util/io/src/test/scala/RichURISpecification.scala
@@ -1,0 +1,43 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2012 Eugene Vigdorchik */
+
+package sbt
+
+import org.scalacheck._
+import Gen._
+import Prop._
+import java.net.URI
+
+object RichURISpecification extends Properties("Rich URI") {
+	val strGen = {
+		val charGen = frequency((1, value(' ')), (9, alphaChar))
+		val emptyGen = for(cs <- listOf1(charGen)) yield cs.mkString 
+		emptyGen map (_.trim) filter (!_.isEmpty)
+	}
+
+	implicit def arbitraryURI: Arbitrary[URI] =
+		Arbitrary(
+			for (scheme <- identifier;
+					 userInfo <- strGen;
+					 host <- identifier;
+					 port <- posNum[Int];
+					 path <- strGen;
+					 query <- strGen;
+					 fragment <- strGen)
+				 yield new URI(scheme, userInfo, host, port, "/" + path, query, fragment)
+		)
+
+	property("withoutFragment should drop fragment") = forAll {	(uri: URI) => 
+		val uri1 =
+			if (uri.getFragment ne null)
+				new URI(uri.getScheme, uri.getSchemeSpecificPart, null)
+			else
+				uri
+		new RichURI(uri).withoutFragment == uri1
+	}
+
+	property("withoutMarkerScheme should drop scheme") = forAll {	(uri: URI) =>
+		val uri1 = new URI(uri.getRawSchemeSpecificPart + "#" + uri.getRawFragment)
+		new RichURI(uri).withoutMarkerScheme == uri1
+	}
+}

--- a/util/io/src/test/scala/RichURISpecification.scala
+++ b/util/io/src/test/scala/RichURISpecification.scala
@@ -26,7 +26,10 @@ object RichURISpecification extends Properties("Rich URI") {
 					 path <- nullable(strGen);
 					 query <- nullable(strGen);
 					 fragment <- nullable(strGen))
-				 yield new URI(scheme, userInfo, host, port, "/" + path, query, fragment)
+				 yield {
+ 					 val pathSlashed = if (path eq null) null else "/" + path
+					 new URI(scheme, userInfo, host, port, pathSlashed, query, fragment)
+				 }
 		)
 
 	property("withoutFragment should drop fragment") = forAll {	(uri: URI) => 


### PR DESCRIPTION
In fact, I believe the previous code contains an error: when a single string is supplied as URI constructor argument, it's assumed already escaped, unlike other constructors where escaping is done for arguments.
