### PR TITLE
Tweak build to include appropriate fixes/adaptations for Scala 2.11.0-M7

### DIFF
--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -261,7 +261,7 @@ object Sbt extends Build
 		scalacOptions := Nil,
 		ivyScala ~= { _.map(_.copy(checkExplicit = false, overrideScalaVersion = false)) },
 		exportedProducts in Compile := Nil,
-		libraryDependencies <+= scalaVersion( "org.scala-lang" % "scala-compiler" % _ % "provided")
+    libraryDependencies += scalaCompilerInit.value % "provided"
 	)
 	//
 	def compileInterfaceSettings: Seq[Setting[_]] = precompiledSettings ++ Seq[Setting[_]](
@@ -273,7 +273,7 @@ object Sbt extends Build
 		artifact in (Compile, packageSrc) := Artifact(srcID).copy(configurations = Compile :: Nil).extra("e:component" -> srcID)
 	)
 	def compilerSettings = Seq(
-		libraryDependencies <+= scalaVersion( "org.scala-lang" % "scala-compiler" % _ % "test"),
+		libraryDependencies += scalaCompilerInit.value % "test",
 		unmanagedJars in Test <<= (packageSrc in compileInterfaceSub in Compile).map(x => Seq(x).classpath)
 	)
 	def precompiled(scalav: String): Project = baseProject(compilePath / "interface", "Precompiled " + scalav.replace('.', '_')) dependsOn(interfaceSub) settings(precompiledSettings : _*) settings(
@@ -287,6 +287,7 @@ object Sbt extends Build
 		sources in Test := Nil
 	)
 	def ioSettings: Seq[Setting[_]] = Seq(
-		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test")
+    // here we use the common scalaCompiler "fixed" depdendency, but in the test scope.
+		libraryDependencies += scalaCompilerInit.value % "test"
 	)
 }


### PR DESCRIPTION
- Limit M7 hackery to one location in the build
- Migrate scala-compiler dependency declarations to use workaround for M7
- fix libModular to work with new module organizations.
- Bump versions of modules used for 2.11 build.

Review by @harrah  cc @adriaanm

Note: This does not include the type fixes in the 0.13-2.11 branch, but includes different build hackery for 2.11.  I'd like to standardize on this mechanism for dbuild (changing scalaVersion in ThisBuild fixes all deps appropriately).
