### PR TITLE
Supply default terminal width to fix #795

### DIFF
--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -56,7 +56,8 @@ object Graph
 	// [info]   |
 	// [info]   +-quux
 	def toAscii[A](top: A, children: A => Seq[A], display: A => String): String = {
-		val maxColumn = JLine.usingTerminal(_.getWidth) - 8
+		val defaultWidth = 40
+		val maxColumn = Math.min(JLine.usingTerminal(_.getWidth), defaultWidth) - 8
 		val twoSpaces = " " + " " // prevent accidentally being converted into a tab
 		def limitLine(s: String): String =
 			if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."


### PR DESCRIPTION
It compiles. I didn't try to reproduce the bug with dump terminal.
