### PR TITLE
Add a link to sbt-pack plugin

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -136,7 +136,7 @@ Release plugins
    https://github.com/gseitz/sbt-release
 -  sbt-unique-version (emulates unique snapshots):
    https://github.com/sbt/sbt-unique-version
--  sbt-pack (generates paackages with dependent jars and launch scripts):
+-  sbt-pack (generates packages with dependent jars and launch scripts):
    https://github.com/xerial/sbt-pack
 
 System plugins

--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -136,6 +136,8 @@ Release plugins
    https://github.com/gseitz/sbt-release
 -  sbt-unique-version (emulates unique snapshots):
    https://github.com/sbt/sbt-unique-version
+-  sbt-pack (generates paackages with dependent jars and launch scripts):
+   https://github.com/xerial/sbt-pack
 
 System plugins
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi, 

I created a new sbt plugin, sbt-pack https://github.com/xerial/sbt-pack,  
which collects dependent jars in a project then creates launch scripts to run Scala programs as a command line program. 

Please add a link from sbt documentation to sbt-pack.

Thanks in advance.
