### PR TITLE
refix #795

### DIFF
--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -57,7 +57,7 @@ object Graph
 	// [info]   +-quux
 	def toAscii[A](top: A, children: A => Seq[A], display: A => String): String = {
 		val defaultWidth = 40
-		val maxColumn = math.min(JLine.usingTerminal(_.getWidth), defaultWidth) - 8
+		val maxColumn = math.max(JLine.usingTerminal(_.getWidth), defaultWidth) - 8
 		val twoSpaces = " " + " " // prevent accidentally being converted into a tab
 		def limitLine(s: String): String =
 			if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."


### PR DESCRIPTION
`math.min` should have been `math.max` here.
It's currently chopping off the output of inspect tree.
