### PR TITLE
Introduce incremental compiler options.

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -22,7 +22,7 @@ object IncrementalCompile
 	def doCompile(compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, internalMap: File => Option[File], externalAPI: (File, String) => Option[Source], current: ReadStamps, output: Output) = (srcs: Set[File], changes: DependencyChanges) => {
 		val callback = new AnalysisCallback(internalMap, externalAPI, current, output)
 		compile(srcs, changes, callback)
-		callback.get 
+		callback.get
 	}
 	def getExternalAPI(entry: String => Option[File], forEntry: File => Option[Analysis]): (File, String) => Option[Source] =
 	 (file: File,className: String) =>
@@ -49,9 +49,9 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 	}
 
 	override def toString = ( List("APIs", "Binary deps", "Products", "Source deps") zip List(apis, binaryDeps, classes, sourceDeps)).map { case (label, map) => label + "\n\t" + map.mkString("\n\t") }.mkString("\n")
-	
+
 	import collection.mutable.{HashMap, HashSet, ListBuffer, Map, Set}
-	
+
 	private[this] val apis = new HashMap[File, (Int, SourceAPI)]
 	private[this] val unreporteds = new HashMap[File, ListBuffer[Problem]]
 	private[this] val reporteds = new HashMap[File, ListBuffer[Problem]]
@@ -113,13 +113,13 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 				// dependency is some other binary on the classpath
 				externalBinaryDependency(classFile, name, source)
 		}
-		
+
 	def generatedClass(source: File, module: File, name: String) =
 	{
 		add(classes, source, (module, name))
 		classToSource.put(module, source)
 	}
-	
+
 	def api(sourceFile: File, source: SourceAPI) {
 		import xsbt.api.{APIUtil, HashAPI}
 		if (APIUtil.hasMacro(source)) macroSources += sourceFile
@@ -128,7 +128,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 
 	def endSource(sourcePath: File): Unit =
 		assert(apis.contains(sourcePath))
-	
+
 	def get: Analysis = addCompilation( addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) ) )
 	def addProducts(base: Analysis): Analysis = addAll(base, classes) { case (a, src, (prod, name)) => a.addProduct(src, prod, current product prod, name ) }
 	def addBinaries(base: Analysis): Analysis = addAll(base, binaryDeps)( (a, src, bin) => a.addBinaryDep(src, bin, binaryClassName(bin), current binary bin) )
@@ -145,7 +145,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 	def getOrNil[A,B](m: collection.Map[A, Seq[B]], a: A): Seq[B] = m.get(a).toList.flatten
 	def addExternals(base: Analysis): Analysis = (base /: extSrcDeps) { case (a, (source, name, api)) => a.addExternalDep(source, name, api) }
 	def addCompilation(base: Analysis): Analysis = base.copy(compilations = base.compilations.add(compilation))
-		
+
 	def addAll[A,B](base: Analysis, m: Map[A, Set[B]])( f: (Analysis, A, B) => Analysis): Analysis =
 		(base /: m) { case (outer, (a, bs)) =>
 			(outer /: bs) { (inner, b) =>

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -12,7 +12,11 @@ import java.io.File
 
 object IncrementalCompile
 {
-	def apply(sources: Set[File], entry: String => Option[File], compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, previous: Analysis, forEntry: File => Option[Analysis], output: Output, log: Logger): (Boolean, Analysis) =
+	def apply(sources: Set[File], entry: String => Option[File],
+	    compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit,
+	    previous: Analysis,
+	    forEntry: File => Option[Analysis],
+	    output: Output, log: Logger): (Boolean, Analysis) =
 	{
 		val current = Stamps.initial(Stamp.exists, Stamp.hash, Stamp.lastModified)
 		val internalMap = (f: File) => previous.relations.produced(f).headOption

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -16,12 +16,13 @@ object IncrementalCompile
 	    compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit,
 	    previous: Analysis,
 	    forEntry: File => Option[Analysis],
-	    output: Output, log: Logger): (Boolean, Analysis) =
+	    output: Output, log: Logger,
+	    options: IncOptions): (Boolean, Analysis) =
 	{
 		val current = Stamps.initial(Stamp.exists, Stamp.hash, Stamp.lastModified)
 		val internalMap = (f: File) => previous.relations.produced(f).headOption
 		val externalAPI = getExternalAPI(entry, forEntry)
-		Incremental.compile(sources, entry, previous, current, forEntry, doCompile(compile, internalMap, externalAPI, current, output), log)
+		Incremental.compile(sources, entry, previous, current, forEntry, doCompile(compile, internalMap, externalAPI, current, output), log, options)
 	}
 	def doCompile(compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, internalMap: File => Option[File], externalAPI: (File, String) => Option[Source], current: ReadStamps, output: Output) = (srcs: Set[File], changes: DependencyChanges) => {
 		val callback = new AnalysisCallback(internalMap, externalAPI, current, output)

--- a/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
@@ -1,0 +1,87 @@
+package sbt.inc
+
+/**
+ * Case class that represents all configuration options for incremental compiler.
+ *
+ * Those are options that configure incremental compiler itself and not underlying
+ * Java/Scala compiler.
+ */
+case class IncOptions(
+    /** After which step include whole transitive closure of invalidated source files. */
+    val transitiveStep: Int,
+    /**
+     * What's the fraction of invalidated source files when we switch to recompiling
+     * all files and giving up incremental compilation altogether. That's useful in
+     * cases when probability that we end up recompiling most of source files but
+     * in multiple steps is high. Multi-step incremental recompilation is slower
+     * than recompiling everything in one step.
+     */
+    val recompileAllFraction: Double,
+    /** Print very detail information about relations (like dependencies between source files). */
+    val relationsDebug: Boolean,
+    /**
+     * Enable tools for debugging API changes. At the moment that option is unused but in the
+     * future it will enable for example:
+     *   - disabling API hashing and API minimization (potentially very memory consuming)
+     *   - dumping textual API representation into files
+     */
+    val apiDebug: Boolean,
+    /**
+     * The directory where we dump textual representation of APIs. This method might be called
+     * only if apiDebug returns true. This is unused option at the moment as the needed functionality
+     * is not implemented yet.
+     */
+    val apiDumpDirectory: Option[java.io.File])
+
+object IncOptions {
+	val Default = IncOptions(
+		transitiveStep = 2,
+		recompileAllFraction = 0.5,
+		relationsDebug = false,
+		apiDebug = false,
+		apiDumpDirectory = None)
+
+	val transitiveStepKey       = "transitiveStep"
+	val recompileAllFractionKey = "recompileAllFraction"
+	val relationsDebugKey       = "relationsDebug"
+	val apiDebugKey             = "apiDebug"
+	val apiDumpDirectoryKey     = "apiDumpDirectory"
+
+	def fromStringMap(m: java.util.Map[String, String]): IncOptions = {
+		// all the code below doesn't look like idiomatic Scala for a good reason: we are working with Java API
+		def getTransitiveStep: Int = {
+			val k = transitiveStepKey
+			if (m.containsKey(k)) m.get(k).toInt else Default.transitiveStep
+		}
+		def getRecompileAllFraction: Double = {
+			val k = recompileAllFractionKey
+			if (m.containsKey(k)) m.get(k).toDouble else Default.recompileAllFraction
+		}
+		def getRelationsDebug: Boolean = {
+			val k = relationsDebugKey
+			if (m.containsKey(k)) m.get(k).toBoolean else Default.relationsDebug
+		}
+		def getApiDebug: Boolean = {
+			val k = apiDebugKey
+			if (m.containsKey(k)) m.get(k).toBoolean else Default.apiDebug
+		}
+		def getApiDumpDirectory: Option[java.io.File] = {
+			val k = apiDumpDirectoryKey
+			if (m.containsKey(k))
+				Some(new java.io.File(m.get(k)))
+			else None
+		}
+
+		IncOptions(getTransitiveStep, getRecompileAllFraction, getRelationsDebug, getApiDebug, getApiDumpDirectory)
+	}
+
+	def toStringMap(o: IncOptions): java.util.Map[String, String] = {
+		val m = new java.util.HashMap[String, String]
+		m.put(transitiveStepKey, o.transitiveStep.toString)
+		m.put(recompileAllFractionKey, o.recompileAllFraction.toString)
+		m.put(relationsDebugKey, o.relationsDebug.toString)
+		m.put(apiDebugKey, o.apiDebug.toString)
+		o.apiDumpDirectory.foreach(f => m.put(apiDumpDirectoryKey, f.toString))
+		m
+	}
+}

--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -16,7 +16,13 @@ object Incremental
 	final val TransitiveStep = 2
 	final val RecompileAllFraction = 0.5
 
-	def compile(sources: Set[File], entry: String => Option[File], previous: Analysis, current: ReadStamps, forEntry: File => Option[Analysis], doCompile: (Set[File], DependencyChanges) => Analysis, log: Logger)(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
+	def compile(sources: Set[File],
+	    entry: String => Option[File],
+	    previous: Analysis,
+	    current: ReadStamps,
+	    forEntry: File => Option[Analysis],
+	    doCompile: (Set[File], DependencyChanges) => Analysis,
+	    log: Logger)(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
 	{
 		val initialChanges = changedInitial(entry, sources, previous, current, forEntry)
 		val binaryChanges = new DependencyChanges {
@@ -33,7 +39,8 @@ object Incremental
 	val incDebugProp = "xsbt.inc.debug"
 	// TODO: the Analysis for the last successful compilation should get returned + Boolean indicating success
 	// TODO: full external name changes, scopeInvalidations
-	def cycle(invalidatedRaw: Set[File], allSources: Set[File], binaryChanges: DependencyChanges, previous: Analysis, doCompile: (Set[File], DependencyChanges) => Analysis, cycleNum: Int, log: Logger): Analysis =
+	def cycle(invalidatedRaw: Set[File], allSources: Set[File], binaryChanges: DependencyChanges, previous: Analysis,
+	    doCompile: (Set[File], DependencyChanges) => Analysis, cycleNum: Int, log: Logger): Analysis =
 		if(invalidatedRaw.isEmpty)
 			previous
 		else

--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -101,7 +101,7 @@ object Incremental
 	{
 		val previous = previousAnalysis.stamps
 		val previousAPIs = previousAnalysis.apis
-		
+
 		val srcChanges = changes(previous.allInternalSources.toSet, sources,  f => !equivS.equiv( previous.internalSource(f), current.internalSource(f) ) )
 		val removedProducts = previous.allProducts.filter( p => !equivS.equiv( previous.product(p), current.product(p) ) ).toSet
 		val binaryDepChanges = previous.allBinaries.filter( externalBinaryModified(entry, forEntry, previous, current)).toSet
@@ -158,7 +158,7 @@ object Incremental
 
 	/** Returns the transitive source dependencies of `initial`, excluding the files in `initial` in most cases.
 	* In three-stage incremental compilation, the `initial` files are the sources from step 2 that had API changes.
-	* Because strongly connected components (cycles) are included in step 2, the files with API changes shouldn't 
+	* Because strongly connected components (cycles) are included in step 2, the files with API changes shouldn't
 	* need to be compiled in step 3 if their dependencies haven't changed.  If there are new cycles introduced after
 	* step 2, these can require step 2 sources to be included in step 3 recompilation.
 	*/

--- a/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
@@ -25,22 +25,45 @@ final class CompileConfiguration(val sources: Seq[File], val classpath: Seq[File
 
 class AggressiveCompile(cacheFile: File)
 {
-	def apply(compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, sources: Seq[File], classpath: Seq[File], output: Output, cache: GlobalsCache, progress: Option[CompileProgress] = None, options: Seq[String] = Nil, javacOptions: Seq[String] = Nil, analysisMap: File => Option[Analysis] = { _ => None }, definesClass: DefinesClass = Locate.definesClass _, reporter: Reporter, compileOrder: CompileOrder = Mixed, skip: Boolean = false)(implicit log: Logger): Analysis =
+	def apply(compiler: AnalyzingCompiler,
+	    javac: xsbti.compile.JavaCompiler,
+	    sources: Seq[File], classpath: Seq[File],
+	    output: Output,
+	    cache: GlobalsCache,
+	    progress: Option[CompileProgress] = None,
+	    options: Seq[String] = Nil,
+	    javacOptions: Seq[String] = Nil,
+	    analysisMap: File => Option[Analysis] = { _ => None },
+	    definesClass: DefinesClass = Locate.definesClass _,
+	    reporter: Reporter,
+	    compileOrder: CompileOrder = Mixed,
+	    skip: Boolean = false)(implicit log: Logger): Analysis =
 	{
 		val setup = new CompileSetup(output, new CompileOptions(options, javacOptions), compiler.scalaInstance.actualVersion, compileOrder)
-		compile1(sources, classpath, setup, progress, store, analysisMap, definesClass, compiler, javac, reporter, skip, cache)
+		compile1(sources, classpath, setup, progress, store, analysisMap, definesClass,
+		    compiler, javac, reporter, skip, cache)
 	}
 
 	def withBootclasspath(args: CompilerArguments, classpath: Seq[File]): Seq[File] =
 		args.bootClasspathFor(classpath) ++ args.finishClasspath(classpath)
 
-	def compile1(sources: Seq[File], classpath: Seq[File], setup: CompileSetup, progress: Option[CompileProgress], store: AnalysisStore, analysis: File => Option[Analysis], definesClass: DefinesClass, compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, reporter: Reporter, skip: Boolean, cache: GlobalsCache)(implicit log: Logger): Analysis =
+	def compile1(sources: Seq[File],
+	    classpath: Seq[File],
+	    setup: CompileSetup, progress: Option[CompileProgress],
+		store: AnalysisStore,
+		analysis: File => Option[Analysis],
+		definesClass: DefinesClass,
+		compiler: AnalyzingCompiler,
+		javac: xsbti.compile.JavaCompiler,
+		reporter: Reporter, skip: Boolean,
+		cache: GlobalsCache)(implicit log: Logger): Analysis =
 	{
 		val (previousAnalysis, previousSetup) = extract(store.get())
 		if(skip)
 			previousAnalysis
 		else {
-			val config = new CompileConfiguration(sources, classpath, previousAnalysis, previousSetup, setup, progress, analysis, definesClass, reporter, compiler, javac, cache)
+			val config = new CompileConfiguration(sources, classpath, previousAnalysis, previousSetup, setup,
+			    progress, analysis, definesClass, reporter, compiler, javac, cache)
 			val (modified, result) = compile2(config)
 			if(modified)
 				store.set(result, setup)

--- a/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
@@ -56,7 +56,7 @@ class AggressiveCompile(cacheFile: File)
 		val cArgs = new CompilerArguments(compiler.scalaInstance, compiler.cp)
 		val searchClasspath = explicitBootClasspath(options.options) ++ withBootclasspath(cArgs, absClasspath)
 		val entry = Locate.entry(searchClasspath, definesClass)
-		
+
 		val compile0 = (include: Set[File], changes: DependencyChanges, callback: AnalysisCallback) => {
 			val outputDirs = outputDirectories(output)
 			outputDirs foreach (IO.createDirectory)
@@ -111,7 +111,7 @@ class AggressiveCompile(cacheFile: File)
 				}
 			if(order == JavaThenScala) { compileJava(); compileScala() } else { compileScala(); compileJava() }
 		}
-		
+
 		val sourcesSet = sources.toSet
 		val analysis = previousSetup match {
 			case Some(previous) if equiv.equiv(previous, currentSetup) => previousAnalysis

--- a/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
@@ -1,7 +1,7 @@
 package sbt.compiler
 
 	import sbt.CompileSetup
-	import sbt.inc.Analysis
+	import sbt.inc.{Analysis, IncOptions}
 	import xsbti.{Logger, Maybe}
 	import xsbti.compile._
 
@@ -17,7 +17,9 @@ object IC extends IncrementalCompiler[Analysis, AnalyzingCompiler]
 		val agg = new AggressiveCompile(setup.cacheFile)
 		val aMap = (f: File) => m2o(analysisMap(f))
 		val defClass = (f: File) => { val dc = definesClass(f); (name: String) => dc.apply(name) }
-		agg(scalac, javac, sources, classpath, output, cache, m2o(progress), scalacOptions, javacOptions, aMap, defClass, reporter, order, skip)(log)
+		val incOptions = IncOptions.fromStringMap(incrementalCompilerOptions)
+		agg(scalac, javac, sources, classpath, output, cache, m2o(progress), scalacOptions, javacOptions, aMap,
+		    defClass, reporter, order, skip, incOptions)(log)
 	}
 
 	private[this] def m2o[S](opt: Maybe[S]): Option[S] = if(opt.isEmpty) None else Some(opt.get)

--- a/interface/src/main/java/xsbti/compile/Setup.java
+++ b/interface/src/main/java/xsbti/compile/Setup.java
@@ -1,6 +1,8 @@
 package xsbti.compile;
 
 import java.io.File;
+import java.util.Map;
+
 import xsbti.Maybe;
 import xsbti.Reporter;
 
@@ -30,4 +32,16 @@ public interface Setup<Analysis>
 
 	/** The reporter that should be used to report scala compilation to. */
 	Reporter reporter();
+
+	/**
+	 * Returns incremental compiler options.
+	 *
+	 * @see sbt.inc.IncOptions for details
+	 *
+	 * You can get default options by calling <code>sbt.inc.IncOptions.toStringMap(sbt.inc.IncOptions.Default)</code>.
+	 *
+	 * In the future, we'll extend API in <code>xsbti</code> to provide factory methods that would allow to obtain
+	 * defaults values so one can depend on <code>xsbti</code> package only.
+	 **/
+	Map<String, String> incrementalCompilerOptions();
 }

--- a/interface/src/main/java/xsbti/compile/Setup.java
+++ b/interface/src/main/java/xsbti/compile/Setup.java
@@ -19,7 +19,7 @@ public interface Setup<Analysis>
 	boolean skip();
 
 	/** The file used to cache information across compilations.
-	* This file can be removed to force a full recompilation. 
+	* This file can be removed to force a full recompilation.
 	* The file should be unique and not shared between compilations. */
 	File cacheFile();
 

--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -76,7 +76,8 @@ object Compiler
 			import in.incSetup._
 
 		val agg = new AggressiveCompile(cacheFile)
-		agg(scalac, javac, sources, classpath, CompileOutput(classesDirectory), cache, None, options, javacOptions, analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip)(log)
+		agg(scalac, javac, sources, classpath, CompileOutput(classesDirectory), cache, None, options, javacOptions,
+		    analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip)(log)
 	}
 
 	private[sbt] def foldMappers[A](mappers: Seq[A => Option[A]]) =

--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -17,7 +17,7 @@ object Compiler
 
 	final case class Inputs(compilers: Compilers, config: Options, incSetup: IncSetup)
 	final case class Options(classpath: Seq[File], sources: Seq[File], classesDirectory: File, options: Seq[String], javacOptions: Seq[String], maxErrors: Int, sourcePositionMapper: Position => Position, order: CompileOrder)
-	final case class IncSetup(analysisMap: File => Option[Analysis], definesClass: DefinesClass, skip: Boolean, cacheFile: File, cache: GlobalsCache)
+	final case class IncSetup(analysisMap: File => Option[Analysis], definesClass: DefinesClass, skip: Boolean, cacheFile: File, cache: GlobalsCache, incOptions: IncOptions)
 	final case class Compilers(scalac: AnalyzingCompiler, javac: JavaTool)
 
 	@deprecated("Use the other inputs variant.", "0.12.0")
@@ -27,7 +27,7 @@ object Compiler
 		val classesDirectory = outputDirectory / "classes"
 		val cacheFile = outputDirectory / "cache_old_style"
 		val augClasspath = classesDirectory.asFile +: classpath
-		val incSetup = IncSetup(Map.empty, definesClass, false, cacheFile, CompilerCache.fresh)
+		val incSetup = IncSetup(Map.empty, definesClass, false, cacheFile, CompilerCache.fresh, IncOptions.Default)
 		inputs(augClasspath, sources, classesDirectory, options, javacOptions, maxErrors, Nil, order)(compilers, incSetup, log)
 	}
 	def inputs(classpath: Seq[File], sources: Seq[File], classesDirectory: File, options: Seq[String], javacOptions: Seq[String], maxErrors: Int, sourcePositionMappers: Seq[Position => Option[Position]], order: CompileOrder)(implicit compilers: Compilers, incSetup: IncSetup, log: Logger): Inputs =
@@ -77,7 +77,7 @@ object Compiler
 
 		val agg = new AggressiveCompile(cacheFile)
 		agg(scalac, javac, sources, classpath, CompileOutput(classesDirectory), cache, None, options, javacOptions,
-		    analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip)(log)
+		    analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip, incOptions)(log)
 	}
 
 	private[sbt] def foldMappers[A](mappers: Seq[A => Option[A]]) =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -312,7 +312,7 @@ object Defaults extends BuildCommon
 	def scalaInstanceFromUpdate: Initialize[Task[ScalaInstance]] = Def.task {
 		val toolReport = update.value.configuration(Configurations.ScalaTool.name) getOrElse
 			error(noToolConfiguration(managedScalaInstance.value))
-		def files(id: String) = 
+		def files(id: String) =
 			for { m <- toolReport.modules if m.module.name == id;
 				(art, file) <- m.artifacts if art.`type` == Artifact.DefaultType }
 			yield file
@@ -610,7 +610,7 @@ object Defaults extends BuildCommon
 			val hasJava = srcs.exists(_.name.endsWith(".java"))
 			val cp = in.config.classpath.toList.filterNot(_ == in.config.classesDirectory)
 			val label = nameForSrc(config.name)
-			val (options, runDoc) = 
+			val (options, runDoc) =
 				if(hasScala)
 					(in.config.options ++ Opts.doc.externalAPI(xapis), Doc.scaladoc(label, s.cacheDirectory / "scala", in.compilers.scalac))
 				else if(hasJava)
@@ -859,7 +859,7 @@ object Classpaths
 		fullResolvers <<= (projectResolver,externalResolvers,sbtPlugin,sbtResolver,bootResolvers,overrideBuildResolvers) map { (proj,rs,isPlugin,sbtr, boot, overrideFlag) =>
 			boot match {
 				case Some(repos) if overrideFlag => proj +: repos
-				case _ => 
+				case _ =>
 					val base = if(isPlugin) sbtr +: sbtPluginReleases +: rs else rs
 					proj +: base
 			}
@@ -1079,7 +1079,7 @@ object Classpaths
 	def projectDependenciesTask: Initialize[Task[Seq[ModuleID]]] =
 		(thisProjectRef, settings, buildDependencies) map { (ref, data, deps) =>
 			deps.classpath(ref) flatMap { dep => (projectID in dep.project) get data map {
-				_.copy(configurations = dep.configuration, explicitArtifacts = Nil) } 
+				_.copy(configurations = dep.configuration, explicitArtifacts = Nil) }
 			}
 	}
 
@@ -1319,11 +1319,11 @@ object Classpaths
 	def bootRepositories(app: xsbti.AppConfiguration): Option[Seq[Resolver]] =
 		try { Some(app.provider.scalaProvider.launcher.ivyRepositories.toSeq map bootRepository) }
 		catch { case _: NoSuchMethodError => None }
-	
+
 	private[this] def mavenCompatible(ivyRepo: xsbti.IvyRepository): Boolean =
 		try { ivyRepo.mavenCompatible }
 		catch { case _: NoSuchMethodError => false }
-		
+
 	private[this] def bootRepository(repo: xsbti.Repository): Resolver =
 	{
 		import xsbti.Predefined

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -204,6 +204,7 @@ object Defaults extends BuildCommon
 		compilersSetting,
 		javacOptions in GlobalScope :== Nil,
 		scalacOptions in GlobalScope :== Nil,
+		incOptions in GlobalScope :== sbt.inc.IncOptions.Default,
 		scalaInstance <<= scalaInstanceTask,
 		scalaVersion in GlobalScope := appConfiguration.value.provider.scalaProvider.version,
 		scalaBinaryVersion in GlobalScope := binaryScalaVersion(scalaVersion.value),
@@ -643,8 +644,8 @@ object Defaults extends BuildCommon
 
 	def compileTask = (compileInputs in compile, streams) map { (i,s) => Compiler(i,s.log) }
 	def compileIncSetupTask =
-		(dependencyClasspath, skip in compile, definesClass, compilerCache, streams) map { (cp, skip, definesC, cache, s) =>
-			Compiler.IncSetup(analysisMap(cp), definesC, skip, s.cacheDirectory / "inc_compile", cache)
+		(dependencyClasspath, skip in compile, definesClass, compilerCache, streams, incOptions) map { (cp, skip, definesC, cache, s, incOptions) =>
+			Compiler.IncSetup(analysisMap(cp), definesC, skip, s.cacheDirectory / "inc_compile", cache, incOptions)
 		}
 	def compileInputsSettings: Seq[Setting[_]] =
 		Seq(compileInputs := {
@@ -1017,7 +1018,7 @@ object Classpaths
 		val si = Defaults.unmanagedScalaInstanceOnly.value.map(si => (si, scalaOrganization.value))
 		val show = Reference.display(thisProjectRef.value)
 		cachedUpdate(s.cacheDirectory, show, ivyModule.value, updateConfiguration.value, si, skip = (skip in update).value, force = isRoot, depsUpdated = depsUpdated, log = s.log)
-	} 
+	}
 
 	def cachedUpdate(cacheFile: File, label: String, module: IvySbt#Module, config: UpdateConfiguration, scalaInstance: Option[(ScalaInstance, String)], skip: Boolean, force: Boolean, depsUpdated: Boolean, log: Logger): UpdateReport =
 	{

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -128,6 +128,7 @@ object Keys
 	val scaladocOptions = TaskKey[Seq[String]]("scaladoc-options", "Options for Scaladoc.", DTask)
 	val scalacOptions = TaskKey[Seq[String]]("scalac-options", "Options for the Scala compiler.", BPlusTask)
 	val javacOptions = TaskKey[Seq[String]]("javac-options", "Options for the Java compiler.", BPlusTask)
+	val incOptions = TaskKey[sbt.inc.IncOptions]("inc-options", "Options for the incremental compiler.", BTask)
 	val compileOrder = SettingKey[CompileOrder]("compile-order", "Configures the order in which Java and sources within a single compilation are compiled.  Valid values are: JavaThenScala, ScalaThenJava, or Mixed.", BPlusSetting)
 	val initialCommands = SettingKey[String]("initial-commands", "Initial commands to execute when starting up the Scala interpreter.", AMinusSetting)
 	val cleanupCommands = SettingKey[String]("cleanup-commands", "Commands to execute before the Scala interpreter exits.", BMinusSetting)


### PR DESCRIPTION
Introduce a way to configure incremental compiler itself instead
of underlying Java/Scala compiler.

Check 9cfbeb5 for details.

NOTE: This is API breaking change that is likely to affect both zinc and Eclipse IDE so CCing @dragos and @pvlugter. The fix should be very easy as I provide the right defaults. See `sbt.inc.IncOptions.Default`.
