### PR TITLE
Add a mode where missing source files are not considered deleted.

### DIFF
--- a/compile/inc/Compile.scala
+++ b/compile/inc/Compile.scala
@@ -12,12 +12,12 @@ import java.io.File
 
 object IncrementalCompile
 {
-	def apply(sources: Set[File], entry: String => Option[File], compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, previous: Analysis, forEntry: File => Option[Analysis], outputPath: File, log: Logger): (Boolean, Analysis) =
+	def apply(sources: Set[File], deletedSources: Option[Set[File]], entry: String => Option[File], compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, previous: Analysis, forEntry: File => Option[Analysis], outputPath: File, log: Logger): (Boolean, Analysis) =
 	{
 		val current = Stamps.initial(Stamp.exists, Stamp.hash, Stamp.lastModified)
 		val internalMap = (f: File) => previous.relations.produced(f).headOption
 		val externalAPI = getExternalAPI(entry, forEntry)
-		Incremental.compile(sources, entry, previous, current, forEntry, doCompile(compile, internalMap, externalAPI, current, outputPath), log)
+		Incremental.compile(sources, deletedSources, entry, previous, current, forEntry, doCompile(compile, internalMap, externalAPI, current, outputPath), log)
 	}
 	def doCompile(compile: (Set[File], DependencyChanges, xsbti.AnalysisCallback) => Unit, internalMap: File => Option[File], externalAPI: (File, String) => Option[Source], current: ReadStamps, outputPath: File) = (srcs: Set[File], changes: DependencyChanges) => {
 		val callback = new AnalysisCallback(internalMap, externalAPI, current, outputPath)

--- a/compile/integration/AggressiveCompile.scala
+++ b/compile/integration/AggressiveCompile.scala
@@ -19,28 +19,35 @@ import inc._
 	import xsbti.compile.{CompileOrder, DependencyChanges, GlobalsCache}
 	import CompileOrder.{JavaThenScala, Mixed, ScalaThenJava}
 
-final class CompileConfiguration(val sources: Seq[File], val classpath: Seq[File],
+final class CompileConfiguration(val sources: Seq[File], val deletedSources: Option[Seq[File]], val classpath: Seq[File],
 	val previousAnalysis: Analysis, val previousSetup: Option[CompileSetup], val currentSetup: CompileSetup, val getAnalysis: File => Option[Analysis], val definesClass: DefinesClass,
 	val maxErrors: Int, val compiler: AnalyzingCompiler, val javac: xsbti.compile.JavaCompiler, val cache: GlobalsCache)
 
 class AggressiveCompile(cacheFile: File)
 {
-	def apply(compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, sources: Seq[File], classpath: Seq[File], outputDirectory: File, cache: GlobalsCache, options: Seq[String] = Nil, javacOptions: Seq[String] = Nil, analysisMap: File => Option[Analysis] = const(None), definesClass: DefinesClass = Locate.definesClass _, maxErrors: Int = 100, compileOrder: CompileOrder = Mixed, skip: Boolean = false)(implicit log: Logger): Analysis =
+	def apply(compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, sources: Seq[File], classpath: Seq[File], outputDirectory: File, cache: GlobalsCache, options: Seq[String] = Nil, javacOptions: Seq[String] = Nil, analysisMap: File => Option[Analysis] = const(None), definesClass: DefinesClass = Locate.definesClass _, maxErrors: Int = 100, explicitDeletes: Boolean = false, compileOrder: CompileOrder = Mixed, skip: Boolean = false)(implicit log: Logger): Analysis =
 	{
 		val setup = new CompileSetup(outputDirectory, new CompileOptions(options, javacOptions), compiler.scalaInstance.actualVersion, compileOrder)
-		compile1(sources, classpath, setup, store, analysisMap, definesClass, compiler, javac, maxErrors, skip, cache)
+		compile1(sources, classpath, setup, store, analysisMap, definesClass, compiler, javac, maxErrors, explicitDeletes, skip, cache)
 	}
 
 	def withBootclasspath(args: CompilerArguments, classpath: Seq[File]): Seq[File] =
 		args.bootClasspathFor(classpath) ++ args.extClasspath ++ args.finishClasspath(classpath)
 
-	def compile1(sources: Seq[File], classpath: Seq[File], setup: CompileSetup, store: AnalysisStore, analysis: File => Option[Analysis], definesClass: DefinesClass, compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, maxErrors: Int, skip: Boolean, cache: GlobalsCache)(implicit log: Logger): Analysis =
+	def compile1(sources: Seq[File], classpath: Seq[File], setup: CompileSetup, store: AnalysisStore, analysis: File => Option[Analysis], definesClass: DefinesClass, compiler: AnalyzingCompiler, javac: xsbti.compile.JavaCompiler, maxErrors: Int, explicitDeletes: Boolean, skip: Boolean, cache: GlobalsCache)(implicit log: Logger): Analysis =
 	{
 		val (previousAnalysis, previousSetup) = extract(store.get())
 		if(skip)
 			previousAnalysis
 		else {
-			val config = new CompileConfiguration(sources, classpath, previousAnalysis, previousSetup, setup, analysis, definesClass, maxErrors, compiler, javac, cache)
+			val (existingSources, deletedSources) =
+				if (explicitDeletes) {
+					val (existing, deleted) = sources partition (_.exists)
+					(existing, Some(deleted))
+				} else {
+					(sources, None)
+				}
+			val config = new CompileConfiguration(existingSources, deletedSources, classpath, previousAnalysis, previousSetup, setup, analysis, definesClass, maxErrors, compiler, javac, cache)
 			val (modified, result) = compile2(config)
 			if(modified)
 				store.set(result, setup)
@@ -89,11 +96,12 @@ class AggressiveCompile(cacheFile: File)
 		}
 		
 		val sourcesSet = sources.toSet
+		val deletedSourcesSet = deletedSources map (_.toSet)
 		val analysis = previousSetup match {
 			case Some(previous) if equiv.equiv(previous, currentSetup) => previousAnalysis
 			case _ => Incremental.prune(sourcesSet, previousAnalysis)
 		}
-		IncrementalCompile(sourcesSet, entry, compile0, analysis, getAnalysis, outputDirectory, log)
+		IncrementalCompile(sourcesSet, deletedSourcesSet, entry, compile0, analysis, getAnalysis, outputDirectory, log)
 	}
 	private[this] def timed[T](label: String, log: Logger)(t: => T): T =
 	{

--- a/compile/integration/IncrementalCompiler.scala
+++ b/compile/integration/IncrementalCompiler.scala
@@ -17,7 +17,8 @@ object IC extends IncrementalCompiler[Analysis, AnalyzingCompiler]
 		val agg = new AggressiveCompile(setup.cacheFile)
 		val aMap = (f: File) => m2o(analysisMap(f))
 		val defClass = (f: File) => { val dc = definesClass(f); (name: String) => dc.apply(name) }
-		agg(scalac, javac, sources, classpath, classesDirectory, cache, scalacOptions, javacOptions, aMap, defClass, maxErrors, order, skip)(log)
+		val explicitDeletes = false
+		agg(scalac, javac, sources, classpath, classesDirectory, cache, scalacOptions, javacOptions, aMap, defClass, maxErrors, explicitDeletes, order, skip)(log)
 	}
 
 	private[this] def m2o[S](opt: Maybe[S]): Option[S] = if(opt.isEmpty) None else Some(opt.get)

--- a/interface/src/main/java/xsbti/compile/Options.java
+++ b/interface/src/main/java/xsbti/compile/Options.java
@@ -16,7 +16,8 @@ public interface Options
 	/** The directory where class files should be generated.
 	* Incremental compilation will manage the class files in this directory.
 	* In particular, outdated class files will be deleted before compilation.
-	* It is important that this directory is exclusively used for one set of sources. */
+	* It is important that this directory is exclusively used for one set of sources, unless
+	* compiling with explicitDeletes=true . */
 	File classesDirectory();
 
 	/** The options to pass to the Scala compiler other than the sources and classpath to use. */

--- a/main/actions/Compiler.scala
+++ b/main/actions/Compiler.scala
@@ -76,6 +76,7 @@ object Compiler
 			import in.incSetup._
 
 		val agg = new AggressiveCompile(cacheFile)
-		agg(scalac, javac, sources, classpath, classesDirectory, cache, options, javacOptions, analysisMap, definesClass, maxErrors, order, skip)(log)
+		val explicitDeletes = false
+		agg(scalac, javac, sources, classpath, classesDirectory, cache, options, javacOptions, analysisMap, definesClass, maxErrors, explicitDeletes, order, skip)(log)
 	}
 }

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -14,7 +14,7 @@ object Sbt extends Build
 	override lazy val settings = super.settings ++ buildSettings ++ Status.settings
 	def buildSettings = Seq(
 		organization := "org.scala-sbt",
-		version := "0.12.4",
+		version := "0.12.5",
 		publishArtifact in packageDoc := false,
 		scalaVersion := "2.9.2",
 		publishMavenStyle := false,


### PR DESCRIPTION
Deleted source files must be explicitly provided.

This makes it practical to build only the needed parts of a large
single-tree codebase, without SBT requiring knowledge of the whole
world of sources.
