### PR TITLE
Allow specifying sbt.boot.properties as a URI

### DIFF
--- a/launch/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launch/src/main/scala/xsbt/boot/Configuration.scala
@@ -126,8 +126,11 @@ object Configuration
 	}
 	// single-arg constructor doesn't properly escape
 	def filePathURI(path: String): URI = {
-		val f = new File(path)
-		new URI(if(f.isAbsolute) "file" else null, path, null)
+		if(path.startsWith("file:")) new URI(path)
+		else {
+			val f = new File(path)
+			new URI(if(f.isAbsolute) "file" else null, path, null)
+		}
 	}
 	def directoryURI(dir: File): URI = directoryURI(dir.toURI)
 	def directoryURI(uri: URI): URI = 

--- a/launch/src/test/scala/URITests.scala
+++ b/launch/src/test/scala/URITests.scala
@@ -40,4 +40,20 @@ object URITests extends Properties("URI Tests")
 		s"via file: $viaFile" |:
 		(viaPath == viaFile)
 	}
+
+	property("filePathURI supports URIs") =  secure {
+		val s = "file:///is/a/uri/with%20spaces"
+		val decoded = "/is/a/uri/with spaces"
+		val encoded = "/is/a/uri/with%20spaces"
+		val fpURI = filePathURI(s)
+		val directURI = new URI(s)
+		s"filePathURI: $fpURI" |:
+		s"direct URI: $directURI" |:
+		s"getPath: ${fpURI.getPath}" |:
+		s"getRawPath: ${fpURI.getRawPath}" |:
+		(fpURI == directURI) &&
+		(fpURI.getPath == decoded) &&
+		(fpURI.getRawPath == encoded)
+	}
+
 }

--- a/src/sphinx/Detailed-Topics/Command-Line-Reference.rst
+++ b/src/sphinx/Detailed-Topics/Command-Line-Reference.rst
@@ -210,7 +210,11 @@ influence SBT execution. Also see :doc:`Launcher`.
 | `sbt.version`                | Version   | 0.11.3              | sbt version to use, usually taken from             | 
 |                              |           |                     | project/build.properties                           |
 +------------------------------+-----------+---------------------+----------------------------------------------------+
-| `sbt.boot.properties`        | File      |                     |                                                    |
+| `sbt.boot.properties`        | File      |                     | The path to find the SBT boot properties file.     |
+|                              |           |                     | This can be a relative path, relative to the SBT   |
+|                              |           |                     | base directory, the users home directory or the    |
+|                              |           |                     | location of the sbt jar file, or it can be an      |
+|                              |           |                     | absolute path, or it can be an absolute file URI.  |
 +------------------------------+-----------+---------------------+----------------------------------------------------+
 | `sbt.override.build.repos`   | Boolean   | false               | If true, repositories configured in a build        | 
 |                              |           |                     | definition are ignored and the repositories        |

--- a/src/sphinx/Detailed-Topics/Launcher.rst
+++ b/src/sphinx/Detailed-Topics/Launcher.rst
@@ -57,13 +57,14 @@ increasing order of precedence:
 -  Put a configuration file named `sbt.boot.properties` on the
    classpath. Put it in the classpath root without the `/sbt` prefix.
 -  Specify the location of an alternate configuration on the command
-   line. This can be done by either specifying the location as the
-   system property `sbt.boot.properties` or as the first argument to
-   the launcher prefixed by `'@'`. The system property has lower
-   precedence. Resolution of a relative path is first attempted against
-   the current working directory, then against the user's home
-   directory, and then against the directory containing the launcher
-   jar. An error is generated if none of these attempts succeed.
+   line, either as a path or an absolute URI. This can be done by
+   either specifying the location as the system property
+   `sbt.boot.properties` or as the first argument to the launcher
+   prefixed by `'@'`. The system property has lower precedence.
+   Resolution of a relative path is first attempted against the current
+   working directory, then against the user's home directory, and then
+   against the directory containing the launcher jar. An error is
+   generated if none of these attempts succeed.
 
 Syntax
 ~~~~~~


### PR DESCRIPTION
This allows straight forward system independent generation of the property, since URIs are well specified and only support one file separator.

Play was relying on this behaviour in SBT 0.12, which worked by accident.  This makes it explicitly supported, tested and documented.
