### PR TITLE
Extend reporter to be used by the IDE.

### DIFF
--- a/compile/interface/DelegatingReporter.scala
+++ b/compile/interface/DelegatingReporter.scala
@@ -27,6 +27,12 @@ private final class DelegatingReporter(warnFatal: Boolean, private[this] var del
 	override def hasErrors = delegate.hasErrors
 	override def hasWarnings = delegate.hasWarnings
 	def problems = delegate.problems
+	override def comment(pos: Position, msg: String) {
+		delegate match {
+			case ext: xsbti.ExtendedReporter => ext.comment(convert(pos), msg)
+			case _ =>
+		}
+	}
 
 	override def reset =
 	{

--- a/interface/src/main/java/xsbti/ExtendedReporter.java
+++ b/interface/src/main/java/xsbti/ExtendedReporter.java
@@ -1,0 +1,10 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2012 Eugene Vigdorchik
+ */
+package xsbti;
+
+/** An addition to standard reporter. Used by the IDE. */
+public interface ExtendedReporter extends Reporter
+{
+	public void comment(Position pos, String msg);
+}


### PR DESCRIPTION
IDE uses "comment" method to track TODOs inside comments. Since scala.tools.nsc.reporters.Reporter already has the subject method, it looks natural to mirror it in sbt as well.
