### PR TITLE
0.12.4: Fix scala version, 0.12.4 uses v2.9.2.

### DIFF
--- a/src/sphinx/Extending/Plugins.rst
+++ b/src/sphinx/Extending/Plugins.rst
@@ -222,7 +222,7 @@ Introduction
 ------------
 
 A minimal plugin is a Scala library that is built against the version of
-Scala that sbt runs (currently, 2.9.1) or a Java library. Nothing
+Scala that sbt runs (currently, 2.9.2) or a Java library. Nothing
 special needs to be done for this type of library, as shown in the
 previous section. A more typical plugin will provide sbt tasks,
 commands, or settings. This kind of plugin may provide these settings


### PR DESCRIPTION
See: https://github.com/sbt/sbt/blob/0.12.4/project/Sbt.scala#L19
