### PR TITLE
Log socket accept errors when forking tests

### DIFF
--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -46,7 +46,11 @@ private[sbt] object ForkTests
 						try {
 							server.accept()
 						} catch {
-							case _: java.net.SocketException => return
+							case e: java.net.SocketException =>
+                log.error("Could not accept connection from test agent: " + e.getClass + ": " + e.getMessage)
+                log.trace(e)
+                server.close()
+                return
 						}
 					val os = new ObjectOutputStream(socket.getOutputStream)
 					// Must flush the header that the constructor writes, otherwise the ObjectInputStream on the other end may block indefinitely


### PR DESCRIPTION
If an exception is thrown when accepting a connection from a forked test agent, currently I'm seeing that all that happens is SBT hangs with no output.  Thread dumps show that the main process is waiting for the agent to return, while the agent is waiting for the server to send it something.

This change logs the exception, so that at least the error can be googled. It also cleans up the server socket.
