### PR TITLE
Don't fork JVM when no tests are given to run. Closes a case of #512

### DIFF
--- a/main/actions/ForkTests.scala
+++ b/main/actions/ForkTests.scala
@@ -61,14 +61,14 @@ private[sbt] object ForkTests {
 						}
 
 						try {
-							os.writeBoolean(log.ansiCodesSupported)
+							os.writeObject(Boolean.box(log.ansiCodesSupported))
 							
 							val testsFiltered = tests.filter(test => filters.forall(_(test.name))).map{
 								t => new ForkTestDefinition(t.name, t.fingerprint)
 							}.toArray
 							os.writeObject(testsFiltered)
 
-							os.writeInt(frameworks.size)
+							os.writeObject(Int.box(frameworks.size))
 							for ((clazz, args) <- argMap) {
 								os.writeObject(clazz)
 								os.writeObject(args.toArray)

--- a/main/actions/ForkTests.scala
+++ b/main/actions/ForkTests.scala
@@ -37,7 +37,7 @@ private[sbt] object ForkTests {
 			object Acceptor extends Runnable {
 				val results = collection.mutable.Map.empty[String, TestResult.Value]
 				def output = (overall(results.values), results.toMap)
-  				def run = {
+				def run = {
 						val socket = server.accept()
 						val os = new ObjectOutputStream(socket.getOutputStream)
 						val is = new ObjectInputStream(socket.getInputStream)
@@ -81,20 +81,23 @@ private[sbt] object ForkTests {
 					}
 			}
 
-			try {
-				testListeners.foreach(_.doInit())
-				new Thread(Acceptor).start()
+			if (!tests.isEmpty) {
+				try {
+					testListeners.foreach(_.doInit())
+					new Thread(Acceptor).start()
 
-				val fullCp = classpath ++: Seq(IO.classLocationFile[ForkMain], IO.classLocationFile[Framework])
-				val options = javaOpts ++: Seq("-classpath", fullCp mkString File.pathSeparator, classOf[ForkMain].getCanonicalName, server.getLocalPort.toString)
-				val ec = Fork.java(javaHome, options, StdoutOutput)
-				if (ec != 0) log.error("Running java with options " + options.mkString(" ") + " failed with exit code " + ec)
-			} finally {
-				server.close()
-			}
-			val result = Acceptor.output
-			testListeners.foreach(_.doComplete(result._1))
-  		result
+					val fullCp = classpath ++: Seq(IO.classLocationFile[ForkMain], IO.classLocationFile[Framework])
+					val options = javaOpts ++: Seq("-classpath", fullCp mkString File.pathSeparator, classOf[ForkMain].getCanonicalName, server.getLocalPort.toString)
+					val ec = Fork.java(javaHome, options, StdoutOutput)
+					if (ec != 0) log.error("Running java with options " + options.mkString(" ") + " failed with exit code " + ec)
+				} finally {
+					server.close()
+				}
+				val result = Acceptor.output
+				testListeners.foreach(_.doComplete(result._1))
+				result
+			} else
+				(TestResult.Passed, Map.empty[String, TestResult.Value])
 		} tagw (config.tags: _*)
 	}
 }

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -94,7 +94,7 @@ public class ForkMain {
 			}
 		}
 		void run(ObjectInputStream is, final ObjectOutputStream os) throws Exception {
-			final boolean ansiCodesSupported = is.readBoolean();
+			final boolean ansiCodesSupported = ((Boolean)is.readObject()).booleanValue();
 			Logger[] loggers = {
 				new Logger() {
 					public boolean ansiCodesSupported() { return ansiCodesSupported; }
@@ -107,7 +107,7 @@ public class ForkMain {
 			};
 
 			final ForkTestDefinition[] tests = (ForkTestDefinition[]) is.readObject();
-			int nFrameworks = is.readInt();
+			int nFrameworks = ((Integer)is.readObject()).intValue();
 			for (int i = 0; i < nFrameworks; i++) {
 				final Framework framework;
 				final String implClassName = (String) is.readObject();


### PR DESCRIPTION
It looks like Object{Input/Output}Stream don't like it when empty arrays are serialized. An optimization any way.
