### PR TITLE
Test case for dependencies involving implicits and higher-kinds.

### DIFF
--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/A1.scala
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/A1.scala
@@ -1,0 +1,3 @@
+import scala.languageFeature.higherKinds
+trait A
+object A

--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/A2.scala
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/A2.scala
@@ -1,0 +1,5 @@
+import scala.languageFeature.higherKinds
+trait A
+object A {
+  implicit def m[MM[_], A]: MM[A] = ???
+}

--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/B.scala
@@ -1,0 +1,2 @@
+
+trait B extends A

--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/C.scala
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/C.scala
@@ -1,0 +1,3 @@
+object Test {
+  implicitly[M[B]]
+}

--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/M.scala
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/changes/M.scala
@@ -1,0 +1,6 @@
+import scala.languageFeature.higherKinds
+
+class M[A](a: A)
+object M {
+  implicit def m[MM[_], A]: MM[A] = ???
+}

--- a/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/pending
+++ b/sbt/src/sbt-test/source-dependencies/implicit-search-higher-kinded/pending
@@ -1,0 +1,14 @@
+# Tests if dependencies on implicit scope are tracked properly
+# We use higher kinded types in order to make type checker to
+# infer more and thus obscure true dependencies
+$ copy-file changes/A1.scala A.scala
+$ copy-file changes/B.scala B.scala
+$ copy-file changes/M.scala M.scala
+$ copy-file changes/C.scala C.scala
+> compile
+
+$ copy-file changes/A2.scala A.scala
+-> compile
+
+> clean
+-> compile


### PR DESCRIPTION
This is a pending test case for sbt/sbt#686 which tests if dependencies
are track properly when it comes to implicit scope.

This test is marked as pending because sbt does not track
dependencies correctly in this case.
