### PR TITLE
Fix for dependency on class file corresponding to a package. (#620)

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Analyzer.scala
+++ b/compile/interface/src/main/scala/xsbt/Analyzer.scala
@@ -81,6 +81,9 @@ final class Analyzer(val global: CallbackGlobal) extends Compat
 
 	private[this] final val classSeparator = '.'
 	private[this] def classFile(sym: Symbol): Option[(AbstractFile, String, Boolean)] =
+	// package can never have a corresponding class file; this test does not
+	// catch package objects (that do not have this flag set)
+	if (sym hasFlag scala.tools.nsc.symtab.Flags.PACKAGE) None else
 	{
 		import scala.tools.nsc.symtab.Flags
 		val name = flatname(sym, classSeparator) + moduleSuffix(sym)

--- a/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/build.sbt
@@ -1,0 +1,6 @@
+TaskKey[Unit]("verify-binary-deps") <<= (compile in Compile, classDirectory in Compile, baseDirectory) map {
+  (a: sbt.inc.Analysis, classDir: java.io.File, base: java.io.File) =>
+    val nestedPkgClass = classDir / "test/nested.class"
+    val fooSrc = base / "src/main/scala/test/nested/Foo.scala"
+    assert(!a.relations.binaryDeps(fooSrc).contains(nestedPkgClass), a.relations.toString)
+}

--- a/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/src/main/scala/test/Nested.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/src/main/scala/test/Nested.scala
@@ -1,0 +1,3 @@
+package test
+
+trait Nested

--- a/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/src/main/scala/test/nested/Foo.scala
+++ b/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/src/main/scala/test/nested/Foo.scala
@@ -1,0 +1,5 @@
+package test.nested
+
+trait Foo {
+	def xyz(x: test.Nested)
+}

--- a/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/test
+++ b/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/test
@@ -1,0 +1,7 @@
+# Tests for bug when sbt would introduce dependency on non-existing
+# class files corresponding to packages
+
+> compile
+# verifies that there's no dependency on a class file corresponding
+# to a package
+> verify-binary-deps


### PR DESCRIPTION
While trying to determine binary dependencies sbt lookups class files
corresponding to symbols. It tried to do that for packages and most of the
time would fail because packages don't have corresponding class file
generated. However, in case of case insensitive file system, combined
with special nesting structure you could get spurious dependency.
See added test case for an example of such structure.

The remedy is to never even try to locate class files corresponding to
packages.

Fixes #620.
