### PR TITLE
Replaces method call deprecated in 2.10

### DIFF
--- a/compile/inc/Incremental.scala
+++ b/compile/inc/Incremental.scala
@@ -151,7 +151,7 @@ object Incremental
 		// include any file that depends on included files
 		def recheck(included: Set[File], process: Set[File], excluded: Set[File]): Set[File] =
 		{
-			val newIncludes = (process flatMap dependsOnSrc) ** excluded
+			val newIncludes = (process flatMap dependsOnSrc) & excluded
 			if(newIncludes.isEmpty)
 				included
 			else


### PR DESCRIPTION
immutable.Set.*\* was deprecated in 2.8 and removed in 2.10.

Fix #530
