### PR TITLE
Fixes #706 - Binary Compatibility lost in Launcher.

### DIFF
--- a/launch/interface/src/main/java/xsbti/ApplicationID.java
+++ b/launch/interface/src/main/java/xsbti/ApplicationID.java
@@ -2,15 +2,55 @@ package xsbti;
 
 import java.io.File;
 
+/**
+ * This represents an identification for the sbt launcher to load and run
+ * an sbt launched application using ivy.
+ */
 public interface ApplicationID
 {
+	/**
+	 * @return
+	 *   The Ivy orgnaization / Maven groupId where we can find the application to launch.
+	 */
 	public String groupID();
+	/**
+	 * @return
+	 *    The ivy module name / Maven artifactId where we can find the application to launch.
+	 */
 	public String name();
+	/**
+	 * @return
+	 *    The ivy/maven version of the module we should resolve.
+	 */
 	public String version();
 
+	/**
+	 * @return
+	 *    The fully qualified name of the class that extends xsbti.AppMain
+	 */
 	public String mainClass();
+	/**
+	 * @return
+	 *    Additional ivy components we should resolve with the main application artifacts.
+	 */
 	public String[] mainComponents();
+	/**
+	 * @deprecated
+	 * This method is no longer used if the crossVersionedValue method is available.
+	 * 
+	 * @return
+	 *    True if the application is cross-versioned by binary-compatible version string,
+	 *    False if there is no cross-versioning.
+	 */
+	@Deprecated
 	public boolean crossVersioned();
+	
+	/**
+	 * 
+	 * @since 0.13.0
+	 * @return
+	 *    The type of cross-versioning the launcher should use to resolve this artifact.
+	 */
 	public CrossValue crossVersionedValue();
 	
 	/** Files to add to the application classpath. */

--- a/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -78,8 +78,18 @@ object Application
 	def apply(id: xsbti.ApplicationID): Application =
 	{
 		import id._
-		Application(groupID, name, new Explicit(version), mainClass, mainComponents.toList, crossVersionedValue, classpathExtra)
+		Application(groupID, name, new Explicit(version), mainClass, mainComponents.toList, safeCrossVersionedValue(id), classpathExtra)
 	}
+
+	private def safeCrossVersionedValue(id: xsbti.ApplicationID): xsbti.CrossValue =
+		try id.crossVersionedValue
+		catch {
+			case _: AbstractMethodError =>
+				// Before 0.13 this method did not exist on application, so we need to provide a default value
+				//in the event we're dealing with an older Application.
+				if(id.crossVersioned) xsbti.CrossValue.Binary
+				else xsbti.CrossValue.Disabled
+		}
 }
 
 object Repository


### PR DESCRIPTION
This checks to see if the new `crossVersionedValue` is actually implemented
by an AppID and delegates to the deprecated `crossVersioned` method if
there are any issues.   This preserves the binary compatibility from
folks using Launcher interface pre-0.13 and post-0.13.
