### PR TITLE
Add equals/hashCode to APIs, and deprecate groupBy.

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/APIs.scala
+++ b/compile/inc/src/main/scala/sbt/inc/APIs.scala
@@ -85,5 +85,5 @@ private class MAPIs(val internal: Map[File, Source], val external: Map[String, S
 
 	override def toString: String = "API(internal: %d, external: %d)".format(internal.size, external.size)
 
-	private[this] def sorted[T](m: Map[T, Source])(implicit ord: math.Ordering[T]): Array[(T, Source)] = Sorting.stableSort[(T, Source), T](m.toSeq, _._1)
+	private[this] def sorted[T](m: Map[T, Source]): Seq[(T, Source)] = m.toSeq.sortBy(_._1)
 }

--- a/compile/inc/src/main/scala/sbt/inc/APIs.scala
+++ b/compile/inc/src/main/scala/sbt/inc/APIs.scala
@@ -7,6 +7,8 @@ package inc
 import xsbti.api.Source
 import java.io.File
 import APIs.getAPI
+import scala.util.Sorting
+import xsbt.api.SameAPI
 
 trait APIs
 {
@@ -27,6 +29,7 @@ trait APIs
 
 	def removeInternal(remove: Iterable[File]): APIs
 	def filterExt(keep: String => Boolean): APIs
+	@deprecated("OK to remove in 0.14", "0.13.1")
 	def groupBy[K](internal: (File) => K, keepExternal: Map[K, String => Boolean]): Map[K, APIs]
 
 	def internal: Map[File, Source]
@@ -58,11 +61,29 @@ private class MAPIs(val internal: Map[File, Source], val external: Map[String, S
 	
 	def removeInternal(remove: Iterable[File]): APIs = new MAPIs(internal -- remove, external)
 	def filterExt(keep: String => Boolean): APIs = new MAPIs(internal, external.filterKeys(keep))
-		
+	@deprecated("Broken implementation. OK to remove in 0.14", "0.13.1")
 	def groupBy[K](f: (File) => K, keepExternal: Map[K, String => Boolean]): Map[K, APIs] =
 		internal.groupBy(item => f(item._1)) map { group => (group._1, new MAPIs(group._2, external).filterExt(keepExternal.getOrElse(group._1, _ => false)))}
 
 	def internalAPI(src: File) = getAPI(internal, src)
 	def externalAPI(ext: String) = getAPI(external, ext)
-	
+
+	override def equals(other: Any): Boolean = other match {
+		case o: MAPIs => {
+			def areEqual[T](x: Map[T, Source], y: Map[T, Source])(implicit ord: math.Ordering[T]) = {
+				x.size == y.size && (sorted(x) zip sorted(y) forall { z => z._1._1 == z._2._1 && SameAPI(z._1._2, z._2._2)})
+			}
+			areEqual(internal, o.internal) && areEqual(external, o.external)
+		}
+		case _ => false
+	}
+
+	override lazy val hashCode: Int = {
+		def hash[T](m: Map[T, Source])(implicit ord: math.Ordering[T]) = sorted(m).map(x => (x._1, x._2.apiHash).hashCode).hashCode
+		(hash(internal), hash(external)).hashCode
+	}
+
+	override def toString: String = "API(internal: %d, external: %d)".format(internal.size, external.size)
+
+	private[this] def sorted[T](m: Map[T, Source])(implicit ord: math.Ordering[T]): Array[(T, Source)] = Sorting.stableSort[(T, Source), T](m.toSeq, _._1)
 }

--- a/compile/inc/src/main/scala/sbt/inc/APIs.scala
+++ b/compile/inc/src/main/scala/sbt/inc/APIs.scala
@@ -85,5 +85,5 @@ private class MAPIs(val internal: Map[File, Source], val external: Map[String, S
 
 	override def toString: String = "API(internal: %d, external: %d)".format(internal.size, external.size)
 
-	private[this] def sorted[T](m: Map[T, Source]): Seq[(T, Source)] = m.toSeq.sortBy(_._1)
+	private[this] def sorted[T](m: Map[T, Source])(implicit ord: math.Ordering[T]): Seq[(T, Source)] = m.toSeq.sortBy(_._1)
 }


### PR DESCRIPTION
equals/hashCode are useful for debugging/verifying/testing,
and the groupBy implementation is naive. It'll be replaced
by a groupBy implementation in Analysis that will handle
external/internal dep transitions correction.

Feel free to close the other pull request and merge this one, to keep your git history clean.
