### PR TITLE
Add `compilations` field to `Analysis`.

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Compilations.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compilations.scala
@@ -1,0 +1,20 @@
+package sbt.inc
+
+import xsbti.api.Compilation
+
+/** Information about compiler runs accumulated since `clean` command has been run. */
+trait Compilations {
+  def allCompilations: Seq[Compilation]
+  def ++(o: Compilations): Compilations
+  def add(c: Compilation): Compilations
+}
+
+object Compilations {
+  val empty: Compilations = new MCompilations(Seq.empty)
+  def make(s: Seq[Compilation]): Compilations = new MCompilations(s)
+}
+
+private final class MCompilations(val allCompilations: Seq[Compilation]) extends Compilations {
+  def ++(o: Compilations): Compilations = new MCompilations(allCompilations ++ o.allCompilations)
+  def add(c: Compilation): Compilations = new MCompilations(allCompilations :+ c)
+}

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -129,7 +129,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 	def endSource(sourcePath: File): Unit =
 		assert(apis.contains(sourcePath))
 	
-	def get: Analysis = addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) )
+	def get: Analysis = addCompilation( addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) ) )
 	def addProducts(base: Analysis): Analysis = addAll(base, classes) { case (a, src, (prod, name)) => a.addProduct(src, prod, current product prod, name ) }
 	def addBinaries(base: Analysis): Analysis = addAll(base, binaryDeps)( (a, src, bin) => a.addBinaryDep(src, bin, binaryClassName(bin), current binary bin) )
 	def addSources(base: Analysis): Analysis =
@@ -144,6 +144,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 		}
 	def getOrNil[A,B](m: collection.Map[A, Seq[B]], a: A): Seq[B] = m.get(a).toList.flatten
 	def addExternals(base: Analysis): Analysis = (base /: extSrcDeps) { case (a, (source, name, api)) => a.addExternalDep(source, name, api) }
+	def addCompilation(base: Analysis): Analysis = base.copy(compilations = base.compilations.add(compilation))
 		
 	def addAll[A,B](base: Analysis, m: Map[A, Set[B]])( f: (Analysis, A, B) => Analysis): Analysis =
 		(base /: m) { case (outer, (a, bs)) =>

--- a/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
+++ b/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
@@ -4,7 +4,7 @@
 package sbt
 package inc
 
-	import xsbti.api.Source
+	import xsbti.api.{Source, Compilation}
 	import xsbti.{Position,Problem,Severity}
 	import xsbti.compile.{CompileOrder, Output => APIOutput, SingleOutput, MultipleOutput}
 	import MultipleOutput.OutputGroup
@@ -45,8 +45,9 @@ object AnalysisFormats
 		}
 	}
 
-	implicit def analysisFormat(implicit stampsF: Format[Stamps], apisF: Format[APIs], relationsF: Format[Relations], infosF: Format[SourceInfos]): Format[Analysis] =
-		asProduct4( Analysis.Empty.copy _)( a => (a.stamps, a.apis, a.relations, a.infos))(stampsF, apisF, relationsF, infosF)
+	implicit def analysisFormat(implicit stampsF: Format[Stamps], apisF: Format[APIs], relationsF: Format[Relations],
+	    infosF: Format[SourceInfos], compilationsF: Format[Compilations]): Format[Analysis] =
+		asProduct5( Analysis.Empty.copy _)( a => (a.stamps, a.apis, a.relations, a.infos, a.compilations))(stampsF, apisF, relationsF, infosF, compilationsF)
 
 	implicit def infosFormat(implicit infoF: Format[Map[File, SourceInfo]]): Format[SourceInfos] =
 		wrap[SourceInfos, Map[File, SourceInfo]]( _.allInfos, SourceInfos.make _)
@@ -55,6 +56,11 @@ object AnalysisFormats
 		wrap[SourceInfo, (Seq[Problem],Seq[Problem])](si => (si.reportedProblems, si.unreportedProblems), { case (a,b) => SourceInfos.makeInfo(a,b)})
 
 	implicit def problemFormat: Format[Problem] =	asProduct4(problem _)( p => (p.category, p.position, p.message, p.severity))
+
+	implicit def compilationsFormat: Format[Compilations] = {
+	  implicit val compilationSeqF = seqFormat(xsbt.api.CompilationFormat)
+	  wrap[Compilations, Seq[Compilation]](_.allCompilations, Compilations.make _)
+	}
 
 	implicit def positionFormat: Format[Position] =
 		asProduct7( position _ )( p => (m2o(p.line), p.lineContent, m2o(p.offset), m2o(p.pointer), m2o(p.pointerSpace), m2o(p.sourcePath), m2o(p.sourceFile)))

--- a/compile/persist/src/main/scala/xsbt/api/CompilationFormat.scala
+++ b/compile/persist/src/main/scala/xsbt/api/CompilationFormat.scala
@@ -1,0 +1,16 @@
+package xsbt.api
+
+import xsbti.api._
+import sbinary._
+
+object CompilationFormat extends Format[Compilation] {
+  import java.io._
+  def reads(in: Input): Compilation = {
+	val oin = new ObjectInputStream(new InputWrapperStream(in))
+	try { oin.readObject.asInstanceOf[Compilation] } finally { oin.close() }
+  }
+  def writes(out: Output, src: Compilation) {
+    val oout = new ObjectOutputStream(new OutputWrapperStream(out))
+	try { oout.writeObject(src) } finally { oout.close() }
+  }
+}


### PR DESCRIPTION
We store `Seq[xsbt.api.Compilation]` in `Analysis`. Compilation are
being appended to sequence for every iteration of the incremental
compiler.

Note that `Compilation`s are never removed from the sequence unless
you start from scratch with empty `Analysis`. You can do that by using
sbt's `clean` command.

The main use-case for using `compilations` field is to determine how
many iterations it took to compilen give code. The `Compilation` object
are also stored in `Source` objects so there's an indirect way to recover
information about files being recompiled in every iteration.

Since `Analysis` is persisted you can use this mechanism to track entire
sessions spanning multiple `compile` commands.
