### PR TITLE
avoid deadlock in ConsoleOut.systemOutOverwrite

### DIFF
--- a/util/log/src/main/scala/sbt/ConsoleOut.scala
+++ b/util/log/src/main/scala/sbt/ConsoleOut.scala
@@ -34,8 +34,8 @@ object ConsoleOut
 		def println(): Unit = synchronized {
 			val s = current.toString
 			if(ConsoleLogger.formatEnabled && last.exists(lmsg => f(s, lmsg)))
-				System.out.print(OverwriteLine)
-			System.out.println(s)
+				lockObject.print(OverwriteLine)
+			lockObject.println(s)
 			last = Some(s)
 			current = new java.lang.StringBuffer
 		}


### PR DESCRIPTION
System.out can be reset after being captured by `val lockObject`.
Then locking `lockObject` and calling `println()` could lead to a
deadlock.
