### PR TITLE
Update to jansi 1.11

### DIFF
--- a/project/Util.scala
+++ b/project/Util.scala
@@ -156,7 +156,7 @@ object Common
 {
 	def lib(m: ModuleID) = libraryDependencies += m
 	lazy val jlineDep = "jline" % "jline" % "2.11"
-	lazy val jansiDep = "org.fusesource.jansi" % "jansi" % "1.9" // jline pom doesn't explicitly declare it?
+	lazy val jansiDep = "org.fusesource.jansi" % "jansi" % "1.11" // jline pom doesn't explicitly declare it?
 	lazy val jline = Seq(lib(jlineDep), lib(jansiDep))
 	lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0-rc1")
 	lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")


### PR DESCRIPTION
jline actually bundles jansi. Version used by jline 2.11 is jansi 1.11:

https://github.com/jline/jline2/blob/jline-2.11/pom.xml#L117
