### PR TITLE
Include all JAR packaging types in the default classpathTypes.  Fixes #5...

### DIFF
--- a/main/Defaults.scala
+++ b/main/Defaults.scala
@@ -100,7 +100,7 @@ object Defaults extends BuildCommon
 		javaOptions :== Nil,
 		sbtPlugin :== false,
 		crossPaths :== true,
-		classpathTypes :== Set("jar", "bundle", "hk2-jar", "orbit"),
+		classpathTypes :== Set("jar", "bundle") ++ CustomPomParser.JarPackagings,
 		aggregate :== true,
 		maxErrors :== 100,
 		showTiming :== true,


### PR DESCRIPTION
...50

These special types need to be recognized in both the POM parser and added to the classpath.
The previous code was not DRY, and eclipse-plugin was in one but not the other.  This ensures
new types can be added in the future without risking this type of oversight.
