### PR TITLE
ScalaTest Test Argument Fix

### DIFF
--- a/sbt/src/sbt-test/tests/arguments-new/build.sbt
+++ b/sbt/src/sbt-test/tests/arguments-new/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0.M6-SNAP26" % "test"
+libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0.M6-SNAP28" % "test"
 
 
 testOptions in Configurations.Test ++= {

--- a/sbt/src/sbt-test/tests/do-not-discover/build.sbt
+++ b/sbt/src/sbt-test/tests/do-not-discover/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/done/build.sbt
+++ b/sbt/src/sbt-test/tests/done/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")
 

--- a/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")
 

--- a/sbt/src/sbt-test/tests/nested-subproc/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-subproc/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")
 

--- a/sbt/src/sbt-test/tests/single-runner/build.sbt
+++ b/sbt/src/sbt-test/tests/single-runner/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/task/build.sbt
+++ b/sbt/src/sbt-test/tests/task/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.10.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP26"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.0.M6-SNAP28"
 
 testOptions in Test += Tests.Argument("-r", "custom.CustomReporter")


### PR DESCRIPTION
Changed all scripted tests that use ScalaTest 2.0.M6-SNAP26 to use 2.0.M6-SNAP28, which fixes the pending arguments-new test.
