### PR TITLE
Filter test options are backwards

### DIFF
--- a/src/sphinx/Detailed-Topics/Testing.rst
+++ b/src/sphinx/Detailed-Topics/Testing.rst
@@ -375,8 +375,8 @@ However, different tests are run depending on the configuration.
           .settings( inConfig(FunTest)(Defaults.testTasks) : _*)
           .settings(
             libraryDependencies += specs,
-            testOptions in Test := Seq(Tests.Filter(itFilter)),
-            testOptions in FunTest := Seq(Tests.Filter(unitFilter))
+            testOptions in Test := Seq(Tests.Filter(unitFilter)),
+            testOptions in FunTest := Seq(Tests.Filter(itFilter))
           )
 
       def itFilter(name: String): Boolean = name endsWith "ITest"


### PR DESCRIPTION
The itFilter, defined as integration tests are configured to be run under task 'test' where I think you meant to hav then run under 'fun:test' and vise versa for the unitFilter.
