### PR TITLE
Fix deriveAndLocal bug

### DIFF
--- a/util/collection/src/test/scala/SettingsTest.scala
+++ b/util/collection/src/test/scala/SettingsTest.scala
@@ -32,8 +32,7 @@ object SettingsTest extends Properties("settings")
 				else
 					iterate(value(t-1) )
 			}
-		try { evaluate( setting(chk, iterate(top)) :: Nil); true }
-		catch { case e: java.lang.Exception => ("Unexpected exception: " + e) |: false }
+		evaluate( setting(chk, iterate(top)) :: Nil); true
 	}
 
   property("Derived setting chain depending on (prev derived, normal setting)") = forAllNoShrink(Gen.choose(1, 100)) { derivedSettings }

--- a/util/collection/src/test/scala/SettingsTest.scala
+++ b/util/collection/src/test/scala/SettingsTest.scala
@@ -21,7 +21,7 @@ object SettingsTest extends Properties("settings")
 		singleIntTest( chainBind(value(abs)), 0 )
 	}
 
-	property("Allows references to completed settings") = forAllNoShrink(30) { allowedReference _ }
+	property("Allows references to completed settings") = forAllNoShrink(30) { allowedReference }
 	final def allowedReference(intermediate: Int): Prop =
 	{
 		val top = value(intermediate)
@@ -35,6 +35,32 @@ object SettingsTest extends Properties("settings")
 		try { evaluate( setting(chk, iterate(top)) :: Nil); true }
 		catch { case e: java.lang.Exception => ("Unexpected exception: " + e) |: false }
 	}
+
+  property("Derived setting chain depending on (prev derived, normal setting)") = forAllNoShrink(Gen.choose(1, 100)) { derivedSettings }
+  final def derivedSettings(nr: Int): Prop =
+  {
+    val alphaStr = Gen.alphaStr
+    val genScopedKeys = {
+      val attrKeys = for {
+        list <- Gen.listOfN(nr, alphaStr) suchThat (l => l.size == l.distinct.size)
+        item <- list
+      } yield AttributeKey[Int](item)
+      attrKeys map (_ map (ak => ScopedKey(Scope(0), ak)))
+    }
+    forAll(genScopedKeys) { scopedKeys =>
+      val last = scopedKeys.last
+      val derivedSettings: Seq[Setting[Int]] = (
+        for {
+          List(scoped0, scoped1) <- chk :: scopedKeys sliding 2
+          nextInit = if (scoped0 == chk) chk
+                     else (scoped0 zipWith chk) { (p, _) => p + 1 }
+        } yield derive(setting(scoped1, nextInit))
+      ).toSeq
+
+      { checkKey(last, Some(nr-1), evaluate(setting(chk, value(0)) +: derivedSettings)) :| "Not derived?" } &&
+      { checkKey( last, None, evaluate(derivedSettings)) :| "Should not be derived" }
+    }
+  }
 
 // Circular (dynamic) references currently loop infinitely.
 //  This is the expected behavior (detecting dynamic cycles is expensive),


### PR DESCRIPTION
In my quests to derive some settings, I have noticed that one of my 2 `DerivedSetting`s was actually derived, but the other one which depended on the first one, did not. Let's call them A and B, B depending on A (both representing their respective values of type `Derived`). To note is that B depended not just on A, but on a plain setting C as well, which is relevant.
Turns out, the issue was that in `def localAndDerived`, `(d: Derived).inScopes` has the new scope added to it, even if the derived setting `d` didn't actually resolve yet, because not all of its dependencies were defined yet. In this case, it happened when processing the B's "plain setting" dependency C.
This had the effect that at the time when all of B's dependencies came to be defined (i.e. A got derived), it became possible that the same scope had already been added to B (because both B's dependencies, A and C, were defined in the same scope), so no further attempts to check B's dependencies by calling `allDepsDefined` were made anymore, leaving B forever undefined.

As an aside note, that also prompted me to look at `val sortedDerivs` in deriveAndLocal, and noticing that it's not used - presumably the topological sort is only called to issue warnings about cycles?

Sorry about spacing diffs, that was as a result of retabbing.

I believe this patch is applicable to 0.13 as well, as the last commit that touched this is `4bb9633` slightly after 0.13.0-M2.
