### PR TITLE
Updated the host name used for publishing artifacts to the community repository

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -28,7 +28,8 @@ You'll also need to add your credentials somewhere.  For example, you might use 
  
 ::
 
-     credentials += Credentials("Artifactory Realm", "repo.scala-sbt.org", "jsuereth", "@my encrypted password@")
+     credentials += Credentials("Artifactory Realm", 
+ "scalasbt.artifactoryonline.com", "@user name@", "@my encrypted password@")
  
 Where ``@my encrypted password@`` is actually obtained using the following `instructions <http://wiki.jfrog.org/confluence/display/RTF/Centrally+Secure+Passwords>`_.
  


### PR DESCRIPTION
I had a minor problem with the instructions for publishing artifacts on the community repository. It seems to me that the host for the credentials should be different (otherwise
I was getting an authentication error). In this PR I set the host name that worked for me.
