### PR TITLE
override repositories flag breaks inter-project dependencies

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -787,7 +787,7 @@ object Classpaths
 		bootResolvers <<= appConfiguration map bootRepositories,
 		fullResolvers <<= (projectResolver,externalResolvers,sbtPlugin,sbtResolver,bootResolvers,overrideBuildResolvers) map { (proj,rs,isPlugin,sbtr, boot, overrideFlag) =>
 			boot match {
-				case Some(repos) if overrideFlag => repos
+				case Some(repos) if overrideFlag => proj +: repos
 				case _ => 
 					val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
 					proj +: base


### PR DESCRIPTION
This adds the project resolver back into the resolvers list when the override repositories flag is enabled, thereby having SBT actually function for non-trival projects.    

I'd say this is a critical fix.
