### PR TITLE
Add SBT version to example path for credentials file

### DIFF
--- a/src/sphinx/Community/Using-Sonatype.rst
+++ b/src/sphinx/Community/Using-Sonatype.rst
@@ -117,7 +117,7 @@ Fourth - Adding credentials
 ---------------------------
 
 The credentials for your Sonatype OSSRH account need to be added
-somewhere. Common convention is a `~/.sbt/sonatype.sbt` file with the
+somewhere. Common convention is a `~/.sbt/<sbt version>/sonatype.sbt` file with the
 following:
 
 ::


### PR DESCRIPTION
As of sbt 0.13, the credentials won't be found if they aren't within a version directory.
