### PR TITLE
Mark `source-dependencies/import` test as pending.

### DIFF
--- a/sbt/src/sbt-test/source-dependencies/import/pending
+++ b/sbt/src/sbt-test/source-dependencies/import/pending
@@ -4,5 +4,5 @@
 $ copy-file changes/A.scala A.scala
 
 # 'import a.b' should now fail in B.scala
-# disabled because scalac doesn't track this dependency
-#-> compile
+# succeeds because scalac doesn't track this dependency
+-> compile


### PR DESCRIPTION
Instead of commenting out failing part of a test case just mark
the whole test case as pending.
