### PR TITLE
Analysis.groupBy implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 project/boot/
 .release.sbt
 __pycache__
+*.iml

--- a/compile/inc/APIs.scala
+++ b/compile/inc/APIs.scala
@@ -27,6 +27,7 @@ trait APIs
 	
 	def removeInternal(remove: Iterable[File]): APIs
 	def filterExt(keep: String => Boolean): APIs
+	def groupBy[K](internal: (File) => K, keepExternal: Map[K, String => Boolean]): Map[K, APIs]
 	
 	def internal: Map[File, Source]
 	def external: Map[String, Source]
@@ -58,6 +59,9 @@ private class MAPIs(val internal: Map[File, Source], val external: Map[String, S
 	def removeInternal(remove: Iterable[File]): APIs = new MAPIs(internal -- remove, external)
 	def filterExt(keep: String => Boolean): APIs = new MAPIs(internal, external.filterKeys(keep))
 		
+	def groupBy[K](f: (File) => K, keepExternal: Map[K, String => Boolean]): Map[K, APIs] =
+		internal.groupBy(item => f(item._1)) map { group => (group._1, new MAPIs(group._2, external).filterExt(keepExternal.getOrElse(group._1, _ => false)))}
+	
 	def internalAPI(src: File) = getAPI(internal, src)
 	def externalAPI(ext: String) = getAPI(external, ext)
 	

--- a/compile/inc/Analysis.scala
+++ b/compile/inc/Analysis.scala
@@ -23,6 +23,8 @@ trait Analysis
 	def addExternalDep(src: File, dep: String, api: Source): Analysis
 	def addProduct(src: File, product: File, stamp: Stamp, name: String): Analysis
 
+	def groupBy[K](f: (File => K)): Map[K, Analysis]
+
 	override lazy val toString = Analysis.summary(this)
 }
 
@@ -61,7 +63,7 @@ private class MAnalysis(val stamps: Stamps, val apis: APIs, val relations: Relat
 	def -- (sources: Iterable[File]): Analysis =
 	{
 		val newRelations = relations -- sources
-		def keep[T](f: (Relations, T) => Set[_]): T => Boolean = file => !f(newRelations, file).isEmpty
+		def keep[T](f: (Relations, T) => Set[_]): T => Boolean = keepFor(newRelations)(f)
 		
 		val newAPIs = apis.removeInternal(sources).filterExt( keep(_ usesExternal _) )
 		val newStamps = stamps.filter( keep(_ produced _), sources, keep(_ usesBinary _))
@@ -81,4 +83,32 @@ private class MAnalysis(val stamps: Stamps, val apis: APIs, val relations: Relat
 
 	def addProduct(src: File, product: File, stamp: Stamp, name: String): Analysis =
 		copy( stamps.markProduct(product, stamp), apis, relations.addProduct(src, product, name), infos )
+	
+	def groupBy[K](f: (File => K)): Map[K, Analysis] = {
+		def outerJoin(stampsMap: Map[K, Stamps],
+									apisMap: Map[K, APIs],
+									relationsMap: Map[K, Relations],
+									infosMap: Map[K, SourceInfos]): Map[K, Analysis] = {
+			Map(
+					(stampsMap.keySet ++ apisMap.keySet ++ relationsMap.keySet ++ infosMap.keySet).toList map({
+							k: K => {
+									(k, new MAnalysis(
+											stampsMap.getOrElse(k, Stamps.empty),
+											apisMap.getOrElse(k, APIs.empty),
+											relationsMap.getOrElse(k, Relations.empty),
+											infosMap.getOrElse(k, SourceInfos.empty)
+									))
+							}
+					}): _*)
+		}
+
+    val relationsMap: Map[K, Relations] = relations.groupBy(f)
+    val keepExternal: Map[K, String => Boolean] = relationsMap map { item => (item._1, keepFor(item._2)((rel: Relations, file: String) => rel.usesExternal(file)))}
+    val keepProduced: Map[K, File => Boolean] = relationsMap map { item => (item._1, keepFor(item._2)((rel: Relations, file: File) => rel.produced(file)))}
+    val keepBinary: Map[K, File => Boolean] = relationsMap map { item => (item._1, keepFor(item._2)((rel: Relations, file: File) => rel.usesBinary(file)))}
+    outerJoin(stamps.groupBy(keepProduced, f, keepBinary), apis.groupBy(f, keepExternal), relationsMap, infos.groupBy(f))
+  }
+
+  private def keepFor[T](newRelations: Relations)(f: (Relations, T) => Set[_]): T => Boolean = file => !f(newRelations, file).isEmpty
+
 }

--- a/compile/inc/SourceInfo.scala
+++ b/compile/inc/SourceInfo.scala
@@ -15,6 +15,7 @@ trait SourceInfos
 	def ++(o: SourceInfos): SourceInfos
 	def add(file: File, info: SourceInfo): SourceInfos
 	def --(files: Iterable[File]): SourceInfos
+	def groupBy[K](f: (File) => K): Map[K, SourceInfos]
 	def get(file: File): SourceInfo
 	def allInfos: Map[File, SourceInfo]
 }
@@ -31,6 +32,7 @@ private final class MSourceInfos(val allInfos: Map[File, SourceInfo]) extends So
 {
 	def ++(o: SourceInfos) = new MSourceInfos(allInfos ++ o.allInfos)
 	def --(sources: Iterable[File]) = new MSourceInfos(allInfos -- sources)
+	def groupBy[K](f: (File) => K): Map[K, SourceInfos] = allInfos.groupBy(item => f(item._1)) map { group => (group._1, new MSourceInfos(group._2)) }
 	def add(file: File, info: SourceInfo) = new MSourceInfos(allInfos + ((file, info)))
 	def get(file:File) = allInfos.getOrElse(file, SourceInfos.emptyInfo)
 }

--- a/util/relation/Relation.scala
+++ b/util/relation/Relation.scala
@@ -73,6 +73,9 @@ trait Relation[A,B]
 	/** Returns a relation with only pairs (a,b) for which f(a,b) is true.*/
 	def filter(f: (A,B) => Boolean): Relation[A,B]
 	
+	/** Partitions this relation into a map of relations according to some discriminator function. */
+	def groupBy[K](f: ((A,B)) => K): Map[K, Relation[A,B]]
+
 	/** Returns all pairs in this relation.*/
 	def all: Traversable[(A,B)]
 	
@@ -116,6 +119,8 @@ private final class MRelation[A,B](fwd: Map[A, Set[B]], rev: Map[B, Set[A]]) ext
 
 	def filter(f: (A,B) => Boolean): Relation[A,B] = Relation.empty[A,B] ++ all.filter(f.tupled)
 
+	def groupBy[K](f: ((A,B)) => K): Map[K, Relation[A,B]] = all.groupBy(f) mapValues { Relation.empty[A,B] ++ _ }
+	
 	def contains(a: A, b: B): Boolean = forward(a)(b)
 
 	override def toString = all.map { case (a,b) => a + " -> " + b }.mkString("Relation [", ", ", "]")


### PR DESCRIPTION
This can be used in zinc to provide a more efficient implementation of analysis splitting.

I have tested this to the best of my ability, but please eyeball the code carefully for correctness; This is my first time reading, let alone modifying, xsbt code, so my overall familiarity is weak. Thanks!
