### PR TITLE
fix scaladoc cache bug. when use -doc-root-content

### DIFF
--- a/main/actions/src/main/scala/sbt/Doc.scala
+++ b/main/actions/src/main/scala/sbt/Doc.scala
@@ -17,12 +17,15 @@ package sbt
 
 object Doc
 {
-		import RawCompileLike._
+	import RawCompileLike._
 	def scaladoc(label: String, cache: File, compiler: AnalyzingCompiler): Gen =
-		cached(cache, prepare(label + " Scala API documentation", compiler.doc))
-
+		scaladoc(label, cache, compiler, Seq())
+	def scaladoc(label: String, cache: File, compiler: AnalyzingCompiler, fileInputOptions: Seq[String]): Gen =
+		cached(cache, fileInputOptions, prepare(label + " Scala API documentation", compiler.doc))
 	def javadoc(label: String, cache: File, doc: sbt.compiler.Javadoc): Gen =
-		cached(cache, prepare(label + " Java API documentation", filterSources(javaSourcesOnly, doc.doc)))
+		javadoc(label, cache, doc, Seq())
+	def javadoc(label: String, cache: File, doc: sbt.compiler.Javadoc, fileInputOptions: Seq[String]): Gen =
+		cached(cache, fileInputOptions, prepare(label + " Java API documentation", filterSources(javaSourcesOnly, doc.doc)))
 
 	val javaSourcesOnly: File => Boolean = _.getName.endsWith(".java")
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -659,6 +659,7 @@ object Defaults extends BuildCommon
 	def docSetting(key: TaskKey[File]) = docTaskSettings(key)
 	def docTaskSettings(key: TaskKey[File] = doc): Seq[Setting[_]] = inTask(key)(Seq(
 		apiMappings ++= { if(autoAPIMappings.value) APIMappings.extract(dependencyClasspath.value, streams.value.log).toMap else Map.empty[File,URL] },
+		fileInputOptions := Seq("-doc-root-content", "-diagrams-dot-path"),
 		key in TaskGlobal := {
 			val s = streams.value
 			val cs = compilers.value
@@ -671,13 +672,14 @@ object Defaults extends BuildCommon
 			val hasJava = srcs.exists(_.name.endsWith(".java"))
 			val cp = data(dependencyClasspath.value).toList
 			val label = nameForSrc(configuration.value.name)
+			val fiOpts = fileInputOptions.value
 			val (options, runDoc) =
 				if(hasScala)
 					(sOpts ++ Opts.doc.externalAPI(xapis), // can't put the .value calls directly here until 2.10.2
-						Doc.scaladoc(label, s.cacheDirectory / "scala", cs.scalac.onArgs(exported(s, "scaladoc"))))
+						Doc.scaladoc(label, s.cacheDirectory / "scala", cs.scalac.onArgs(exported(s, "scaladoc")), fiOpts))
 				else if(hasJava)
 					(jOpts,
-						Doc.javadoc(label, s.cacheDirectory / "java", cs.javac.onArgs(exported(s, "javadoc"))))
+						Doc.javadoc(label, s.cacheDirectory / "java", cs.javac.onArgs(exported(s, "javadoc")), fiOpts))
 				else
 					(Nil, RawCompileLike.nop)
 			runDoc(srcs, cp, out, options, maxErrors.value, s.log)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -134,6 +134,7 @@ object Keys
 	val definedSbtPlugins = TaskKey[Set[String]]("defined-sbt-plugins", "The set of names of Plugin implementations defined by this project.", CTask)
 	val sbtPlugin = SettingKey[Boolean]("sbt-plugin", "If true, enables adding sbt as a dependency and auto-generation of the plugin descriptor file.", BMinusSetting)
 	val printWarnings = TaskKey[Unit]("print-warnings", "Shows warnings from compilation, including ones that weren't printed initially.", BPlusTask)
+	val fileInputOptions = SettingKey[Seq[String]]("file-input-options", "Options that take file input, which may invalidate the cache.", CSetting)
 
 	val clean = TaskKey[Unit]("clean", "Deletes files produced by the build, such as generated sources, compiled classes, and task caches.", APlusTask)
 	val console = TaskKey[Unit]("console", "Starts the Scala interpreter with the project classes on the classpath.", APlusTask)

--- a/sbt/src/sbt-test/actions/doc-file-options/Main.scala
+++ b/sbt/src/sbt-test/actions/doc-file-options/Main.scala
@@ -1,0 +1,3 @@
+object Main{
+
+}

--- a/sbt/src/sbt-test/actions/doc-file-options/build.sbt
+++ b/sbt/src/sbt-test/actions/doc-file-options/build.sbt
@@ -1,0 +1,16 @@
+val newContents = "bbbbbbbbb"
+
+val rootContentFile = "root.txt"
+
+scalaVersion := "2.10.2"
+
+scalacOptions in (Compile, doc) := Seq("-doc-root-content", rootContentFile)
+
+TaskKey[Unit]("changeRootContent") := {
+	IO.write(file(rootContentFile), newContents)
+}
+
+TaskKey[Unit]("check") := {
+	val packageHtml = (target in Compile in doc).value / "package.html"
+	assert(IO.read(packageHtml).contains(newContents), s"does not contains ${newContents} in ${packageHtml}" )
+}

--- a/sbt/src/sbt-test/actions/doc-file-options/root.txt
+++ b/sbt/src/sbt-test/actions/doc-file-options/root.txt
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaa

--- a/sbt/src/sbt-test/actions/doc-file-options/test
+++ b/sbt/src/sbt-test/actions/doc-file-options/test
@@ -1,0 +1,4 @@
+> doc
+> changeRootContent
+> doc
+> check


### PR DESCRIPTION
### steps

Define build.sbt that uses scaladoc `-doc-root-content` option.

``` scala
scalacOptions in (Compile, doc) := Seq("-doc-root-content", "root.txt")
```
1. Run `doc` task from the shell.
2. Change the content of root.txt.
3. Run `doc` task again.
### problem

The `doc` does not reflect the change in root.txt.
### what this pull request changes

The cache is updated if the file specified by `-doc-root-content` changes.
