### PR TITLE
Add test for pickled existential types bug (#616)

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Compilations.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compilations.scala
@@ -1,0 +1,20 @@
+package sbt.inc
+
+import xsbti.api.Compilation
+
+/** Information about compiler runs accumulated since `clean` command has been run. */
+trait Compilations {
+  def allCompilations: Seq[Compilation]
+  def ++(o: Compilations): Compilations
+  def add(c: Compilation): Compilations
+}
+
+object Compilations {
+  val empty: Compilations = new MCompilations(Seq.empty)
+  def make(s: Seq[Compilation]): Compilations = new MCompilations(s)
+}
+
+private final class MCompilations(val allCompilations: Seq[Compilation]) extends Compilations {
+  def ++(o: Compilations): Compilations = new MCompilations(allCompilations ++ o.allCompilations)
+  def add(c: Compilation): Compilations = new MCompilations(allCompilations :+ c)
+}

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -129,7 +129,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 	def endSource(sourcePath: File): Unit =
 		assert(apis.contains(sourcePath))
 	
-	def get: Analysis = addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) )
+	def get: Analysis = addCompilation( addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) ) )
 	def addProducts(base: Analysis): Analysis = addAll(base, classes) { case (a, src, (prod, name)) => a.addProduct(src, prod, current product prod, name ) }
 	def addBinaries(base: Analysis): Analysis = addAll(base, binaryDeps)( (a, src, bin) => a.addBinaryDep(src, bin, binaryClassName(bin), current binary bin) )
 	def addSources(base: Analysis): Analysis =
@@ -144,6 +144,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 		}
 	def getOrNil[A,B](m: collection.Map[A, Seq[B]], a: A): Seq[B] = m.get(a).toList.flatten
 	def addExternals(base: Analysis): Analysis = (base /: extSrcDeps) { case (a, (source, name, api)) => a.addExternalDep(source, name, api) }
+	def addCompilation(base: Analysis): Analysis = base.copy(compilations = base.compilations.add(compilation))
 		
 	def addAll[A,B](base: Analysis, m: Map[A, Set[B]])( f: (Analysis, A, B) => Analysis): Analysis =
 		(base /: m) { case (outer, (a, bs)) =>

--- a/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
+++ b/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
@@ -4,7 +4,7 @@
 package sbt
 package inc
 
-	import xsbti.api.Source
+	import xsbti.api.{Source, Compilation}
 	import xsbti.{Position,Problem,Severity}
 	import xsbti.compile.{CompileOrder, Output => APIOutput, SingleOutput, MultipleOutput}
 	import MultipleOutput.OutputGroup
@@ -45,8 +45,9 @@ object AnalysisFormats
 		}
 	}
 
-	implicit def analysisFormat(implicit stampsF: Format[Stamps], apisF: Format[APIs], relationsF: Format[Relations], infosF: Format[SourceInfos]): Format[Analysis] =
-		asProduct4( Analysis.Empty.copy _)( a => (a.stamps, a.apis, a.relations, a.infos))(stampsF, apisF, relationsF, infosF)
+	implicit def analysisFormat(implicit stampsF: Format[Stamps], apisF: Format[APIs], relationsF: Format[Relations],
+	    infosF: Format[SourceInfos], compilationsF: Format[Compilations]): Format[Analysis] =
+		asProduct5( Analysis.Empty.copy _)( a => (a.stamps, a.apis, a.relations, a.infos, a.compilations))(stampsF, apisF, relationsF, infosF, compilationsF)
 
 	implicit def infosFormat(implicit infoF: Format[Map[File, SourceInfo]]): Format[SourceInfos] =
 		wrap[SourceInfos, Map[File, SourceInfo]]( _.allInfos, SourceInfos.make _)
@@ -55,6 +56,11 @@ object AnalysisFormats
 		wrap[SourceInfo, (Seq[Problem],Seq[Problem])](si => (si.reportedProblems, si.unreportedProblems), { case (a,b) => SourceInfos.makeInfo(a,b)})
 
 	implicit def problemFormat: Format[Problem] =	asProduct4(problem _)( p => (p.category, p.position, p.message, p.severity))
+
+	implicit def compilationsFormat: Format[Compilations] = {
+	  implicit val compilationSeqF = seqFormat(xsbt.api.CompilationFormat)
+	  wrap[Compilations, Seq[Compilation]](_.allCompilations, Compilations.make _)
+	}
 
 	implicit def positionFormat: Format[Position] =
 		asProduct7( position _ )( p => (m2o(p.line), p.lineContent, m2o(p.offset), m2o(p.pointer), m2o(p.pointerSpace), m2o(p.sourcePath), m2o(p.sourceFile)))

--- a/compile/persist/src/main/scala/xsbt/api/CompilationFormat.scala
+++ b/compile/persist/src/main/scala/xsbt/api/CompilationFormat.scala
@@ -1,0 +1,16 @@
+package xsbt.api
+
+import xsbti.api._
+import sbinary._
+
+object CompilationFormat extends Format[Compilation] {
+  import java.io._
+  def reads(in: Input): Compilation = {
+	val oin = new ObjectInputStream(new InputWrapperStream(in))
+	try { oin.readObject.asInstanceOf[Compilation] } finally { oin.close() }
+  }
+  def writes(out: Output, src: Compilation) {
+    val oout = new ObjectOutputStream(new OutputWrapperStream(out))
+	try { oout.writeObject(src) } finally { oout.close() }
+  }
+}

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/build.sbt
@@ -1,0 +1,12 @@
+logLevel := Level.Debug
+
+scalaVersion := "2.9.2"
+
+// dumps analysis into target/analysis-dump.txt file
+InputKey[Unit]("check-number-of-compiler-iterations") <<= inputTask { (argTask: TaskKey[Seq[String]]) =>
+  (argTask, compile in Compile) map { (args: Seq[String], a: sbt.inc.Analysis) =>
+    assert(args.size == 1)
+    val expectedIterationsNumber = args(0).toInt
+    assert(a.compilations.allCompilations.size == expectedIterationsNumber, "a.compilations.allCompilations.size = %d (expected %d)".format(a.compilations.allCompilations.size, expectedIterationsNumber))
+  }
+}

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/changes/B1.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/changes/B1.scala
@@ -1,0 +1,5 @@
+package test6
+
+class B extends A {
+  def wibble = println("fooo")
+}

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/pending
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/pending
@@ -1,0 +1,12 @@
+# Tests if existential types are pickled correctly so they
+# do not introduce unnecessary compile iterations
+
+# introduces first compile iteration
+> compile
+# this change is local to a method and does not change the api so introduces
+# only one additional compile iteration
+$ copy-file changes/B1.scala src/main/scala/B.scala
+# second iteration
+> compile
+# check if there are only two compile iterations being performed
+> check-number-of-compiler-iterations 2

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/A.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/A.scala
@@ -1,0 +1,9 @@
+package test6
+
+trait A {
+  object Foo extends Module[Foo[_]]
+
+  class Foo[TResult]
+
+  def b = new B
+}

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/B.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/B.scala
@@ -1,0 +1,5 @@
+package test6
+
+class B extends A {
+  def wibble = println("foo")
+}

--- a/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/Module.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-pickled-existential/src/main/scala/Module.scala
@@ -1,0 +1,3 @@
+package test6
+
+class Module[T]


### PR DESCRIPTION
This test fails at the moment because there's one unnecessary
compile iteration performed. Thus the test is marked as pending.

Since the test is compiler version specific, I set it to 2.9.2
(latest stable version).

Note: this pull request depends on #617. If you merge this pull request, you'll merge automatically #617.
