### PR TITLE
proc interpolator  + `ProcessBuilder.lines` workaround. Fixes #819

### DIFF
--- a/src/sphinx/Community/ChangeSummary_0.14.0.rst
+++ b/src/sphinx/Community/ChangeSummary_0.14.0.rst
@@ -30,7 +30,7 @@ Details of major changes
 
     gitHeadCommitSha in ThisBuild := proc"git rev-parse HEAD".lines.head
 
-Each expression embedded in `proc` strings are treated as an argument, so this could be used to pass strings with white spaces. One exception is expressions of type `Seq[Any]`, which is expanded into a list of arguments.
+Each expression embedded in `proc` strings is treated as an argument, so this could be used to pass strings with white spaces. One exception is an expression of type `Seq[Any]`, which is expanded into a list of arguments.
 
 ::
 
@@ -51,3 +51,19 @@ This is useful when implementing input tasks.
       val args: Seq[String] = spaceDelimited("<arg>").parsed
       proc"git ${args}".!
     }
+
+Note the embedded expression must appear in the beginning of a `proc` string or directly after a whitespace.
+
+::
+
+    val badGrepFoo = taskKey[Unit]("bad grep for def foo")
+
+    badGrepFoo := {
+      proc"grep def${" foo"} ${(sources in Compile).value}".!
+    }
+
+This will result in an error when the task is called:
+
+::
+
+    [error] (helloworld/*:badGrepFoo) proc found an expression but whitespace was expected:  foo

--- a/src/sphinx/Community/ChangeSummary_0.14.0.rst
+++ b/src/sphinx/Community/ChangeSummary_0.14.0.rst
@@ -1,0 +1,53 @@
+==============
+0.14.0 Changes
+==============
+
+Overview
+========
+
+Features, fixes, changes with compatibility implications
+--------------------------------------------------------
+
+- String enrichment to `ProcessBuilder` is deprecated. Use `proc` interpolator.
+- `ProcessBuilder`'s `lines` methods are now implicitly added to `ProcessBuilder`. This is to avoid conflict with `StringOp`'s `lines`.
+
+Improvements
+------------
+
+- `proc` interpolator. (gh-913) Details below.
+
+Details of major changes
+========================
+
+`proc` interpolator
+-------------------
+
+`proc` interpolator was added to create `ProcessBuilder` in the build definition.
+
+::
+
+    val gitHeadCommitSha = settingKey[String]("current git commit SHA")
+
+    gitHeadCommitSha in ThisBuild := proc"git rev-parse HEAD".lines.head
+
+Each expression embedded in `proc` strings are treated as an argument, so this could be used to pass strings with white spaces. One exception is expressions of type `Seq[Any]`, which is expanded into a list of arguments.
+
+::
+
+    val grepFoo = taskKey[Unit]("grep for def foo")
+
+    grepFoo := {
+      proc"grep ${"def foo"} ${(sources in Compile).value}".!
+    }
+
+This is useful when implementing input tasks.
+
+::
+
+    val git = inputKey[Unit]("git")
+
+    git := {
+      import sbt.complete.Parsers._
+      val args: Seq[String] = spaceDelimited("<arg>").parsed
+      proc"git ${args}".!
+    }

--- a/util/process/src/main/scala/sbt/Process.scala
+++ b/util/process/src/main/scala/sbt/Process.scala
@@ -7,6 +7,7 @@ import java.lang.{Process => JProcess, ProcessBuilder => JProcessBuilder}
 import java.io.{Closeable, File, IOException}
 import java.io.{BufferedReader, InputStream, InputStreamReader, OutputStream, PipedInputStream, PipedOutputStream}
 import java.net.URL
+import collection.mutable.ArrayBuffer
 
 trait ProcessExtra
 {
@@ -14,12 +15,15 @@ trait ProcessExtra
 	implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)
 	implicit def fileToProcess(file: File): FilePartialBuilder = apply(file)
 	implicit def urlToProcess(url: URL): URLPartialBuilder = apply(url)
-	@deprecated("Use string interpolation", "0.13.0")
+	@deprecated("Use proc string interpolation", "0.13.0")
 	implicit def xmlToProcess(command: scala.xml.Elem): ProcessBuilder = apply(command)
 	implicit def buildersToProcess[T](builders: Seq[T])(implicit convert: T => SourcePartialBuilder): Seq[SourcePartialBuilder] = applySeq(builders)
-
+	@deprecated("Use proc string interpolation", "0.14.0")
 	implicit def stringToProcess(command: String): ProcessBuilder = apply(command)
+	@deprecated("Use proc string interpolation", "0.14.0")
 	implicit def stringSeqToProcess(command: Seq[String]): ProcessBuilder = apply(command)
+	implicit def stringContextToProcessString(sc: StringContext): ProcessString = new ProcessString(sc)
+	implicit def processBuilderToProcessBuilderLines(pb: ProcessBuilder): ProcessBuilderLines = new ProcessBuilderLines(pb)
 }
 
 /** Methods for constructing simple commands that can then be combined. */
@@ -61,6 +65,22 @@ object Process extends ProcessExtra
 
 	def apply(value: Boolean): ProcessBuilder = apply(value.toString, if(value) 0 else 1)
 	def apply(name: String, exitValue: => Int): ProcessBuilder = new DummyProcessBuilder(name, exitValue)
+	def apply(sc: StringContext, args: Any*): ProcessBuilder =
+	{
+		val strings = sc.parts.iterator
+		val expressions = args.iterator
+		val buf = new ArrayBuffer[String]()
+		def splitAndAppendAll(s: String): Unit = buf appendAll s.trim.split("""\s+""").filter(_ != "")
+		splitAndAppendAll(strings.next)
+		while(strings.hasNext) {
+			expressions.next match {
+				case xs: Seq[_] => buf appendAll xs.map(_.toString)
+				case x          => buf append x.toString
+			}
+			splitAndAppendAll(strings.next)
+		}
+		apply(buf.toArray)
+	}
 
 	def cat(file: SourcePartialBuilder, files: SourcePartialBuilder*): ProcessBuilder = cat(file :: files.toList)
 	def cat(files: Seq[SourcePartialBuilder]): ProcessBuilder =
@@ -126,22 +146,6 @@ trait ProcessBuilder extends SourcePartialBuilder with SinkPartialBuilder
 	/** Starts the process represented by this builder, blocks until it exits, and returns the output as a String.  Standard error is
 	* sent to the provided ProcessLogger.  If the exit code is non-zero, an exception is thrown.*/
 	def !!(log: ProcessLogger) : String
-	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-	* but the process has not completed.  Standard error is sent to the console.  If the process exits with a non-zero value,
-	* the Stream will provide all lines up to termination and then throw an exception. */
-	def lines: Stream[String]
-	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-	* but the process has not completed.  Standard error is sent to the provided ProcessLogger.  If the process exits with a non-zero value,
-	* the Stream will provide all lines up to termination but will not throw an exception. */
-	def lines(log: ProcessLogger): Stream[String]
-	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-	* but the process has not completed.  Standard error is sent to the console. If the process exits with a non-zero value,
-	* the Stream will provide all lines up to termination but will not throw an exception. */
-	def lines_! : Stream[String]
-	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
-	* but the process has not completed.  Standard error is sent to the provided ProcessLogger. If the process exits with a non-zero value,
-	* the Stream will provide all lines up to termination but will not throw an exception. */
-	def lines_!(log: ProcessLogger): Stream[String]
 	/** Starts the process represented by this builder, blocks until it exits, and returns the exit code.  Standard output and error are
 	* sent to the console.*/
 	def ! : Int
@@ -182,6 +186,9 @@ trait ProcessBuilder extends SourcePartialBuilder with SinkPartialBuilder
 	def ### (other: ProcessBuilder): ProcessBuilder
 
 	def canPipeTo: Boolean
+
+	// Called by class ProcessBuilderLines
+	private[sbt] def outputLines(withInput: Boolean, nonZeroException: Boolean, log: Option[ProcessLogger]): Stream[String]
 }
 /** Each method will be called in a separate thread.*/
 final class ProcessIO(val writeInput: OutputStream => Unit, val processOutput: InputStream => Unit, val processError: InputStream => Unit, val inheritInput: JProcessBuilder => Boolean) extends NotNull
@@ -195,4 +202,27 @@ trait ProcessLogger
 	def info(s: => String): Unit
 	def error(s: => String): Unit
 	def buffer[T](f: => T): T
+}
+class ProcessString(sc: StringContext)
+{
+	def proc(args: Any*): ProcessBuilder = Process(sc, args.toSeq: _*)
+}
+class ProcessBuilderLines(pb: ProcessBuilder)
+{
+	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
+	* but the process has not completed.  Standard error is sent to the console.  If the process exits with a non-zero value,
+	* the Stream will provide all lines up to termination and then throw an exception. */
+	def lines: Stream[String] = pb.outputLines(false, true, None)
+	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
+	* but the process has not completed.  Standard error is sent to the provided ProcessLogger.  If the process exits with a non-zero value,
+	* the Stream will provide all lines up to termination but will not throw an exception. */
+	def lines(log: ProcessLogger): Stream[String] = pb.outputLines(false, true, Some(log))
+	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
+	* but the process has not completed.  Standard error is sent to the console. If the process exits with a non-zero value,
+	* the Stream will provide all lines up to termination but will not throw an exception. */
+	def lines_! : Stream[String] = pb.outputLines(false, false, None)
+	/** Starts the process represented by this builder.  The output is returned as a Stream that blocks when lines are not available
+	* but the process has not completed.  Standard error is sent to the provided ProcessLogger. If the process exits with a non-zero value,
+	* the Stream will provide all lines up to termination but will not throw an exception. */
+	def lines_!(log: ProcessLogger): Stream[String] = pb.outputLines(false, false, Some(log))
 }

--- a/util/process/src/main/scala/sbt/ProcessImpl.scala
+++ b/util/process/src/main/scala/sbt/ProcessImpl.scala
@@ -149,13 +149,8 @@ private abstract class AbstractProcessBuilder extends ProcessBuilder with SinkPa
 	def !!(log: ProcessLogger) = getString(Some(log), false)
 	def !!< = getString(None, true)
 	def !!<(log: ProcessLogger) = getString(Some(log), true)
-
-	def lines: Stream[String] = lines(false, true, None)
-	def lines(log: ProcessLogger): Stream[String] = lines(false, true, Some(log))
-	def lines_! : Stream[String] = lines(false, false, None)
-	def lines_!(log: ProcessLogger): Stream[String] = lines(false, false, Some(log))
-
-	private[this] def lines(withInput: Boolean, nonZeroException: Boolean, log: Option[ProcessLogger]): Stream[String] =
+	
+	private[sbt] def outputLines(withInput: Boolean, nonZeroException: Boolean, log: Option[ProcessLogger]): Stream[String] =
 	{
 		val streamed = Streamed[String](nonZeroException)
 		val process = run(new ProcessIO(BasicIO.input(withInput), BasicIO.processFully(streamed.process), BasicIO.getErr(log), BasicIO.inheritInput(withInput)))


### PR DESCRIPTION
This PR addresses sbt/sbt#819 for 0.14
## ProcessBuilder.lines workaround
1. `ProcessBuilder.lines` is moves  to `ProcessBuilderLines`. (`ProcessBuilder` converts implicitly to it)
2. `stringToProcess` and `stringSeqToProcess` are deprecated.

Existing code using `Process(...).lines` are source compat. For example, Suerethian versioning works as is:

``` scala
val gitHeadCommitSha = settingKey[String]("current git commit SHA")

gitHeadCommitSha in ThisBuild := Process("git rev-parse HEAD").lines.head
```
### 0.14?

I've used "0.14.0" in deprecation annotation. Don't merge this into 0.13 branch.
Here's from the newly added `ChangeSummary_0.14.0.rst`:
## `proc` interpolator

`proc` interpolator was added to create `ProcessBuilder` in the build definition.

::

```
val gitHeadCommitSha = settingKey[String]("current git commit SHA")

gitHeadCommitSha in ThisBuild := proc"git rev-parse HEAD".lines.head
```

Each expression embedded in `proc` strings are treated as an argument, so this could be used to pass strings with white spaces. One exception is expressions of type `Seq[Any]`, which is expanded into a list of arguments.

::

```
val grepFoo = taskKey[Unit]("grep for def foo")

grepFoo := {
  proc"grep ${"def foo"} ${(sources in Compile).value}".!
}
```

This is useful when implementing input tasks.

::

```
val git = inputKey[Unit]("git")

git := {
  import sbt.complete.Parsers._
  val args: Seq[String] = spaceDelimited("<arg>").parsed
  proc"git ${args}".!
}
```
