### PR TITLE
Second draft to execute the forked tests in parallel.

### DIFF
--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -12,7 +12,7 @@ import ForkMain._
 
 private[sbt] object ForkTests
 {
-	def apply(runners: Map[TestFramework, Runner],  tests: List[TestDefinition], config: Execution, classpath: Seq[File], fork: ForkOptions, log: Logger, parallel: Boolean): Task[TestOutput]  = {
+	def apply(runners: Map[TestFramework, Runner],  tests: List[TestDefinition], config: Execution, classpath: Seq[File], fork: ForkOptions, log: Logger): Task[TestOutput]  = {
 		val opts = processOptions(config, tests, log)
 
 			import std.TaskExtra._
@@ -23,7 +23,7 @@ private[sbt] object ForkTests
 			if(opts.tests.isEmpty)
 				constant( TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty) )
 			else
-				mainTestTask(runners, opts, classpath, fork, log, parallel).tagw(config.tags: _*)
+				mainTestTask(runners, opts, classpath, fork, log, config.parallel).tagw(config.tags: _*)
 		main.dependsOn( all(opts.setup) : _*) flatMap { results =>
 			all(opts.cleanup).join.map( _ => results)
 		}

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -195,6 +195,7 @@ object Keys
 	val testOptions = TaskKey[Seq[TestOption]]("test-options", "Options for running tests.", BPlusTask)
 	val testFrameworks = SettingKey[Seq[TestFramework]]("test-frameworks", "Registered, although not necessarily present, test frameworks.", CTask)
 	val testListeners = TaskKey[Seq[TestReportListener]]("test-listeners", "Defines test listeners.", DTask)
+	val testForkedParallel = SettingKey[Boolean]("test-forked-parallel", "Whether forked tests should be executed in parallel", CTask)
 	val testExecution = TaskKey[Tests.Execution]("test-execution", "Settings controlling test execution", DTask)
 	val testFilter = TaskKey[Seq[String] => Seq[String => Boolean]]("test-filter", "Filter controlling whether the test is executed", DTask)
 	val testGrouping = TaskKey[Seq[Tests.Group]]("test-grouping", "Collects discovered tests into groups. Whether to fork and the options for forking are configurable on a per-group basis.", BMinusTask)

--- a/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
+++ b/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
@@ -1,0 +1,19 @@
+import sbt._
+import Keys._
+import Tests._
+import Defaults._
+
+object ForkParallelTest extends Build {
+	val check = taskKey[Unit]("Check that tests are executed in parallel")
+
+	lazy val root = Project("root", file("."), settings = defaultSettings ++ Seq(
+		scalaVersion := "2.9.2",
+		libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
+		fork in Test := true,
+		check := {
+			if( ! (file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() )) {
+				sys.error("Forked tests were not executed in parallel!")
+			}
+		}
+	))
+}

--- a/sbt/src/sbt-test/tests/fork-parallel/src/test/scala/tests.scala
+++ b/sbt/src/sbt-test/tests/fork-parallel/src/test/scala/tests.scala
@@ -1,0 +1,53 @@
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Test
+import scala.annotation.tailrec
+
+object ParallelTest {
+	val nbConcurrentTests = new AtomicInteger(0)
+	val maxConcurrentTests = new AtomicInteger(0)
+
+	private def updateMaxConcurrentTests(currentMax: Int, newMax: Int) : Boolean = {
+		if( maxConcurrentTests.compareAndSet(currentMax, newMax) ) {
+			val f = new File("max-concurrent-tests_" + newMax)
+			f.createNewFile
+			true
+		} else {
+			false
+		}
+	}
+
+	@tailrec
+	def execute(f : => Unit) {
+		val nb = nbConcurrentTests.incrementAndGet()
+		val max = maxConcurrentTests.get()
+		if( nb <= max || updateMaxConcurrentTests(max, nb)) {
+			f
+			nbConcurrentTests.getAndDecrement
+		} else {
+			nbConcurrentTests.getAndDecrement
+			execute(f)
+		}
+	}
+}
+
+class Test1 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test2 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test3 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test4 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}

--- a/sbt/src/sbt-test/tests/fork-parallel/test
+++ b/sbt/src/sbt-test/tests/fork-parallel/test
@@ -1,0 +1,7 @@
+> test
+-> check
+
+> clean
+> set testForkedParallel := true
+> test
+> check

--- a/sbt/src/sbt-test/tests/fork/project/ForkTestsTest.scala
+++ b/sbt/src/sbt-test/tests/fork/project/ForkTestsTest.scala
@@ -26,7 +26,7 @@ object ForkTestsTest extends Build {
 			val (exist, absent) = files.partition(_.exists)
 			exist.foreach(_.delete())
 			if(absent.nonEmpty)
-				error("Files were not created:\n\t" + absent.mkString("\n\t"))
+				sys.error("Files were not created:\n\t" + absent.mkString("\n\t"))
 		},
 		concurrentRestrictions := Tags.limit(Tags.ForkedTestGroup, 2) :: Nil,
 		libraryDependencies += "org.scalatest" %% "scalatest" % "1.8" % "test"

--- a/testing/agent/src/main/java/sbt/ForkConfiguration.java
+++ b/testing/agent/src/main/java/sbt/ForkConfiguration.java
@@ -1,0 +1,21 @@
+package sbt;
+
+import java.io.Serializable;
+
+public final class ForkConfiguration implements Serializable {
+	private boolean ansiCodesSupported;
+	private boolean parallel;
+
+	public ForkConfiguration(boolean ansiCodesSupported, boolean parallel) {
+		this.ansiCodesSupported = ansiCodesSupported;
+		this.parallel = parallel;
+	}
+
+	public boolean isAnsiCodesSupported() {
+		return ansiCodesSupported;
+	}
+
+	public boolean isParallel() {
+		return parallel;
+	}
+}

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -12,10 +12,15 @@ import java.io.Serializable;
 import java.net.Socket;
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
 
 public class ForkMain {
+
+	// serializables
+	// -----------------------------------------------------------------------------
+
 	static class SubclassFingerscan implements SubclassFingerprint, Serializable {
 		private boolean isModule;
 		private String superclassName;
@@ -29,6 +34,7 @@ public class ForkMain {
 		public String superclassName() { return superclassName; }
 		public boolean requireNoArgConstructor() { return requireNoArgConstructor; }
 	}
+
 	static class AnnotatedFingerscan implements AnnotatedFingerprint, Serializable {
 		private boolean isModule;
 		private String annotationName;
@@ -39,6 +45,54 @@ public class ForkMain {
 		public boolean isModule() { return isModule; }
 		public String annotationName() { return annotationName; }
 	}
+
+	static class ForkEvent implements Event, Serializable {
+		private String fullyQualifiedName;
+		private Fingerprint fingerprint;
+		private Selector selector;
+		private Status status;
+		private OptionalThrowable throwable;
+		private long duration;
+
+		ForkEvent(Event e) {
+			fullyQualifiedName = e.fullyQualifiedName();
+			Fingerprint rawFingerprint = e.fingerprint();
+
+			if (rawFingerprint instanceof SubclassFingerprint)
+				this.fingerprint = new SubclassFingerscan((SubclassFingerprint) rawFingerprint);
+			else
+				this.fingerprint = new AnnotatedFingerscan((AnnotatedFingerprint) rawFingerprint);
+
+			selector = e.selector();
+			checkSerializableSelector(selector);
+			status = e.status();
+			OptionalThrowable originalThrowable = e.throwable();
+
+			if (originalThrowable.isDefined())
+				this.throwable = new OptionalThrowable(new ForkError(originalThrowable.get()));
+			else
+				this.throwable = originalThrowable;
+
+			this.duration = e.duration();
+		}
+
+		public String fullyQualifiedName() { return fullyQualifiedName; }
+		public Fingerprint fingerprint() { return fingerprint; }
+		public Selector selector() { return selector; }
+		public Status status() { return status; }
+		public OptionalThrowable throwable() { return throwable; }
+		public long duration() { return duration; }
+
+		static void checkSerializableSelector(Selector selector) {
+			if (! (selector instanceof Serializable)) {
+				throw new UnsupportedOperationException("Selector implementation must be Serializable, but " + selector.getClass().getName() + " is not.");
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------------
+
+
 	static class ForkError extends Exception {
 		private String originalMessage;
 		private ForkError cause;
@@ -50,62 +104,50 @@ public class ForkMain {
 		public String getMessage() { return originalMessage; }
 		public Exception getCause() { return cause; }
 	}
-	
-	static Selector forkSelector(Selector selector) {
-		if (selector instanceof Serializable)
-			return selector;
-		else
-			throw new UnsupportedOperationException("Selector implementation must be Serializable, but " + selector.getClass().getName() + " is not.");
-	}
-	
-	static class ForkEvent implements Event, Serializable {
-		private String fullyQualifiedName;
-		private Fingerprint fingerprint;
-		private Selector selector;
-		private Status status;
-		private OptionalThrowable throwable;
-		private long duration;
-		ForkEvent(Event e) {
-			fullyQualifiedName = e.fullyQualifiedName();
-			Fingerprint rawFingerprint = e.fingerprint();
-			if (rawFingerprint instanceof SubclassFingerprint) 
-				this.fingerprint = new SubclassFingerscan((SubclassFingerprint) rawFingerprint);
-			else 
-				this.fingerprint = new AnnotatedFingerscan((AnnotatedFingerprint) rawFingerprint);
-			selector = forkSelector(e.selector());
-			status = e.status();
-			OptionalThrowable originalThrowable = e.throwable();
-			if (originalThrowable.isDefined())
-				this.throwable = new OptionalThrowable(new ForkError(originalThrowable.get()));
-			else
-				this.throwable = originalThrowable;
-			this.duration = e.duration();
-		}
-		public String fullyQualifiedName() { return fullyQualifiedName; }
-		public Fingerprint fingerprint() { return fingerprint; }
-		public Selector selector() { return selector; }
-		public Status status() { return status; }
-		public OptionalThrowable throwable() { return throwable; }
-		public long duration() { return duration; }
-	}
+
+
+	// main
+	// ----------------------------------------------------------------------------------------------------------------
+
 	public static void main(String[] args) throws Exception {
 		Socket socket = new Socket(InetAddress.getByName(null), Integer.valueOf(args[0]));
 		final ObjectInputStream is = new ObjectInputStream(socket.getInputStream());
 		final ObjectOutputStream os = new ObjectOutputStream(socket.getOutputStream());
 		// Must flush the header that the constructor writes, otherwise the ObjectInputStream on the other end may block indefinitely
 		os.flush();
+
 		try {
+			new Run().run(is, os);
+		} finally {
 			try {
-				new Run().run(is, os);
-			} finally {
 				is.close();
 				os.close();
+			} finally {
+				System.exit(0);
 			}
-		} finally {
-			System.exit(0);
 		}
 	}
+
+	// ----------------------------------------------------------------------------------------------------------------
+
+
 	private static class Run {
+
+		void run(ObjectInputStream is, ObjectOutputStream os) throws Exception {
+			try {
+				runTests(is, os);
+			} catch (RunAborted e) {
+				internalError(e);
+			} catch (Throwable t) {
+				try {
+					logError(os, "Uncaught exception when running tests: " + t.toString());
+					write(os, new ForkError(t));
+				} catch (Throwable t2) {
+					internalError(t2);
+				}
+			}
+		}
+
 		boolean matches(Fingerprint f1, Fingerprint f2) {
 			if (f1 instanceof SubclassFingerprint && f2 instanceof SubclassFingerprint) {
 				final SubclassFingerprint sf1 = (SubclassFingerprint) f1;
@@ -118,9 +160,11 @@ public class ForkMain {
 			}
 			return false;
 		}
+
 		class RunAborted extends RuntimeException {
 			RunAborted(Exception e) { super(e); }
 		}
+
 		synchronized void write(ObjectOutputStream os, Object obj) {
 			try {
 				os.writeObject(obj);
@@ -129,29 +173,47 @@ public class ForkMain {
 				throw new RunAborted(e);
 			}
 		}
-		void logError(ObjectOutputStream os, String message) {
-			write(os, new Object[]{ForkTags.Error, message});
+
+		void log(ObjectOutputStream os, String message, ForkTags level) {
+			write(os, new Object[]{level, message});
 		}
-		void logDebug(ObjectOutputStream os, String message) {
-			write(os, new Object[]{ForkTags.Debug, message});
+
+		void logDebug(ObjectOutputStream os, String message) { log(os, message, ForkTags.Debug); }
+		void logInfo(ObjectOutputStream os, String message) { log(os, message, ForkTags.Info); }
+		void logWarn(ObjectOutputStream os, String message) { log(os, message, ForkTags.Warn); }
+		void logError(ObjectOutputStream os, String message) { log(os, message, ForkTags.Error); }
+
+		Logger remoteLogger(final boolean ansiCodesSupported, final ObjectOutputStream os) {
+			return new Logger() {
+				public boolean ansiCodesSupported() { return ansiCodesSupported; }
+				public void error(String s) { logError(os, s); }
+				public void warn(String s) { logWarn(os, s); }
+				public void info(String s) { logInfo(os, s); }
+				public void debug(String s) { logDebug(os, s); }
+				public void trace(Throwable t) { write(os, new ForkError(t)); }
+			};
 		}
+
 		void writeEvents(ObjectOutputStream os, TaskDef taskDef, ForkEvent[] events) {
 			write(os, new Object[]{taskDef.fullyQualifiedName(), events});
 		}
+
+		ExecutorService executorService(ForkConfiguration config) {
+			if(config.isParallel()) {
+				// more options later...
+				// TODO we might want to configure the blocking queue with size #proc
+				return Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+			} else {
+				return Executors.newSingleThreadExecutor();
+			}
+		}
+
 		void runTests(ObjectInputStream is, final ObjectOutputStream os) throws Exception {
-			final boolean ansiCodesSupported = is.readBoolean();
+			final ForkConfiguration config = (ForkConfiguration) is.readObject();
+			ExecutorService executor = executorService(config);
 			final TaskDef[] tests = (TaskDef[]) is.readObject();
 			int nFrameworks = is.readInt();
-			Logger[] loggers = {
-				new Logger() {
-					public boolean ansiCodesSupported() { return ansiCodesSupported; }
-					public void error(String s) { logError(os, s); }
-					public void warn(String s) { write(os, new Object[]{ForkTags.Warn, s}); }
-					public void info(String s) { write(os, new Object[]{ForkTags.Info, s}); }
-					public void debug(String s) { write(os, new Object[]{ForkTags.Debug, s}); }
-					public void trace(Throwable t) { write(os, new ForkError(t)); }
-				}
-			};
+			Logger[] loggers = { remoteLogger(config.isAnsiCodesSupported(), os) };
 
 			for (int i = 0; i < nFrameworks; i++) {
 				final String[] implClassNames = (String[]) is.readObject();
@@ -165,7 +227,7 @@ public class ForkMain {
 						if (rawFramework instanceof Framework)
 							framework = (Framework) rawFramework;
 						else
-							framework = new FrameworkWrapper((org.scalatools.testing.Framework) rawFramework);
+							framework = new FrameworkAdapter((org.scalatools.testing.Framework) rawFramework);
 						break;
 					} catch (ClassNotFoundException e) {
 						logDebug(os, "Framework implementation '" + implClassName + "' not present.");
@@ -186,89 +248,66 @@ public class ForkMain {
 				final Runner runner = framework.runner(frameworkArgs, remoteFrameworkArgs, getClass().getClassLoader());
 				Task[] tasks = runner.tasks(filteredTests.toArray(new TaskDef[filteredTests.size()]));
 				logDebug(os, "Runner for " + framework.getClass().getName() + " produced " + tasks.length + " initial tasks for " + filteredTests.size() + " tests.");
-				for (Task task : tasks)
-					runTestSafe(task, runner, loggers, os);
+
+				runTestTasks(executor, tasks, loggers, os);
+
 				runner.done();
 			}
 			write(os, ForkTags.Done);
 			is.readObject();
 		}
-		class NestedTask {
-			private String parentName;
-			private Task task;
-			NestedTask(String parentName, Task task) {
-				this.parentName = parentName;
-				this.task = task;
-			}
-			public String getParentName() {
-				return parentName;
-			}
-			public Task getTask() {
-				return task;
-			}
-		}
-		void runTestSafe(Task task, Runner runner, Logger[] loggers, ObjectOutputStream os) {
-			TaskDef taskDef = task.taskDef();
-			try {
-				List<NestedTask> nestedTasks = new ArrayList<NestedTask>();
-				for (Task nt : runTest(taskDef, task, loggers, os))
-					nestedTasks.add(new NestedTask(taskDef.fullyQualifiedName(), nt));
-				while (true) {
-					List<NestedTask> newNestedTasks = new ArrayList<NestedTask>();
-					int nestedTasksLength = nestedTasks.size();
-					for (int i = 0; i < nestedTasksLength; i++) {
-						NestedTask nestedTask = nestedTasks.get(i);
-						String nestedParentName = nestedTask.getParentName() + "-" + i;
-						for (Task nt : runTest(nestedTask.getTask().taskDef(), nestedTask.getTask(), loggers, os)) {
-							newNestedTasks.add(new NestedTask(nestedParentName, nt));
-						}
-					}
-					if (newNestedTasks.size() == 0)
-						break;
-					else {
-						nestedTasks = newNestedTasks;
+
+		void runTestTasks(ExecutorService executor, Task[] tasks, Logger[] loggers, ObjectOutputStream os) {
+			if( tasks.length > 0 ) {
+				List<Future<Task[]>> futureNestedTasks = new ArrayList<Future<Task[]>>();
+				for( Task task : tasks ) {
+					futureNestedTasks.add(runTest(executor, task, loggers, os));
+				}
+
+				// Note: this could be optimized further, we could have a callback once a test finishes that executes immediately the nested tasks
+				//       At the moment, I'm especially interested in JUnit, which doesn't have nested tasks.
+				List<Task> nestedTasks = new ArrayList<Task>();
+				for( Future<Task[]> futureNestedTask : futureNestedTasks ) {
+					try {
+						nestedTasks.addAll( Arrays.asList(futureNestedTask.get()));
+					} catch (Exception e) {
+						logError(os, "Failed to execute task " + futureNestedTask);
 					}
 				}
-			} catch (Throwable t) {
-				writeEvents(os, taskDef, new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) });
+				runTestTasks(executor, nestedTasks.toArray(new Task[nestedTasks.size()]), loggers, os);
 			}
 		}
-		Task[] runTest(TaskDef taskDef, Task task, Logger[] loggers, ObjectOutputStream os) {
-			ForkEvent[] events;
-			Task[] nestedTasks;
-			try {
-				final List<ForkEvent> eventList = new ArrayList<ForkEvent>();
-				EventHandler handler = new EventHandler() { public void handle(Event e){ eventList.add(new ForkEvent(e)); } };
-				logDebug(os, "  Running " + taskDef);
-				nestedTasks = task.execute(handler, loggers);
-				if(nestedTasks.length > 0 || eventList.size() > 0)
-					logDebug(os, "    Produced " + nestedTasks.length + " nested tasks and " + eventList.size() + " events.");
-				events = eventList.toArray(new ForkEvent[eventList.size()]);
-			}
-			catch (Throwable t) {
-				nestedTasks = new Task[0];
-				events = new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) };
-			}
-			writeEvents(os, taskDef, events);
-			return nestedTasks;
-		}
-		void run(ObjectInputStream is, ObjectOutputStream os) throws Exception {
-			try {
-				runTests(is, os);
-			} catch (RunAborted e) {
-				internalError(e);
-			} catch (Throwable t) {
-				try {
-					logError(os, "Uncaught exception when running tests: " + t.toString());
-					write(os, new ForkError(t));
-				} catch (Throwable t2) {
-					internalError(t2);
+
+		Future<Task[]> runTest(ExecutorService executor, final Task task, final Logger[] loggers, final ObjectOutputStream os) {
+			return executor.submit(new Callable<Task[]>() {
+				@Override
+				public Task[] call() {
+					ForkEvent[] events;
+					Task[] nestedTasks;
+					TaskDef taskDef = task.taskDef();
+					try {
+						final List<ForkEvent> eventList = new ArrayList<ForkEvent>();
+						EventHandler handler = new EventHandler() { public void handle(Event e){ eventList.add(new ForkEvent(e)); } };
+						logDebug(os, "  Running " + taskDef);
+						nestedTasks = task.execute(handler, loggers);
+						if(nestedTasks.length > 0 || eventList.size() > 0)
+							logDebug(os, "    Produced " + nestedTasks.length + " nested tasks and " + eventList.size() + " events.");
+						events = eventList.toArray(new ForkEvent[eventList.size()]);
+					}
+					catch (Throwable t) {
+						nestedTasks = new Task[0];
+						events = new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) };
+					}
+					writeEvents(os, taskDef, events);
+					return nestedTasks;
 				}
-			}
+			});
 		}
+
 		void internalError(Throwable t) {
 			System.err.println("Internal error when running tests: " + t.toString());
 		}
+
 		ForkEvent testEvent(final String fullyQualifiedName, final Fingerprint fingerprint, final Selector selector, final Status r, final ForkError err, final long duration) {
 			final OptionalThrowable throwable;
 			if (err == null)
@@ -280,21 +319,18 @@ public class ForkMain {
 				public Fingerprint fingerprint() { return fingerprint; }
 				public Selector selector() { return selector; }
 				public Status status() { return r; }
-				public OptionalThrowable throwable() { 
-					return throwable; 
+				public OptionalThrowable throwable() {
+					return throwable;
 				}
 				public long duration() {
 					return duration;
 				}
 			});
 		}
-		ForkEvent testError(ObjectOutputStream os, TaskDef taskDef, String message) {
-			logError(os, message);
-			return testEvent(taskDef.fullyQualifiedName(), taskDef.fingerprint(), new SuiteSelector(), Status.Error, null, 0);
-		}
+
 		ForkEvent testError(ObjectOutputStream os, TaskDef taskDef, String message, Throwable t) {
 			logError(os, message);
-         ForkError fe = new ForkError(t);
+			ForkError fe = new ForkError(t);
 			write(os, fe);
 			return testEvent(taskDef.fullyQualifiedName(), taskDef.fingerprint(), new SuiteSelector(), Status.Error, fe, 0);
 		}

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -227,7 +227,7 @@ public class ForkMain {
 						if (rawFramework instanceof Framework)
 							framework = (Framework) rawFramework;
 						else
-							framework = new FrameworkAdapter((org.scalatools.testing.Framework) rawFramework);
+							framework = new FrameworkWrapper((org.scalatools.testing.Framework) rawFramework);
 						break;
 					} catch (ClassNotFoundException e) {
 						logDebug(os, "Framework implementation '" + implClassName + "' not present.");

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -198,19 +198,22 @@ public class ForkMain {
 			write(os, new Object[]{taskDef.fullyQualifiedName(), events});
 		}
 
-		ExecutorService executorService(ForkConfiguration config) {
+		ExecutorService executorService(ForkConfiguration config, ObjectOutputStream os) {
 			if(config.isParallel()) {
+				int nbThreads = Runtime.getRuntime().availableProcessors();
+				logDebug(os, "Create a test executor with a thread pool of " + nbThreads + " threads.");
 				// more options later...
 				// TODO we might want to configure the blocking queue with size #proc
-				return Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+				return Executors.newFixedThreadPool(nbThreads);
 			} else {
+				logDebug(os, "Create a single-thread test executor");
 				return Executors.newSingleThreadExecutor();
 			}
 		}
 
 		void runTests(ObjectInputStream is, final ObjectOutputStream os) throws Exception {
 			final ForkConfiguration config = (ForkConfiguration) is.readObject();
-			ExecutorService executor = executorService(config);
+			ExecutorService executor = executorService(config, os);
 			final TaskDef[] tests = (TaskDef[]) is.readObject();
 			int nFrameworks = is.readInt();
 			Logger[] loggers = { remoteLogger(config.isAnsiCodesSupported(), os) };

--- a/testing/agent/src/main/java/sbt/FrameworkWrapper.java
+++ b/testing/agent/src/main/java/sbt/FrameworkWrapper.java
@@ -6,11 +6,11 @@ import sbt.testing.*;
  * Adapts the old {@link org.scalatools.testing.Framework} interface into the new
  * {@link sbt.testing.Framework}
  */
-final class FrameworkAdapter implements Framework {
+final class FrameworkWrapper implements Framework {
 
 	private org.scalatools.testing.Framework oldFramework;
 
-	public FrameworkAdapter(org.scalatools.testing.Framework oldFramework) {
+	public FrameworkWrapper(org.scalatools.testing.Framework oldFramework) {
 		this.oldFramework = oldFramework;
 	}
 
@@ -25,26 +25,26 @@ final class FrameworkAdapter implements Framework {
 		for (int i=0; i < length; i++) {
 			org.scalatools.testing.Fingerprint oldFingerprint = oldFingerprints[i];
 			if (oldFingerprint instanceof org.scalatools.testing.TestFingerprint)
-				fingerprints[i] = new SubclassFingerprintAdapter((org.scalatools.testing.TestFingerprint) oldFingerprint);
+				fingerprints[i] = new SubclassFingerprintWrapper((org.scalatools.testing.TestFingerprint) oldFingerprint);
 			else if (oldFingerprint instanceof org.scalatools.testing.SubclassFingerprint)
-				fingerprints[i] = new SubclassFingerprintAdapter((org.scalatools.testing.SubclassFingerprint) oldFingerprint);
+				fingerprints[i] = new SubclassFingerprintWrapper((org.scalatools.testing.SubclassFingerprint) oldFingerprint);
 			else
-				fingerprints[i] = new AnnotatedFingerprintAdapter((org.scalatools.testing.AnnotatedFingerprint) oldFingerprint);
+				fingerprints[i] = new AnnotatedFingerprintWrapper((org.scalatools.testing.AnnotatedFingerprint) oldFingerprint);
 		}
 		return fingerprints;
 	}
 
 	public Runner runner(String[] args, String[] remoteArgs, ClassLoader testClassLoader) {
-		return new RunnerAdapter(oldFramework, testClassLoader, args);
+		return new RunnerWrapper(oldFramework, testClassLoader, args);
 	}
 }
 
-final class SubclassFingerprintAdapter implements SubclassFingerprint {
+final class SubclassFingerprintWrapper implements SubclassFingerprint {
 	private String superclassName;
 	private boolean isModule;
 	private boolean requireNoArgConstructor;
 
-	public SubclassFingerprintAdapter(org.scalatools.testing.SubclassFingerprint oldFingerprint) {
+	public SubclassFingerprintWrapper(org.scalatools.testing.SubclassFingerprint oldFingerprint) {
 		this.superclassName = oldFingerprint.superClassName();
 		this.isModule = oldFingerprint.isModule();
 		this.requireNoArgConstructor = false;  // Old framework SubclassFingerprint does not require no arg constructor
@@ -63,11 +63,11 @@ final class SubclassFingerprintAdapter implements SubclassFingerprint {
 	}
 }
 
-final class AnnotatedFingerprintAdapter implements AnnotatedFingerprint {
+final class AnnotatedFingerprintWrapper implements AnnotatedFingerprint {
 	private String annotationName;
 	private boolean isModule;
 
-	public AnnotatedFingerprintAdapter(org.scalatools.testing.AnnotatedFingerprint oldFingerprint) {
+	public AnnotatedFingerprintWrapper(org.scalatools.testing.AnnotatedFingerprint oldFingerprint) {
 		this.annotationName = oldFingerprint.annotationName();
 		this.isModule = oldFingerprint.isModule();
 	}
@@ -81,31 +81,31 @@ final class AnnotatedFingerprintAdapter implements AnnotatedFingerprint {
 	}
 }
 
-final class EventHandlerAdapter implements org.scalatools.testing.EventHandler {
+final class EventHandlerWrapper implements org.scalatools.testing.EventHandler {
 
 	private EventHandler newEventHandler;
 	private String fullyQualifiedName;
 	private Fingerprint fingerprint;
 
-	public EventHandlerAdapter(EventHandler newEventHandler, String fullyQualifiedName, Fingerprint fingerprint) {
+	public EventHandlerWrapper(EventHandler newEventHandler, String fullyQualifiedName, Fingerprint fingerprint) {
 		this.newEventHandler = newEventHandler;
 		this.fullyQualifiedName = fullyQualifiedName;
 		this.fingerprint = fingerprint;
 	}
 
 	public void handle(org.scalatools.testing.Event oldEvent) {
-		newEventHandler.handle(new EventAdapter(oldEvent, fullyQualifiedName, fingerprint));
+		newEventHandler.handle(new EventWrapper(oldEvent, fullyQualifiedName, fingerprint));
 	}
 }
 
-final class EventAdapter implements Event {
+final class EventWrapper implements Event {
 
 	private org.scalatools.testing.Event oldEvent;
 	private String className;
 	private Fingerprint fingerprint;
 	private OptionalThrowable throwable;
 
-	public EventAdapter(org.scalatools.testing.Event oldEvent, String className, Fingerprint fingerprint) {
+	public EventWrapper(org.scalatools.testing.Event oldEvent, String className, Fingerprint fingerprint) {
 		this.oldEvent = oldEvent;
 		this.className = className;
 		this.fingerprint = fingerprint;
@@ -152,13 +152,13 @@ final class EventAdapter implements Event {
 	}
 }
 
-final class RunnerAdapter implements Runner {
+final class RunnerWrapper implements Runner {
 
 	private org.scalatools.testing.Framework oldFramework;
 	private ClassLoader testClassLoader;
 	private String[] args;
 
-	public RunnerAdapter(org.scalatools.testing.Framework oldFramework, ClassLoader testClassLoader, String[] args) {
+	public RunnerWrapper(org.scalatools.testing.Framework oldFramework, ClassLoader testClassLoader, String[] args) {
 		this.oldFramework = oldFramework;
 		this.testClassLoader = testClassLoader;
 		this.args = args;
@@ -200,7 +200,7 @@ final class RunnerAdapter implements Runner {
 						public String superClassName() { return subclassFingerprint.superclassName(); }
 					};
 				final String name = taskDef.fullyQualifiedName();
-				runner.run(name, oldFingerprint, new EventHandlerAdapter(eventHandler, name, subclassFingerprint), args);
+				runner.run(name, oldFingerprint, new EventHandlerWrapper(eventHandler, name, subclassFingerprint), args);
 			}
 			
 			private void runRunner2(org.scalatools.testing.Runner2 runner, Fingerprint fingerprint, EventHandler eventHandler) {
@@ -220,7 +220,7 @@ final class RunnerAdapter implements Runner {
 					};
 				}
 				final String name = taskDef.fullyQualifiedName();
-				runner.run(name, oldFingerprint, new EventHandlerAdapter(eventHandler, name, fingerprint), args);
+				runner.run(name, oldFingerprint, new EventHandlerWrapper(eventHandler, name, fingerprint), args);
 			}
         
 			public Task[] execute(EventHandler eventHandler, Logger[] loggers) {

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -34,7 +34,7 @@ case class TestFramework(val implClassNames: String*)
 				{
 					Some(Class.forName(head, true, loader).newInstance match {
 						case newFramework: Framework => newFramework
-						case oldFramework: OldFramework => new FrameworkWrapper(oldFramework)
+						case oldFramework: OldFramework => new FrameworkAdapter(oldFramework)
 					})
 				}
 				catch 
@@ -65,15 +65,15 @@ final class TestDefinition(val name: String, val fingerprint: Fingerprint, val e
 
 final class TestRunner(delegate: Runner, listeners: Seq[TestReportListener], log: Logger) {
 
-    final def tasks(testDefs: Set[TestDefinition]): Array[TestTask] = 
-      delegate.tasks(testDefs.map(df => new TaskDef(df.name, df.fingerprint, df.explicitlySpecified, df.selectors)).toArray)
+	final def tasks(testDefs: Set[TestDefinition]): Array[TestTask] =
+		delegate.tasks(testDefs.map(df => new TaskDef(df.name, df.fingerprint, df.explicitlySpecified, df.selectors)).toArray)
 
 	final def run(taskDef: TaskDef, testTask: TestTask): (SuiteResult, Seq[TestTask]) =
 	{
-        val testDefinition = new TestDefinition(taskDef.fullyQualifiedName, taskDef.fingerprint, taskDef.explicitlySpecified, taskDef.selectors)
+		val testDefinition = new TestDefinition(taskDef.fullyQualifiedName, taskDef.fingerprint, taskDef.explicitlySpecified, taskDef.selectors)
 		log.debug("Running " + taskDef)
 		val name = testDefinition.name
-		
+
 		def runTest() =
 		{
 			// here we get the results! here is where we'd pass in the event listener
@@ -167,7 +167,7 @@ object TestFramework
 	{
 		import scala.collection.mutable.{HashMap, HashSet, Set}
 		val map = new HashMap[Framework, Set[TestDefinition]]
- 		def assignTest(test: TestDefinition)
+		def assignTest(test: TestDefinition)
 		{
 			def isTestForFramework(framework: Framework) = getFingerprints(framework).exists {t => matches(t, test.fingerprint) }
 			for(framework <- frameworks.find(isTestForFramework))
@@ -192,8 +192,8 @@ object TestFramework
 				val runner = runners(framework)
 				val testTasks = withContextLoader(loader) { runner.tasks(testDefinitions) }
 				for (testTask <- testTasks) yield {
-				  val taskDef = testTask.taskDef
-				  (taskDef.fullyQualifiedName, createTestFunction(loader, taskDef, runner, testTask))
+					val taskDef = testTask.taskDef
+					(taskDef.fullyQualifiedName, createTestFunction(loader, taskDef, runner, testTask))
 				}
 			}
 

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -34,7 +34,7 @@ case class TestFramework(val implClassNames: String*)
 				{
 					Some(Class.forName(head, true, loader).newInstance match {
 						case newFramework: Framework => newFramework
-						case oldFramework: OldFramework => new FrameworkAdapter(oldFramework)
+						case oldFramework: OldFramework => new FrameworkWrapper(oldFramework)
 					})
 				}
 				catch 


### PR DESCRIPTION
This feature is not activated by default. To enable it set `testForkedParallel` to `true`.

The test-agent then executes the tests in a thread pool.
For now it has a fixed size set to the number of available processors.
The concurrent restrictions configuration should be used.
