### PR TITLE
Add pending test case for #958 (incremental compiler bug)

### DIFF
--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
@@ -1,0 +1,1 @@
+incOptions := sbt.inc.IncOptions.Default

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/changes/A1.scala
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/changes/A1.scala
@@ -1,0 +1,3 @@
+class A {
+//	def initialized: Boolean = false
+}

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/changes/A2.scala
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/changes/A2.scala
@@ -1,0 +1,3 @@
+class A {
+	def initialized: Boolean = false
+}

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/pending
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/pending
@@ -1,0 +1,9 @@
+> compile
+# comment out `initialized` method in A
+$ copy-file changes/A1.scala src/main/scala/A.scala
+# compilation of A.scala succeeds but B.scala gets invalidated (properly) and B.scala fails to compile
+-> compile
+# we change A.scala to its original shape so compilation should succeed again
+$ copy-file changes/A2.scala src/main/scala/A.scala
+# this fails at the moment due to use of stale class file for A, see #958 for details
+> compile

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/src/main/scala/A.scala
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/src/main/scala/A.scala
@@ -1,0 +1,3 @@
+class A {
+	def initialized: Boolean = false
+}

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/src/main/scala/B.scala
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/src/main/scala/B.scala
@@ -1,0 +1,3 @@
+class B {
+	def foo(a: A): Boolean = a.initialized
+}


### PR DESCRIPTION
The ticket contains detailed description of the problem. The test case
just shows that if we set `incOptions := sbt.inc.IncOptions.Default`
then the incremental compiler doesn't recover from compiler errors
properly.
