### PR TITLE
Add a pending test case for private var declared in a trait.

### DIFF
--- a/sbt/src/sbt-test/source-dependencies/trait-private-var/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/trait-private-var/A.scala
@@ -1,0 +1,3 @@
+trait A {
+	def bar: Int = 0
+}

--- a/sbt/src/sbt-test/source-dependencies/trait-private-var/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/trait-private-var/B.scala
@@ -1,0 +1,3 @@
+object B extends A {
+	def main(args: Array[String]): Unit = println(bar)
+}

--- a/sbt/src/sbt-test/source-dependencies/trait-private-var/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/trait-private-var/changes/A.scala
@@ -1,0 +1,5 @@
+trait A {
+	private var foo = 12
+	// we need to access foo to trigger AbstractMethodError
+	def bar: Int = foo
+}

--- a/sbt/src/sbt-test/source-dependencies/trait-private-var/pending
+++ b/sbt/src/sbt-test/source-dependencies/trait-private-var/pending
@@ -1,0 +1,14 @@
+# compile and run for the first time to verify that everything works
+> run
+
+# introduce private var and refer to it in a trait that we inherit from
+# there'll be pair of getters and setters generated for private var that
+# has to be implemented by a class (where you can declare corresponding field)
+$ copy-file changes/A.scala A.scala
+
+# this fails with AbstractMethodError because getters and setters for
+# a private var are not generated because introduction of a private var
+# does not trigger recompilation of B
+# B is not recompiled because incremental compiler tracks only public
+# interace (members visible from outside of given trait/class)
+> run


### PR DESCRIPTION
Added a test-case for an edge case where an introduction of private member
(var in this case) should trigger recompilation of all classes that
inherit from a trait where the member is declared.

The reason is that current encoding of traits make it impossible for them
to declare fields directly so fields are being introduced in classes
inheriting from those traits. Check the test case for details.
