### PR TITLE
added test-output segregation in forked-tests

### DIFF
--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -23,13 +23,13 @@ private[sbt] object ForkTests
 			if(opts.tests.isEmpty)
 				constant( TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty) )
 			else
-				mainTestTask(runners, opts, classpath, fork, log).tagw(config.tags: _*)
+				mainTestTask(runners, opts, classpath, fork, log, config.parallel).tagw(config.tags: _*)
 		main.dependsOn( all(opts.setup) : _*) flatMap { results =>
 			all(opts.cleanup).join.map( _ => results)
 		}
 	}
 
-	private[this] def mainTestTask(runners: Map[TestFramework, Runner], opts: ProcessedOptions, classpath: Seq[File], fork: ForkOptions, log: Logger): Task[TestOutput] =
+	private[this] def mainTestTask(runners: Map[TestFramework, Runner], opts: ProcessedOptions, classpath: Seq[File], fork: ForkOptions, log: Logger, parallel: Boolean): Task[TestOutput] =
 		std.TaskExtra.task
 		{
 			val server = new ServerSocket(0)
@@ -41,7 +41,8 @@ private[sbt] object ForkTests
 			object Acceptor extends Runnable {
 				val resultsAcc = mutable.Map.empty[String, SuiteResult]
 				lazy val result = TestOutput(overall(resultsAcc.values.map(_.result)), resultsAcc.toMap, Iterable.empty)
-				def run: Unit = {
+
+				def run() {
 					val socket =
 						try {
 							server.accept()
@@ -58,21 +59,21 @@ private[sbt] object ForkTests
 					val is = new ObjectInputStream(socket.getInputStream)
 
 					try {
-						os.writeBoolean(log.ansiCodesSupported)
+						val config = new ForkConfiguration(log.ansiCodesSupported, parallel)
+						os.writeObject(config)
 
 						val taskdefs = opts.tests.map(t => new TaskDef(t.name, forkFingerprint(t.fingerprint), t.explicitlySpecified, t.selectors))
 						os.writeObject(taskdefs.toArray)
 
 						os.writeInt(runners.size)
 						for ((testFramework, mainRunner) <- runners) {
-							val remoteArgs = mainRunner.remoteArgs()
 							os.writeObject(testFramework.implClassNames.toArray)
 							os.writeObject(mainRunner.args)
-							os.writeObject(remoteArgs)
+							os.writeObject(mainRunner.remoteArgs)
 						}
 						os.flush()
 
-						(new React(is, os, log, opts.testListeners, resultsAcc)).react()
+						new React(is, os, log, opts.testListeners, resultsAcc).react()
 					} finally {
 						is.close();	os.close(); socket.close()
 					}

--- a/main/actions/src/main/scala/sbt/Tests.scala
+++ b/main/actions/src/main/scala/sbt/Tests.scala
@@ -218,7 +218,7 @@ object Tests
 	}
 
 	def processResults(results: Iterable[(String, SuiteResult)]): Output =
-		Output(overall(results.map(_._2.result)), results.toMap, Iterable.empty)
+		Output(TestResult.overall(results.map(_._2.result)), results.toMap, Iterable.empty)
 	def foldTasks(results: Seq[Task[Output]], parallel: Boolean): Task[Output] = 
 		if (parallel)
 			reduced(results.toIndexedSeq, {
@@ -231,11 +231,10 @@ object Tests
 			}
 			sequence(results.toList, List()) map { ress =>
 				val (rs, ms) = ress.unzip { e => (e.overall, e.events) }
-				Output(overall(rs), ms reduce (_ ++ _), Iterable.empty)
+				Output(TestResult.overall(rs), ms reduce (_ ++ _), Iterable.empty)
 			}
 		}
-	def overall(results: Iterable[TestResult.Value]): TestResult.Value =
-		(TestResult.Passed /: results) { (acc, result) => if(acc.id < result.id) result else acc }
+
 	def discover(frameworks: Seq[Framework], analysis: Analysis, log: Logger): (Seq[TestDefinition], Set[String]) =
 		discover(frameworks flatMap TestFramework.getFingerprints, allDefs(analysis), log)
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -506,6 +506,7 @@ object Defaults extends BuildCommon
 						s.log.debug(s"Forking tests - parallelism = ${forkedConfig.parallel}")
 						ForkTests(runners, tests.toList, forkedConfig, cp.files, opts, s.log) tag Tags.ForkedTestGroup
 					case Tests.InProcess =>
+						s.log.debug("Not forking tests")
 						Tests(frameworks, loader, runners, tests, config, s.log)
 				}
 		}

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -104,6 +104,7 @@ object Defaults extends BuildCommon
 		exportJars :== false,
 		fork :== false,
 		testForkedParallel :== false,
+		testHideSuccessfulOutput :== false,
 		javaOptions :== Nil,
 		sbtPlugin :== false,
 		crossPaths :== true,
@@ -360,7 +361,7 @@ object Defaults extends BuildCommon
 		definedTests <<= detectTests,
 		definedTestNames <<= definedTests map ( _.map(_.name).distinct) storeAs definedTestNames triggeredBy compile,
 		testFilter in testQuick <<= testQuickFilter,
-		executeTests <<= (streams in test, loadedTestFrameworks, testLoader, testGrouping in test, testExecution in test, fullClasspath in test, javaHome in test, testForkedParallel) flatMap allTestGroupsTask,
+		executeTests <<= (streams in test, loadedTestFrameworks, testLoader, testGrouping in test, testExecution in test, fullClasspath in test, javaHome in test, testForkedParallel, testHideSuccessfulOutput) flatMap allTestGroupsTask,
 		test := {
 			implicit val display = Project.showContextKey(state.value)
 			Tests.showResults(streams.value.log, executeTests.value, noTestsMessage(resolvedScoped.value))
@@ -471,7 +472,7 @@ object Defaults extends BuildCommon
 			implicit val display = Project.showContextKey(state.value)
 			val modifiedOpts = Tests.Filters(filter(selected)) +: Tests.Argument(frameworkOptions : _*) +: config.options
 			val newConfig = config.copy(options = modifiedOpts)
-			val output = allTestGroupsTask(s, loadedTestFrameworks.value, testLoader.value, testGrouping.value, newConfig, fullClasspath.value, javaHome.value, testForkedParallel.value)
+			val output = allTestGroupsTask(s, loadedTestFrameworks.value, testLoader.value, testGrouping.value, newConfig, fullClasspath.value, javaHome.value, testForkedParallel.value, testHideSuccessfulOutput.value)
 			val processed =
 				for(out <- output) yield
 					Tests.showResults(s.log, out, noTestsMessage(resolvedScoped.value))
@@ -493,18 +494,18 @@ object Defaults extends BuildCommon
 	}
 
 	def allTestGroupsTask(s: TaskStreams, frameworks: Map[TestFramework,Framework], loader: ClassLoader, groups: Seq[Tests.Group], config: Tests.Execution,	cp: Classpath, javaHome: Option[File]): Task[Tests.Output] = {
-		allTestGroupsTask(s,frameworks,loader, groups, config, cp, javaHome, forkedParallelExecution = false)
+		allTestGroupsTask(s,frameworks,loader, groups, config, cp, javaHome, forkedParallelExecution = false, hideSuccessfulOutput = false)
 	}
 
-	def allTestGroupsTask(s: TaskStreams, frameworks: Map[TestFramework,Framework], loader: ClassLoader, groups: Seq[Tests.Group], config: Tests.Execution,	cp: Classpath, javaHome: Option[File], forkedParallelExecution: Boolean): Task[Tests.Output] = {
+	def allTestGroupsTask(s: TaskStreams, frameworks: Map[TestFramework,Framework], loader: ClassLoader, groups: Seq[Tests.Group], config: Tests.Execution,	cp: Classpath, javaHome: Option[File], forkedParallelExecution: Boolean, hideSuccessfulOutput: Boolean): Task[Tests.Output] = {
 		val runners = createTestRunners(frameworks, loader, config)
 		val groupTasks = groups map {
 			case Tests.Group(name, tests, runPolicy) =>
 				runPolicy match {
 					case Tests.SubProcess(opts) =>
 						val forkedConfig = config.copy(parallel = config.parallel && forkedParallelExecution)
-						s.log.debug(s"Forking tests - parallelism = ${forkedConfig.parallel}")
-						ForkTests(runners, tests.toList, forkedConfig, cp.files, opts, s.log) tag Tags.ForkedTestGroup
+						s.log.debug(s"Forking tests - parallelism=${forkedConfig.parallel}, hiding-successful-output=${hideSuccessfulOutput}")
+						ForkTests(runners, tests.toList, forkedConfig, cp.files, opts, s.log, hideSuccessfulOutput) tag Tags.ForkedTestGroup
 					case Tests.InProcess =>
 						s.log.debug("Not forking tests")
 						Tests(frameworks, loader, runners, tests, config, s.log)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -349,6 +349,7 @@ object Defaults extends BuildCommon
 			Seq(ScalaCheck, Specs2, Specs, ScalaTest, JUnit)
 		},
 		testListeners :== Nil,
+		testReportJUnitXml :== false,
 		testOptions :== Nil,
 		testFilter in testOnly :== (selectedFilter _)
 	))
@@ -364,7 +365,8 @@ object Defaults extends BuildCommon
 			Tests.showResults(streams.value.log, executeTests.value, noTestsMessage(resolvedScoped.value))
 		},
 		testOnly <<= inputTests(testOnly),
-		testQuick <<= inputTests(testQuick)
+		testQuick <<= inputTests(testQuick),
+		testListeners ++= (if( testReportJUnitXml.value ) Seq(new JUnitXmlTestsListener(target.value.getAbsolutePath)) else Nil)
 	)
 	private[this] def noTestsMessage(scoped: ScopedKey[_])(implicit display: Show[ScopedKey[_]]): String =
 		"No tests to run for " + display(scoped)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -103,6 +103,7 @@ object Defaults extends BuildCommon
 		outputStrategy :== None,
 		exportJars :== false,
 		fork :== false,
+		testForkedParallel :== false,
 		javaOptions :== Nil,
 		sbtPlugin :== false,
 		crossPaths :== true,
@@ -358,7 +359,7 @@ object Defaults extends BuildCommon
 		definedTests <<= detectTests,
 		definedTestNames <<= definedTests map ( _.map(_.name).distinct) storeAs definedTestNames triggeredBy compile,
 		testFilter in testQuick <<= testQuickFilter,
-		executeTests <<= (streams in test, loadedTestFrameworks, testLoader, testGrouping in test, testExecution in test, fullClasspath in test, javaHome in test) flatMap allTestGroupsTask,
+		executeTests <<= (streams in test, loadedTestFrameworks, testLoader, testGrouping in test, testExecution in test, fullClasspath in test, javaHome in test, testForkedParallel) flatMap allTestGroupsTask,
 		test := {
 			implicit val display = Project.showContextKey(state.value)
 			Tests.showResults(streams.value.log, executeTests.value, noTestsMessage(resolvedScoped.value))
@@ -468,7 +469,7 @@ object Defaults extends BuildCommon
 			implicit val display = Project.showContextKey(state.value)
 			val modifiedOpts = Tests.Filters(filter(selected)) +: Tests.Argument(frameworkOptions : _*) +: config.options
 			val newConfig = config.copy(options = modifiedOpts)
-			val output = allTestGroupsTask(s, loadedTestFrameworks.value, testLoader.value, testGrouping.value, newConfig, fullClasspath.value, javaHome.value)
+			val output = allTestGroupsTask(s, loadedTestFrameworks.value, testLoader.value, testGrouping.value, newConfig, fullClasspath.value, javaHome.value, testForkedParallel.value)
 			val processed =
 				for(out <- output) yield
 					Tests.showResults(s.log, out, noTestsMessage(resolvedScoped.value))
@@ -476,7 +477,7 @@ object Defaults extends BuildCommon
 		}
 	}
 
-	def createTestRunners(frameworks: Map[TestFramework,Framework], loader: ClassLoader, config: Tests.Execution) = {
+	def createTestRunners(frameworks: Map[TestFramework,Framework], loader: ClassLoader, config: Tests.Execution) : Map[TestFramework, Runner] = {
 		import Tests.Argument
 		val opts = config.options.toList
 		frameworks.map { case (tf, f) =>
@@ -490,12 +491,18 @@ object Defaults extends BuildCommon
 	}
 
 	def allTestGroupsTask(s: TaskStreams, frameworks: Map[TestFramework,Framework], loader: ClassLoader, groups: Seq[Tests.Group], config: Tests.Execution,	cp: Classpath, javaHome: Option[File]): Task[Tests.Output] = {
+		allTestGroupsTask(s,frameworks,loader, groups, config, cp, javaHome, forkedParallelExecution = false)
+	}
+
+	def allTestGroupsTask(s: TaskStreams, frameworks: Map[TestFramework,Framework], loader: ClassLoader, groups: Seq[Tests.Group], config: Tests.Execution,	cp: Classpath, javaHome: Option[File], forkedParallelExecution: Boolean): Task[Tests.Output] = {
 		val runners = createTestRunners(frameworks, loader, config)
 		val groupTasks = groups map {
 			case Tests.Group(name, tests, runPolicy) =>
 				runPolicy match {
 					case Tests.SubProcess(opts) =>
-						ForkTests(runners, tests.toList, config, cp.files, opts, s.log) tag Tags.ForkedTestGroup
+						val forkedConfig = config.copy(parallel = config.parallel && forkedParallelExecution)
+						s.log.debug(s"Forking tests - parallelism = ${forkedConfig.parallel}")
+						ForkTests(runners, tests.toList, forkedConfig, cp.files, opts, s.log) tag Tags.ForkedTestGroup
 					case Tests.InProcess =>
 						Tests(frameworks, loader, runners, tests, config, s.log)
 				}

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -195,6 +195,7 @@ object Keys
 	val testOptions = TaskKey[Seq[TestOption]]("test-options", "Options for running tests.", BPlusTask)
 	val testFrameworks = SettingKey[Seq[TestFramework]]("test-frameworks", "Registered, although not necessarily present, test frameworks.", CTask)
 	val testListeners = TaskKey[Seq[TestReportListener]]("test-listeners", "Defines test listeners.", DTask)
+	val testForkedParallel = SettingKey[Boolean]("test-forked-parallel", "Whether forked tests should be executed in parallel", CTask)
 	val testExecution = TaskKey[Tests.Execution]("test-execution", "Settings controlling test execution", DTask)
 	val testFilter = TaskKey[Seq[String] => Seq[String => Boolean]]("test-filter", "Filter controlling whether the test is executed", DTask)
 	val testGrouping = TaskKey[Seq[Tests.Group]]("test-grouping", "Collects discovered tests into groups. Whether to fork and the options for forking are configurable on a per-group basis.", BMinusTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -197,6 +197,7 @@ object Keys
 	val testListeners = TaskKey[Seq[TestReportListener]]("test-listeners", "Defines test listeners.", DTask)
 	val testForkedParallel = SettingKey[Boolean]("test-forked-parallel", "Whether forked tests should be executed in parallel", CTask)
 	val testReportJUnitXml = SettingKey[Boolean]("test-report-junit-xml", "Produce JUnit XML test reports", BPlusTask)
+	val testHideSuccessfulOutput = SettingKey[Boolean]("test-hide-successful-output","Do not show standard output of successful tests - this works only in forked tests")
 	val testExecution = TaskKey[Tests.Execution]("test-execution", "Settings controlling test execution", DTask)
 	val testFilter = TaskKey[Seq[String] => Seq[String => Boolean]]("test-filter", "Filter controlling whether the test is executed", DTask)
 	val testGrouping = TaskKey[Seq[Tests.Group]]("test-grouping", "Collects discovered tests into groups. Whether to fork and the options for forking are configurable on a per-group basis.", BMinusTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -195,6 +195,7 @@ object Keys
 	val testOptions = TaskKey[Seq[TestOption]]("test-options", "Options for running tests.", BPlusTask)
 	val testFrameworks = SettingKey[Seq[TestFramework]]("test-frameworks", "Registered, although not necessarily present, test frameworks.", CTask)
 	val testListeners = TaskKey[Seq[TestReportListener]]("test-listeners", "Defines test listeners.", DTask)
+	val testReportJUnitXml = SettingKey[Boolean]("test-report-junit-xml", "Produce JUnit XML test reports", BPlusTask)
 	val testExecution = TaskKey[Tests.Execution]("test-execution", "Settings controlling test execution", DTask)
 	val testFilter = TaskKey[Seq[String] => Seq[String => Boolean]]("test-filter", "Filter controlling whether the test is executed", DTask)
 	val testGrouping = TaskKey[Seq[Tests.Group]]("test-grouping", "Collects discovered tests into groups. Whether to fork and the options for forking are configurable on a per-group basis.", BMinusTask)

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -81,7 +81,7 @@ object Sbt extends Build
 	  // Runner for uniform test interface
 	lazy val testingSub = baseProject(file("testing"), "Testing") dependsOn(ioSub, classpathSub, logSub, launchInterfaceSub, testAgentSub) settings(testInterface)
   	// Testing agent for running tests in a separate process.
-	lazy val testAgentSub = minProject(file("testing/agent"), "Test Agent") settings(testInterface)
+	lazy val testAgentSub = minProject(file("testing/agent"), "Test Agent") settings(testInterface) settings(lib("cglib" % "cglib-nodep" % "2.2.2"))
 
 		// Basic task engine
 	lazy val taskSub = testedBaseProject(tasksPath, "Tasks") dependsOn(controlSub, collectionSub)

--- a/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
+++ b/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
@@ -11,8 +11,16 @@ object ForkParallelTest extends Build {
 		libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
 		fork in Test := true,
 		check := {
-			if( ! (file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() )) {
-				sys.error("Forked tests were not executed in parallel!")
+			val nbProc = java.lang.Runtime.getRuntime().availableProcessors()
+			if( nbProc < 4 ) {
+				streams.value.log.warn("With fewer than 4 processors this test is meaningless")
+			} else {
+				// we've got at least 4 processors, we'll check the upper end but also 3 and 4 as the upper might not
+				// be reached if the system is under heavy load.
+				if( ! (file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() ||
+							 file("max-concurrent-tests_" + (nbProc -1)).exists() || file("max-concurrent-tests_" + nbProc).exists())) {
+					sys.error("Forked tests were not executed in parallel!")
+				}
 			}
 		}
 	))

--- a/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
+++ b/sbt/src/sbt-test/tests/fork-parallel/project/ForkParallelTest.scala
@@ -1,0 +1,19 @@
+import sbt._
+import Keys._
+import Tests._
+import Defaults._
+
+object ForkParallelTest extends Build {
+	val check = taskKey[Unit]("Check that tests are executed in parallel")
+
+	lazy val root = Project("root", file("."), settings = defaultSettings ++ Seq(
+		scalaVersion := "2.9.2",
+		libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
+		fork in Test := true,
+		check := {
+			if( ! (file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() )) {
+				sys.error("Forked tests were not executed in parallel!")
+			}
+		}
+	))
+}

--- a/sbt/src/sbt-test/tests/fork-parallel/src/test/scala/tests.scala
+++ b/sbt/src/sbt-test/tests/fork-parallel/src/test/scala/tests.scala
@@ -1,0 +1,53 @@
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Test
+import scala.annotation.tailrec
+
+object ParallelTest {
+	val nbConcurrentTests = new AtomicInteger(0)
+	val maxConcurrentTests = new AtomicInteger(0)
+
+	private def updateMaxConcurrentTests(currentMax: Int, newMax: Int) : Boolean = {
+		if( maxConcurrentTests.compareAndSet(currentMax, newMax) ) {
+			val f = new File("max-concurrent-tests_" + newMax)
+			f.createNewFile
+			true
+		} else {
+			false
+		}
+	}
+
+	@tailrec
+	def execute(f : => Unit) {
+		val nb = nbConcurrentTests.incrementAndGet()
+		val max = maxConcurrentTests.get()
+		if( nb <= max || updateMaxConcurrentTests(max, nb)) {
+			f
+			nbConcurrentTests.getAndDecrement
+		} else {
+			nbConcurrentTests.getAndDecrement
+			execute(f)
+		}
+	}
+}
+
+class Test1 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test2 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test3 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}
+
+class Test4 {
+	@Test
+	def slow() { ParallelTest.execute { Thread.sleep(1000) } }
+}

--- a/sbt/src/sbt-test/tests/fork-parallel/test
+++ b/sbt/src/sbt-test/tests/fork-parallel/test
@@ -1,0 +1,7 @@
+> test
+-> check
+
+> clean
+> set testForkedParallel := true
+> test
+> check

--- a/sbt/src/sbt-test/tests/fork/project/ForkTestsTest.scala
+++ b/sbt/src/sbt-test/tests/fork/project/ForkTestsTest.scala
@@ -26,7 +26,7 @@ object ForkTestsTest extends Build {
 			val (exist, absent) = files.partition(_.exists)
 			exist.foreach(_.delete())
 			if(absent.nonEmpty)
-				error("Files were not created:\n\t" + absent.mkString("\n\t"))
+				sys.error("Files were not created:\n\t" + absent.mkString("\n\t"))
 		},
 		concurrentRestrictions := Tags.limit(Tags.ForkedTestGroup, 2) :: Nil,
 		libraryDependencies += "org.scalatest" %% "scalatest" % "1.8" % "test"

--- a/sbt/src/sbt-test/tests/hide-successful-output/project/HideSuccessfulOutputBuild.scala
+++ b/sbt/src/sbt-test/tests/hide-successful-output/project/HideSuccessfulOutputBuild.scala
@@ -1,0 +1,26 @@
+import sbt._
+import Keys._
+import scala.xml.XML
+import Tests._
+import Defaults._
+import org.backuity.matchete.AssertionMatchers
+
+object HideSuccessfulOutputBuild extends Build with AssertionMatchers {
+
+	val check = taskKey[Unit]("make sure successful test output isn't present in the dumped stdout")
+
+	val main = project.in(file(".")).settings(
+
+		libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
+
+		// hiding successful output only works in forked mode
+		fork in Test := true,
+
+		check := {
+			val content = IO.read(file("stdout.dump")).trim
+			val ansiFreeContent = content.replaceAll("\\p{C}", "")
+			ansiFreeContent must not(contain("shouldn't show up"))
+			ansiFreeContent must contain("must show up")
+		}
+	)
+}

--- a/sbt/src/sbt-test/tests/hide-successful-output/project/machete.sbt
+++ b/sbt/src/sbt-test/tests/hide-successful-output/project/machete.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("releases")
+
+libraryDependencies += "org.backuity" %% "matchete" % "1.1"

--- a/sbt/src/sbt-test/tests/hide-successful-output/src/test/scala/tests.scala
+++ b/sbt/src/sbt-test/tests/hide-successful-output/src/test/scala/tests.scala
@@ -1,0 +1,42 @@
+import org.junit.Test
+
+package a.failing.pkg {
+
+	class FailingTest {
+		@Test
+		def fail() {
+			for( i <- 1 to 10 ) {
+				println("This must show up")
+				Thread.sleep(10)
+			}
+			sys.error("fail")
+		}
+	}
+
+	class SuccessfulTest {
+		@Test
+		def success1() {
+			for( i <- 1 to 10 ) {
+				println("This shouldn't show up 1")
+				Thread.sleep(10)
+			}
+		}
+
+		@Test
+		def success2() {
+			new Thread() {
+				override def run() {
+					for( i <- 1 to 10 ) {
+						println("This shouldn't show up (from thread)")
+						Thread.sleep(10)
+					}
+				}
+			}.start()
+
+			for( i <- 1 to 10 ) {
+				println("This shouldn't show up 2")
+				Thread.sleep(10)
+			}
+		}
+	}
+}

--- a/sbt/src/sbt-test/tests/hide-successful-output/test
+++ b/sbt/src/sbt-test/tests/hide-successful-output/test
@@ -1,0 +1,11 @@
+> set testHideSuccessfulOutput := true
+
+# parallel tests are more likely to fail at hiding the standard output
+> set testForkedParallel := true
+-> test
+> check
+
+> set testForkedParallel := false
+-> test
+> check
+

--- a/sbt/src/sbt-test/tests/junit-xml-report/project/JUnitXmlReportTest.scala
+++ b/sbt/src/sbt-test/tests/junit-xml-report/project/JUnitXmlReportTest.scala
@@ -3,13 +3,19 @@ import Keys._
 import scala.xml.XML
 import Tests._
 import Defaults._
+import org.backuity.matchete.{Matcher, AssertionMatchers, XmlMatchers, FileMatchers}
 
-object JUnitXmlReportTest extends Build {
+object JUnitXmlReportTest extends Build with AssertionMatchers with XmlMatchers with FileMatchers {
 	val checkReport = taskKey[Unit]("Check the test reports")
 	val checkNoReport = taskKey[Unit]("Check that no reports are present")
 
 	private val oneSecondReportFile = "target/test-reports/a.pkg.OneSecondTest.xml"
 	private val failingReportFile = "target/test-reports/another.pkg.FailingTest.xml"
+	private val consoleReportFile = "target/test-reports/console.test.pkg.ConsoleTests.xml"
+
+	def greaterThan(float: Float) : Matcher[String] = be("greater than " + float) {
+		case attr => attr.toFloat must be_>=(float)
+	}
 
 	lazy val root = Project("root", file("."), settings = defaultSettings ++ Seq(
 		scalaVersion := "2.9.2",
@@ -17,27 +23,49 @@ object JUnitXmlReportTest extends Build {
 
 		testReportJUnitXml := true,
 
-		// TODO use matchers instead of sys.error
 		checkReport := {
 			val oneSecondReport = XML.loadFile(oneSecondReportFile)
-			if( oneSecondReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
-			// somehow the 'success' event doesn't go through... TODO investigate
-//			if( (oneSecondReport \ "@time").text.toFloat < 1f ) sys.error("expected test to take at least 1 sec")
-			if( (oneSecondReport \ "@name").text != "a.pkg.OneSecondTest" ) sys.error("wrong test name: " + (oneSecondReport \ "@name").text)
-			// TODO more checks
+			oneSecondReport must haveLabel("testsuite")
+			oneSecondReport must haveAttribute("name", equalTo("a.pkg.OneSecondTest"))
+
+			// junit-interface does not report time yet...
+//			oneSecondReport must haveAttribute("time", greaterThan(1f))
+
+			oneSecondReport \ "testcase" must containExactly(
+				a("one-second testcase") { case tc =>
+					tc must haveAttribute("name", equalTo("oneSecond"))
+					tc must haveAttribute("classname", equalTo("a.pkg.OneSecondTest"))
+//					tc must haveAttribute("time", greaterThan(1f))
+				})
 
 			val failingReport = XML.loadFile(failingReportFile)
-			if( failingReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
-			if( (failingReport \ "@failures").text != "2" ) sys.error("expected 2 failures")
-			if( (failingReport \ "@name").text != "another.pkg.FailingTest" ) sys.error("wrong test name: " + (failingReport \ "@name").text)
+			failingReport must haveLabel("testsuite")
+			failingReport must haveAttribute("failures", equalTo("2"))
+//			failingReport must haveAttribute("time", greaterThan(1.5f)) // time is sumed-up in the testsuite element
+			failingReport must haveAttribute("name", equalTo("another.pkg.FailingTest"))
 			// TODO more checks -> the two test cases with time etc..
 
-			// TODO check console output is in the report
+			val consoleReport = XML.loadFile(consoleReportFile)
+			consoleReport must haveLabel("testsuite")
+			consoleReport must haveAttribute("tests", equalTo("2"))
+			consoleReport must haveAttribute("name", equalTo("console.test.pkg.ConsoleTests"))
+			consoleReport must haveAttribute("failures", equalTo("0"))
+			consoleReport \ "testcase" must containExactly(
+				a("sayHello test-case") { case tc =>
+					tc must haveAttribute("name", equalTo("sayHello"))
+					tc must haveAttribute("classname", equalTo("console.test.pkg.ConsoleTests"))
+					tc \ "system-out" must haveTrimmedText("Hello\nWorld!")},
+
+				a("multiThreadedHello test-case") { case tc =>
+					tc must haveAttribute("name", equalTo("multiThreadedHello"))
+					tc must haveAttribute("classname", equalTo("console.test.pkg.ConsoleTests"))
+					(tc \ "system-out").text.trim.split("\n").toList must containElements( (for( i <- 1 to 15) yield s"Hello from thread $i") : _*)})
 		},
 
 		checkNoReport := {
-			if( file(oneSecondReportFile).exists() ) sys.error(oneSecondReportFile + " should not exist")
-			if( file(failingReportFile).exists() ) sys.error(failingReportFile + " should not exist")
+			file(oneSecondReportFile) must not(exist)
+			file(failingReportFile) must not(exist)
+			file(consoleReportFile) must not(exist)
 		}
 	))
 }

--- a/sbt/src/sbt-test/tests/junit-xml-report/project/JUnitXmlReportTest.scala
+++ b/sbt/src/sbt-test/tests/junit-xml-report/project/JUnitXmlReportTest.scala
@@ -1,0 +1,43 @@
+import sbt._
+import Keys._
+import scala.xml.XML
+import Tests._
+import Defaults._
+
+object JUnitXmlReportTest extends Build {
+	val checkReport = taskKey[Unit]("Check the test reports")
+	val checkNoReport = taskKey[Unit]("Check that no reports are present")
+
+	private val oneSecondReportFile = "target/test-reports/a.pkg.OneSecondTest.xml"
+	private val failingReportFile = "target/test-reports/another.pkg.FailingTest.xml"
+
+	lazy val root = Project("root", file("."), settings = defaultSettings ++ Seq(
+		scalaVersion := "2.9.2",
+		libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test",
+
+		testReportJUnitXml := true,
+
+		// TODO use matchers instead of sys.error
+		checkReport := {
+			val oneSecondReport = XML.loadFile(oneSecondReportFile)
+			if( oneSecondReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
+			// somehow the 'success' event doesn't go through... TODO investigate
+//			if( (oneSecondReport \ "@time").text.toFloat < 1f ) sys.error("expected test to take at least 1 sec")
+			if( (oneSecondReport \ "@name").text != "a.pkg.OneSecondTest" ) sys.error("wrong test name: " + (oneSecondReport \ "@name").text)
+			// TODO more checks
+
+			val failingReport = XML.loadFile(failingReportFile)
+			if( failingReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
+			if( (failingReport \ "@failures").text != "2" ) sys.error("expected 2 failures")
+			if( (failingReport \ "@name").text != "another.pkg.FailingTest" ) sys.error("wrong test name: " + (failingReport \ "@name").text)
+			// TODO more checks -> the two test cases with time etc..
+
+			// TODO check console output is in the report
+		},
+
+		checkNoReport := {
+			if( file(oneSecondReportFile).exists() ) sys.error(oneSecondReportFile + " should not exist")
+			if( file(failingReportFile).exists() ) sys.error(failingReportFile + " should not exist")
+		}
+	))
+}

--- a/sbt/src/sbt-test/tests/junit-xml-report/project/matchete.sbt
+++ b/sbt/src/sbt-test/tests/junit-xml-report/project/matchete.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("releases")
+
+libraryDependencies += "org.backuity" %% "matchete" % "1.1"

--- a/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/tests.scala
+++ b/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/tests.scala
@@ -1,0 +1,49 @@
+import org.junit.Test
+
+package a.pkg {
+	class OneSecondTest {
+		@Test
+		def oneSecond() {
+			Thread.sleep(1000)
+		}
+	}
+}
+
+package another.pkg {
+	class FailingTest {
+		@Test
+		def failure1_OneSecond() {
+			Thread.sleep(1000)
+			sys.error("fail1")
+		}
+
+		@Test
+		def failure2_HalfSecond() {
+			Thread.sleep(500)
+			sys.error("fail2")
+		}
+	}
+}
+
+package console.test.pkg {
+	// we won't check console output in the report
+	// until SBT supports that
+	class ConsoleTests {
+		@Test
+		def sayHello() {
+			println("Hello")
+			System.out.println("World!")
+		}
+
+		@Test
+		def multiThreadedHello() {
+			for( i <- 1 to 5 ) {
+				new Thread("t-" + i) {
+					override def run() {
+						println("Hello from thread " + i)
+					}
+				}.start()
+			}
+		}
+	}
+}

--- a/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/tests.scala
+++ b/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/tests.scala
@@ -37,13 +37,15 @@ package console.test.pkg {
 
 		@Test
 		def multiThreadedHello() {
-			for( i <- 1 to 5 ) {
+			val threads = for( i <- 1 to 15 ) yield {
 				new Thread("t-" + i) {
 					override def run() {
 						println("Hello from thread " + i)
 					}
-				}.start()
+				}
 			}
+			threads.foreach( _.start() )
+			threads.foreach( _.join() )
 		}
 	}
 }

--- a/sbt/src/sbt-test/tests/junit-xml-report/test
+++ b/sbt/src/sbt-test/tests/junit-xml-report/test
@@ -1,0 +1,11 @@
+-> test
+> checkReport
+
+# there might be discrepancies between the 'normal' and the 'forked' mode
+
+> clean
+> checkNoReport
+
+> set fork in Test := true
+-> test
+> checkReport

--- a/sbt/src/sbt-test/tests/junit-xml-report/test
+++ b/sbt/src/sbt-test/tests/junit-xml-report/test
@@ -1,11 +1,36 @@
+# This test is twofold:
+#
+#  - it checks the junit xml report format (provided by `JUnitXmlTestsListener`)
+#
+#  - it checks the segregation of test output. When tests run concurrently things printed on the standard output
+#    get mixed up. SBT can tell the test output appart so that each test is reported with its own standard output.
+#
+# ------------------------------------------------------------------------------------------------------------
+
+# for now test output segregation works only in fork mode
+> set fork in Test := true
+
+# try parallel first (as it is more likely to fail than its serial counterpart)
+> set testForkedParallel := true
 -> test
 > checkReport
-
-# there might be discrepancies between the 'normal' and the 'forked' mode
 
 > clean
 > checkNoReport
 
-> set fork in Test := true
+> set testForkedParallel := false
 -> test
 > checkReport
+
+# TODO - check non-forked mode
+
+# there might be discrepancies between the 'normal' and the 'forked' mode
+
+# > set fork in Test := false
+# > clean
+# > checkNoReport
+
+# -> test
+# > checkReport
+
+## AND serial non-forked...

--- a/sbt/src/sbt-test/tests/t543/project/Ticket543Test.scala
+++ b/sbt/src/sbt-test/tests/t543/project/Ticket543Test.scala
@@ -13,7 +13,7 @@ object Ticket543Test extends Build {
 		scalaVersion := "2.9.2",
 		fork := true,
 		testListeners += new TestReportListener {
-		  def testEvent(event: TestEvent) {
+		  def testEvent(event: SuiteReport) {
 				for (e <- event.detail.filter(_.status == sbt.testing.Status.Failure)) {
 					if (e.throwable != null && e.throwable.isDefined) {
 						val caw = new CharArrayWriter
@@ -23,9 +23,9 @@ object Ticket543Test extends Build {
 					}
 				}
 		  }
-		  def startGroup(name: String) {}
-		  def endGroup(name: String, t: Throwable) {}
-		  def endGroup(name: String, result: TestResult.Value) {}
+		  def startSuite(name: String) {}
+		  def endSuite(name: String, t: Throwable) {}
+		  def endSuite(name: String, result: TestResult.Value) {}
 		},
 		check := {
 			val exists = marker.exists

--- a/testing/agent/src/main/java/sbt/ForkConfiguration.java
+++ b/testing/agent/src/main/java/sbt/ForkConfiguration.java
@@ -1,0 +1,21 @@
+package sbt;
+
+import java.io.Serializable;
+
+public final class ForkConfiguration implements Serializable {
+	private boolean ansiCodesSupported;
+	private boolean parallel;
+
+	public ForkConfiguration(boolean ansiCodesSupported, boolean parallel) {
+		this.ansiCodesSupported = ansiCodesSupported;
+		this.parallel = parallel;
+	}
+
+	public boolean isAnsiCodesSupported() {
+		return ansiCodesSupported;
+	}
+
+	public boolean isParallel() {
+		return parallel;
+	}
+}

--- a/testing/agent/src/main/java/sbt/ForkConfiguration.java
+++ b/testing/agent/src/main/java/sbt/ForkConfiguration.java
@@ -5,10 +5,12 @@ import java.io.Serializable;
 public final class ForkConfiguration implements Serializable {
 	private boolean ansiCodesSupported;
 	private boolean parallel;
+	private boolean hideStandardOutput;
 
-	public ForkConfiguration(boolean ansiCodesSupported, boolean parallel) {
+	public ForkConfiguration(boolean ansiCodesSupported, boolean parallel, boolean hideStandardOutput) {
 		this.ansiCodesSupported = ansiCodesSupported;
 		this.parallel = parallel;
+		this.hideStandardOutput = hideStandardOutput;
 	}
 
 	public boolean isAnsiCodesSupported() {
@@ -17,5 +19,9 @@ public final class ForkConfiguration implements Serializable {
 
 	public boolean isParallel() {
 		return parallel;
+	}
+
+	public boolean isHideStandardOutput() {
+		return hideStandardOutput;
 	}
 }

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -12,10 +12,15 @@ import java.io.Serializable;
 import java.net.Socket;
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
 
 public class ForkMain {
+
+	// serializables
+	// -----------------------------------------------------------------------------
+
 	static class SubclassFingerscan implements SubclassFingerprint, Serializable {
 		private boolean isModule;
 		private String superclassName;
@@ -29,6 +34,7 @@ public class ForkMain {
 		public String superclassName() { return superclassName; }
 		public boolean requireNoArgConstructor() { return requireNoArgConstructor; }
 	}
+
 	static class AnnotatedFingerscan implements AnnotatedFingerprint, Serializable {
 		private boolean isModule;
 		private String annotationName;
@@ -39,6 +45,54 @@ public class ForkMain {
 		public boolean isModule() { return isModule; }
 		public String annotationName() { return annotationName; }
 	}
+
+	static class ForkEvent implements Event, Serializable {
+		private String fullyQualifiedName;
+		private Fingerprint fingerprint;
+		private Selector selector;
+		private Status status;
+		private OptionalThrowable throwable;
+		private long duration;
+
+		ForkEvent(Event e) {
+			fullyQualifiedName = e.fullyQualifiedName();
+			Fingerprint rawFingerprint = e.fingerprint();
+
+			if (rawFingerprint instanceof SubclassFingerprint)
+				this.fingerprint = new SubclassFingerscan((SubclassFingerprint) rawFingerprint);
+			else
+				this.fingerprint = new AnnotatedFingerscan((AnnotatedFingerprint) rawFingerprint);
+
+			selector = e.selector();
+			checkSerializableSelector(selector);
+			status = e.status();
+			OptionalThrowable originalThrowable = e.throwable();
+
+			if (originalThrowable.isDefined())
+				this.throwable = new OptionalThrowable(new ForkError(originalThrowable.get()));
+			else
+				this.throwable = originalThrowable;
+
+			this.duration = e.duration();
+		}
+
+		public String fullyQualifiedName() { return fullyQualifiedName; }
+		public Fingerprint fingerprint() { return fingerprint; }
+		public Selector selector() { return selector; }
+		public Status status() { return status; }
+		public OptionalThrowable throwable() { return throwable; }
+		public long duration() { return duration; }
+
+		static void checkSerializableSelector(Selector selector) {
+			if (! (selector instanceof Serializable)) {
+				throw new UnsupportedOperationException("Selector implementation must be Serializable, but " + selector.getClass().getName() + " is not.");
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------------
+
+
 	static class ForkError extends Exception {
 		private String originalMessage;
 		private ForkError cause;
@@ -50,62 +104,50 @@ public class ForkMain {
 		public String getMessage() { return originalMessage; }
 		public Exception getCause() { return cause; }
 	}
-	
-	static Selector forkSelector(Selector selector) {
-		if (selector instanceof Serializable)
-			return selector;
-		else
-			throw new UnsupportedOperationException("Selector implementation must be Serializable, but " + selector.getClass().getName() + " is not.");
-	}
-	
-	static class ForkEvent implements Event, Serializable {
-		private String fullyQualifiedName;
-		private Fingerprint fingerprint;
-		private Selector selector;
-		private Status status;
-		private OptionalThrowable throwable;
-		private long duration;
-		ForkEvent(Event e) {
-			fullyQualifiedName = e.fullyQualifiedName();
-			Fingerprint rawFingerprint = e.fingerprint();
-			if (rawFingerprint instanceof SubclassFingerprint) 
-				this.fingerprint = new SubclassFingerscan((SubclassFingerprint) rawFingerprint);
-			else 
-				this.fingerprint = new AnnotatedFingerscan((AnnotatedFingerprint) rawFingerprint);
-			selector = forkSelector(e.selector());
-			status = e.status();
-			OptionalThrowable originalThrowable = e.throwable();
-			if (originalThrowable.isDefined())
-				this.throwable = new OptionalThrowable(new ForkError(originalThrowable.get()));
-			else
-				this.throwable = originalThrowable;
-			this.duration = e.duration();
-		}
-		public String fullyQualifiedName() { return fullyQualifiedName; }
-		public Fingerprint fingerprint() { return fingerprint; }
-		public Selector selector() { return selector; }
-		public Status status() { return status; }
-		public OptionalThrowable throwable() { return throwable; }
-		public long duration() { return duration; }
-	}
+
+
+	// main
+	// ----------------------------------------------------------------------------------------------------------------
+
 	public static void main(String[] args) throws Exception {
 		Socket socket = new Socket(InetAddress.getByName(null), Integer.valueOf(args[0]));
 		final ObjectInputStream is = new ObjectInputStream(socket.getInputStream());
 		final ObjectOutputStream os = new ObjectOutputStream(socket.getOutputStream());
 		// Must flush the header that the constructor writes, otherwise the ObjectInputStream on the other end may block indefinitely
 		os.flush();
+
 		try {
+			new Run().run(is, os);
+		} finally {
 			try {
-				new Run().run(is, os);
-			} finally {
 				is.close();
 				os.close();
+			} finally {
+				System.exit(0);
 			}
-		} finally {
-			System.exit(0);
 		}
 	}
+
+	// ----------------------------------------------------------------------------------------------------------------
+
+
 	private static class Run {
+
+		void run(ObjectInputStream is, ObjectOutputStream os) throws Exception {
+			try {
+				runTests(is, os);
+			} catch (RunAborted e) {
+				internalError(e);
+			} catch (Throwable t) {
+				try {
+					logError(os, "Uncaught exception when running tests: " + t.toString());
+					write(os, new ForkError(t));
+				} catch (Throwable t2) {
+					internalError(t2);
+				}
+			}
+		}
+
 		boolean matches(Fingerprint f1, Fingerprint f2) {
 			if (f1 instanceof SubclassFingerprint && f2 instanceof SubclassFingerprint) {
 				final SubclassFingerprint sf1 = (SubclassFingerprint) f1;
@@ -118,9 +160,11 @@ public class ForkMain {
 			}
 			return false;
 		}
+
 		class RunAborted extends RuntimeException {
 			RunAborted(Exception e) { super(e); }
 		}
+
 		synchronized void write(ObjectOutputStream os, Object obj) {
 			try {
 				os.writeObject(obj);
@@ -129,29 +173,50 @@ public class ForkMain {
 				throw new RunAborted(e);
 			}
 		}
-		void logError(ObjectOutputStream os, String message) {
-			write(os, new Object[]{ForkTags.Error, message});
+
+		void log(ObjectOutputStream os, String message, ForkTags level) {
+			write(os, new Object[]{level, message});
 		}
-		void logDebug(ObjectOutputStream os, String message) {
-			write(os, new Object[]{ForkTags.Debug, message});
+
+		void logDebug(ObjectOutputStream os, String message) { log(os, message, ForkTags.Debug); }
+		void logInfo(ObjectOutputStream os, String message) { log(os, message, ForkTags.Info); }
+		void logWarn(ObjectOutputStream os, String message) { log(os, message, ForkTags.Warn); }
+		void logError(ObjectOutputStream os, String message) { log(os, message, ForkTags.Error); }
+
+		Logger remoteLogger(final boolean ansiCodesSupported, final ObjectOutputStream os) {
+			return new Logger() {
+				public boolean ansiCodesSupported() { return ansiCodesSupported; }
+				public void error(String s) { logError(os, s); }
+				public void warn(String s) { logWarn(os, s); }
+				public void info(String s) { logInfo(os, s); }
+				public void debug(String s) { logDebug(os, s); }
+				public void trace(Throwable t) { write(os, new ForkError(t)); }
+			};
 		}
+
 		void writeEvents(ObjectOutputStream os, TaskDef taskDef, ForkEvent[] events) {
 			write(os, new Object[]{taskDef.fullyQualifiedName(), events});
 		}
+
+		ExecutorService executorService(ForkConfiguration config, ObjectOutputStream os) {
+			if(config.isParallel()) {
+				int nbThreads = Runtime.getRuntime().availableProcessors();
+				logDebug(os, "Create a test executor with a thread pool of " + nbThreads + " threads.");
+				// more options later...
+				// TODO we might want to configure the blocking queue with size #proc
+				return Executors.newFixedThreadPool(nbThreads);
+			} else {
+				logDebug(os, "Create a single-thread test executor");
+				return Executors.newSingleThreadExecutor();
+			}
+		}
+
 		void runTests(ObjectInputStream is, final ObjectOutputStream os) throws Exception {
-			final boolean ansiCodesSupported = is.readBoolean();
+			final ForkConfiguration config = (ForkConfiguration) is.readObject();
+			ExecutorService executor = executorService(config, os);
 			final TaskDef[] tests = (TaskDef[]) is.readObject();
 			int nFrameworks = is.readInt();
-			Logger[] loggers = {
-				new Logger() {
-					public boolean ansiCodesSupported() { return ansiCodesSupported; }
-					public void error(String s) { logError(os, s); }
-					public void warn(String s) { write(os, new Object[]{ForkTags.Warn, s}); }
-					public void info(String s) { write(os, new Object[]{ForkTags.Info, s}); }
-					public void debug(String s) { write(os, new Object[]{ForkTags.Debug, s}); }
-					public void trace(Throwable t) { write(os, new ForkError(t)); }
-				}
-			};
+			Logger[] loggers = { remoteLogger(config.isAnsiCodesSupported(), os) };
 
 			for (int i = 0; i < nFrameworks; i++) {
 				final String[] implClassNames = (String[]) is.readObject();
@@ -186,89 +251,66 @@ public class ForkMain {
 				final Runner runner = framework.runner(frameworkArgs, remoteFrameworkArgs, getClass().getClassLoader());
 				Task[] tasks = runner.tasks(filteredTests.toArray(new TaskDef[filteredTests.size()]));
 				logDebug(os, "Runner for " + framework.getClass().getName() + " produced " + tasks.length + " initial tasks for " + filteredTests.size() + " tests.");
-				for (Task task : tasks)
-					runTestSafe(task, runner, loggers, os);
+
+				runTestTasks(executor, tasks, loggers, os);
+
 				runner.done();
 			}
 			write(os, ForkTags.Done);
 			is.readObject();
 		}
-		class NestedTask {
-			private String parentName;
-			private Task task;
-			NestedTask(String parentName, Task task) {
-				this.parentName = parentName;
-				this.task = task;
-			}
-			public String getParentName() {
-				return parentName;
-			}
-			public Task getTask() {
-				return task;
-			}
-		}
-		void runTestSafe(Task task, Runner runner, Logger[] loggers, ObjectOutputStream os) {
-			TaskDef taskDef = task.taskDef();
-			try {
-				List<NestedTask> nestedTasks = new ArrayList<NestedTask>();
-				for (Task nt : runTest(taskDef, task, loggers, os))
-					nestedTasks.add(new NestedTask(taskDef.fullyQualifiedName(), nt));
-				while (true) {
-					List<NestedTask> newNestedTasks = new ArrayList<NestedTask>();
-					int nestedTasksLength = nestedTasks.size();
-					for (int i = 0; i < nestedTasksLength; i++) {
-						NestedTask nestedTask = nestedTasks.get(i);
-						String nestedParentName = nestedTask.getParentName() + "-" + i;
-						for (Task nt : runTest(nestedTask.getTask().taskDef(), nestedTask.getTask(), loggers, os)) {
-							newNestedTasks.add(new NestedTask(nestedParentName, nt));
-						}
-					}
-					if (newNestedTasks.size() == 0)
-						break;
-					else {
-						nestedTasks = newNestedTasks;
+
+		void runTestTasks(ExecutorService executor, Task[] tasks, Logger[] loggers, ObjectOutputStream os) {
+			if( tasks.length > 0 ) {
+				List<Future<Task[]>> futureNestedTasks = new ArrayList<Future<Task[]>>();
+				for( Task task : tasks ) {
+					futureNestedTasks.add(runTest(executor, task, loggers, os));
+				}
+
+				// Note: this could be optimized further, we could have a callback once a test finishes that executes immediately the nested tasks
+				//       At the moment, I'm especially interested in JUnit, which doesn't have nested tasks.
+				List<Task> nestedTasks = new ArrayList<Task>();
+				for( Future<Task[]> futureNestedTask : futureNestedTasks ) {
+					try {
+						nestedTasks.addAll( Arrays.asList(futureNestedTask.get()));
+					} catch (Exception e) {
+						logError(os, "Failed to execute task " + futureNestedTask);
 					}
 				}
-			} catch (Throwable t) {
-				writeEvents(os, taskDef, new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) });
+				runTestTasks(executor, nestedTasks.toArray(new Task[nestedTasks.size()]), loggers, os);
 			}
 		}
-		Task[] runTest(TaskDef taskDef, Task task, Logger[] loggers, ObjectOutputStream os) {
-			ForkEvent[] events;
-			Task[] nestedTasks;
-			try {
-				final List<ForkEvent> eventList = new ArrayList<ForkEvent>();
-				EventHandler handler = new EventHandler() { public void handle(Event e){ eventList.add(new ForkEvent(e)); } };
-				logDebug(os, "  Running " + taskDef);
-				nestedTasks = task.execute(handler, loggers);
-				if(nestedTasks.length > 0 || eventList.size() > 0)
-					logDebug(os, "    Produced " + nestedTasks.length + " nested tasks and " + eventList.size() + " events.");
-				events = eventList.toArray(new ForkEvent[eventList.size()]);
-			}
-			catch (Throwable t) {
-				nestedTasks = new Task[0];
-				events = new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) };
-			}
-			writeEvents(os, taskDef, events);
-			return nestedTasks;
-		}
-		void run(ObjectInputStream is, ObjectOutputStream os) throws Exception {
-			try {
-				runTests(is, os);
-			} catch (RunAborted e) {
-				internalError(e);
-			} catch (Throwable t) {
-				try {
-					logError(os, "Uncaught exception when running tests: " + t.toString());
-					write(os, new ForkError(t));
-				} catch (Throwable t2) {
-					internalError(t2);
+
+		Future<Task[]> runTest(ExecutorService executor, final Task task, final Logger[] loggers, final ObjectOutputStream os) {
+			return executor.submit(new Callable<Task[]>() {
+				@Override
+				public Task[] call() {
+					ForkEvent[] events;
+					Task[] nestedTasks;
+					TaskDef taskDef = task.taskDef();
+					try {
+						final List<ForkEvent> eventList = new ArrayList<ForkEvent>();
+						EventHandler handler = new EventHandler() { public void handle(Event e){ eventList.add(new ForkEvent(e)); } };
+						logDebug(os, "  Running " + taskDef);
+						nestedTasks = task.execute(handler, loggers);
+						if(nestedTasks.length > 0 || eventList.size() > 0)
+							logDebug(os, "    Produced " + nestedTasks.length + " nested tasks and " + eventList.size() + " events.");
+						events = eventList.toArray(new ForkEvent[eventList.size()]);
+					}
+					catch (Throwable t) {
+						nestedTasks = new Task[0];
+						events = new ForkEvent[] { testError(os, taskDef, "Uncaught exception when running " + taskDef.fullyQualifiedName() + ": " + t.toString(), t) };
+					}
+					writeEvents(os, taskDef, events);
+					return nestedTasks;
 				}
-			}
+			});
 		}
+
 		void internalError(Throwable t) {
 			System.err.println("Internal error when running tests: " + t.toString());
 		}
+
 		ForkEvent testEvent(final String fullyQualifiedName, final Fingerprint fingerprint, final Selector selector, final Status r, final ForkError err, final long duration) {
 			final OptionalThrowable throwable;
 			if (err == null)
@@ -280,21 +322,18 @@ public class ForkMain {
 				public Fingerprint fingerprint() { return fingerprint; }
 				public Selector selector() { return selector; }
 				public Status status() { return r; }
-				public OptionalThrowable throwable() { 
-					return throwable; 
+				public OptionalThrowable throwable() {
+					return throwable;
 				}
 				public long duration() {
 					return duration;
 				}
 			});
 		}
-		ForkEvent testError(ObjectOutputStream os, TaskDef taskDef, String message) {
-			logError(os, message);
-			return testEvent(taskDef.fullyQualifiedName(), taskDef.fingerprint(), new SuiteSelector(), Status.Error, null, 0);
-		}
+
 		ForkEvent testError(ObjectOutputStream os, TaskDef taskDef, String message, Throwable t) {
 			logError(os, message);
-         ForkError fe = new ForkError(t);
+			ForkError fe = new ForkError(t);
 			write(os, fe);
 			return testEvent(taskDef.fullyQualifiedName(), taskDef.fingerprint(), new SuiteSelector(), Status.Error, fe, 0);
 		}

--- a/testing/agent/src/main/java/sbt/ForkTags.java
+++ b/testing/agent/src/main/java/sbt/ForkTags.java
@@ -4,6 +4,6 @@
 package sbt;
 
 public enum ForkTags {
-	Error, Warn, Info, Debug, Done;
+	Error, Warn, Info, Debug, Done, StartSuite, EndTest, EndSuite, EndSuiteError;
 }
 

--- a/testing/agent/src/main/java/sbt/FrameworkWrapper.java
+++ b/testing/agent/src/main/java/sbt/FrameworkWrapper.java
@@ -1,8 +1,11 @@
 package sbt;
 
 import sbt.testing.*;
-import java.io.Serializable;
 
+/**
+ * Adapts the old {@link org.scalatools.testing.Framework} interface into the new
+ * {@link sbt.testing.Framework}
+ */
 final class FrameworkWrapper implements Framework {
 
 	private org.scalatools.testing.Framework oldFramework;

--- a/testing/agent/src/main/java/sbt/InitializedInheritableThreadLocal.java
+++ b/testing/agent/src/main/java/sbt/InitializedInheritableThreadLocal.java
@@ -1,0 +1,19 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+class InitializedInheritableThreadLocal<T> extends InheritableThreadLocal<T> {
+
+    private final T initialValue;
+
+    public InitializedInheritableThreadLocal(T initialValue) {
+        this.initialValue = initialValue;
+    }
+
+    @Override
+    protected T initialValue() {
+        return initialValue;
+    }
+}

--- a/testing/agent/src/main/java/sbt/NullOutputListener.java
+++ b/testing/agent/src/main/java/sbt/NullOutputListener.java
@@ -1,0 +1,16 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+public class NullOutputListener implements OutputListener {
+
+    @Override
+    public void out(String text) {
+    }
+
+    @Override
+    public void err(String text) {
+    }
+}

--- a/testing/agent/src/main/java/sbt/NullOutputStream.java
+++ b/testing/agent/src/main/java/sbt/NullOutputStream.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sbt;
+ 
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This OutputStream writes all data to the famous <b>/dev/null</b>.
+ * <p>
+ * This output stream has no destination (file/socket etc.) and all
+ * bytes written to it are ignored and lost.
+ * 
+ * @version $Id: NullOutputStream.java 1302056 2012-03-18 03:03:38Z ggregory $
+ */
+public class NullOutputStream extends OutputStream {
+    
+    /**
+     * A singleton.
+     */
+    public static final NullOutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     * @param b The bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     */
+    @Override
+    public void write(byte[] b, int off, int len) {
+        //to /dev/null
+    }
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     * @param b The byte to write
+     */
+    @Override
+    public void write(int b) {
+        //to /dev/null
+    }
+
+    /**
+     * Does nothing - output to <code>/dev/null</code>.
+     * @param b The bytes to write
+     * @throws IOException never
+     */
+    @Override
+    public void write(byte[] b) throws IOException {
+        //to /dev/null
+    }
+
+}

--- a/testing/agent/src/main/java/sbt/OutErr.java
+++ b/testing/agent/src/main/java/sbt/OutErr.java
@@ -1,0 +1,18 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+import java.io.PrintStream;
+
+public interface OutErr {
+
+    PrintStream out();
+
+    PrintStream err();
+
+    void setOut(PrintStream out);
+
+    void setErr(PrintStream err);
+}

--- a/testing/agent/src/main/java/sbt/OutputCapturer.java
+++ b/testing/agent/src/main/java/sbt/OutputCapturer.java
@@ -1,0 +1,118 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class OutputCapturer {
+
+    // PrintStream does not do any buffering of its own; only the OutputStream that it delegates to may buffer.
+
+    private final OutCapturer outCapturer = new OutCapturer();
+    private final ErrCapturer errCapturer = new ErrCapturer();
+    private final PrintStream out;
+    private final PrintStream err;
+
+    public OutputCapturer() {
+        this(new NullOutputStream(), new NullOutputStream(), StandardCharsets.UTF_16BE);
+    }
+
+    public OutputCapturer(OutputStream realOut, OutputStream realErr, Charset charset) {
+        OutputStream capturedOut = new WriterOutputStream(outCapturer, charset);
+        OutputStream capturedErr = new WriterOutputStream(errCapturer, charset);
+        err = createNonSynchronizedPrintStream(new OutputStreamReplicator(realErr, capturedErr), charset);
+        out = SynchronizedPrintStream.create(new OutputStreamReplicator(realOut, capturedOut), charset, err);
+    }
+
+    private static PrintStream createNonSynchronizedPrintStream(OutputStream out, Charset charset) {
+        try {
+            return new PrintStream(out, false, charset.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public PrintStream out() {
+        return out;
+    }
+
+    public PrintStream err() {
+        return err;
+    }
+
+	/** capture the output of the current thread */
+    public void captureTo(OutputListener listener) {
+        outCapturer.setListener(listener);
+        errCapturer.setListener(listener);
+    }
+
+
+    private static class OutCapturer extends AbstractCapturer {
+        @Override
+        public void write(String text) {
+            listener.get().out(text);
+        }
+    }
+
+    private static class ErrCapturer extends AbstractCapturer {
+        @Override
+        public void write(String text) {
+            listener.get().err(text);
+        }
+    }
+
+    private static abstract class AbstractCapturer extends Writer {
+        protected final ThreadLocal<OutputListener> listener = new InitializedInheritableThreadLocal<OutputListener>(new NullOutputListener());
+
+		/** set the listener for the current thread */
+        public void setListener(OutputListener listener) {
+            this.listener.set(listener);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) {
+            write(new String(cbuf, off, len));
+        }
+
+        @Override
+        public abstract void write(String text);
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class OutputStreamReplicator extends OutputStream {
+        private final OutputStream out1;
+        private final OutputStream out2;
+
+        public OutputStreamReplicator(OutputStream out1, OutputStream out2) {
+            this.out1 = out1;
+            this.out2 = out2;
+        }
+
+        @Override
+        public void write(byte[] bytes, int off, int len) throws IOException {
+            out1.write(bytes, off, len);
+            out1.flush();
+            out2.write(bytes, off, len);
+            out2.flush();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out1.write(b);
+            out1.flush();
+            out2.write(b);
+            out2.flush();
+        }
+    }
+}

--- a/testing/agent/src/main/java/sbt/OutputCapturerInstaller.java
+++ b/testing/agent/src/main/java/sbt/OutputCapturerInstaller.java
@@ -1,0 +1,19 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+public class OutputCapturerInstaller {
+
+    private final OutErr outErr;
+
+    public OutputCapturerInstaller(OutErr outErr) {
+        this.outErr = outErr;
+    }
+
+    public void install(OutputCapturer capturer) {
+        outErr.setOut(capturer.out());
+        outErr.setErr(capturer.err());
+    }
+}

--- a/testing/agent/src/main/java/sbt/OutputListener.java
+++ b/testing/agent/src/main/java/sbt/OutputListener.java
@@ -1,0 +1,12 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+public interface OutputListener {
+
+    void out(String text);
+
+    void err(String text);
+}

--- a/testing/agent/src/main/java/sbt/OutputStringBuilder.java
+++ b/testing/agent/src/main/java/sbt/OutputStringBuilder.java
@@ -1,0 +1,23 @@
+package sbt;
+
+public class OutputStringBuilder implements OutputListener {
+	private StringBuilder outBuilder = new StringBuilder();
+	private StringBuilder errBuilder = new StringBuilder();
+
+	public void out(String text) {
+		outBuilder.append(text);
+	}
+
+	public void err(String text) {
+		errBuilder.append(text);
+	}
+
+	public String getOut() { return outBuilder.toString(); }
+	public String getErr() { return errBuilder.toString(); }
+
+	public String getOutAndReset() {
+		String out = getOut();
+		outBuilder.setLength(0); // reset
+		return out;
+	}
+}

--- a/testing/agent/src/main/java/sbt/OutputStringBuilder.java
+++ b/testing/agent/src/main/java/sbt/OutputStringBuilder.java
@@ -1,8 +1,9 @@
 package sbt;
 
 public class OutputStringBuilder implements OutputListener {
-	private StringBuilder outBuilder = new StringBuilder();
-	private StringBuilder errBuilder = new StringBuilder();
+
+	private final StringBuffer outBuilder = new StringBuffer();
+	private final StringBuffer errBuilder = new StringBuffer();
 
 	public void out(String text) {
 		outBuilder.append(text);
@@ -16,8 +17,10 @@ public class OutputStringBuilder implements OutputListener {
 	public String getErr() { return errBuilder.toString(); }
 
 	public String getOutAndReset() {
-		String out = getOut();
-		outBuilder.setLength(0); // reset
-		return out;
+		synchronized (outBuilder) {
+			String out = getOut();
+			outBuilder.setLength(0); // reset
+			return out;
+		}
 	}
 }

--- a/testing/agent/src/main/java/sbt/SynchronizedPrintStream.java
+++ b/testing/agent/src/main/java/sbt/SynchronizedPrintStream.java
@@ -1,0 +1,71 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+import net.sf.cglib.core.*;
+import net.sf.cglib.proxy.*;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+
+class SynchronizedPrintStream {
+
+    @SuppressWarnings({"UnusedDeclaration", "MismatchedReadAndWriteOfArray"})
+    private static final Class<?>[] DO_NOT_REMOVE_WHEN_MINIMIZING_THE_JAR = {
+            // these are the same as in net.sf.cglib.proxy.CallbackInfo.CALLBACKS
+            NoOp.class,
+            MethodInterceptor.class,
+            InvocationHandler.class,
+            LazyLoader.class,
+            Dispatcher.class,
+            FixedValue.class,
+            ProxyRefDispatcher.class,
+    };
+
+    public static PrintStream create(OutputStream out, Charset charset, Object sharedLock) {
+        Enhancer e = new Enhancer();
+        e.setSuperclass(PrintStream.class);
+        e.setCallback(new SynchronizedMethodInterceptor(sharedLock));
+        e.setNamingPolicy(new PrefixOverridingNamingPolicy(SynchronizedPrintStream.class.getName()));
+        e.setUseFactory(false);
+        return (PrintStream) e.create(
+                new Class[]{OutputStream.class, boolean.class, String.class},
+                new Object[]{out, false, charset.name()}
+        );
+    }
+
+    private static class SynchronizedMethodInterceptor implements MethodInterceptor {
+        private final Object sharedLock;
+
+        public SynchronizedMethodInterceptor(Object sharedLock) {
+            this.sharedLock = sharedLock;
+        }
+
+        @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+        @Override
+        public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+            synchronized (obj) {
+                synchronized (sharedLock) {
+                    return proxy.invokeSuper(obj, args);
+                }
+            }
+        }
+    }
+
+    private static class PrefixOverridingNamingPolicy extends DefaultNamingPolicy {
+        private final String prefix;
+
+        private PrefixOverridingNamingPolicy(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String getClassName(String prefix, String source, Object key, Predicate names) {
+            return super.getClassName(this.prefix, source, key, names);
+        }
+    }
+}

--- a/testing/agent/src/main/java/sbt/SystemOutErr.java
+++ b/testing/agent/src/main/java/sbt/SystemOutErr.java
@@ -1,0 +1,30 @@
+// Copyright © 2011-2013, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package sbt;
+
+import java.io.PrintStream;
+
+public class SystemOutErr implements OutErr {
+
+    @Override
+    public PrintStream out() {
+        return System.out;
+    }
+
+    @Override
+    public PrintStream err() {
+        return System.err;
+    }
+
+    @Override
+    public void setOut(PrintStream out) {
+        System.setOut(out);
+    }
+
+    @Override
+    public void setErr(PrintStream err) {
+        System.setErr(err);
+    }
+}

--- a/testing/agent/src/main/java/sbt/WriterOutputStream.java
+++ b/testing/agent/src/main/java/sbt/WriterOutputStream.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sbt;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+
+/**
+ * {@link OutputStream} implementation that transforms a byte stream to a
+ * character stream using a specified charset encoding and writes the resulting
+ * stream to a {@link Writer}. The stream is transformed using a
+ * {@link CharsetDecoder} object, guaranteeing that all charset
+ * encodings supported by the JRE are handled correctly.
+ * <p>
+ * The output of the {@link CharsetDecoder} is buffered using a fixed size buffer.
+ * This implies that the data is written to the underlying {@link Writer} in chunks
+ * that are no larger than the size of this buffer. By default, the buffer is
+ * flushed only when it overflows or when {@link #flush()} or {@link #close()}
+ * is called. In general there is therefore no need to wrap the underlying {@link Writer}
+ * in a {@link java.io.BufferedWriter}. {@link WriterOutputStream} can also
+ * be instructed to flush the buffer after each write operation. In this case, all
+ * available data is written immediately to the underlying {@link Writer}, implying that
+ * the current position of the {@link Writer} is correlated to the current position
+ * of the {@link WriterOutputStream}.
+ * <p>
+ * {@link WriterOutputStream} implements the inverse transformation of {@link java.io.OutputStreamWriter};
+ * in the following example, writing to <tt>out2</tt> would have the same result as writing to
+ * <tt>out</tt> directly (provided that the byte sequence is legal with respect to the
+ * charset encoding):
+ * <pre>
+ * OutputStream out = ...
+ * Charset cs = ...
+ * OutputStreamWriter writer = new OutputStreamWriter(out, cs);
+ * WriterOutputStream out2 = new WriterOutputStream(writer, cs);</pre>
+ * {@link WriterOutputStream} implements the same transformation as {@link java.io.InputStreamReader},
+ * except that the control flow is reversed: both classes transform a byte stream
+ * into a character stream, but {@link java.io.InputStreamReader} pulls data from the underlying stream,
+ * while {@link WriterOutputStream} pushes it to the underlying stream.
+ * <p>
+ * Note that while there are use cases where there is no alternative to using
+ * this class, very often the need to use this class is an indication of a flaw
+ * in the design of the code. This class is typically used in situations where an existing
+ * API only accepts an {@link OutputStream} object, but where the stream is known to represent
+ * character data that must be decoded for further use.
+ * <p>
+ * Instances of {@link WriterOutputStream} are not thread safe.
+ * 
+ * @see org.apache.commons.io.input.ReaderInputStream
+ * 
+ * @since 2.0
+ */
+public class WriterOutputStream extends OutputStream {
+    private static final int DEFAULT_BUFFER_SIZE = 1024;
+
+    private final Writer writer;
+    private final CharsetDecoder decoder;
+    private final boolean writeImmediately;
+
+    /**
+     * ByteBuffer used as input for the decoder. This buffer can be small
+     * as it is used only to transfer the received data to the
+     * decoder.
+     */
+    private final ByteBuffer decoderIn = ByteBuffer.allocate(128);
+
+    /**
+     * CharBuffer used as output for the decoder. It should be
+     * somewhat larger as we write from this buffer to the
+     * underlying Writer.
+     */
+    private final CharBuffer decoderOut;
+
+    /**
+     * Constructs a new {@link WriterOutputStream} with a default output buffer size of
+     * 1024 characters. The output buffer will only be flushed when it overflows or when
+     * {@link #flush()} or {@link #close()} is called.
+     * 
+     * @param writer the target {@link Writer}
+     * @param decoder the charset decoder
+     * @since 2.1
+     */
+    public WriterOutputStream(Writer writer, CharsetDecoder decoder) {
+        this(writer, decoder, DEFAULT_BUFFER_SIZE, false);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream}.
+     * 
+     * @param writer the target {@link Writer}
+     * @param decoder the charset decoder
+     * @param bufferSize the size of the output buffer in number of characters
+     * @param writeImmediately If <tt>true</tt> the output buffer will be flushed after each
+     *                         write operation, i.e. all available data will be written to the
+     *                         underlying {@link Writer} immediately. If <tt>false</tt>, the
+     *                         output buffer will only be flushed when it overflows or when
+     *                         {@link #flush()} or {@link #close()} is called.
+     * @since 2.1
+     */
+    public WriterOutputStream(Writer writer, CharsetDecoder decoder, int bufferSize, boolean writeImmediately) {
+        this.writer = writer;
+        this.decoder = decoder;
+        this.writeImmediately = writeImmediately;
+        decoderOut = CharBuffer.allocate(bufferSize);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream}.
+     * 
+     * @param writer the target {@link Writer}
+     * @param charset the charset encoding
+     * @param bufferSize the size of the output buffer in number of characters
+     * @param writeImmediately If <tt>true</tt> the output buffer will be flushed after each
+     *                         write operation, i.e. all available data will be written to the
+     *                         underlying {@link Writer} immediately. If <tt>false</tt>, the
+     *                         output buffer will only be flushed when it overflows or when
+     *                         {@link #flush()} or {@link #close()} is called.
+     */
+    public WriterOutputStream(Writer writer, Charset charset, int bufferSize, boolean writeImmediately) {
+        this(writer,
+             charset.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE)
+                    .replaceWith("?"),
+             bufferSize,
+             writeImmediately);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream} with a default output buffer size of
+     * 1024 characters. The output buffer will only be flushed when it overflows or when
+     * {@link #flush()} or {@link #close()} is called.
+     * 
+     * @param writer the target {@link Writer}
+     * @param charset the charset encoding
+     */
+    public WriterOutputStream(Writer writer, Charset charset) {
+        this(writer, charset, DEFAULT_BUFFER_SIZE, false);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream}.
+     * 
+     * @param writer the target {@link Writer}
+     * @param charsetName the name of the charset encoding
+     * @param bufferSize the size of the output buffer in number of characters
+     * @param writeImmediately If <tt>true</tt> the output buffer will be flushed after each
+     *                         write operation, i.e. all available data will be written to the
+     *                         underlying {@link Writer} immediately. If <tt>false</tt>, the
+     *                         output buffer will only be flushed when it overflows or when
+     *                         {@link #flush()} or {@link #close()} is called.
+     */
+    public WriterOutputStream(Writer writer, String charsetName, int bufferSize, boolean writeImmediately) {
+        this(writer, Charset.forName(charsetName), bufferSize, writeImmediately);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream} with a default output buffer size of
+     * 1024 characters. The output buffer will only be flushed when it overflows or when
+     * {@link #flush()} or {@link #close()} is called.
+     * 
+     * @param writer the target {@link Writer}
+     * @param charsetName the name of the charset encoding
+     */
+    public WriterOutputStream(Writer writer, String charsetName) {
+        this(writer, charsetName, DEFAULT_BUFFER_SIZE, false);
+    }
+
+    /**
+     * Constructs a new {@link WriterOutputStream} that uses the default character encoding
+     * and with a default output buffer size of 1024 characters. The output buffer will only
+     * be flushed when it overflows or when {@link #flush()} or {@link #close()} is called.
+     * 
+     * @param writer the target {@link Writer}
+     */
+    public WriterOutputStream(Writer writer) {
+        this(writer, Charset.defaultCharset(), DEFAULT_BUFFER_SIZE, false);
+    }
+
+    /**
+     * Write bytes from the specified byte array to the stream.
+     * 
+     * @param b the byte array containing the bytes to write
+     * @param off the start offset in the byte array
+     * @param len the number of bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        while (len > 0) {
+            int c = Math.min(len, decoderIn.remaining());
+            decoderIn.put(b, off, c);
+            processInput(false);
+            len -= c;
+            off += c;
+        }
+        if (writeImmediately) {
+            flushOutput();
+        }
+    }
+
+    /**
+     * Write bytes from the specified byte array to the stream.
+     * 
+     * @param b the byte array containing the bytes to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    /**
+     * Write a single byte to the stream.
+     * 
+     * @param b the byte to write
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void write(int b) throws IOException {
+        write(new byte[] { (byte)b }, 0, 1);
+    }
+
+    /**
+     * Flush the stream. Any remaining content accumulated in the output buffer
+     * will be written to the underlying {@link Writer}. After that
+     * {@link Writer#flush()} will be called. 
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void flush() throws IOException {
+        flushOutput();
+        writer.flush();
+    }
+
+    /**
+     * Close the stream. Any remaining content accumulated in the output buffer
+     * will be written to the underlying {@link Writer}. After that
+     * {@link Writer#close()} will be called. 
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        processInput(true);
+        flushOutput();
+        writer.close();
+    }
+
+    /**
+     * Decode the contents of the input ByteBuffer into a CharBuffer.
+     * 
+     * @param endOfInput indicates end of input
+     * @throws IOException if an I/O error occurs
+     */
+    private void processInput(boolean endOfInput) throws IOException {
+        // Prepare decoderIn for reading
+        decoderIn.flip();
+        CoderResult coderResult;
+        while (true) {
+            coderResult = decoder.decode(decoderIn, decoderOut, endOfInput);
+            if (coderResult.isOverflow()) {
+                flushOutput();
+            } else if (coderResult.isUnderflow()) {
+                break;
+            } else {
+                // The decoder is configured to replace malformed input and unmappable characters,
+                // so we should not get here.
+                throw new IOException("Unexpected coder result");
+            }
+        }
+        // Discard the bytes that have been read
+        decoderIn.compact();
+    }
+
+    /**
+     * Flush the output.
+     * 
+     * @throws IOException if an I/O error occurs
+     */
+    private void flushOutput() throws IOException {
+        if (decoderOut.position() > 0) {
+            writer.write(decoderOut.array(), 0, decoderOut.position());
+            decoderOut.rewind();
+        }
+    }
+}

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -9,7 +9,7 @@ import testing.{Event => TEvent, Status => TStatus, OptionalThrowable, TestSelec
 
 /**
  * A tests listener that outputs the results it receives in junit xml
- * report format.
+ * report format. XSD can be found here: http://windyroad.com.au/dl/Open%20Source/JUnit.xsd (note: we might want to download this into the project?)
  * @param outputDir path to the dir in which a folder with results is generated
  */
 class JUnitXmlTestsListener(val outputDir:String) extends TestsListener
@@ -20,7 +20,7 @@ class JUnitXmlTestsListener(val outputDir:String) extends TestsListener
     val targetDir = new File(outputDir + "/test-reports/")
 
     /**all system properties as XML*/
-    val properties =
+    def properties =
         <properties> {
             val iter = System.getProperties.entrySet.iterator
             val props:ListBuffer[Node] = new ListBuffer()
@@ -32,137 +32,75 @@ class JUnitXmlTestsListener(val outputDir:String) extends TestsListener
         }
         </properties>
 
-    /** Gathers data for one Test Suite. We map test groups to TestSuites.
-     * Each TestSuite gets its own output file.
-     */
-    class TestSuite(val name:String) {
-        val events:ListBuffer[TEvent] = new ListBuffer()
+		private def cdata(content: String) = scala.xml.Unparsed("<![CDATA[%s]]>".format(content))
 
-        /**Adds one test result to this suite.*/
-        def addEvent(e:TEvent) = events += e
+		private def stackTraceToString(t: Throwable) : String = {
+			val stringWriter = new StringWriter()
+			val writer = new PrintWriter(stringWriter)
+			t.printStackTrace(writer)
+			writer.flush()
+			stringWriter.toString
+		}
 
-        /** Returns the number of tests of each state for the specified. */
-        def count(status: TStatus) = events.count(_.status == status)
+    def toXml(name:String, suite: SuiteReport, suiteError: Option[Throwable]) : Elem = {
+				val errors = if( suite.result.errorCount == 0 && suiteError.isDefined) 1 else suite.result.errorCount
 
-        /** Stops the time measuring and emits the XML for
-         * All tests collected so far.
-         */
-        def stop():Elem = {
-            val duration  = events.map(_.duration()).sum
+				<testsuite hostname={hostname} name={name}
+											 tests={suite.detail.size + ""} errors={errors + ""} failures={suite.result.failureCount + ""}
+											 time={(suite.duration / 1000.0).toString} >
+						{properties}
+						{
+								for (e <- suite.detail) yield
+								<testcase classname={name}
+													name={
+														e.detail.selector match {
+															case selector: TestSelector => selector.testName.split('.').last
+															case _ => "(It is not a test)"
+														}
+													}
+													time={(e.detail.duration() / 1000.0).toString}> {
+										val trace: String = if (e.detail.throwable.isDefined) {
+											stackTraceToString(e.detail.throwable.get)
+										}
+										else {
+											""
+										}
+										e.detail.status match {
+												case TStatus.Error   if (e.detail.throwable.isDefined) => <error message={e.detail.throwable.get.getMessage} type={e.detail.throwable.get.getClass.getName}>{trace}</error>
+												case TStatus.Error                              => <error message={"No Exception or message provided"} />
+												case TStatus.Failure if (e.detail.throwable.isDefined) => <failure message={e.detail.throwable.get.getMessage} type={e.detail.throwable.get.getClass.getName}>{trace}</failure>
+												case TStatus.Failure                            => <failure message={"No Exception or message provided"} />
+												case TStatus.Skipped                            => <skipped />
+												case _               => {}
+												}
+								}
+									<system-out>{cdata(e.stdout)}</system-out>
+								</testcase>
 
-            val (errors, failures, tests) = (count(TStatus.Error), count(TStatus.Failure), events.size)
+						}
+						<system-out><![CDATA[]]></system-out>
+						<system-err>{cdata(suiteError.map(stackTraceToString).getOrElse(""))}</system-err>
+						</testsuite>
 
-            val result = <testsuite hostname={hostname} name={name}
-                           tests={tests + ""} errors={errors + ""} failures={failures + ""}
-                           time={(duration/1000.0).toString} >
-                {properties}
-                {
-                    for (e <- events) yield
-                    <testcase classname={name}
-                              name={
-                                e.selector match {
-                                  case selector: TestSelector => selector.testName.split('.').last
-                                  case _ => "(It is not a test)"
-                                }
-                              }
-                              time={(e.duration() / 1000.0).toString}> {
-                        var trace:String = if (e.throwable.isDefined) {
-                            val stringWriter = new StringWriter()
-                            val writer = new PrintWriter(stringWriter)
-                            e.throwable.get.printStackTrace(writer)
-                            writer.flush()
-                            stringWriter.toString
-                        }
-                        else {
-                            ""
-                        }
-                        e.status match {
-                            case TStatus.Error   if (e.throwable.isDefined) => <error message={e.throwable.get.getMessage} type={e.throwable.get.getClass.getName}>{trace}</error>
-                            case TStatus.Error                              => <error message={"No Exception or message provided"} />
-                            case TStatus.Failure if (e.throwable.isDefined) => <failure message={e.throwable.get.getMessage} type={e.throwable.get.getClass.getName}>{trace}</failure>
-                            case TStatus.Failure                            => <failure message={"No Exception or message provided"} />
-                            case TStatus.Skipped                            => <skipped />
-                            case _               => {}
-                            }
-                    }
-                    </testcase>
-
-                }
-                <system-out><![CDATA[]]></system-out>
-                <system-err><![CDATA[]]></system-err>
-                </testsuite>
-
-            result
-        }
     }
 
-    /**The currently running test suite*/
-    var testSuite = new DynamicVariable(null: TestSuite)
-
-    /**Creates the output Dir*/
     override def doInit() = {targetDir.mkdirs()}
 
-    /** Starts a new, initially empty Suite with the given name.
-     */
-    override def startGroup(name: String) {testSuite.value_=(new TestSuite(name))}
-
-    /** Adds all details for the given even to the current suite.
-     */
-    override def testEvent(event: TestEvent): Unit = for (e <- event.detail) {testSuite.value.addEvent(e)}
-
-    /** called for each class or equivalent grouping
-     *  We map one group to one Testsuite, so for each Group
-     *  we create an XML like this:
-     *  <?xml version="1.0" encoding="UTF-8" ?>
-     *  <testsuite errors="x" failures="y" tests="z" hostname="example.com" name="eu.henkelmann.bla.SomeTest" time="0.23">
-     *       <properties>
-     *           <property name="os.name" value="Linux" />
-     *           ...
-     *       </properties>
-     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testFooWorks" time="0.0" >
-     *           <error message="the foo did not work" type="java.lang.NullPointerException">... stack ...</error>
-     *       </testcase>
-     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testBarThrowsException" time="0.0" />
-     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testBaz" time="0.0">
-     *           <failure message="the baz was no bar" type="junit.framework.AssertionFailedError">...stack...</failure>
-     *        </testcase>
-     *       <system-out><![CDATA[]]></system-out>
-     *       <system-err><![CDATA[]]></system-err>
-     *  </testsuite>
-     */
-    override def endGroup(name: String, t: Throwable) = {
-        // create our own event to record the error
-        val event = new TEvent {
-            def fullyQualifiedName= name
-            //def description =
-              //"Throwable escaped the test run of '%s'".format(name)
-              def duration = -1
-            def status  = TStatus.Error
-            def fingerprint = null
-            def selector = null
-            def throwable = new OptionalThrowable(t)
-        }
-        testSuite.value.addEvent(event)
-        writeSuite()
+    override def endSuite(name: String, t: Throwable, suite: Option[SuiteReport]) = {
+        writeSuite(name, suite.getOrElse(SuiteReport.Error), Some(t))
     }
 
     /** Ends the current suite, wraps up the result and writes it to an XML file
      *  in the output folder that is named after the suite.
      */
-    override def endGroup(name: String, result: TestResult.Value) = {
-        writeSuite()
+    override def endSuite(name: String, suite: SuiteReport) = {
+        writeSuite(name, suite)
     }
 
-    private def writeSuite() = {
-      val file = new File(targetDir, testSuite.value.name + ".xml").getAbsolutePath
+    private def writeSuite(name: String, suite: SuiteReport, suiteError: Option[Throwable] = None) = {
+      val file = new File(targetDir, name + ".xml").getAbsolutePath
       // TODO would be nice to have a logger and log this with level debug
       // System.err.println("Writing JUnit XML test report: " + file)
-      XML.save (file, testSuite.value.stop(), "UTF-8", true, null)
+      XML.save (file, toXml(name, suite, suiteError), "UTF-8", true, null)
     }
-
-    /**Does nothing, as we write each file after a suite is done.*/
-    override def doComplete(finalResult: TestResult.Value): Unit = {}
-
-    /**Returns None*/
-    override def contentLogger(test: TestDefinition): Option[ContentLogger] = None
 }

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -1,0 +1,168 @@
+package sbt
+
+import java.io.{StringWriter, PrintWriter, File}
+import java.net.InetAddress
+import scala.collection.mutable.ListBuffer
+import scala.util.DynamicVariable
+import scala.xml.{Elem, Node, XML}
+import testing.{Event => TEvent, Status => TStatus, OptionalThrowable, TestSelector}
+
+/**
+ * A tests listener that outputs the results it receives in junit xml
+ * report format.
+ * @param outputDir path to the dir in which a folder with results is generated
+ */
+class JUnitXmlTestsListener(val outputDir:String) extends TestsListener
+{
+		/**Current hostname so we know which machine executed the tests*/
+    val hostname = InetAddress.getLocalHost.getHostName
+    /**The dir in which we put all result files. Is equal to the given dir + "/test-reports"*/
+    val targetDir = new File(outputDir + "/test-reports/")
+
+    /**all system properties as XML*/
+    val properties =
+        <properties> {
+            val iter = System.getProperties.entrySet.iterator
+            val props:ListBuffer[Node] = new ListBuffer()
+            while (iter.hasNext) {
+                val next = iter.next
+                props += <property name={next.getKey.toString} value={next.getValue.toString} />
+            }
+            props
+        }
+        </properties>
+
+    /** Gathers data for one Test Suite. We map test groups to TestSuites.
+     * Each TestSuite gets its own output file.
+     */
+    class TestSuite(val name:String) {
+        val events:ListBuffer[TEvent] = new ListBuffer()
+
+        /**Adds one test result to this suite.*/
+        def addEvent(e:TEvent) = events += e
+
+        /** Returns the number of tests of each state for the specified. */
+        def count(status: TStatus) = events.count(_.status == status)
+
+        /** Stops the time measuring and emits the XML for
+         * All tests collected so far.
+         */
+        def stop():Elem = {
+            val duration  = events.map(_.duration()).sum
+
+            val (errors, failures, tests) = (count(TStatus.Error), count(TStatus.Failure), events.size)
+
+            val result = <testsuite hostname={hostname} name={name}
+                           tests={tests + ""} errors={errors + ""} failures={failures + ""}
+                           time={(duration/1000.0).toString} >
+                {properties}
+                {
+                    for (e <- events) yield
+                    <testcase classname={name}
+                              name={
+                                e.selector match {
+                                  case selector: TestSelector => selector.testName.split('.').last
+                                  case _ => "(It is not a test)"
+                                }
+                              }
+                              time={(e.duration() / 1000.0).toString}> {
+                        var trace:String = if (e.throwable.isDefined) {
+                            val stringWriter = new StringWriter()
+                            val writer = new PrintWriter(stringWriter)
+                            e.throwable.get.printStackTrace(writer)
+                            writer.flush()
+                            stringWriter.toString
+                        }
+                        else {
+                            ""
+                        }
+                        e.status match {
+                            case TStatus.Error   if (e.throwable.isDefined) => <error message={e.throwable.get.getMessage} type={e.throwable.get.getClass.getName}>{trace}</error>
+                            case TStatus.Error                              => <error message={"No Exception or message provided"} />
+                            case TStatus.Failure if (e.throwable.isDefined) => <failure message={e.throwable.get.getMessage} type={e.throwable.get.getClass.getName}>{trace}</failure>
+                            case TStatus.Failure                            => <failure message={"No Exception or message provided"} />
+                            case TStatus.Skipped                            => <skipped />
+                            case _               => {}
+                            }
+                    }
+                    </testcase>
+
+                }
+                <system-out><![CDATA[]]></system-out>
+                <system-err><![CDATA[]]></system-err>
+                </testsuite>
+
+            result
+        }
+    }
+
+    /**The currently running test suite*/
+    var testSuite = new DynamicVariable(null: TestSuite)
+
+    /**Creates the output Dir*/
+    override def doInit() = {targetDir.mkdirs()}
+
+    /** Starts a new, initially empty Suite with the given name.
+     */
+    override def startGroup(name: String) {testSuite.value_=(new TestSuite(name))}
+
+    /** Adds all details for the given even to the current suite.
+     */
+    override def testEvent(event: TestEvent): Unit = for (e <- event.detail) {testSuite.value.addEvent(e)}
+
+    /** called for each class or equivalent grouping
+     *  We map one group to one Testsuite, so for each Group
+     *  we create an XML like this:
+     *  <?xml version="1.0" encoding="UTF-8" ?>
+     *  <testsuite errors="x" failures="y" tests="z" hostname="example.com" name="eu.henkelmann.bla.SomeTest" time="0.23">
+     *       <properties>
+     *           <property name="os.name" value="Linux" />
+     *           ...
+     *       </properties>
+     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testFooWorks" time="0.0" >
+     *           <error message="the foo did not work" type="java.lang.NullPointerException">... stack ...</error>
+     *       </testcase>
+     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testBarThrowsException" time="0.0" />
+     *       <testcase classname="eu.henkelmann.bla.SomeTest" name="testBaz" time="0.0">
+     *           <failure message="the baz was no bar" type="junit.framework.AssertionFailedError">...stack...</failure>
+     *        </testcase>
+     *       <system-out><![CDATA[]]></system-out>
+     *       <system-err><![CDATA[]]></system-err>
+     *  </testsuite>
+     */
+    override def endGroup(name: String, t: Throwable) = {
+        // create our own event to record the error
+        val event = new TEvent {
+            def fullyQualifiedName= name
+            //def description =
+              //"Throwable escaped the test run of '%s'".format(name)
+              def duration = -1
+            def status  = TStatus.Error
+            def fingerprint = null
+            def selector = null
+            def throwable = new OptionalThrowable(t)
+        }
+        testSuite.value.addEvent(event)
+        writeSuite()
+    }
+
+    /** Ends the current suite, wraps up the result and writes it to an XML file
+     *  in the output folder that is named after the suite.
+     */
+    override def endGroup(name: String, result: TestResult.Value) = {
+        writeSuite()
+    }
+
+    private def writeSuite() = {
+      val file = new File(targetDir, testSuite.value.name + ".xml").getAbsolutePath
+      // TODO would be nice to have a logger and log this with level debug
+      // System.err.println("Writing JUnit XML test report: " + file)
+      XML.save (file, testSuite.value.stop(), "UTF-8", true, null)
+    }
+
+    /**Does nothing, as we write each file after a suite is done.*/
+    override def doComplete(finalResult: TestResult.Value): Unit = {}
+
+    /**Returns None*/
+    override def contentLogger(test: TestDefinition): Option[ContentLogger] = None
+}

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -65,15 +65,15 @@ final class TestDefinition(val name: String, val fingerprint: Fingerprint, val e
 
 final class TestRunner(delegate: Runner, listeners: Seq[TestReportListener], log: Logger) {
 
-    final def tasks(testDefs: Set[TestDefinition]): Array[TestTask] = 
-      delegate.tasks(testDefs.map(df => new TaskDef(df.name, df.fingerprint, df.explicitlySpecified, df.selectors)).toArray)
+	final def tasks(testDefs: Set[TestDefinition]): Array[TestTask] =
+		delegate.tasks(testDefs.map(df => new TaskDef(df.name, df.fingerprint, df.explicitlySpecified, df.selectors)).toArray)
 
 	final def run(taskDef: TaskDef, testTask: TestTask): (SuiteResult, Seq[TestTask]) =
 	{
-        val testDefinition = new TestDefinition(taskDef.fullyQualifiedName, taskDef.fingerprint, taskDef.explicitlySpecified, taskDef.selectors)
+		val testDefinition = new TestDefinition(taskDef.fullyQualifiedName, taskDef.fingerprint, taskDef.explicitlySpecified, taskDef.selectors)
 		log.debug("Running " + taskDef)
 		val name = testDefinition.name
-		
+
 		def runTest() =
 		{
 			// here we get the results! here is where we'd pass in the event listener
@@ -167,7 +167,7 @@ object TestFramework
 	{
 		import scala.collection.mutable.{HashMap, HashSet, Set}
 		val map = new HashMap[Framework, Set[TestDefinition]]
- 		def assignTest(test: TestDefinition)
+		def assignTest(test: TestDefinition)
 		{
 			def isTestForFramework(framework: Framework) = getFingerprints(framework).exists {t => matches(t, test.fingerprint) }
 			for(framework <- frameworks.find(isTestForFramework))
@@ -192,8 +192,8 @@ object TestFramework
 				val runner = runners(framework)
 				val testTasks = withContextLoader(loader) { runner.tasks(testDefinitions) }
 				for (testTask <- testTasks) yield {
-				  val taskDef = testTask.taskDef
-				  (taskDef.fullyQualifiedName, createTestFunction(loader, taskDef, runner, testTask))
+					val taskDef = testTask.taskDef
+					(taskDef.fullyQualifiedName, createTestFunction(loader, taskDef, runner, testTask))
 				}
 			}
 

--- a/testing/src/main/scala/sbt/TestStatusReporter.scala
+++ b/testing/src/main/scala/sbt/TestStatusReporter.scala
@@ -12,15 +12,12 @@ private[sbt] class TestStatusReporter(f: File) extends TestsListener
 {
 	private lazy val succeeded = TestStatus.read(f)
 
-	def doInit {}
-	def startGroup(name: String) { succeeded remove name }
-	def testEvent(event: TestEvent) {}
-	def endGroup(name: String, t: Throwable) {}
-	def endGroup(name: String, result: TestResult.Value) {
-		if(result == TestResult.Passed)
+	override def startSuite(name: String) { succeeded remove name }
+	override def endSuite(name: String, suite: SuiteReport) {
+		if(suite.result.result == TestResult.Passed)
 			succeeded(name) = System.currentTimeMillis
 	}
-	def doComplete(finalResult: TestResult.Value) {
+	override def doComplete(finalResult: TestResult.Value) {
 		TestStatus.write(succeeded, "Successful Tests", f)
 	}
 }


### PR DESCRIPTION
I've copied jumi `fi.jumi.core.stdout` package into the test agent.
It needs cglib.
While doing this I simplified the test report API. A TestEvent is now a
SuiteReport and it is made of TestReport. A TestReport contains the test
stdout capture. I've successfully tested it on a test project,
but I'm going to add a scripted test for it.
