### PR TITLE
use CrossVersion.full for unstable Scala by default

### DIFF
--- a/ivy/src/main/scala/sbt/CrossVersion.scala
+++ b/ivy/src/main/scala/sbt/CrossVersion.scala
@@ -67,9 +67,9 @@ object CrossVersion
 			m
 	}
 
-	// @deprecated("Use CrossVersion.isScalaApiCompatible or CrossVersion.isSbtApiCompatible", "0.13.0")
+	@deprecated("Use CrossVersion.isScalaApiCompatible or CrossVersion.isSbtApiCompatible", "0.13.0")
 	def isStable(v: String): Boolean = isScalaApiCompatible(v)
-	// @deprecated("Use CrossVersion.scalaApiVersion or CrossVersion.sbtApiVersion", "0.13.0")
+	@deprecated("Use CrossVersion.scalaApiVersion or CrossVersion.sbtApiVersion", "0.13.0")
 	def selectVersion(full: String, binary: String): String = if(isStable(full)) binary else full
 	def isSbtApiCompatible(v: String): Boolean = sbtApiVersion(v).isDefined
 	/** Returns sbt binary interface x.y API compatible with the given version string v. 
@@ -113,6 +113,7 @@ object CrossVersion
 	
 	def binaryScalaVersion(full: String): String = binaryVersionWithApi(full, TransitionScalaVersion)(scalaApiVersion)
 	def binarySbtVersion(full: String): String = binaryVersionWithApi(full, TransitionSbtVersion)(sbtApiVersion)
+	@deprecated("Use CrossVersion.scalaApiVersion or CrossVersion.sbtApiVersion", "0.13.0")
 	def binaryVersion(full: String, cutoff: String): String = binaryVersionWithApi(full, cutoff)(scalaApiVersion)
 	private[this] def binaryVersionWithApi(full: String, cutoff: String)(apiVersion: String => Option[(Int,Int)]): String =
 	{

--- a/ivy/src/main/scala/sbt/CrossVersion.scala
+++ b/ivy/src/main/scala/sbt/CrossVersion.scala
@@ -67,9 +67,41 @@ object CrossVersion
 			m
 	}
 
-	def isStable(v: String): Boolean = !v.contains("-")
+	// @deprecated("Use CrossVersion.isScalaApiCompatible or CrossVersion.isSbtApiCompatible", "0.13.0")
+	def isStable(v: String): Boolean = isScalaApiCompatible(v)
+	// @deprecated("Use CrossVersion.scalaApiVersion or CrossVersion.sbtApiVersion", "0.13.0")
 	def selectVersion(full: String, binary: String): String = if(isStable(full)) binary else full
-
+	def isSbtApiCompatible(v: String): Boolean = sbtApiVersion(v).isDefined
+	/** Returns sbt binary interface x.y API compatible with the given version string v. 
+	 * RCs for x.y.0 are considered API compatible.
+	 * Compatibile versions include 0.12.0-1 and 0.12.0-RC1 for Some(0, 12).
+	 */
+	def sbtApiVersion(v: String): Option[(Int, Int)] =
+	{
+		val ReleaseV = """(\d+)\.(\d+)\.(\d+)(-\d+)?""".r
+		val CandidateV = """(\d+)\.(\d+)\.(\d+)(-RC\d+)""".r
+		val NonReleaseV = """(\d+)\.(\d+)\.(\d+)(-\w+)""".r
+		v match {
+			case ReleaseV(x, y, z, ht)    => Some((x.toInt, y.toInt))
+			case CandidateV(x, y, z, ht)  => Some((x.toInt, y.toInt))
+			case NonReleaseV(x, y, z, ht) if z.toInt > 0 => Some((x.toInt, y.toInt))
+			case _ => None
+		}
+	}
+	def isScalaApiCompatible(v: String): Boolean = scalaApiVersion(v).isDefined
+	/** Returns Scala binary interface x.y API compatible with the given version string v. 
+	 * Compatibile versions include 2.10.0-1 and 2.10.1-M1 for Some(2, 10), but not 2.10.0-RC1.
+	 */
+	def scalaApiVersion(v: String): Option[(Int, Int)] =
+	{
+		val ReleaseV = """(\d+)\.(\d+)\.(\d+)(-\d+)?""".r
+		val NonReleaseV = """(\d+)\.(\d+)\.(\d+)(-\w+)""".r
+		v match {
+			case ReleaseV(x, y, z, ht)    => Some((x.toInt, y.toInt))
+			case NonReleaseV(x, y, z, ht) if z.toInt > 0 => Some((x.toInt, y.toInt))
+			case _ => None
+		}
+	}
 	val PartialVersion = """(\d+)\.(\d+)(?:\..+)?""".r
 	def partialVersion(s: String): Option[(Int,Int)] =
 		s match {
@@ -79,12 +111,13 @@ object CrossVersion
 	private[this] def isNewer(major: Int, minor: Int, minMajor: Int, minMinor: Int): Boolean =
 		major > minMajor || (major == minMajor && minor >= minMinor)
 	
-	def binaryScalaVersion(full: String): String = binaryVersion(full, TransitionScalaVersion)
-	def binarySbtVersion(full: String): String = binaryVersion(full, TransitionSbtVersion)
-	def binaryVersion(full: String, cutoff: String): String =
+	def binaryScalaVersion(full: String): String = binaryVersionWithApi(full, TransitionScalaVersion)(scalaApiVersion)
+	def binarySbtVersion(full: String): String = binaryVersionWithApi(full, TransitionSbtVersion)(sbtApiVersion)
+	def binaryVersion(full: String, cutoff: String): String = binaryVersionWithApi(full, cutoff)(scalaApiVersion)
+	private[this] def binaryVersionWithApi(full: String, cutoff: String)(apiVersion: String => Option[(Int,Int)]): String =
 	{
 		def sub(major: Int, minor: Int) = major + "." + minor
-		(partialVersion(full), partialVersion(cutoff)) match {
+		(apiVersion(full), partialVersion(cutoff)) match {
 			case (Some((major, minor)), None) => sub(major, minor)
 			case (Some((major, minor)), Some((minMajor, minMinor))) if isNewer(major, minor, minMajor, minMinor) => sub(major, minor)
 			case _ => full

--- a/ivy/src/test/scala/CrossVersionTest.scala
+++ b/ivy/src/test/scala/CrossVersionTest.scala
@@ -22,6 +22,12 @@ object CrossVersionTest extends Specification
 		"return sbt API for 0.12.0 as Some((0, 12))" in {
 			CrossVersion.sbtApiVersion("0.12.0") must_== Some((0, 12))
 		}
+		"return sbt API for 0.12.1-SNAPSHOT as Some((0, 12))" in {
+			CrossVersion.sbtApiVersion("0.12.1-SNAPSHOT") must_== Some((0, 12))
+		}
+		"return sbt API for 0.12.1-RC1 as Some((0, 12))" in {
+			CrossVersion.sbtApiVersion("0.12.1-RC1") must_== Some((0, 12))
+		}
 		"return sbt API for 0.12.1 as Some((0, 12))" in {
 			CrossVersion.sbtApiVersion("0.12.1") must_== Some((0, 12))
 		}
@@ -30,6 +36,9 @@ object CrossVersionTest extends Specification
 		}
 		"return sbt API compatibility for 0.12.0-RC1 as true" in {
 			CrossVersion.isSbtApiCompatible("0.12.0-RC1") must_== true
+		}
+		"return sbt API compatibility for 0.12.1-RC1 as true" in {
+			CrossVersion.isSbtApiCompatible("0.12.1-RC1") must_== true
 		}
 		"return binary sbt version for 0.11.3 as 0.11.3" in {
 			CrossVersion.binarySbtVersion("0.11.3") must_== "0.11.3"
@@ -42,6 +51,12 @@ object CrossVersionTest extends Specification
 		}
 		"return binary sbt version for 0.12.0 as 0.12" in {
 			CrossVersion.binarySbtVersion("0.12.0") must_== "0.12"
+		}
+		"return binary sbt version for 0.12.1-SNAPSHOT as 0.12" in {
+			CrossVersion.binarySbtVersion("0.12.1-SNAPSHOT") must_== "0.12"
+		}
+		"return binary sbt version for 0.12.1-RC1 as 0.12" in {
+			CrossVersion.binarySbtVersion("0.12.1-RC1") must_== "0.12"
 		}
 		"return binary sbt version for 0.12.1 as 0.12" in {
 			CrossVersion.binarySbtVersion("0.12.1") must_== "0.12"
@@ -65,6 +80,12 @@ object CrossVersionTest extends Specification
 		"return Scala API for 2.10.0-1 as Some((2, 10))" in {
 			CrossVersion.scalaApiVersion("2.10.0-1") must_== Some((2, 10))
 		}
+		"return Scala API for 2.10.1-SNAPSHOT as Some((2, 10))" in {
+			CrossVersion.scalaApiVersion("2.10.1-SNAPSHOT") must_== Some((2, 10))
+		}
+		"return Scala API for 2.10.1-RC1 as Some((2, 10))" in {
+			CrossVersion.scalaApiVersion("2.10.1-RC1") must_== Some((2, 10))
+		}
 		"return Scala API for 2.10.1 as Some((2, 10))" in {
 			CrossVersion.scalaApiVersion("2.10.1") must_== Some((2, 10))
 		}
@@ -73,6 +94,9 @@ object CrossVersionTest extends Specification
 		}
 		"return Scala API compatibility for 2.10.0-RC1 as false" in {
 			CrossVersion.isScalaApiCompatible("2.10.0-RC1") must_== false
+		}
+		"return Scala API compatibility for 2.10.1-RC1 as false" in {
+			CrossVersion.isScalaApiCompatible("2.10.1-RC1") must_== true
 		}
 		"return binary Scala version for 2.9.2 as 2.9.2" in {
 			CrossVersion.binaryScalaVersion("2.9.2") must_== "2.9.2"
@@ -85,6 +109,12 @@ object CrossVersionTest extends Specification
 		}
 		"return binary Scala version for 2.10.0 as 2.10" in {
 			CrossVersion.binaryScalaVersion("2.10.0") must_== "2.10"
+		}
+		"return binary Scala version for 2.10.1-M1 as 2.10" in {
+			CrossVersion.binaryScalaVersion("2.10.1-M1") must_== "2.10"
+		}
+		"return binary Scala version for 2.10.1-RC1 as 2.10" in {
+			CrossVersion.binaryScalaVersion("2.10.1-RC1") must_== "2.10"
 		}
 		"return binary Scala version for 2.10.1 as 2.10" in {
 			CrossVersion.binaryScalaVersion("2.10.1") must_== "2.10"

--- a/ivy/src/test/scala/CrossVersionTest.scala
+++ b/ivy/src/test/scala/CrossVersionTest.scala
@@ -1,0 +1,93 @@
+package sbt
+
+import java.io.File
+import org.specs2._
+import mutable.Specification
+
+object CrossVersionTest extends Specification
+{
+	"Cross version" should {
+		"return sbt API for xyz as None" in {
+			CrossVersion.sbtApiVersion("xyz") must_== None
+		}
+		"return sbt API for 0.12 as None" in {
+			CrossVersion.sbtApiVersion("0.12") must_== None
+		}
+		"return sbt API for 0.12.0-SNAPSHOT as None" in {
+			CrossVersion.sbtApiVersion("0.12.0-SNAPSHOT") must_== None
+		}
+		"return sbt API for 0.12.0-RC1 as Some((0, 12))" in {
+			CrossVersion.sbtApiVersion("0.12.0-RC1") must_== Some((0, 12))
+		}
+		"return sbt API for 0.12.0 as Some((0, 12))" in {
+			CrossVersion.sbtApiVersion("0.12.0") must_== Some((0, 12))
+		}
+		"return sbt API for 0.12.1 as Some((0, 12))" in {
+			CrossVersion.sbtApiVersion("0.12.1") must_== Some((0, 12))
+		}
+		"return sbt API compatibility for 0.12.0-M1 as false" in {
+			CrossVersion.isSbtApiCompatible("0.12.0-M1") must_== false
+		}
+		"return sbt API compatibility for 0.12.0-RC1 as true" in {
+			CrossVersion.isSbtApiCompatible("0.12.0-RC1") must_== true
+		}
+		"return binary sbt version for 0.11.3 as 0.11.3" in {
+			CrossVersion.binarySbtVersion("0.11.3") must_== "0.11.3"
+		}
+		"return binary sbt version for 0.12.0-M1 as 0.12.0-M1" in {
+			CrossVersion.binarySbtVersion("0.12.0-M1") must_== "0.12.0-M1"
+		}
+		"return binary sbt version for 0.12.0-RC1 as 0.12" in {
+			CrossVersion.binarySbtVersion("0.12.0-RC1") must_== "0.12"
+		}
+		"return binary sbt version for 0.12.0 as 0.12" in {
+			CrossVersion.binarySbtVersion("0.12.0") must_== "0.12"
+		}
+		"return binary sbt version for 0.12.1 as 0.12" in {
+			CrossVersion.binarySbtVersion("0.12.1") must_== "0.12"
+		}
+
+		"return Scala API for xyz as None" in {
+			CrossVersion.scalaApiVersion("xyz") must_== None
+		}
+		"return Scala API for 2.10 as None" in {
+			CrossVersion.scalaApiVersion("2.10") must_== None
+		}
+		"return Scala API for 2.10.0-SNAPSHOT as None" in {
+			CrossVersion.scalaApiVersion("2.10.0-SNAPSHOT") must_== None
+		}
+		"return Scala API for 2.10.0-RC1 as None" in {
+			CrossVersion.scalaApiVersion("2.10.0-RC1") must_== None
+		}
+		"return Scala API for 2.10.0 as Some((2, 10))" in {
+			CrossVersion.scalaApiVersion("2.10.0") must_== Some((2, 10))
+		}
+		"return Scala API for 2.10.0-1 as Some((2, 10))" in {
+			CrossVersion.scalaApiVersion("2.10.0-1") must_== Some((2, 10))
+		}
+		"return Scala API for 2.10.1 as Some((2, 10))" in {
+			CrossVersion.scalaApiVersion("2.10.1") must_== Some((2, 10))
+		}
+		"return Scala API compatibility for 2.10.0-M1 as false" in {
+			CrossVersion.isScalaApiCompatible("2.10.0-M1") must_== false
+		}
+		"return Scala API compatibility for 2.10.0-RC1 as false" in {
+			CrossVersion.isScalaApiCompatible("2.10.0-RC1") must_== false
+		}
+		"return binary Scala version for 2.9.2 as 2.9.2" in {
+			CrossVersion.binaryScalaVersion("2.9.2") must_== "2.9.2"
+		}
+		"return binary Scala version for 2.10.0-M1 as 2.10.0-M1" in {
+			CrossVersion.binaryScalaVersion("2.10.0-M1") must_== "2.10.0-M1"
+		}
+		"return binary Scala version for 2.10.0-RC1 as 2.10.0-RC1" in {
+			CrossVersion.binaryScalaVersion("2.10.0-RC1") must_== "2.10.0-RC1"
+		}
+		"return binary Scala version for 2.10.0 as 2.10" in {
+			CrossVersion.binaryScalaVersion("2.10.0") must_== "2.10"
+		}
+		"return binary Scala version for 2.10.1 as 2.10" in {
+			CrossVersion.binaryScalaVersion("2.10.1") must_== "2.10"
+		}
+	}
+}


### PR DESCRIPTION
### sbt 0.12.1 behavior

```
> ++ 2.10.0-RC2
Setting version to 2.10.0-RC2
[info] Set current project to helloworld (in build file:/Users/foo/bar/)
> cross-version
[info] Binary
> scala-binary-version
[info] 2.10
```

The cross version is `Binary` by default. This publishes the application with `_2.10` suffix.
### what this changes

```
> ++ 2.10.0-RC2
Setting version to 2.10.0-RC2
[info] Set current project to default-c60480 (in build file:/Users/foo/bar/)
> cross-version
[info] Binary
> scala-binary-version
[info] 2.10.0-RC2
```

The cross version is still `Binary`, but the binary version is calculated to be `2.10.0-RC2` since it's non-final.
### historical notes

The originating commit for this behavior is harrah/xsbt@13e62fd6452974a77eb9b9ac9a60a613316b1d14 Use binary version for cross-version even for snapshots and milestones, and it is behaving as designed. The commit message reads:

> Rely instead on users not publishing the same stable version against both stable Scala or sbt releases and snapshots/milestones.

The change was applied both to the binary versions of sbt and Scala, and was first introduced in sbt [0.12.0-RC1](https://groups.google.com/d/topic/simple-build-tool/eAGOACDH59E/discussion), which allowed sbt 0.12 plugins to be published ahead of sbt 0.12.0 release.

Unlike sbt that's been keeping the compatibility, there's no such guarantee for Scala milestones and RCs. Here are related threads on ML:
- [Scala version suffix in published artifact names](https://groups.google.com/forum/#!topic/simple-build-tool/miiQwiuxuIY/discussion)
- [the price of the wrong defaults](https://groups.google.com/d/topic/simple-build-tool/d_Kd6H_QMmM/discussion)

In the former thread it was suggested:

>  I would use a snapshot, a version bump, or append the full version.

There are pressures on library authors to cross publish against 2.10.0 RCs driven by user demands and curiosity for new features added in 2.10, and most authors I think are opting for full version instead of snapshot or version bump. See [community projects published for RC2](https://groups.google.com/forum/#!topic/scala-language/rbUwCwFEiIE/discussion).

This is a matter of setting `crossVersion`, so each project can work around this by knowing about this issue and writing logic around `scalaVersion`. For example the following would replicate the sbt 0.12.0 beta behavior, which I assume many are using:

``` scala
crossVersion <<= scalaVersion { sv => if (sv contains "-") CrossVersion.full else CrossVersion.binary }
```
### opinion

Since not every sbt user is an sbt geek, the default behavior should be safer.
