### PR TITLE
tiny documentation fix

### DIFF
--- a/src/sphinx/Detailed-Topics/Scripts.rst
+++ b/src/sphinx/Detailed-Topics/Scripts.rst
@@ -39,7 +39,7 @@ Duplicate your standard ``sbt`` script, which was set up according to
 :doc:`Setup </Getting-Started/Setup>`, as ``scalas`` and ``screpl`` (or
 whatever names you like).
 
-``scalas`` is the script runner and should use ``sbt.ConsoleMain`` as
+``scalas`` is the script runner and should use ``sbt.ScriptMain`` as
 the main class, by adding the ``-Dsbt.main.class=sbt.ScriptMain``
 parameter to the ``java`` command. Its command line should look like:
 


### PR DESCRIPTION
The main class should be "sbt.ScriptMain" in the paragraph about the scalas
