### PR TITLE
Update Using-Sonatype.rst: `publish` should now be `publish-signed` when using pgp plugin

### DIFF
--- a/src/sphinx/Community/Using-Sonatype.rst
+++ b/src/sphinx/Community/Using-Sonatype.rst
@@ -135,11 +135,11 @@ Ivy to use the credentials.*
 Finally - Publish
 -----------------
 
-In sbt, run ``publish`` and you should see something like the following:
+In sbt, run ``publish-signed`` and you should see something like the following:
 
 .. code-block:: console
 
-    > publish
+    > publish-signed
     Please enter your PGP passphrase> ***********
     [info] Packaging /home/josh/projects/typesafe/scala-arm/target/scala-2.9.1/scala-arm_2.9.1-1.2.jar ...
     [info] Wrote /home/josh/projects/typesafe/scala-arm/target/scala-2.9.1/scala-arm_2.9.1-1.2.pom


### PR DESCRIPTION
according to this

http://www.scala-sbt.org/sbt-pgp/usage.html#publishing_artifacts

"The PGP plugin NO LONGER wires into the default publish and publish-local tasks of sbt. If you want to published signed artifacts, you must use the new publish-signed and publish-local-signed tasks."

This bit me when i tried to do this today, should update the docs to refer to the proper command `publish-signed` so the next guy who tries this doesn't get bitten.
