### PR TITLE
sbt-fx was renamed to sbt-fxml

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -201,7 +201,7 @@ Code generator plugins
    https://github.com/xuwei-k/sbtend
 -  sbt-boilerplate (generating scala.Tuple/Function related boilerplate code):
    https://github.com/sbt/sbt-boilerplate
--  sbt-fx (Generates controller classes for JavaFX FXML files): https://bitbucket.org/phdoerfler/sbt-fx
+-  sbt-fxml (Generates controller classes for JavaFX FXML files): https://bitbucket.org/phdoerfler/sbt-fxml
 
 Database plugins
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There is a similarily named plugin "sbt-javafx" which is not listed here and which I discovered afterwards
