### PR TITLE
Source position mapper support

### DIFF
--- a/compile/AnalyzingCompiler.scala
+++ b/compile/AnalyzingCompiler.scala
@@ -20,7 +20,7 @@ final class AnalyzingCompiler(val scalaInstance: xsbti.compile.ScalaInstance, va
 	{
 		val arguments = (new CompilerArguments(scalaInstance, cp))(Nil, classpath, None, options)
 		val output = CompileOutput(singleOutput)
-		compile(sources, changes, arguments, output, callback, new LoggerReporter(maximumErrors, log), cache, log, None)
+		compile(sources, changes, arguments, output, callback, new LoggerReporter(maximumErrors, log, p => p), cache, log, None)
 	}
 
 	def compile(sources: Seq[File], changes: DependencyChanges, options: Seq[String], output: Output, callback: AnalysisCallback, reporter: Reporter, cache: GlobalsCache, log: Logger, progressOpt: Option[CompileProgress]): Unit =

--- a/compile/LoggerReporter.scala
+++ b/compile/LoggerReporter.scala
@@ -45,7 +45,7 @@ object LoggerReporter
 		}
 }
 	
-class LoggerReporter(maximumErrors: Int, log: Logger) extends xsbti.Reporter
+class LoggerReporter(maximumErrors: Int, log: Logger, sourcePositionMapper: Position => Position = {p => p}) extends xsbti.Reporter
 {
 	val positions = new mutable.HashMap[PositionKey, Severity]
 	val count = new EnumMap[Severity, Int](classOf[Severity])
@@ -115,15 +115,16 @@ class LoggerReporter(maximumErrors: Int, log: Logger) extends xsbti.Reporter
 	
 	def log(pos: Position, msg: String, severity: Severity): Unit =
 	{
-		allProblems += problem("", pos, msg, severity)
+		val mappedPos = sourcePositionMapper(pos)
+		allProblems += problem("", mappedPos, msg, severity)
 		severity match
 		{
 			case Warn | Error =>
 			{
-				if(!testAndLog(pos, severity))
-					display(pos, msg, severity)
+				if(!testAndLog(mappedPos, severity))
+					display(mappedPos, msg, severity)
 			}
-			case _ => display(pos, msg, severity)
+			case _ => display(mappedPos, msg, severity)
 		}
 	}
 

--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -586,9 +586,7 @@ object Defaults extends BuildCommon
 	def printWarningsTask: Initialize[Task[Unit]] =
 		(streams, compile, maxErrors, sourcePositionMappers) map { (s, analysis, max, spms) =>
 			val problems = analysis.infos.allInfos.values.flatMap(i =>  i.reportedProblems++ i.unreportedProblems)
-			val reporter = new LoggerReporter(max, s.log,
-				spms.foldRight({p: xsbti.Position => p}) { (mapper, mappers) => {p: xsbti.Position => mapper(p).getOrElse(mappers(p))}}
-			)
+			val reporter = new LoggerReporter(max, s.log, Compiler.foldMappers(spms))
 			problems foreach { p => reporter.display(p.position, p.message, p.severity) }
 		}
 

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -160,6 +160,7 @@ object Keys
 	val doc = TaskKey[File]("doc", "Generates API documentation.", AMinusTask)
 	val copyResources = TaskKey[Seq[(File,File)]]("copy-resources", "Copies resources to the output directory.", AMinusTask)
 	val aggregate = SettingKey[Boolean]("aggregate", "Configures task aggregation.", BMinusSetting)
+	val sourcePositionMappers = TaskKey[Seq[xsbti.Position => Option[xsbti.Position]]]("source-position-mappers", "Maps positions in generated source files to the original source it was generated from", DTask)
 
 	// package keys
 	val packageBin = TaskKey[File]("package-bin", "Produces a main artifact, such as a binary jar.", ATask)

--- a/main/actions/Compiler.scala
+++ b/main/actions/Compiler.scala
@@ -33,9 +33,7 @@ object Compiler
 	def inputs(classpath: Seq[File], sources: Seq[File], classesDirectory: File, options: Seq[String], javacOptions: Seq[String], maxErrors: Int, sourcePositionMappers: Seq[Position => Option[Position]], order: CompileOrder)(implicit compilers: Compilers, incSetup: IncSetup, log: Logger): Inputs =
 		new Inputs(
 			compilers,
-			new Options(classpath, sources, classesDirectory, options, javacOptions, maxErrors,
-				sourcePositionMappers.foldRight({p: Position => p}) { (mapper, mappers) => {p: Position => mapper(p).getOrElse(mappers(p))}},
-				order),
+			new Options(classpath, sources, classesDirectory, options, javacOptions, maxErrors, foldMappers(sourcePositionMappers), order),
 			incSetup
 		)
 
@@ -80,4 +78,7 @@ object Compiler
 		val agg = new AggressiveCompile(cacheFile)
 		agg(scalac, javac, sources, classpath, CompileOutput(classesDirectory), cache, None, options, javacOptions, analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip)(log)
 	}
+
+	private[sbt] def foldMappers[A](mappers: Seq[A => Option[A]]) =
+		mappers.foldRight({p: A => p}) { (mapper, mappers) => {p: A => mapper(p).getOrElse(mappers(p))}}
 }


### PR DESCRIPTION
This pull request implements support for mapping the position of a warning/error in one file to a position in another file.  This is to facilitate error reporting when generating scala source code from other files.
