### PR TITLE
Added JDK 7 specific memory settings to the Setup Notes

### DIFF
--- a/src/sphinx/Detailed-Topics/Setup-Notes.rst
+++ b/src/sphinx/Detailed-Topics/Setup-Notes.rst
@@ -34,6 +34,12 @@ application. For example a common set of memory-related options is:
 
     java -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m``
 
+For JDK 7 (which doesn't default to the ConcurrentMarkSweep garbage collector):
+
+.. code-block:: console
+
+    java -Xmx1536M -Xss1M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256m``
+
 Boot directory
 --------------
 


### PR DESCRIPTION
JDK 7 defaults to the G1 GC so when I switched to JDK 7 to run SBT, I started running into OutOfMemoryExceptions again, which was because the CMSClassUnloadingEnabled option had no effect anymore. 

This adds an example for JDK 7 that adds a JVM option to switch the GC back to ConcMarkSweep so class unloading works again.
