### PR TITLE
Make the DelegatingReporter aware of -nowarn

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Command.scala
+++ b/compile/interface/src/main/scala/xsbt/Command.scala
@@ -23,4 +23,7 @@ object Command
 	
 	def getWarnFatal(settings: Settings): Boolean =
 		settings.Xwarnfatal.value
+
+	def getNoWarn(settings: Settings): Boolean =
+		settings.nowarn.value
 }

--- a/sbt/src/sbt-test/reporter/nowarn/build.sbt
+++ b/sbt/src/sbt-test/reporter/nowarn/build.sbt
@@ -1,0 +1,24 @@
+lazy val sub1 = project
+
+lazy val sub2 = project
+
+val assertNoWarning = taskKey[Unit]("checks warning *is not* emitted")
+
+val assertWarning = taskKey[Unit]("checks warning *is* emitted")
+
+def check(expectation: Boolean) = Def.task[Unit] {
+  val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
+  val last: String = IO.read(lastLog)
+  val contains = last.contains("a pure expression does nothing in statement position")
+  if (expectation && !contains)
+    sys.error("compiler output does not contain warning")
+  else if (!expectation && contains)
+    sys.error(s"compiler output still contains warning")
+  else {
+    IO.write(lastLog, "") // clear the backing log for for 'last'.
+  }
+}
+
+assertWarning <<= check(true)
+
+assertNoWarning <<= check(false)

--- a/sbt/src/sbt-test/reporter/nowarn/sub1/warney.scala
+++ b/sbt/src/sbt-test/reporter/nowarn/sub1/warney.scala
@@ -1,0 +1,6 @@
+object warney {
+	def foo = {
+    0
+  	0
+	}
+}

--- a/sbt/src/sbt-test/reporter/nowarn/sub2/sub2.scala
+++ b/sbt/src/sbt-test/reporter/nowarn/sub2/sub2.scala
@@ -1,0 +1,1 @@
+object sub2

--- a/sbt/src/sbt-test/reporter/nowarn/test
+++ b/sbt/src/sbt-test/reporter/nowarn/test
@@ -1,0 +1,11 @@
+> compile
+
+> assertWarning
+
+> 'set every scalacOptions := Seq("-nowarn")'
+
+> clean
+
+> compile
+
+> assertNoWarning


### PR DESCRIPTION
The test case compiles a project without and with this
setting and checks that a warning is and isn't emitted
respectively.

It's a multi-project build; this bug didn't seem to turn
up in a single-project build.

Review by @harrah 
/cc @paulp
