### PR TITLE
Actually pass in the artifact, rather than just a global match

### DIFF
--- a/ivy/Ivy.scala
+++ b/ivy/Ivy.scala
@@ -335,7 +335,7 @@ private object IvySbt
 			case _ => m
 		}
 	}
-		
+
 	private def toIvyArtifact(moduleID: ModuleDescriptor, a: Artifact, configurations: Iterable[String]): MDArtifact =
 	{
 		val artifact = new MDArtifact(moduleID, a.name, a.`type`, a.extension, null, extra(a, false))
@@ -447,7 +447,7 @@ private object IvySbt
 			{
 				for(conf <- dependencyDescriptor.getModuleConfigurations)
 				{
-					dependencyDescriptor.addExcludeRule(conf, IvyScala.excludeRule(excls.organization, excls.name, excls.configurations, "*"))
+					dependencyDescriptor.addExcludeRule(conf, IvyScala.excludeRule(excls.organization, excls.name, excls.configurations, excls.artifact))
 				}
 			}
 			moduleID.addDependency(dependencyDescriptor)
@@ -462,7 +462,7 @@ private object IvySbt
 		moduleID.addDependencyDescriptorMediator(overrideID, matcher, overrideWith)
 	}
 	/** It is necessary to explicitly modify direct dependencies because Ivy gives
-	* "IllegalStateException: impossible to get artifacts when data has not been loaded." 
+	* "IllegalStateException: impossible to get artifacts when data has not been loaded."
 	* when a direct dependency is overridden with a newer version."*/
 	def overrideDirect(dependencies: Seq[ModuleID], overrides: Set[ModuleID]): Seq[ModuleID] =
 	{


### PR DESCRIPTION
This adds in the ability to properly match on artifact type. It depends on an earlier commit Mark made: 59a7432c. This added the parameter needed in IvyScala.scala to pass the artifact type (it's called excludeTypePattern, there, but in Ivy it's actually for the artifact).
