### PR TITLE
prevent another StringIndexOutOfBoundsException in Graph.toAscii

### DIFF
--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -63,12 +63,14 @@ object Graph
 			if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."
 			else s
 		def insertBar(s: String, at: Int): String =
-			s.slice(0, at) +
-			(s(at).toString match {
-				case " " => "|"
-				case x => x
-			}) +
-			s.slice(at + 1, s.length)
+			if (at < s.length)
+				s.slice(0, at) +
+				(s(at).toString match {
+					case " " => "|"
+					case x => x
+				}) +
+				s.slice(at + 1, s.length)
+			else s
 		def toAsciiLines(node: A, level: Int): Vector[String] = {
 			val line = limitLine((twoSpaces * level) + (if (level == 0) "" else "+-") + display(node))
 			val cs = Vector(children(node): _*)


### PR DESCRIPTION
This was observed for deep graphs in jrudolph/sbt-dependency-graph#36.

See also https://github.com/jrudolph/sbt-dependency-graph/commit/0bcd2e03f49f6c7133e9ef9e40b95d40970e4a29 where this was fixed in sbt-dependency-graph's fork of this code.
