### PR TITLE
ivy version 2.3.0-rc1 in documents

### DIFF
--- a/src/sphinx/Detailed-Topics/Artifacts.rst
+++ b/src/sphinx/Detailed-Topics/Artifacts.rst
@@ -127,7 +127,7 @@ For example:
     Artifact("myproject", "jdk15")
 
 See the `Ivy
-documentation <http://ant.apache.org/ivy/history/2.2.0/ivyfile/dependency-artifact.html>`_
+documentation <http://ant.apache.org/ivy/history/2.3.0-rc1/ivyfile/dependency-artifact.html>`_
 for more details on artifacts. See the `Artifact
 API <../../api/sbt/Artifact$.html>`_ for
 combining the parameters above and specifying [Configurations] and extra

--- a/src/sphinx/Detailed-Topics/Library-Management.rst
+++ b/src/sphinx/Detailed-Topics/Library-Management.rst
@@ -124,7 +124,7 @@ the version of Scala you are using. See :doc:`Cross-Build` for details.
 Ivy can select the latest revision of a module according to constraints
 you specify. Instead of a fixed revision like ``"1.6.1"``, you specify
 ``"latest.integration"``, ``"2.9.+"``, or ``"[1.0,)"``. See the `Ivy
-revisions <http://ant.apache.org/ivy/history/2.2.0/ivyfile/dependency.html#revision>`_
+revisions <http://ant.apache.org/ivy/history/2.3.0-rc1/ivyfile/dependency.html#revision>`_
 documentation for details.
 
 Resolvers
@@ -320,7 +320,7 @@ Extra Attributes
 ~~~~~~~~~~~~~~~~
 
 `Extra
-attributes <http://ant.apache.org/ivy/history/2.2.0/concept.html#extra>`_
+attributes <http://ant.apache.org/ivy/history/2.3.0-rc1/concept.html#extra>`_
 can be specified by passing key/value pairs to the ``extra`` method.
 
 To select dependencies by extra attributes:

--- a/src/sphinx/Detailed-Topics/Publishing.rst
+++ b/src/sphinx/Detailed-Topics/Publishing.rst
@@ -163,5 +163,5 @@ change the version number each time you publish. Ivy maintains a cache,
 and it stores even local projects in that cache. If Ivy already has a
 version cached, it will not check the local repository for updates,
 unless the version number matches a `changing
-pattern <http://ant.apache.org/ivy/history/2.0.0/concept.html#change>`_,
+pattern <http://ant.apache.org/ivy/history/2.3.0-rc1/concept.html#change>`_,
 and ``SNAPSHOT`` is one such pattern.

--- a/src/sphinx/Dormant/Configurations.rst
+++ b/src/sphinx/Dormant/Configurations.rst
@@ -21,7 +21,7 @@ Configurations
 Ivy configurations are a useful feature for your build when you use
 managed dependencies. They are essentially named sets of dependencies.
 You can read the `Ivy
-documentation <http://ant.apache.org/ivy/history/2.2.0/tutorial/conf.html>`_
+documentation <http://ant.apache.org/ivy/history/2.3.0-rc1/tutorial/conf.html>`_
 for details. Their use in sbt is described on this page.
 
 Usage
@@ -46,7 +46,7 @@ your dependency definition:
 
 This says that your project's ``test`` configuration uses
 ``ScalaTest``'s ``default`` configuration. Again, see the `Ivy
-documentation <http://ant.apache.org/ivy/history/2.2.0/tutorial/conf.html>`_
+documentation <http://ant.apache.org/ivy/history/2.3.0-rc1/tutorial/conf.html>`_
 for more advanced mappings. Most projects published to Maven
 repositories will use the ``default`` or ``compile`` configuration.
 

--- a/src/sphinx/Getting-Started/Library-Dependencies.rst
+++ b/src/sphinx/Getting-Started/Library-Dependencies.rst
@@ -157,7 +157,7 @@ be a single fixed version. Ivy can select the latest revision of a
 module according to constraints you specify. Instead of a fixed revision
 like ``"1.6.1"``, you specify ``"latest.integration"``, ``"2.9.+"``, or
 ``"[1.0,)"``. See the `Ivy
-revisions <http://ant.apache.org/ivy/history/2.2.0/ivyfile/dependency.html#revision>`_
+revisions <http://ant.apache.org/ivy/history/2.3.0-rc1/ivyfile/dependency.html#revision>`_
 documentation for details.
 
 Resolvers


### PR DESCRIPTION
current sbt depends on ivy 2.3.0-rc1
https://github.com/harrah/xsbt/blob/v0.12.1/project/Util.scala#L147
