### PR TITLE
Cleanup parameter list of `ScriptedTests`.

### DIFF
--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -16,8 +16,6 @@ object ScriptedPlugin extends Plugin {
 	val sbtLauncher = SettingKey[File]("sbt-launcher")
 	val sbtTestDirectory = SettingKey[File]("sbt-test-directory")
 	val scriptedBufferLog = SettingKey[Boolean]("scripted-buffer-log")
-	final case class ScriptedScalas(build: String, versions: String)
-	val scriptedScalas = SettingKey[ScriptedScalas]("scripted-scalas")
 
 	val scriptedClasspath = TaskKey[PathFinder]("scripted-classpath")
 	val scriptedTests = TaskKey[AnyRef]("scripted-tests")
@@ -43,7 +41,6 @@ object ScriptedPlugin extends Plugin {
 		try {
 			scriptedRun.value.invoke(
 				scriptedTests.value, sbtTestDirectory.value, scriptedBufferLog.value: java.lang.Boolean,
-				scriptedSbt.value.toString, scriptedScalas.value.build, scriptedScalas.value.versions,
 				args.toArray, sbtLauncher.value, scriptedLaunchOpts.value.toArray)
 		}
 		catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
@@ -52,7 +49,6 @@ object ScriptedPlugin extends Plugin {
 	val scriptedSettings = Seq(
 		ivyConfigurations += scriptedConf,
 		scriptedSbt <<= (appConfiguration)(_.provider.id.version),
-		scriptedScalas <<= (scalaVersion) { (scala) => ScriptedScalas(scala, scala) },
 		libraryDependencies <<= (libraryDependencies, scriptedSbt) {(deps, version) => deps :+ "org.scala-sbt" % "scripted-sbt" % version % scriptedConf.toString },
 		sbtLauncher <<= (appConfiguration)(app => IO.classLocationFile(app.provider.scalaProvider.launcher.getClass)),
 		sbtTestDirectory <<= sourceDirectory / "sbt-test",

--- a/scripted/sbt/src/main/scala/sbt/test/ScriptedTests.scala
+++ b/scripted/sbt/src/main/scala/sbt/test/ScriptedTests.scala
@@ -12,7 +12,7 @@ import xsbt.IPC
 import xsbt.test.{CommentHandler, FileCommands, ScriptRunner, TestScriptParser}
 import IO.wrapNull
 
-final class ScriptedTests(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, launcher: File, launchOpts: Seq[String])
+final class ScriptedTests(resourceBaseDirectory: File, bufferLog: Boolean, launcher: File, launchOpts: Seq[String])
 {
 	private val testResources = new Resources(resourceBaseDirectory)
 	
@@ -102,14 +102,14 @@ object ScriptedTests
 		val bootProperties = new File(args(5))
 		val tests = args.drop(6)
 		val logger = ConsoleLogger()
-		run(directory, buffer, sbtVersion, defScalaVersion, buildScalaVersions, tests, logger, bootProperties, Array())
+		run(directory, buffer, tests, logger, bootProperties, Array())
 	}
-	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], bootProperties: File, launchOpts: Array[String]): Unit =
-		run(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, tests, ConsoleLogger(), bootProperties, launchOpts)//new FullLogger(Logger.xlog2Log(log)))
+	def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], bootProperties: File, launchOpts: Array[String]): Unit =
+		run(resourceBaseDirectory, bufferLog, tests, ConsoleLogger(), bootProperties, launchOpts)//new FullLogger(Logger.xlog2Log(log)))
 
-	def run(resourceBaseDirectory: File, bufferLog: Boolean, sbtVersion: String, defScalaVersion: String, buildScalaVersions: String, tests: Array[String], logger: AbstractLogger, bootProperties: File, launchOpts: Array[String])
+	def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], logger: AbstractLogger, bootProperties: File, launchOpts: Array[String])
 	{
-		val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, sbtVersion, defScalaVersion, buildScalaVersions, bootProperties, launchOpts)
+		val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, bootProperties, launchOpts)
 		for( ScriptedTest(group, name) <- get(tests, resourceBaseDirectory, logger) )
 			runner.scriptedTest(group, name, logger)
 	}


### PR DESCRIPTION
All of `sbtVersion`, `defScalaVersion` and `buildScalaVersions` were
not used anymore. According to @harrah they are coming from really
old days of sbt and are not needed because of changes to how sbt
interacts with different Scala versions.
