### PR TITLE
moduleConfigurations: TaskKey

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -283,7 +283,7 @@ object Keys
 	val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)
 	val fullResolvers = TaskKey[Seq[Resolver]]("full-resolvers", "Combines the project resolver, default resolvers, and user-defined resolvers.", CTask)
 	val otherResolvers = SettingKey[Seq[Resolver]]("other-resolvers", "Resolvers not included in the main resolver chain, such as those in module configurations.", CSetting)
-	val moduleConfigurations = SettingKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusSetting)
+	val moduleConfigurations = TaskKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusTask)
 	val retrievePattern = SettingKey[String]("retrieve-pattern", "Pattern used to retrieve managed dependencies to the current build.", DSetting)
 	val retrieveConfiguration = SettingKey[Option[RetrieveConfiguration]]("retrieve-configuration", "Configures retrieving dependencies to the current build.", DSetting)
 	val offline = SettingKey[Boolean]("offline", "Configures sbt to work without a network connection where possible.", ASetting)


### PR DESCRIPTION
I'd like to convert moduleConfigurations to a TaskKey.
The reason is that it doesn't _have_ to be a SettingKey (it's only used in tasks), and as it is, it limits how much you can achieve with it --
Specifically, I'd like to add a moduleConfiguration that forces packages from my company to use our own bespoke chain resolver, which will only query the local ivy and our internal ivy repositories.
However, by doing that, I can't add the inter-project resolver anymore -- it's created by a task, and as I can see, it's only automatically propagated into "sbt-chain", which is what I've been trying to avoid. 

To summarize, if moduleConfigurations were a task I could easily do something like:

```
moduleConfigurations <+= (organization, internalResolver, projectResolver) map { (o,ir, pr) =>
    ModuleConfiguration(o, ChainedResolver("internals", Seq(pr, Resolver.defaultLocal, ir))
}
```

Whereas now I can't add `projectResolver` and so I can't use this set-up for a multi-project build.
