### PR TITLE
Handle compilation cancellation properly.

### DIFF
--- a/interface/src/main/java/xsbti/CompileCancelled.java
+++ b/interface/src/main/java/xsbti/CompileCancelled.java
@@ -1,0 +1,9 @@
+package xsbti;
+
+/**
+ * An exception thrown when compilation cancellation has been requested during
+ * Scala compiler run.
+ */
+public abstract class CompileCancelled extends RuntimeException {
+	public abstract String[] arguments();
+}


### PR DESCRIPTION
Incremental compiler didn't have any explicit logic to handle
cancelled compilation so it would go into inconsistent state.

Specifically, what would happen is that it would treat cancelled
compilation as a compilation that finished normally and try to
produce a new Analysis object out of partial information collected
in AnalysisCallback. The most obvious outcome would be that the
new Analysis would contain latest hashes for source files. The
next time incremental compiler was asked to recompile the same files
that it didn't recompile due to cancelled compilation it would think
they were already successfully compiled and would do nothing.

We fix that problem by following the same logic that handles compilation
errors, cleans up partial results (produced class files) and makes sure
that no Analysis is created out of broken state.

We do that by introducing a new exception `CompileCancelled`
and throwing it at the same spot as an exception signalizing compilation
errors is being thrown. We also modify `IncrementalCompile` to
catch that exception and gracefully return as there was no compilation
invoked.

NOTE: In case there were compilation errors reported _before_
compilation cancellations was requested we'll still report them
using an old mechanism so partial errors are not lost in case
of cancelled compilation.
