### PR TITLE
Fix serialization in Sync.

### DIFF
--- a/main/actions/src/main/scala/sbt/Sync.scala
+++ b/main/actions/src/main/scala/sbt/Sync.scala
@@ -71,8 +71,7 @@ object Sync
 		import sbinary._
 		import Operations.{read, write}
 		import DefaultProtocol.{FileFormat => _, _}
-		val formats = new sbt.inc.InternedAnalysisFormats()
-		import formats._
+		import sbt.inc.AnalysisFormats.{fileFormat, relationFormat}
 
 	def writeInfo[F <: FileInfo](file: File, relation: Relation[File, File], info: Map[File, F])(implicit infoFormat: Format[F]): Unit =
 		IO.gzipFileOut(file) { out =>


### PR DESCRIPTION
The serialized structures there aren't part of an Analysis,
so they aren't interned.

TODO: Refactor InternedAnalysisFormats so that this is more
straightforward and less error-prone.  This commit is
a first-pass fix of the broken test.
