### PR TITLE
Feature descriptor optional and check consistency

### DIFF
--- a/ivy/src/main/scala/sbt/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/ConvertResolver.scala
@@ -76,6 +76,7 @@ private object ConvertResolver
 			case repo: RawRepository => repo.resolver
 		}
 	}
+    
 	private sealed trait DescriptorRequired extends BasicResolver
 	{
 		override def getDependency(dd: DependencyDescriptor, data: ResolveData) =
@@ -122,6 +123,8 @@ private object ConvertResolver
 	private def initializePatterns(resolver: AbstractPatternsBasedResolver, patterns: Patterns, settings: IvySettings)
 	{
 		resolver.setM2compatible(patterns.isMavenCompatible)
+		resolver.setDescriptor(if (patterns.descriptorOptional) BasicResolver.DESCRIPTOR_OPTIONAL else BasicResolver.DESCRIPTOR_REQUIRED)
+		resolver.setCheckconsistency(!patterns.skipConsistencyCheck)
 		patterns.ivyPatterns.foreach(p => resolver.addIvyPattern(settings substitute p))
 		patterns.artifactPatterns.foreach(p => resolver.addArtifactPattern(settings substitute p))
 	}

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -23,20 +23,23 @@ sealed case class MavenRepository(name: String, root: String) extends Resolver
 	override def toString = name + ": " + root
 }
 
-final class Patterns(val ivyPatterns: Seq[String], val artifactPatterns: Seq[String], val isMavenCompatible: Boolean)
+final class Patterns(val ivyPatterns: Seq[String], val artifactPatterns: Seq[String], val isMavenCompatible: Boolean, val descriptorOptional: Boolean, val skipConsistencyCheck: Boolean)
 {
 	private[sbt] def mavenStyle(): Patterns = Patterns(ivyPatterns, artifactPatterns, true)
 	private[sbt] def withIvys(patterns: Seq[String]): Patterns = Patterns(patterns ++ ivyPatterns, artifactPatterns, isMavenCompatible)
 	private[sbt] def withArtifacts(patterns: Seq[String]): Patterns = Patterns(ivyPatterns, patterns ++ artifactPatterns, isMavenCompatible)
-	override def toString = "Patterns(ivyPatterns=%s, artifactPatterns=%s, isMavenCompatible=%s)".format(ivyPatterns, artifactPatterns, isMavenCompatible)
+	override def toString = "Patterns(ivyPatterns=%s, artifactPatterns=%s, isMavenCompatible=%s, descriptorOptional=%s, skipConsistencyCheck=%s)".format(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
 	override def equals(obj: Any): Boolean = {
 		obj match {
 			case other: Patterns =>
-				ivyPatterns == other.ivyPatterns && artifactPatterns == other.artifactPatterns && isMavenCompatible == other.isMavenCompatible
+				ivyPatterns == other.ivyPatterns && artifactPatterns == other.artifactPatterns && isMavenCompatible == other.isMavenCompatible && descriptorOptional == other.descriptorOptional && skipConsistencyCheck == other.skipConsistencyCheck
 			case _ => false
 		}
 	}
-	override def hashCode: Int = (ivyPatterns, artifactPatterns, isMavenCompatible).hashCode
+	override def hashCode: Int = (ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck).hashCode
+
+	@deprecated
+        def this(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean) = this(ivyPatterns, artifactPatterns, isMavenCompatible, false, false)
 }
 object Patterns
 {
@@ -44,7 +47,7 @@ object Patterns
 
 	def apply(artifactPatterns: String*): Patterns = Patterns(true, artifactPatterns : _*)
 	def apply(isMavenCompatible: Boolean, artifactPatterns: String*): Patterns = Patterns(artifactPatterns, artifactPatterns, isMavenCompatible)
-	def apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean): Patterns = new Patterns(ivyPatterns, artifactPatterns, isMavenCompatible)
+	def apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean, descriptorOptional: Boolean = false, skipConsistencyCheck: Boolean = false): Patterns = new Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
 }
 object RepositoryHelpers
 {

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -26,6 +26,8 @@ sealed case class MavenRepository(name: String, root: String) extends Resolver
 final class Patterns(val ivyPatterns: Seq[String], val artifactPatterns: Seq[String], val isMavenCompatible: Boolean, val descriptorOptional: Boolean, val skipConsistencyCheck: Boolean)
 {
 	private[sbt] def mavenStyle(): Patterns = Patterns(ivyPatterns, artifactPatterns, true)
+	private[sbt] def withDescriptorOptional(): Patterns = Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, true, skipConsistencyCheck)
+	private[sbt] def withoutConsistencyCheck(): Patterns = Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, true)
 	private[sbt] def withIvys(patterns: Seq[String]): Patterns = Patterns(patterns ++ ivyPatterns, artifactPatterns, isMavenCompatible)
 	private[sbt] def withArtifacts(patterns: Seq[String]): Patterns = Patterns(ivyPatterns, patterns ++ artifactPatterns, isMavenCompatible)
 	override def toString = "Patterns(ivyPatterns=%s, artifactPatterns=%s, isMavenCompatible=%s, descriptorOptional=%s, skipConsistencyCheck=%s)".format(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
@@ -47,7 +49,8 @@ object Patterns
 
 	def apply(artifactPatterns: String*): Patterns = Patterns(true, artifactPatterns : _*)
 	def apply(isMavenCompatible: Boolean, artifactPatterns: String*): Patterns = Patterns(artifactPatterns, artifactPatterns, isMavenCompatible)
-	def apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean, descriptorOptional: Boolean = false, skipConsistencyCheck: Boolean = false): Patterns = new Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
+	def apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean): Patterns = apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean, false, false) 
+	def apply(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean, descriptorOptional: Boolean, skipConsistencyCheck: Boolean): Patterns = new Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, descriptorOptional, skipConsistencyCheck)
 }
 object RepositoryHelpers
 {
@@ -81,6 +84,13 @@ sealed abstract class PatternsBasedRepository extends Resolver
 
 	/** Enables maven 2 compatibility for this repository. */
 	def mavenStyle() = copy(patterns.mavenStyle())
+
+	/** Makes descriptor metadata optional for this repository. */
+	def descriptorOptional() = copy(patterns.withDescriptorOptional())
+
+	/** Disables consistency checking for this repository. */
+	def skipConsistencyCheck() = copy(patterns.withoutConsistencyCheck())
+
 	/** Adds the given patterns for resolving/publishing Ivy files.*/
 	def ivys(ivyPatterns: String*): RepositoryType = copy(patterns.withIvys(ivyPatterns))
 	/** Adds the given patterns for resolving/publishing artifacts.*/

--- a/launch/interface/src/main/java/xsbti/IvyRepository.java
+++ b/launch/interface/src/main/java/xsbti/IvyRepository.java
@@ -9,4 +9,6 @@ public interface IvyRepository extends Repository
 	String ivyPattern();
 	String artifactPattern();
 	boolean mavenCompatible();
+	boolean skipConsistencyCheck();
+	boolean descriptorOptional();
 }

--- a/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -98,7 +98,7 @@ object Repository
 		def bootOnly: Boolean
 	}
 	final case class Maven(id: String, url: URL, bootOnly: Boolean = false) extends xsbti.MavenRepository with Repository
-	final case class Ivy(id: String, url: URL, ivyPattern: String, artifactPattern: String, mavenCompatible: Boolean, bootOnly: Boolean = false) extends xsbti.IvyRepository with Repository
+	final case class Ivy(id: String, url: URL, ivyPattern: String, artifactPattern: String, mavenCompatible: Boolean, bootOnly: Boolean = false, descriptorOptional: Boolean = false, skipConsistencyCheck: Boolean = false) extends xsbti.IvyRepository with Repository
 	final case class Predefined(id: xsbti.Predefined, bootOnly: Boolean = false) extends xsbti.PredefinedRepository with Repository
 	object Predefined {
 		def apply(s: String): Predefined = new Predefined(xsbti.Predefined.toValue(s), false)

--- a/launch/src/test/scala/ConfigurationParserTest.scala
+++ b/launch/src/test/scala/ConfigurationParserTest.scala
@@ -54,6 +54,22 @@ object ConfigurationParserTest extends Specification
                                 Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
 
                         repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, false))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional, skipConsistencyCheck""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+
+                        repoFileContains("""|[repositories]
+                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional, mavenCompatible, bootOnly""".stripMargin,
+                                Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true, true, true))
+
+                        repoFileContains("""|[repositories]
                                             |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
                                 Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1459,13 +1459,21 @@ object Classpaths
 		try { ivyRepo.mavenCompatible }
 		catch { case _: NoSuchMethodError => false }
 
+	private[this] def skipConsistencyCheck(ivyRepo: xsbti.IvyRepository): Boolean =
+		try { ivyRepo.skipConsistencyCheck }
+		catch { case _: NoSuchMethodError => false }
+
+	private[this] def descriptorOptional(ivyRepo: xsbti.IvyRepository): Boolean =
+		try { ivyRepo.descriptorOptional }
+		catch { case _: NoSuchMethodError => false }
+
 	private[this] def bootRepository(repo: xsbti.Repository): Resolver =
 	{
 		import xsbti.Predefined
 		repo match
 		{
 			case m: xsbti.MavenRepository => MavenRepository(m.id, m.url.toString)
-			case i: xsbti.IvyRepository => Resolver.url(i.id, i.url)(Patterns(i.ivyPattern :: Nil, i.artifactPattern :: Nil, mavenCompatible(i)))
+			case i: xsbti.IvyRepository => Resolver.url(i.id, i.url)(Patterns(i.ivyPattern :: Nil, i.artifactPattern :: Nil, mavenCompatible(i), descriptorOptional(i), skipConsistencyCheck(i)))
 			case p: xsbti.PredefinedRepository => p.id match {
 				case Predefined.Local => Resolver.defaultLocal
 				case Predefined.MavenLocal => Resolver.mavenLocal


### PR DESCRIPTION
These commits refactor ConfigurationParser.getRepositories and add two additional repository options:  `descriptorOptional` and `skipConsistencyCheck`.  These correspond to the Ivy API calls `r.setDescriptor(BasicResolver.DESCRIPTOR_OPTIONAL)` and `r.setCheckconsistency(false)`, where `r` is the resolver in question.  The modifications pass all of the tests in the sbt test task and a couple of additional tests added to exercise the additional flexibility available in `ConfigurationParser`.
