### PR TITLE
Abort running tests on the first failure to communicate

### DIFF
--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -82,10 +82,14 @@ public class ForkMain {
 		final ObjectInputStream is = new ObjectInputStream(socket.getInputStream());
 		final ObjectOutputStream os = new ObjectOutputStream(socket.getOutputStream());
 		try {
-			new Run().run(is, os);
+			try {
+				new Run().run(is, os);
+			} finally {
+				is.close();
+				os.close();
+			}
 		} finally {
-			is.close();
-			os.close();
+			System.exit(0);
 		}
 	}
 	private static class Run {


### PR DESCRIPTION
results back to the main process. Assume the error is not recoverable.
Closes #557.
