### PR TITLE
Flush ObjectOutputStreams after construction

### DIFF
--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -49,6 +49,8 @@ private[sbt] object ForkTests
 							case _: java.net.SocketException => return
 						}
 					val os = new ObjectOutputStream(socket.getOutputStream)
+					// Must flush the header that the constructor writes, otherwise the ObjectInputStream on the other end may block indefinitely
+					os.flush()
 					val is = new ObjectInputStream(socket.getInputStream)
 
 					try {

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -92,6 +92,8 @@ public class ForkMain {
 		Socket socket = new Socket(InetAddress.getByName(null), Integer.valueOf(args[0]));
 		final ObjectInputStream is = new ObjectInputStream(socket.getInputStream());
 		final ObjectOutputStream os = new ObjectOutputStream(socket.getOutputStream());
+		// Must flush the header that the constructor writes, otherwise the ObjectInputStream on the other end may block indefinitely
+		os.flush();
 		try {
 			try {
 				new Run().run(is, os);


### PR DESCRIPTION
This protects against deadlocks between the writing and reading end, since the ObjectOutputStream constructor writes a header, but does not flush, and the ObjectInputStream constructor reads the header, and blocks until it's read.
