### PR TITLE
More detailed logging and APIChanges refactoring

### DIFF
--- a/compile/api/src/main/scala/xsbt/api/SameAPI.scala
+++ b/compile/api/src/main/scala/xsbt/api/SameAPI.scala
@@ -8,6 +8,7 @@ import xsbti.api._
 import Function.tupled
 import scala.collection.{immutable, mutable}
 
+@deprecated("This class is not used in incremental compiler and will be removed in next major version.", "0.13.2")
 class NameChanges(val newTypes: Set[String], val removedTypes: Set[String], val newTerms: Set[String], val removedTerms: Set[String])
 {
 	override def toString =
@@ -19,11 +20,13 @@ class NameChanges(val newTypes: Set[String], val removedTypes: Set[String], val 
 
 object TopLevel
 {
+	@deprecated("The NameChanges class is deprecated and will be removed in next major version.", "0.13.2")
 	def nameChanges(a: Iterable[Source], b: Iterable[Source]): NameChanges = {
 		val api = (_: Source).api
 		apiNameChanges(a map api, b map api)
 	}
 	/** Identifies removed and new top-level definitions by name. */
+	@deprecated("The NameChanges class is deprecated and will be removed in next major version.", "0.13.2")
 	def apiNameChanges(a: Iterable[SourceAPI], b: Iterable[SourceAPI]): NameChanges =
 	{
 		def changes(s: Set[String], t: Set[String]) = (s -- t, t -- s)

--- a/compile/inc/src/main/scala/sbt/inc/Changes.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Changes.scala
@@ -8,10 +8,20 @@ import xsbt.api.NameChanges
 import java.io.File
 
 final case class InitialChanges(internalSrc: Changes[File], removedProducts: Set[File], binaryDeps: Set[File], external: APIChanges[String])
-final class APIChanges[T](val modified: Set[T], val names: NameChanges)
+final class APIChanges[T](val apiChanges: Iterable[APIChange[T]])
 {
-	override def toString = "API Changes: " + modified + "\n" + names
+	override def toString = "API Changes: " + apiChanges
+	def allModified: Iterable[T] = apiChanges.map(_.modified)
 }
+
+sealed abstract class APIChange[T](val modified: T)
+/**
+ * If we recompile a source file that contains a macro definition then we always assume that it's
+ * api has changed. The reason is that there's no way to determine if changes to macros implementation
+ * are affecting its users or not. Therefore we err on the side of caution.
+ */
+case class APIChangeDueToMacroDefinition[T](modified0: T) extends APIChange(modified0)
+case class SourceAPIChange[T](modified0: T) extends APIChange(modified0)
 
 trait Changes[A]
 {


### PR DESCRIPTION
The 7bc5aac commit contains some more detailed logging. See the commit message for details.

The main motivation behind this PR is to reify information about api changes that incremental compiler considers. We introduce a new sealed class `APIChange` that has (at the moment) two subtypes:
- `APIChangeDueToMacroDefinition` - as the name explains, this represents the case where incremental compiler considers an api to be changed just because given source file contains a macro definition
- `SourceAPIChange` - this represents the case of regular api change; at the moment it's just a simple wrapper around value representing source file but in the future it will get expanded to contain more detailed information about API changes (e.g. collection of changed name hashes)

The APIChanges becomes just a collection of APIChange instances. In particular, I removed `names` field that seems to be a dead code in incremental compiler. The `NameChanges` class and methods that refer to
it in `SameAPI` has been deprecated.

The Incremental.scala has been adapted to changed signature of APIChanges class. The `sameSource` method returns representation of APIChange (if there's one) instead of just simple boolean. One notable change is
that information about APIChanges is pushed deeper into invalidation logic. This will allow us to treat the APIChangeDueToMacroDefinition case properly once name hashing scheme arrives.

This commit shouldn't change any behavior and is purely a refactoring.
