### PR TITLE
Warning fixes on 0.13

### DIFF
--- a/compile/inc/src/main/scala/sbt/CompileSetup.scala
+++ b/compile/inc/src/main/scala/sbt/CompileSetup.scala
@@ -3,7 +3,7 @@
  */
 package sbt
 
-	import xsbti.compile.{ CompileOrder, Output, SingleOutput, MultipleOutput }
+	import xsbti.compile.{ CompileOrder, Output => APIOutput, SingleOutput, MultipleOutput}
 	import java.io.File
 
 // this class exists because of Scala's restriction on implicit parameter search.
@@ -11,12 +11,12 @@ package sbt
 //    because complexity(Equiv[Seq[String]]) > complexity(Equiv[CompileSetup])
 //     (6 > 4)
 final class CompileOptions(val options: Seq[String], val javacOptions: Seq[String])
-final class CompileSetup(val output: Output, val options: CompileOptions, val compilerVersion: String, val order: CompileOrder)
+final class CompileSetup(val output: APIOutput, val options: CompileOptions, val compilerVersion: String, val order: CompileOrder)
 
 object CompileSetup
 {
 	// Equiv[CompileOrder.Value] dominates Equiv[CompileSetup]
-	implicit def equivCompileSetup(implicit equivOutput: Equiv[Output], equivOpts: Equiv[CompileOptions], equivComp: Equiv[String]/*, equivOrder: Equiv[CompileOrder]*/): Equiv[CompileSetup] = new Equiv[CompileSetup] {
+	implicit def equivCompileSetup(implicit equivOutput: Equiv[APIOutput], equivOpts: Equiv[CompileOptions], equivComp: Equiv[String]/*, equivOrder: Equiv[CompileOrder]*/): Equiv[CompileSetup] = new Equiv[CompileSetup] {
 		def equiv(a: CompileSetup, b: CompileSetup) =
 			equivOutput.equiv(a.output, b.output) &&
 			equivOpts.equiv(a.options, b.options) &&
@@ -26,8 +26,8 @@ object CompileSetup
 	implicit val equivFile: Equiv[File] = new Equiv[File] {
 		def equiv(a: File, b: File) = a.getAbsoluteFile == b.getAbsoluteFile
 	}
-	implicit val equivOutput: Equiv[Output] = new Equiv[Output] {
-		def equiv(out1: Output, out2: Output) = (out1, out2) match {
+	implicit val equivOutput: Equiv[APIOutput] = new Equiv[APIOutput] {
+		def equiv(out1: APIOutput, out2: APIOutput) = (out1, out2) match {
 			case (m1: MultipleOutput, m2: MultipleOutput) =>
 				m1.outputGroups zip (m2.outputGroups) forall {
 					case (a,b) => 

--- a/interface/src/main/java/xsbti/compile/DefinesClass.java
+++ b/interface/src/main/java/xsbti/compile/DefinesClass.java
@@ -1,7 +1,5 @@
 package xsbti.compile;
 
-import java.io.File;
-
 /**
 * Determines if an entry on a classpath contains a class.
 */

--- a/interface/src/main/java/xsbti/compile/Output.java
+++ b/interface/src/main/java/xsbti/compile/Output.java
@@ -1,6 +1,4 @@
 package xsbti.compile;
-
-import java.io.File;
 /** Abstract interface denoting the output of the compilation. Inheritors are SingleOutput with a global output directory and
  * MultipleOutput that specifies the output directory per source file.
  */

--- a/ivy/src/main/java/sbt/ResolverAdapter.java
+++ b/ivy/src/main/java/sbt/ResolverAdapter.java
@@ -4,6 +4,7 @@ package sbt;
 	import org.apache.ivy.plugins.resolver.DependencyResolver;
 
 // implements the methods with raw types
+@SuppressWarnings("rawtypes")
 public abstract class ResolverAdapter implements DependencyResolver
 {
     public String[] listTokenValues(String token, Map otherTokenValues) { return new String[0]; }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -259,7 +259,7 @@ object IvyActions
 				resolver.publish(artifact, file, overwrite)
 			resolver.commitPublishTransaction()
 		} catch {
-			case e =>
+			case e: Throwable =>
 				try { resolver.abortPublishTransaction() }
 				finally { throw e }
 		}

--- a/launch/src/main/scala/xsbt/boot/Boot.scala
+++ b/launch/src/main/scala/xsbt/boot/Boot.scala
@@ -34,7 +34,7 @@ object Boot
 			case b: BootException => errorAndExit(b.toString)
 			case r: xsbti.RetrieveException => errorAndExit("Error: " + r.getMessage)
 			case r: xsbti.FullReload => Some(r.arguments)
-			case e =>
+			case e: Throwable =>
 				e.printStackTrace
 				errorAndExit(Pre.prefixError(e.toString))
 		}
@@ -55,7 +55,12 @@ object Boot
 				System.setProperty("sbt.log.format", "true")
 		} catch {
 			case ignore: ClassNotFoundException =>
-			case ex => println("Jansi found on class path but initialization failed: " + ex)
+                        /* The below code intentionally traps everything. It technically shouldn't trap the
+                         * non-StackOverflowError VirtualMachineErrors and AWTError would be weird, but this is PermGen
+                         * mitigation code that should not render sbt completely unusable if jansi initialization fails.
+                         * [From Mark Harrah, https://github.com/sbt/sbt/pull/633#issuecomment-11957578].
+                         */
+			case ex: Throwable => println("Jansi found on class path but initialization failed: " + ex)
 		}
 	}
 }

--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -7,11 +7,11 @@ import scala.collection.mutable
 import org.scalatools.testing._
 import java.net.ServerSocket
 import java.io._
-import Tests._
+import Tests.{Output => TestOutput, _}
 import ForkMain._
 
 private[sbt] object ForkTests {
-	def apply(frameworks: Seq[TestFramework], tests: List[TestDefinition], config: Execution, classpath: Seq[File], javaHome: Option[File], javaOpts: Seq[String], log: Logger): Task[Output]  = {
+	def apply(frameworks: Seq[TestFramework], tests: List[TestDefinition], config: Execution, classpath: Seq[File], javaHome: Option[File], javaOpts: Seq[String], log: Logger): Task[TestOutput]  = {
 		val opts = config.options.toList
 		val listeners = opts flatMap {
 			case Listeners(ls) => ls

--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -35,7 +35,7 @@ object MainLoop
 			case e: xsbti.FullReload =>
 				deleteLastLog(logBacking)
 				throw e // pass along a reboot request
-			case e =>
+			case e: Throwable =>
 				System.err.println("sbt appears to be exiting abnormally.\n  The log file for this session is at " + logBacking.file)
 				deleteLastLog(logBacking)
 				throw e

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -23,7 +23,7 @@ object Sbt extends Build
 		resolvers += Resolver.typesafeIvyRepo("releases"),
 		concurrentRestrictions in Global += Util.testExclusiveRestriction,
 		testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
-		javacOptions in compile ++= Seq("-target", "6", "-source", "6")
+		javacOptions in compile ++= Seq("-target", "6", "-source", "6", "-Xlint", "-Xlint:-serial")
 	)
 
 	lazy val myProvided = config("provided") intransitive;

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -27,7 +27,8 @@ object Util
 	def testedBaseProject(path: File, nameString: String) = baseProject(path, nameString) settings( testDependencies : _*)
 	
 	lazy val javaOnly = Seq[Setting[_]](/*crossPaths := false, */compileOrder := CompileOrder.JavaThenScala, unmanagedSourceDirectories in Compile <<= Seq(javaSource in Compile).join)
-	lazy val base: Seq[Setting[_]] = Seq(scalacOptions ++= Seq("-Xelide-below", "0"), projectComponent) ++ Licensed.settings
+	lazy val base: Seq[Setting[_]] = Seq(scalacOptions ++= Seq("-Xelide-below", "0", "-feature", "-language:implicitConversions", "-language:postfixOps",
+                    "-language:higherKinds", "-language:existentials"), projectComponent) ++ Licensed.settings
 	
 	def testDependencies = libraryDependencies ++= Seq(
 		"org.scalacheck" %% "scalacheck" % "1.10.0" % "test",

--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -34,7 +34,7 @@ object TrapExit
 			catch
 			{
 				case e: TrapExitSecurityException => throw e
-				case x =>
+				case x: Throwable =>
 					code.set(1) //exceptions in the main thread cause the exit code to be 1
 					throw x
 			}

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -83,7 +83,7 @@ final class TestRunner(framework: Framework, loader: ClassLoader, listeners: Seq
 		}
 		catch
 		{
-			case e =>
+			case e: Throwable =>
 				safeListenersCall(_.endGroup(name, e))
 				TestResult.Error
 		}

--- a/util/classfile/src/main/scala/sbt/classfile/Analyze.scala
+++ b/util/classfile/src/main/scala/sbt/classfile/Analyze.scala
@@ -21,7 +21,7 @@ private[sbt] object Analyze
 
 		def load(tpe: String, errMsg: => Option[String]): Option[Class[_]] =
 			try { Some(Class.forName(tpe, false, loader)) }
-			catch { case e => errMsg.foreach(msg => log.warn(msg + " : " +e.toString)); None }
+			catch { case e: Throwable => errMsg.foreach(msg => log.warn(msg + " : " +e.toString)); None }
 
 		val productToSource = new mutable.HashMap[File, File]
 		val sourceToClassFiles = new mutable.HashMap[File, Buffer[ClassFile]]

--- a/util/collection/src/main/scala/sbt/INode.scala
+++ b/util/collection/src/main/scala/sbt/INode.scala
@@ -70,7 +70,7 @@ abstract class EvaluateSettings[Scope]
 	}
 	private[this] def run0(work: => Unit): Unit =
 	{
-		try { work } catch { case e => complete.put( Some(e) ) }
+		try { work } catch { case e: Throwable => complete.put( Some(e) ) }
 		workComplete()
 	}
 

--- a/util/collection/src/test/scala/SettingsTest.scala
+++ b/util/collection/src/test/scala/SettingsTest.scala
@@ -33,7 +33,7 @@ object SettingsTest extends Properties("settings")
 					iterate(value(t-1) )
 			}
 		try { evaluate( setting(chk, iterate(top)) :: Nil); true }
-		catch { case e: Exception => ("Unexpected exception: " + e) |: false }
+		catch { case e: java.lang.Exception => ("Unexpected exception: " + e) |: false }
 	}
 
 // Circular (dynamic) references currently loop infinitely.
@@ -45,7 +45,7 @@ object SettingsTest extends Properties("settings")
 	{
 		val ccr = new CCR(intermediate)
 		try { evaluate( setting(chk, ccr.top) :: Nil); false }
-		catch { case e: Exception => true }
+		catch { case e: java.lang.Exception => true }
 	}
 
 	def tests = 

--- a/util/collection/src/test/scala/SettingsTest.scala
+++ b/util/collection/src/test/scala/SettingsTest.scala
@@ -82,7 +82,7 @@ object SettingsTest extends Properties("settings")
 
 	def evaluate(settings: Seq[Setting[_]]): Settings[Scope] =
 		try { make(settings)(delegates, scopeLocal, showFullKey) }
-		catch { case e => e.printStackTrace; throw e }
+		catch { case e: Throwable => e.printStackTrace; throw e }
 }
 // This setup is a workaround for module synchronization issues 
 final class CCR(intermediate: Int)

--- a/util/control/src/main/scala/sbt/ErrorHandling.scala
+++ b/util/control/src/main/scala/sbt/ErrorHandling.scala
@@ -20,7 +20,7 @@ object ErrorHandling
 		{
 			case ex @ (_: Exception | _: StackOverflowError) => Left(ex)
 			case err @ (_: ThreadDeath | _: VirtualMachineError) => throw err
-			case x => Left(x)
+			case x: Throwable => Left(x)
 		}
 
 	def convert[T](f: => T): Either[Exception, T] =

--- a/util/log/src/main/scala/sbt/BufferedLogger.scala
+++ b/util/log/src/main/scala/sbt/BufferedLogger.scala
@@ -33,7 +33,7 @@ class BufferedLogger(delegate: AbstractLogger) extends BasicLogger
 			clear()
 			result
 		}
-		catch { case e => stopQuietly(); throw e }
+		catch { case e: Throwable => stopQuietly(); throw e }
 	}
 	def stopQuietly() = synchronized { try { stop() } catch { case e: Exception => () } }
 


### PR DESCRIPTION
Fix up or silence spurious Eclipse warnings to leave only relevant ones in. I'm happy to redo this pull request in a different ways, and to try sharing the Eclipse setup (even with the Eclipse plugin, it wasn't trivial to set this up).
