### PR TITLE
completions command

### DIFF
--- a/main/command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main/command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -12,6 +12,7 @@ import Path._
 object BasicCommandStrings
 {
 	val HelpCommand = "help"
+	val CompletionsCommand = "completions"
 	val Exit = "exit"
 	val Quit = "quit"
 
@@ -31,6 +32,9 @@ object BasicCommandStrings
 
 	Searches the help according to the provided regular expression.
 """
+
+  	def CompletionsDetailed = "Displays a list of completions for the given argument string (run 'completions <string>')."
+  	def CompletionsBrief = (CompletionsCommand, CompletionsDetailed)
 
 	def HistoryHelpBrief = (HistoryCommands.Start -> "History command help.  Lists and describes all history commands.")
 	def historyHelp = Help(Nil, (HistoryHelpBrief +: HistoryCommands.descriptions).toMap, Set(HistoryCommands.Start))

--- a/main/command/src/main/scala/sbt/BasicCommands.scala
+++ b/main/command/src/main/scala/sbt/BasicCommands.scala
@@ -15,7 +15,7 @@ package sbt
 
 object BasicCommands
 {
-	lazy val allBasicCommands = Seq(nop, ignore, help, multi, ifLast, append, setOnFailure, clearOnFailure, stashOnFailure, popOnFailure, reboot, call, early, exit, continuous, history, shell, read, alias) ++ compatCommands
+	lazy val allBasicCommands = Seq(nop, ignore, help, completionsCommand, multi, ifLast, append, setOnFailure, clearOnFailure, stashOnFailure, popOnFailure, reboot, call, early, exit, continuous, history, shell, read, alias) ++ compatCommands
 
 	def nop = Command.custom(s => success(() => s))
 	def ignore = Command.command(FailureWall)(idFun)
@@ -42,6 +42,21 @@ object BasicCommands
 	}
 	@deprecated("Use Help.moreMessage", "0.13.0")
 	def moreHelp(more: Seq[String]): String = Help.moreMessage(more)
+
+	def completionsCommand = Command.make(CompletionsCommand, CompletionsBrief, CompletionsDetailed)(completionsParser)
+	def completionsParser(state: State) =
+	{
+		applyEffect(singleArgument(Set.empty).?)(runCompletions(state))
+	}
+	def runCompletions(state: State)(input: Option[String]): State = {
+		val str = input.getOrElse("")
+		Parser.completions(state.combinedParser, str, 9).get map {
+			c => if (c.isEmpty) str else str + c.append
+		} foreach { c =>
+			System.out.println("[completions] " + c.replaceAll("\n", " "))
+		}
+		state
+	}
 
 
 	def multiParser(s: State): Parser[Seq[String]] =

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -87,7 +87,7 @@ object BuiltinCommands
 
 	def ConsoleCommands: Seq[Command] = Seq(ignore, exit, IvyConsole.command, setLogLevel, early, act, nop)
 	def ScriptCommands: Seq[Command] = Seq(ignore, exit, Script.command, setLogLevel, early, act, nop)
-	def DefaultCommands: Seq[Command] = Seq(ignore, help, about, tasks, settingsCommand, loadProject,
+	def DefaultCommands: Seq[Command] = Seq(ignore, help, completionsCommand, about, tasks, settingsCommand, loadProject,
 		projects, project, reboot, read, history, set, sessionCommand, inspect, loadProjectImpl, loadFailed, Cross.crossBuild, Cross.switchVersion,
 		setOnFailure, clearOnFailure, stashOnFailure, popOnFailure, setLogLevel,
 		ifLast, multi, shell, continuous, eval, alias, append, last, lastGrep, export, boot, nop, call, exit, early, initialize, act) ++


### PR DESCRIPTION
The completions command is meant for dump terminals that cannot use
the default tab completion. It has been built for use by the emacs
sbt-mode (see https://github.com/hvesalai/sbt-mode), but is equally
useful for other code editors that can integrate with sbt.
