### PR TITLE
Allow the launcher to provide default repositories for SBT builds

### DIFF
--- a/ivy/src/test/scala/ComponentManagerTest.scala
+++ b/ivy/src/test/scala/ComponentManagerTest.scala
@@ -1,7 +1,8 @@
 package sbt
 
 import java.io.File
-import org.specs._
+import org.specs2._
+import mutable.Specification
 import IO.{createDirectory, delete, touch, withTemporaryDirectory}
 import org.apache.ivy.util.ChecksumHelper
 import IfMissing.Fail

--- a/launch/Launch.scala
+++ b/launch/Launch.scala
@@ -97,7 +97,8 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 
 	def globalLock: xsbti.GlobalLock = Locks
 	def ivyHome = orNull(ivyOptions.ivyHome)
-	def ivyRepositories = repositories.toArray
+	def ivyRepositories = (repositories: List[xsbti.Repository]).toArray
+	def appRepositories = ((repositories filterNot (_.bootOnly)): List[xsbti.Repository]).toArray
 	def isOverrideRepositories: Boolean = ivyOptions.isOverrideRepositories
 	def checksums = checksumsList.toArray[String]
 
@@ -278,7 +279,7 @@ class Launch private[xsbt](val bootDirectory: File, val lockBoot: Boolean, val i
 }
 object Launcher
 {
-	def apply(bootDirectory: File, repositories: List[xsbti.Repository]): xsbti.Launcher =
+	def apply(bootDirectory: File, repositories: List[Repository.Repository]): xsbti.Launcher =
 		apply(bootDirectory, IvyOptions(None, Classifiers(Nil, Nil), repositories, BootConfiguration.DefaultChecksums, false))
 	def apply(bootDirectory: File, ivyOptions: IvyOptions): xsbti.Launcher =
 		apply(bootDirectory, ivyOptions, GetLocks.find)

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -8,15 +8,52 @@ public interface Launcher
 	public ScalaProvider getScala(String version);
 	public ScalaProvider getScala(String version, String reason);
 	public ScalaProvider getScala(String version, String reason, String scalaOrg);
+	/**
+	 * returns an `AppProvider` which is able to resolve an application
+	 * and instantiate its `xsbti.Main` in a new classloader.
+	 * See [AppProvider] for more details.
+	 * @param id  The artifact coordinates of the application.
+	 * @param version The version to resolve
+	 */
 	public AppProvider app(ApplicationID id, String version);
+	/**
+	 * This returns the "top" classloader for a launched application.   This classlaoder
+	 * lives somewhere *above* that used for the application.   This classloader
+	 * is used for doing any sort of JNA/native library loads so that downstream
+	 * loaders can share native libraries rather than run into "load-once" restrictions.
+	 */
 	public ClassLoader topLoader();
+	/**
+	 * Return the global lock for interacting with the file system.
+	 *
+	 * A mechanism to do file-based locking correctly on the JVM.  See
+	 * the [[GlobalLock]] class for more details.
+	 */
 	public GlobalLock globalLock();
+	/** Value of the `sbt.boot.dir` property, or the default
+	 *  boot configuration defined in `boot.directory`.
+	 */
 	public File bootDirectory();
-  /** Configured launcher repositories. */
+	/** Configured launcher repositories.  These repositories
+	 *  are the same ones used to load the launcher.
+	 */
 	public xsbti.Repository[] ivyRepositories();
-	/** The user has configured the launcher with the only repositories it wants to use for this applciation. */
+	/** The user has configured the launcher with the only repositories
+	 * it wants to use for this applciation.
+	 */
 	public boolean isOverrideRepositories();
-	// null if none set
+	/**
+	 * The value of `ivy.ivy-home` of the boot properties file.
+	 * This defaults to the `sbt.ivy.home` property, or `~/.ivy2`.
+	 * Use this setting in an application when using Ivy to resolve
+	 * more artifacts.
+	 *
+	 * @returns a file, or null if not set.
+	 */
 	public File ivyHome();
+	/** An array of the checksums that should be checked when retreiving artifacts.
+	 *  Configured via the the `ivy.checksums` section of the boot configuration.
+	 *  Defaults to sha1, md5 or the value of the `sbt.checksums` property.
+	 */
 	public String[] checksums();
 }

--- a/launch/interface/src/main/java/xsbti/Launcher.java
+++ b/launch/interface/src/main/java/xsbti/Launcher.java
@@ -38,6 +38,11 @@ public interface Launcher
 	 *  are the same ones used to load the launcher.
 	 */
 	public xsbti.Repository[] ivyRepositories();
+	/** These are the repositories configured by this launcher
+	 * which should be used by the application when resolving
+	 * further artifacts.
+	 */
+	public xsbti.Repository[] appRepositories();
 	/** The user has configured the launcher with the only repositories
 	 * it wants to use for this applciation.
 	 */

--- a/launch/src/test/scala/ConfigurationParserTest.scala
+++ b/launch/src/test/scala/ConfigurationParserTest.scala
@@ -1,0 +1,76 @@
+package xsbt.boot
+
+import java.io.{File,InputStream}
+import java.net.URL
+import java.util.Properties
+import xsbti._
+import org.specs2._
+import mutable.Specification
+import sbt.IO.{createDirectory, touch,withTemporaryDirectory}
+
+object ConfigurationParserTest extends Specification
+{
+        "Configuration Parser" should {
+                "Correctly parse bootOnly" in {
+
+                        repoFileContains("""|[repositories]
+                                            |  local: bootOnly""".stripMargin,
+                                Repository.Predefined("local", true))
+
+                        repoFileContains("""|[repositories]
+                                            |  local""".stripMargin,
+                                Repository.Predefined("local", false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org""".stripMargin,
+                                Repository.Maven("id", new URL("http://repo1.maven.org"), false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, bootOnly""".stripMargin,
+                                Repository.Maven("id", new URL("http://repo1.maven.org"), true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath]""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+
+                }
+        }
+
+  def repoFileContains(file: String, repo: Repository.Repository) =
+    loadRepoFile(file) must contain(repo)
+
+        def loadRepoFile(file: String) =
+                (new ConfigurationParser) readRepositoriesConfig file
+}

--- a/launch/src/test/scala/ScalaProviderTest.scala
+++ b/launch/src/test/scala/ScalaProviderTest.scala
@@ -4,30 +4,30 @@ import java.io.{File,InputStream}
 import java.net.URL
 import java.util.Properties
 import xsbti._
-import org.specs._
+import org.specs2._
+import mutable.Specification
 import LaunchTest._
 import sbt.IO.{createDirectory, touch,withTemporaryDirectory}
 
 object ScalaProviderTest extends Specification
 {
-	 def provide = addToSusVerb("provide")
-	"Launch" should provide {
-		"ClassLoader for Scala 2.8.0" in { checkScalaLoader("2.8.0") }
-		"ClassLoader for Scala 2.8.2" in { checkScalaLoader("2.8.2") }
-		"ClassLoader for Scala 2.9.0" in { checkScalaLoader("2.9.0") }
-		"ClassLoader for Scala 2.9.2" in { checkScalaLoader("2.9.2") }
+	"Launch" should {
+		"provide ClassLoader for Scala 2.8.0" in { checkScalaLoader("2.8.0") }
+		"provide ClassLoader for Scala 2.8.2" in { checkScalaLoader("2.8.2") }
+		"provide ClassLoader for Scala 2.9.0" in { checkScalaLoader("2.9.0") }
+		"provide ClassLoader for Scala 2.9.2" in { checkScalaLoader("2.9.2") }
 	}
 
 	"Launch" should {
 		"Successfully load an application from local repository and run it with correct arguments" in {
-			checkLoad(List("test"), "xsbt.boot.test.ArgumentTest").asInstanceOf[Exit].code must be(0)
+			checkLoad(List("test"), "xsbt.boot.test.ArgumentTest").asInstanceOf[Exit].code must equalTo(0)
 			checkLoad(List(), "xsbt.boot.test.ArgumentTest") must throwA[RuntimeException]
 		}
 		"Successfully load an application from local repository and run it with correct sbt version" in {
-			checkLoad(List(AppVersion), "xsbt.boot.test.AppVersionTest").asInstanceOf[Exit].code must be(0)
+			checkLoad(List(AppVersion), "xsbt.boot.test.AppVersionTest").asInstanceOf[Exit].code must equalTo(0)
 		}
 		"Add extra resources to the classpath" in {
-			checkLoad(testResources, "xsbt.boot.test.ExtraTest", createExtra).asInstanceOf[Exit].code must be(0)
+			checkLoad(testResources, "xsbt.boot.test.ExtraTest", createExtra).asInstanceOf[Exit].code must equalTo(0)
 		}
 	}
 
@@ -65,7 +65,7 @@ object LaunchTest
 	def testApp(main: String): Application = testApp(main, Array[File]())
 	def testApp(main: String, extra: Array[File]): Application = Application("org.scala-sbt", "launch-test", new Explicit(AppVersion), main, Nil, false, extra)
 	import Predefined._
-	def testRepositories = List(Local, ScalaToolsReleases, ScalaToolsSnapshots).map(Repository.Predefined.apply)
+	def testRepositories = List(Local, ScalaToolsReleases, ScalaToolsSnapshots).map(Repository.Predefined(_))
 	def withLauncher[T](f: xsbti.Launcher => T): T =
 		withTemporaryDirectory { bootDirectory =>
 			f(Launcher(bootDirectory, testRepositories))

--- a/main/Keys.scala
+++ b/main/Keys.scala
@@ -276,6 +276,7 @@ object Keys
 	val projectID = SettingKey[ModuleID]("project-id", "The dependency management descriptor for the current module.", BMinusSetting)
 	val overrideBuildResolvers = SettingKey[Boolean]("override-build-resolvers", "Whether or not all the build resolvers should be overriden with what's defined from the launcher.", BMinusSetting)
 	val bootResolvers = TaskKey[Option[Seq[Resolver]]]("boot-resolvers", "The resolvers used by the sbt launcher.", BMinusSetting)
+	val appResolvers = SettingKey[Option[Seq[Resolver]]]("app-resolvers", "The resolvers configured for this application by the sbt launcher.", BMinusSetting)
 	val externalResolvers = TaskKey[Seq[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.", BMinusSetting)
 	val resolvers = SettingKey[Seq[Resolver]]("resolvers", "The user-defined additional resolvers for automatically managed dependencies.", BMinusTask)
 	val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)

--- a/main/src/test/scala/TagsTest.scala
+++ b/main/src/test/scala/TagsTest.scala
@@ -1,22 +1,25 @@
 package sbt
 
 import org.scalacheck._
-import Gen.{genInt,listOf,genString}
+import Gen.{listOf}
 import Prop.forAll
 import Tags._
 
 object TagsTest extends Properties("Tags")
 {
 	def tagMap: Gen[TagMap] = for(ts <- listOf(tagAndFrequency)) yield ts.toMap
-	def tagAndFrequency: Gen[(Tag, Int)] = for(t <- tag; count <- genInt) yield (t, count)
-	def tag: Gen[Tag] = for(s <- genString) yield Tag(s)
+	def tagAndFrequency: Gen[(Tag, Int)] = for(t <- tag; count <- Arbitrary.arbitrary[Int]) yield (t, count)
+	def tag: Gen[Tag] = for(s <- Arbitrary.arbitrary[String]) yield Tag(s)
+	implicit def aTagMap = Arbitrary(tagMap)
+	implicit def aTagAndFrequency = Arbitrary(tagAndFrequency)
+	implicit def aTag = Arbitrary(tag)
 
 	property("exclusive allows all groups without the exclusive tag") = forAll { (tm: TagMap, tag: Tag) =>
 		excl(tag)(tm - tag)
 	}
 	property("exclusive only allows a group with an excusive tag when the size is one") = forAll { (tm: TagMap, size: Int, etag: Tag) =>
-		val tm: TagMap = tm.updated(etag, math.abs(size))
-		excl(etag)(tm) == (size <= 1)
+		val tm2: TagMap = tm.updated(etag, math.abs(size))
+		excl(etag)(tm2) == (size <= 1)
 	}
 	property("exclusive always allows a group of size one") = forAll { (etag: Tag, mapTag: Tag) =>
 		val tm: TagMap = Map(mapTag -> 1)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -30,8 +30,8 @@ object Util
 	lazy val base: Seq[Setting[_]] = Seq(scalacOptions ++= Seq("-Xelide-below", "0"), projectComponent) ++ Licensed.settings
 	
 	def testDependencies = libraryDependencies ++= Seq(
-		"org.scalacheck" % "scalacheck_2.10.0-M5" % "1.10.0" % "test",
-		"org.scala-tools.testing" % "specs_2.9.1" % "1.6.9" % "test"
+		"org.scalacheck" % "scalacheck_2.10.0-RC3" % "1.10.0" % "test",
+		"org.specs2" % "specs2_2.10.0-RC3" % "1.12.3" % "test"
 	)
 
 	lazy val minimalSettings: Seq[Setting[_]] = Defaults.paths ++ Seq[Setting[_]](crossTarget <<= target.identity, name <<= thisProject(_.id))

--- a/src/sphinx/Detailed-Topics/Launcher.rst
+++ b/src/sphinx/Detailed-Topics/Launcher.rst
@@ -106,7 +106,7 @@ by the following grammar. ``'nl'`` is a newline or end of file and
     resources: "resources" ":" `path` ("," `path`)*
     repository: ( `predefinedRepository` | `customRepository` ) `nl`
     predefinedRepository: "local" | "maven-local" | "maven-central"
-    customRepository: `label` ":" `url` [ ["," `ivyPattern`] "," `artifactPattern` [", mavenCompatible"]]
+    customRepository: `label` ":" `url` [ ["," `ivyPattern`] ["," `artifactPattern`] [", mavenCompatible"] [", bootOnly"]]
     property: `label` ":" `propertyDefinition` ("," `propertyDefinition`)*
     propertyDefinition: `mode` "=" (`set` | `prompt`)
     mode: "quick" | "new" | "fill"
@@ -157,7 +157,7 @@ The default configuration file for sbt looks like:
 
     [repositories]
       local
-      typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+      typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
       maven-central
       sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/util/io/src/test/scala/StashSpec.scala
+++ b/util/io/src/test/scala/StashSpec.scala
@@ -3,7 +3,8 @@
 
 package sbt
 
-import org.specs._
+import org.specs2._
+import mutable.Specification
 
 import IO._
 import java.io.File
@@ -62,7 +63,7 @@ object CheckStash extends Specification
 	def correct(check: File, ref: (File, String)) =
 	{
 		check.exists must beTrue
-		read(check) must beEqual(ref._2)
+		read(check) must equalTo(ref._2)
 	}
 	def noneExist(s: Seq[File]) = s.forall(!_.exists) must beTrue
 	


### PR DESCRIPTION
Among a few minor fixes and documentation updates, this PR primarily adds the ability for the Launcher to provide the default IVY repositories for applications, and modifies SBT to make use of this feature if the launcher it's using supports it, otherwise relying on existing defaults.

Review by @harrah
