### PR TITLE
switch dispatch to dispatch.classic to avoid collisions with plugins which use newer versions of dispatch (0.9+)

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -43,8 +43,8 @@ object Release extends Build
 	def deployLauncher(launcher: ScopedTask[File]) =
 		(launcher, launcherRemotePath, credentials, remoteBase, streams) map { (launchJar, remotePath, creds, base, s) =>
 			val (uname, pwd) = getCredentials(creds, s.log)
-			val request = dispatch.url(base) / remotePath <<< (launchJar, BinaryType) as (uname, pwd)
-			val http = new dispatch.Http
+			val request = dispatch.classic.url(base) / remotePath <<< (launchJar, BinaryType) as (uname, pwd)
+			val http = new dispatch.classic.Http
 			try { http(request.as_str) } finally { http.shutdown() }
 		}
 	def getCredentials(cs: Seq[Credentials], log: Logger): (String, String) =

--- a/project/p.sbt
+++ b/project/p.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-	"net.databinder" %% "dispatch-http" % "0.8.8",
+	"net.databinder" %% "dispatch-http" % "0.8.9",
 	"org.jsoup" % "jsoup" % "1.7.1"
 )
 


### PR DESCRIPTION
I have a plugin registered globally which uses newer version of dispatch (https://github.com/rtimush/sbt-updates) and starting sbt on the sbt project fails with the following error

   Detected sbt version 0.12.2
   Starting sbt: invoke with -help for other options
   [info] Loading global plugins from /home/jozic/.sbt/plugins
   [info] Loading project definition from /home/jozic/projects/sbt/project
   [info] Updating {file:/home/jozic/projects/sbt/project/}default-4a7e17...
   [info] Resolving org.scala-sbt#precompiled-2_10_0;0.12.2 ...
   [info] downloading       http://oss.sonatype.org/content/repositories/releases/net/databinder/dispatch/dispatch-core_2.9.2/0.9.5/dispatch-core_2.9.2-0.9.5.jar ...
   [info]   [SUCCESSFUL ] net.databinder.dispatch#dispatch-core_2.9.2;0.9.5!dispatch-core_2.9.2.jar (1092ms)
   [info] Done updating.
   [info] Compiling 8 Scala sources to /home/jozic/projects/sbt/project/target/scala-   2.9.2/sbt-0.12/classes...
   [error] /home/jozic/projects/sbt/project/Release.scala:46: value / is not a member of com.ning.http.client.RequestBuilder
   [error]          val request = dispatch.url(base) / remotePath <<< (launchJar, BinaryType) as (uname, pwd)
   [error]                                           ^
   [error] /home/jozic/projects/sbt/project/Release.scala:34: type mismatch;
   [error]  found   : sbt.Project.Initialize[sbt.Task[Nothing]]
   [error]  required: sbt.Project.Initialize[sbt.Task[String]]
   [error]      publishLauncher <<= deployLauncher(launcher),
   [error]                                        ^
   [error] two errors found
   [error](compile:compile) Compilation failed
   Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q
