### PR TITLE
Update compile/inc/Incremental.scala: File.getCanonicalPath instead of java.io.File.equals()

### DIFF
--- a/compile/inc/Incremental.scala
+++ b/compile/inc/Incremental.scala
@@ -214,7 +214,7 @@ object Incremental
 					e <- entry(name)
 				} yield {
 					val resolved = Locate.resolve(e, name)
-					(resolved != dependsOn) || !equivS.equiv(previous.binary(dependsOn), current.binary(resolved))
+					(resolved.getCanonicalPath != dependsOn.getCanonicalPath) || !equivS.equiv(previous.binary(dependsOn), current.binary(resolved))
 				}
 			)
 


### PR DESCRIPTION
Fix for http://stackoverflow.com/questions/12972183/sbt-always-does-full-rebuild-because-of-modified-binary-dependency-rt-jar
def externalBinaryModified uses java.io.File.equals() to check if files are the same. It's better to use File.getCanonicalPath in this case.
