### PR TITLE
Switch from JLine 1.0 to 2.10.

### DIFF
--- a/launch/src/main/scala/xsbt/boot/SimpleReader.scala
+++ b/launch/src/main/scala/xsbt/boot/SimpleReader.scala
@@ -3,7 +3,7 @@
  */
 package xsbt.boot
 
-import jline.ConsoleReader
+import jline.console.ConsoleReader
 abstract class JLine
 {
 	protected[this] val reader: ConsoleReader
@@ -17,12 +17,12 @@ abstract class JLine
 }
 private object JLine
 {
-	def terminal = jline.Terminal.getTerminal
+	def terminal = jline.TerminalFactory.get
 	def createReader() =
 		terminal.synchronized
 		{
 			val cr = new ConsoleReader
-			terminal.enableEcho()
+			terminal.setEchoEnabled(true)
 			cr.setBellEnabled(false)
 			cr
 		}
@@ -31,9 +31,9 @@ private object JLine
 		val t = terminal
 		t.synchronized
 		{
-			t.disableEcho()
+			t.setEchoEnabled(false)
 			try { action }
-			finally { t.enableEcho() }
+			finally { t.setEchoEnabled(true) }
 		}
 	}
 }

--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -56,7 +56,7 @@ object Graph
 	// [info]   |
 	// [info]   +-quux
 	def toAscii[A](top: A, children: A => Seq[A], display: A => String): String = {
-		val maxColumn = JLine.usingTerminal(_.getTerminalWidth) - 8
+		val maxColumn = JLine.usingTerminal(_.getWidth) - 8
 		val twoSpaces = " " + " " // prevent accidentally being converted into a tab
 		def limitLine(s: String): String =
 			if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -155,7 +155,7 @@ object %s {
 object Common
 {
 	def lib(m: ModuleID) = libraryDependencies += m
-	lazy val jlineDep = "jline" % "jline" % "1.0" intransitive()
+	lazy val jlineDep = "jline" % "jline" % "2.10" intransitive()
 	lazy val jline = lib(jlineDep)
 	lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0-rc1")
 	lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")

--- a/util/log/src/main/scala/sbt/ConsoleLogger.scala
+++ b/util/log/src/main/scala/sbt/ConsoleLogger.scala
@@ -109,9 +109,9 @@ object ConsoleLogger
 
 	private[this] def ansiSupported =
 		try {
-			val terminal = jline.Terminal.getTerminal
-			terminal.enableEcho() // #460
-			terminal.isANSISupported
+			val terminal = jline.TerminalFactory.get
+			terminal.setEchoEnabled(true) // #460
+			terminal.isAnsiSupported
 		} catch {
 			case e: Exception => !isWindows
 		}


### PR DESCRIPTION
sbt and scala shells behave differently, since the former uses JLine 1.0, while the latter uses a customized version of JLine 2. This is particularly true on FreeBSD, whose terminal is not supported by JLine 1.0. Here is my attempt to switch sbt to use the modern JLine 2 API.
