### PR TITLE
fix publishing instruction on "Community Plugins"

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -29,7 +29,7 @@ You'll also need to add your credentials somewhere.  For example, you might use 
 ::
 
      credentials += Credentials("Artifactory Realm", 
- "scalasbt.artifactoryonline.com", "@user name@", "@my encrypted password@")
+ "repo.scala-sbt.org", "@user name@", "@my encrypted password@")
  
 Where ``@my encrypted password@`` is actually obtained using the following `instructions <http://wiki.jfrog.org/confluence/display/RTF/Centrally+Secure+Passwords>`_.
  

--- a/src/sphinx/conf.py
+++ b/src/sphinx/conf.py
@@ -62,7 +62,7 @@ typesafe_ivy_snapshots = typesafe_base + 'ivy-snapshots/'
 typesafe_ivy_releases = typesafe_base + 'ivy-releases/'
 launcher_release_base = typesafe_ivy_releases + 'org.scala-sbt/sbt-launch/'
 launcher_snapshots_base = typesafe_ivy_snapshots + 'org.scala-sbt/sbt-launch/'
-sbt_native_package_base = 'http://scalasbt.artifactoryonline.com/scalasbt/sbt-native-packages/org/scala-sbt/sbt/'
+sbt_native_package_base = 'http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/'
 
 
 rst_epilog = """


### PR DESCRIPTION
## steps
1. follow the "Community Plugins" page to publish the first plugin on `repo.scala-sbt.org` after an admin creates an account.
## problem

```
[error] (*:publishSigned) java.io.IOException: Access to URL http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/com.example/sbt-foo/scala_2.10/sbt_0.13/0.1.0/docs/sbt-foo-javadoc.jar.asc was
 refused by the server: Unauthorized
```

This is because the current instruction page for 0.12.4 says to use repo.scala-sbt.org but use `"scalasbt.artifactoryonline.com"` for credential.
## what this changes

This backports the fix sbt/sbt@89d15ed from 0.13 branch.
