### PR TITLE
Fix link to sbt-git plugin

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -159,7 +159,7 @@ System plugins
    https://github.com/steppenwells/sbt-sh
 -  cronish-sbt (interval sbt / shell command execution):
    https://github.com/philcali/cronish-sbt
--  git (executes git commands): https://github.com/sbt/sbt-git-plugin
+-  git (executes git commands): https://github.com/sbt/sbt-git
 -  svn (execute svn commands): https://github.com/xuwei-k/sbtsvn
 -  sbt-groll (sbt plugin to navigate the Git history):
    https://github.com/sbt/sbt-groll


### PR DESCRIPTION
The old url https://github.com/sbt/sbt-git-plugin resulted in an 404 error. Changed to https://github.com/sbt/sbt-git which seems to be the correct url for that plugin.
