### PR TITLE
Handle source, docs artifacts correctly for Ivy

### DIFF
--- a/ivy/src/main/scala/sbt/Artifact.scala
+++ b/ivy/src/main/scala/sbt/Artifact.scala
@@ -8,10 +8,10 @@ import java.net.URL
 
 final case class Artifact(name: String, `type`: String, extension: String, classifier: Option[String], configurations: Iterable[Configuration], url: Option[URL], extraAttributes: Map[String,String])
 {
-	def extra(attributes: (String,String)*) = Artifact(name, `type`, extension, classifier, configurations, url, extraAttributes ++ ModuleID.checkE(attributes))
+	def extra(attributes: (String,String)*) = copy(extraAttributes = extraAttributes ++ ModuleID.checkE(attributes))
 }
 
-		import Configurations.{config, Docs, Optional, Pom, Sources, Test}
+		import Configurations.{Runtime, Pom, Test}
 
 object Artifact
 {
@@ -31,12 +31,23 @@ object Artifact
 	def javadoc(name: String) = classified(name, DocClassifier)
 	def pom(name: String) =  Artifact(name, PomType, PomType, None, Pom :: Nil, None)
 
+	// Possible ivy artifact types such that sbt will treat those artifacts at sources / docs
+	val DefaultSourceTypes = Set("src", "source", "sources")
+	val DefaultDocTypes = Set("doc", "docs", "javadoc", "javadocs")
+
 	val DocClassifier = "javadoc"
 	val SourceClassifier = "sources"
+
+	val TestsClassifier = "tests"
+	// Artifact types used when:
+	// * artifacts are explicitly created for Maven dependency resolution (see updateClassifiers)
+	// * declaring artifacts as part of publishing Ivy files.
 	val DocType = "doc"
 	val SourceType = "src"
 	val PomType = "pom"
-	val TestsClassifier = "tests"
+
+	assert (DefaultDocTypes contains DocType)
+	assert (DefaultSourceTypes contains SourceType)
 
 	def extract(url: URL, default: String): String = extract(url.toString, default)
 	def extract(name: String, default: String): String =
@@ -63,13 +74,13 @@ object Artifact
 		base + "-" + module.revision + classifierStr + "." + artifact.extension
 	}
 
-	val classifierConfMap = Map(SourceClassifier -> Sources, DocClassifier -> Docs)
 	val classifierTypeMap = Map(SourceClassifier -> SourceType, DocClassifier -> DocType)
+	// TODO this function shouldn't exist. Configuration should not just be conjured up like that.
 	def classifierConf(classifier: String): Configuration =
 		if(classifier.startsWith(TestsClassifier))
 			Test
 		else
-			classifierConfMap.getOrElse(classifier, Optional)
+			Runtime
 	def classifierType(classifier: String): String = classifierTypeMap.getOrElse(classifier.stripPrefix(TestsClassifier + "-"), DefaultType)
 	def classified(name: String, classifier: String): Artifact =
 		Artifact(name, classifierType(classifier), DefaultExtension, Some(classifier), classifierConf(classifier) :: Nil, None)

--- a/ivy/src/main/scala/sbt/Artifact.scala
+++ b/ivy/src/main/scala/sbt/Artifact.scala
@@ -11,7 +11,7 @@ final case class Artifact(name: String, `type`: String, extension: String, class
 	def extra(attributes: (String,String)*) = copy(extraAttributes = extraAttributes ++ ModuleID.checkE(attributes))
 }
 
-		import Configurations.{Runtime, Pom, Test}
+		import Configurations.{Compile, Pom, Test}
 
 object Artifact
 {
@@ -41,7 +41,7 @@ object Artifact
 	val TestsClassifier = "tests"
 	// Artifact types used when:
 	// * artifacts are explicitly created for Maven dependency resolution (see updateClassifiers)
-	// * declaring artifacts as part of publishing Ivy files.
+	// * declaring artifacts as part of creating Ivy files.
 	val DocType = "doc"
 	val SourceType = "src"
 	val PomType = "pom"
@@ -75,13 +75,19 @@ object Artifact
 	}
 
 	val classifierTypeMap = Map(SourceClassifier -> SourceType, DocClassifier -> DocType)
-	// TODO this function shouldn't exist. Configuration should not just be conjured up like that.
+
+	@deprecated("Configuration should not be decided from the classifier.", "0.14.0")
 	def classifierConf(classifier: String): Configuration =
 		if(classifier.startsWith(TestsClassifier))
 			Test
 		else
-			Runtime
+			Compile
+
 	def classifierType(classifier: String): String = classifierTypeMap.getOrElse(classifier.stripPrefix(TestsClassifier + "-"), DefaultType)
+
+	/** Create a classified explicit artifact, to be used when trying to resolve sources|javadocs from Maven. This is
+	  * necessary because those artifacts are not published in the Ivy generated from the Pom of the module in question.
+	  * The artifact is created under the default configuration. */
 	def classified(name: String, classifier: String): Artifact =
-		Artifact(name, classifierType(classifier), DefaultExtension, Some(classifier), classifierConf(classifier) :: Nil, None)
+		Artifact(name, classifierType(classifier), DefaultExtension, Some(classifier), Nil, None)
 }

--- a/ivy/src/main/scala/sbt/Configuration.scala
+++ b/ivy/src/main/scala/sbt/Configuration.scala
@@ -9,7 +9,7 @@ object Configurations
 	def default: Seq[Configuration] = defaultMavenConfigurations
 	def defaultMavenConfigurations: Seq[Configuration] = Seq(Compile, Runtime, Test, Provided, Optional)
 	def defaultInternal: Seq[Configuration] = Seq(CompileInternal, RuntimeInternal, TestInternal)
-	def auxiliary: Seq[Configuration] = Seq(Sources, Docs, Pom)
+	def auxiliary: Seq[Configuration] = Seq(Pom)
 	def names(cs: Seq[Configuration]) = cs.map(_.name)
 
 	lazy val RuntimeInternal = optionalInternal(Runtime)
@@ -33,10 +33,8 @@ object Configurations
 	lazy val Compile = config("compile")
 	lazy val IntegrationTest = config("it") extend(Runtime)
 	lazy val Provided = config("provided") ;
-	lazy val Docs = config("docs")
 	lazy val Runtime = config("runtime") extend(Compile)
 	lazy val Test = config("test") extend(Runtime)
-	lazy val Sources = config("sources")
 	lazy val System = config("system")
 	lazy val Optional = config("optional")
 	lazy val Pom = config("pom")

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -15,9 +15,7 @@ import CS.singleton
 import org.apache.ivy.{core, plugins, util, Ivy}
 import core.{IvyPatternHelper, LogOptions}
 import core.cache.{CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter}
-import core.module.descriptor.{Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact}
-import core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License}
-import core.module.descriptor.{OverrideDependencyDescriptorMediator}
+import org.apache.ivy.core.module.descriptor.{Artifact => IArtifact, _}
 import core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
 import core.resolve.{IvyNode, ResolveData, ResolvedModuleRevision}
 import core.settings.IvySettings
@@ -603,12 +601,19 @@ private object IvySbt
 			for(conf <- dependencyDescriptor.getModuleConfigurations)
 				dependencyDescriptor.addDependencyArtifact(conf, ivyArtifact)
 		}
-		for(excls <- dependency.exclusions)
+		for {
+			incls <- dependency.inclusions
+			conf <- dependencyDescriptor.getModuleConfigurations }
 		{
-			for(conf <- dependencyDescriptor.getModuleConfigurations)
-			{
-				dependencyDescriptor.addExcludeRule(conf, IvyScala.excludeRule(excls.organization, excls.name, excls.configurations, excls.artifact))
-			}
+			import incls._
+			dependencyDescriptor.addIncludeRule(conf, IvyScala.includeRule(organization, name, configurations, artifact))
+		}
+		for {
+			excls <- dependency.exclusions
+			conf <- dependencyDescriptor.getModuleConfigurations }
+		{
+			import excls._
+			dependencyDescriptor.addExcludeRule(conf, IvyScala.excludeRule(organization, name, configurations, artifact))
 		}
 		dependencyDescriptor
 	}

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -168,28 +168,64 @@ object IvyActions
 		val newConfig = config.copy(module = mod.copy(modules = report.allModules))
 		updateClassifiers(ivySbt, newConfig, log)
 	}
+
+	/**
+	 * Creates explicit artifacts for each classifier in `config.module`, and then attempts to resolve them directly. This
+	 * is for Maven compatibility, where these artifacts are not "published" in the POM, so they don't end up in the Ivy
+	 * that sbt generates for them either.<br>
+	 * In addition, retrieves specific Ivy artifacts if they have one of the requested `config.configuration.types`.
+	 * @param config important to set `config.configuration.types` to only allow artifact types that can correspond to
+	 *               "classified" artifacts (sources and javadocs).
+	 */
 	def updateClassifiers(ivySbt: IvySbt, config: GetClassifiersConfiguration, log: Logger): UpdateReport =
 	{
 		import config.{configuration => c, module => mod, _}
 		import mod.{configurations => confs, _}
 		assert(!classifiers.isEmpty, "classifiers cannot be empty")
-		val baseModules = modules map { m => restrictedCopy(m, true) }
-		val deps = baseModules.distinct flatMap classifiedArtifacts(classifiers, exclude)
+		assert(c.artifactFilter.types.nonEmpty, "UpdateConfiguration must filter on some types")
+		val baseModules = modules map { m => restrictedCopy(m, confs = true) }
+		val deps = baseModules.distinct
+		val classifiedDeps = deps flatMap classifiedArtifacts(classifiers, exclude)
 		val base = restrictedCopy(id, true).copy(name = id.name + classifiers.mkString("$","_",""))
-		val module = new ivySbt.Module(InlineConfiguration(base, ModuleInfo(base.name), deps).copy(ivyScala = ivyScala, configurations = confs))
-		val upConf = new UpdateConfiguration(c.retrieve, true, c.logging)
-		update(module, upConf, log)
+		val module = new ivySbt.Module(InlineConfiguration(base, ModuleInfo(base.name), classifiedDeps, ivyScala = ivyScala, configurations = confs))
+		// This includes c.types which should be passed in too
+		val upConf = c.copy(missingOk = true)
+		val report = update(module, upConf, log)
+		// The artifacts that came from Ivy don't have their classifier set, let's set it according to their types
+		// FIXME: this is only done because IDE plugins depend on `classifier` to determine type. They should now look at the type instead, in relation with (source|doc)ArtifactTypes
+		val typeClassifierMap: Map[String, String] =
+			((sourceArtifactTypes.toIterable map (_ -> Artifact.SourceClassifier))
+			 :: (docArtifactTypes.toIterable map (_ -> Artifact.DocClassifier)) :: Nil).flatten.toMap
+		report.substitute { (conf, mid, artFileSeq) =>
+			artFileSeq map { case (art, f) =>
+				// Deduce the classifier from the type if no classifier is present already
+				art.copy(classifier = art.classifier orElse typeClassifierMap.get(art.`type`)) -> f
+			}
+		}
 	}
+
 	def classifiedArtifacts(classifiers: Seq[String], exclude: Map[ModuleID, Set[String]])(m: ModuleID): Option[ModuleID] =
 	{
 		val excluded = exclude getOrElse(restrictedCopy(m, false), Set.empty)
 		val included = classifiers filterNot excluded
-		if(included.isEmpty) None else Some(m.copy(isTransitive = false, explicitArtifacts = classifiedArtifacts(m.name, included) ))
+
+		if (included.isEmpty)
+			Some(m.copy(isTransitive = false))
+		else {
+			val classifiedArts = classifiedArtifacts(m.name, included)
+			/** Explicitly set an "include all" rule (the default) because otherwise, if we declare ANY explicitArtifacts,
+			  * [[org.apache.ivy.core.resolve.IvyNode#getArtifacts]] (in Ivy 2.3.0-rc1) will not merge in the descriptor's
+			  * artifacts and will only keep the explicitArtifacts */
+			Some(m.copy(isTransitive = false, explicitArtifacts = classifiedArts, inclusions = InclExclRule.everything :: Nil))
+		}
 	}
+  
 	def addExcluded(report: UpdateReport, classifiers: Seq[String], exclude: Map[ModuleID, Set[String]]): UpdateReport =
 		report.addMissing { id => classifiedArtifacts(id.name, classifiers filter getExcluded(id, exclude)) }
+  
 	def classifiedArtifacts(name: String, classifiers: Seq[String]): Seq[Artifact] =
 		classifiers map { c => Artifact.classified(name, c) }
+  
 	private[this] def getExcluded(id: ModuleID, exclude: Map[ModuleID, Set[String]]): Set[String] =
 		exclude.getOrElse(restrictedCopy(id, false), Set.empty[String])
 

--- a/ivy/src/main/scala/sbt/IvyInterface.scala
+++ b/ivy/src/main/scala/sbt/IvyInterface.scala
@@ -19,8 +19,17 @@ final case class ModuleInfo(nameFormal: String, description: String = "", homepa
 /** Basic SCM information for a project module */
 final case class ScmInfo(browseUrl: URL, connection: String, devConnection: Option[String] = None)
 
-/** Rule to exclude unwanted dependencies pulled in transitively by a module. */
-final case class ExclusionRule(organization: String = "*", name: String = "*", artifact: String = "*", configurations: Seq[String] = Nil)
+/** Rule to either:
+  * <ul>
+  * <li> exclude unwanted dependencies pulled in transitively by a module, or to</li>
+  * <li> include and merge artifacts coming from the ModuleDescriptor if "dependencyArtifacts" are also provided.</li>
+  * </ul>
+  * Which one depends on the parameter name which it is passed to, but the filter has the same fields in both cases. */
+final case class InclExclRule(organization: String, name: String, artifact: String = "*", configurations: Seq[String] = Nil)
+
+object InclExclRule {
+	def everything = InclExclRule("*", "*", "*", Nil)
+}
 
 /** Work around the inadequacy of Ivy's ArtifactTypeFilter (that it cannot reverse a filter)
   * @param types represents the artifact types that we should try to resolve for (as in the allowed values of

--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -7,9 +7,8 @@ import java.util.Collections.emptyMap
 import scala.collection.mutable.HashSet
 
 import org.apache.ivy.{core, plugins}
-import core.module.descriptor.{DefaultExcludeRule, ExcludeRule}
-import core.module.descriptor.{DependencyDescriptor, DefaultModuleDescriptor, ModuleDescriptor, OverrideDependencyDescriptorMediator}
-import core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
+import org.apache.ivy.core.module.descriptor._
+import core.module.id.{ArtifactId,ModuleId}
 import plugins.matcher.ExactPatternMatcher
 
 object ScalaArtifacts
@@ -113,4 +112,12 @@ private object IvyScala
 		configurationNames.foreach(rule.addConfiguration)
 		rule
 	}
+
+  private[sbt] def includeRule(organization: String, name: String, configurationNames: Iterable[String], includeTypePattern: String): IncludeRule =
+  {
+    val artifact = new ArtifactId(ModuleId.newInstance(organization, name), "*", includeTypePattern, "*")
+    val rule = new DefaultIncludeRule(artifact, ExactPatternMatcher.INSTANCE, emptyMap[AnyRef,AnyRef])
+    configurationNames.foreach(rule.addConfiguration)
+    rule
+  }
 }

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -5,7 +5,7 @@ package sbt
 
 	import java.net.URL
 
-final case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, isForce: Boolean = false, explicitArtifacts: Seq[Artifact] = Nil, exclusions: Seq[ExclusionRule] = Nil, extraAttributes: Map[String,String] = Map.empty, crossVersion: CrossVersion = CrossVersion.Disabled)
+final case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, isForce: Boolean = false, explicitArtifacts: Seq[Artifact] = Nil, exclusions: Seq[InclExclRule] = Nil, inclusions: Seq[InclExclRule] = Nil, extraAttributes: Map[String,String] = Map.empty, crossVersion: CrossVersion = CrossVersion.Disabled)
 {
 	override def toString: String =
 		organization + ":" + name + ":" + revision +

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -59,10 +59,10 @@ final case class ModuleID(organization: String, name: String, revision: String, 
 
 	/** Applies the provided exclusions to dependencies of this module.  Note that only exclusions that specify
 	* both the exact organization and name and nothing else will be included in a pom.xml.*/
-	def excludeAll(rules: ExclusionRule*) = copy(exclusions = this.exclusions ++ rules)
+	def excludeAll(rules: InclExclRule*) = copy(exclusions = this.exclusions ++ rules)
 
 	/** Excludes the dependency with organization `org` and `name` from being introduced by this dependency during resolution. */
-	def exclude(org: String, name: String) = excludeAll(ExclusionRule(org, name))
+	def exclude(org: String, name: String) = excludeAll(InclExclRule(org, name))
 
 	/** Adds extra attributes for this module.  All keys are prefixed with `e:` if they are not already so prefixed.
 	* This information will only be published in an ivy.xml and not in a pom.xml. */

--- a/ivy/src/main/scala/sbt/UpdateReport.scala
+++ b/ivy/src/main/scala/sbt/UpdateReport.scala
@@ -110,7 +110,7 @@ object UpdateReport
 		def substitute(f: (String, ModuleID, Seq[(Artifact, File)]) => Seq[(Artifact, File)]): UpdateReport =
 			moduleReportMap { (configuration, modReport) =>
 				val newArtifacts = f(configuration, modReport.module, modReport.artifacts)
-				new ModuleReport(modReport.module, newArtifacts, Nil)
+				new ModuleReport(modReport.module, newArtifacts, modReport.missingArtifacts)
 			}
 
 		def toSeq: Seq[(String, ModuleID, Artifact, File)] =

--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -86,9 +86,9 @@ object CacheIvy
 	private[this] val crossToInt = (c: CrossVersion) => c match { case Disabled => 0; case b: Binary => BinaryValue; case f: Full => FullValue }
 
 	implicit def moduleIDFormat(implicit sf: Format[String], bf: Format[Boolean]): Format[ModuleID] =
-		wrap[ModuleID, ((String,String,String,Option[String]),(Boolean,Boolean,Boolean,Seq[Artifact],Seq[ExclusionRule],Map[String,String],CrossVersion))](
-			m => ((m.organization,m.name,m.revision,m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion)),
-			{ case ((o,n,r,cs),(ch,t,f,as,excl,x,cv)) => ModuleID(o,n,r,cs,ch,t,f,as,excl,x,cv) }
+		wrap[ModuleID, ((String,String,String,Option[String]),(Boolean,Boolean,Boolean,Seq[Artifact],Seq[InclExclRule],Seq[InclExclRule],Map[String,String],CrossVersion))](
+			m => ((m.organization,m.name,m.revision,m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.inclusions, m.extraAttributes, m.crossVersion)),
+			{ case ((o,n,r,cs),(ch,t,f,as,excl,incl,x,cv)) => ModuleID(o,n,r,cs,ch,t,f,as,excl,incl,x,cv) }
 		)
 	implicit def moduleSetIC: InputCache[Set[ModuleID]] = basicInput(defaultEquiv, immutableSetFormat)
 
@@ -132,7 +132,7 @@ object CacheIvy
 		implicit def sftpRToHL = (s: SftpRepository) => s.name :+: s.connection :+: s.patterns :+: HNil
 		implicit def rawRToHL = (r: RawRepository) => r.name :+: r.resolver.getClass.getName :+: HNil
 		implicit def chainRToHL = (c: ChainedResolver) => c.name :+: c.resolvers :+: HNil
-		implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.exclusions :+: m.extraAttributes :+: m.crossVersion :+: HNil
+		implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.exclusions :+: m.inclusions :+: m.extraAttributes :+: m.crossVersion :+: HNil
 	}
 	import L3._
 

--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -73,8 +73,8 @@ object CacheIvy
 			{ case (n,t,x,c,cs,u,e) => Artifact(n,t,x,c,cs,u,e) }
 		)
 	}
-	implicit def exclusionRuleFormat(implicit sf: Format[String]): Format[ExclusionRule] =
-		wrap[ExclusionRule, (String, String, String, Seq[String])]( e => (e.organization, e.name, e.artifact, e.configurations), { case (o,n,a,cs) => ExclusionRule(o,n,a,cs) })
+	implicit def exclusionRuleFormat(implicit sf: Format[String]): Format[InclExclRule] =
+		wrap[InclExclRule, (String, String, String, Seq[String])]( e => (e.organization, e.name, e.artifact, e.configurations), { case (o,n,a,cs) => InclExclRule(o,n,a,cs) })
 	implicit def crossVersionFormat: Format[CrossVersion] = wrap(crossToInt, crossFromInt)
 
 	private[this] final val DisabledValue = 0
@@ -149,7 +149,7 @@ object CacheIvy
 		implicit def sshConnectionToHL = (s: SshConnection) => s.authentication :+: s.hostname :+: s.port :+: HNil
 
 		implicit def artifactToHL = (a: Artifact) => a.name :+: a.`type` :+: a.extension :+: a.classifier :+: names(a.configurations) :+: a.url :+: a.extraAttributes :+: HNil
-		implicit def exclusionToHL = (e: ExclusionRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: HNil
+		implicit def inclExclToHL = (e: InclExclRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: HNil
 		implicit def crossToHL = (c: CrossVersion) => crossToInt(c) :+: HNil
 
 /*		implicit def deliverConfToHL = (p: DeliverConfiguration) => p.deliverIvyPattern :+: p.status :+: p.configurations :+: HNil
@@ -162,7 +162,7 @@ object CacheIvy
 	implicit def ivyFileIC: InputCache[IvyFileConfiguration] = wrapIn
 	implicit def connectionIC: InputCache[SshConnection] = wrapIn
 	implicit def artifactIC: InputCache[Artifact] = wrapIn
-	implicit def exclusionIC: InputCache[ExclusionRule] = wrapIn
+	implicit def exclusionIC: InputCache[InclExclRule] = wrapIn
 	implicit def crossVersionIC: InputCache[CrossVersion] = wrapIn
 /*	implicit def publishConfIC: InputCache[PublishConfiguration] = wrapIn
 	implicit def deliverConfIC: InputCache[DeliverConfiguration] = wrapIn*/

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -574,11 +574,11 @@ object Defaults extends BuildCommon
 		val combined = cPart.toList ++ classifier.toList
 		if(combined.isEmpty) a.copy(classifier = None, configurations = cOpt.toList) else {
 			val classifierString = combined mkString "-"
-			val confs = cOpt.toList flatMap { c => artifactConfigurations(a, c, classifier) }
-			a.copy(classifier = Some(classifierString), `type` = Artifact.classifierType(classifierString), configurations = confs)
+			a.copy(classifier = Some(classifierString), `type` = Artifact.classifierType(classifierString), configurations = cOpt.toList)
 		}
 	}
-	// TODO bad, remove. The configuration(s) should not be decided from the classifier.
+
+	@deprecated("The configuration(s) should not be decided based on the classifier.", "0.14.0")
 	def artifactConfigurations(base: Artifact, scope: Configuration, classifier: Option[String]): Iterable[Configuration] =
 		classifier match {
 			case Some(c) => Artifact.classifierConf(c) :: Nil

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -564,6 +564,7 @@ object Defaults extends BuildCommon
 		(t, module, a, sv, sbv, toString) =>
 			t / toString(ScalaVersion(sv, sbv), module, a) asFile
 	}
+
 	def artifactSetting = ((artifact, artifactClassifier).identity zipWith configuration.?) { case ((a,classifier),cOpt) =>
 		val cPart = cOpt flatMap {
 			case Compile => None
@@ -577,6 +578,7 @@ object Defaults extends BuildCommon
 			a.copy(classifier = Some(classifierString), `type` = Artifact.classifierType(classifierString), configurations = confs)
 		}
 	}
+	// TODO bad, remove. The configuration(s) should not be decided from the classifier.
 	def artifactConfigurations(base: Artifact, scope: Configuration, classifier: Option[String]): Iterable[Configuration] =
 		classifier match {
 			case Some(c) => Artifact.classifierConf(c) :: Nil
@@ -945,6 +947,8 @@ object Classpaths
 		resolvers :== Nil,
 		retrievePattern :== Resolver.defaultRetrievePattern,
 		transitiveClassifiers :== Seq(SourceClassifier, DocClassifier),
+		sourceArtifactTypes :== Artifact.DefaultSourceTypes,
+		docArtifactTypes :== Artifact.DefaultDocTypes,
 		sbtDependency := {
 			val app = appConfiguration.value
 			val id = app.provider.id
@@ -1005,7 +1009,14 @@ object Classpaths
 		projectID <<= defaultProjectID,
 		projectID <<= pluginProjectID,
 		projectDescriptors <<= depMap,
-		updateConfiguration := new UpdateConfiguration(retrieveConfiguration.value, false, ivyLoggingLevel.value),
+		updateConfiguration <<= {
+			// Tell the UpdateConfiguration which artifact types are special (for sources and javadocs)
+			val specialArtifactTypes = (sourceArtifactTypes, docArtifactTypes) { _ union _ }
+			// By default, to retrieve all types *but* these (it's assumed that everything else is binary/resource)
+			(retrieveConfiguration, ivyLoggingLevel, specialArtifactTypes) { (retrConf, loggingLevel, artTypes) =>
+				new UpdateConfiguration(retrConf, false, loggingLevel, ArtifactTypeFilter.forbid(artTypes))
+			}
+		},
 		retrieveConfiguration := { if(retrieveManaged.value) Some(new RetrieveConfiguration(managedDirectory.value, retrievePattern.value)) else None },
 		ivyConfiguration <<= mkIvyConfiguration,
 		ivyConfigurations := {
@@ -1027,12 +1038,15 @@ object Classpaths
 		update <<= updateTask tag(Tags.Update, Tags.Network),
 		update := { val report = update.value; ConflictWarning(conflictWarning.value, report, streams.value.log); report },
 		classifiersModule in updateClassifiers := GetClassifiersModule(projectID.value, update.value.allModules, ivyConfigurations.in(updateClassifiers).value, transitiveClassifiers.in(updateClassifiers).value),
-		updateClassifiers <<= (ivySbt, classifiersModule in updateClassifiers, updateConfiguration, ivyScala, appConfiguration, streams) map { (is, mod, c, ivyScala, app, s) =>
-			val out = is.withIvy(s.log)(_.getSettings.getDefaultIvyUserDir)
-			withExcludes(out, mod.classifiers, lock(app)) { excludes =>
-				IvyActions.updateClassifiers(is, GetClassifiersConfiguration(mod, excludes, c, ivyScala), s.log)
-			}
-		} tag(Tags.Update, Tags.Network)
+
+		updateClassifiers <<=
+			(ivySbt, classifiersModule in updateClassifiers, updateConfiguration, ivyScala, appConfiguration, sourceArtifactTypes, docArtifactTypes, streams) map {
+				(is, mod, c, ivyScala, app, srcTypes, docTypes, s) =>
+					val out = is.withIvy(s.log)(_.getSettings.getDefaultIvyUserDir)
+					withExcludes(out, mod.classifiers, lock(app)) { excludes =>
+						IvyActions.updateClassifiers(is, GetClassifiersConfiguration(mod, excludes, c.copy(artifactFilter=c.artifactFilter.invert), ivyScala, srcTypes, docTypes), s.log)
+					}
+			} tag(Tags.Update, Tags.Network)
 	)
 	def warnResolversConflict(ress: Seq[Resolver], log: Logger) {
 		val resset = ress.toSet
@@ -1078,12 +1092,12 @@ object Classpaths
 			val pluginIDs: Seq[ModuleID] = pluginJars.flatMap(_ get moduleID.key)
 			GetClassifiersModule(pid, sbtDep +: pluginIDs, Configurations.Default :: Nil, classifiers)
 		},
-		updateSbtClassifiers in TaskGlobal <<= (ivySbt, classifiersModule, updateConfiguration, ivyScala, appConfiguration, streams) map {
-				(is, mod, c, ivyScala, app, s) =>
+		updateSbtClassifiers in TaskGlobal <<= (ivySbt, classifiersModule, updateConfiguration, ivyScala, appConfiguration, sourceArtifactTypes, docArtifactTypes, streams) map {
+				(is, mod, c, ivyScala, app, srcTypes, docTypes, s) =>
 			val out = is.withIvy(s.log)(_.getSettings.getDefaultIvyUserDir)
 			withExcludes(out, mod.classifiers, lock(app)) { excludes =>
 				val noExplicitCheck = ivyScala.map(_.copy(checkExplicit=false))
-				IvyActions.transitiveScratch(is, "sbt", GetClassifiersConfiguration(mod, excludes, c, noExplicitCheck), s.log)
+				IvyActions.transitiveScratch(is, "sbt", GetClassifiersConfiguration(mod, excludes, c.copy(artifactFilter=c.artifactFilter.invert), noExplicitCheck, srcTypes, docTypes), s.log)
 			}
 		} tag(Tags.Update, Tags.Network)
 	))

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -246,6 +246,8 @@ object Keys
 	val updateClassifiers = TaskKey[UpdateReport]("update-classifiers", "Resolves and optionally retrieves classified artifacts, such as javadocs and sources, for dependency definitions, transitively.", BPlusTask, update)
 	val transitiveClassifiers = SettingKey[Seq[String]]("transitive-classifiers", "List of classifiers used for transitively obtaining extra artifacts for sbt or declared dependencies.", BSetting)
 	val updateSbtClassifiers = TaskKey[UpdateReport]("update-sbt-classifiers", "Resolves and optionally retrieves classifiers, such as javadocs and sources, for sbt, transitively.", BPlusTask, updateClassifiers)
+	val sourceArtifactTypes = SettingKey[Set[String]]("source-artifact-types", "Ivy artifact types that correspond to source artifacts. Used by IDEs to resolve these resources.", BSetting)
+	val docArtifactTypes = SettingKey[Set[String]]("doc-artifact-types", "Ivy artifact types that correspond to javadoc artifacts. Used by IDEs to resolve these resources.", BSetting)
 
 	val publishConfiguration = TaskKey[PublishConfiguration]("publish-configuration", "Configuration for publishing to a repository.", DTask)
 	val publishLocalConfiguration = TaskKey[PublishConfiguration]("publish-local-configuration", "Configuration for publishing to the local Ivy repository.", DTask)

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -34,8 +34,6 @@ package object sbt extends sbt.std.TaskExtra with sbt.Types with sbt.ProcessExtr
 	final val Runtime = C.Runtime
 	final val IntegrationTest = C.IntegrationTest
 	final val Default = C.Default
-	final val Docs = C.Docs
-	final val Sources = C.Sources
 	final val Provided = C.Provided
 // java.lang.System is more important, so don't alias this one
 //	final val System = C.System


### PR DESCRIPTION
Following our discussion at #1004, I've decided to handle the retrieval of source/docs artifacts by their artifact types.
The steps I took are:
- Completely removed the Sources and Docs configurations. They were unused, incorrect with respect to what Ivy considers a configuration to be, and possibly (at least in my case) a source of confusion (should I use this? can I scope settings under it?)
- Therefore sbt now publishes these src/doc artifacts under `runtime`. Why runtime? No reason specifically, and it might change, but for now it seemed like a sensible default.
- Introduce the SettingKeys `sourceArtifactTypes` and `docArtifactTypes`: Sets which contain the artifact types that would qualify them as either source or doc artifacts.
- Introduce a slightly improved (compared to the Ivy version) `ArtifactTypeFilter` which lets you apply the filter normally or inversed. 
- Use this filter in the `update` task (specifically, I added it to `UpdateConfiguration`) to allow "all artifact types except those found in either `sourceArtifactTypes` or`docArtifactTypes`"
- In `updateClassifiers` / `updateSbtClassifiers`, invert the filter from the `UpdateConfiguration`: it will therefore only let through sources and docs
- Pass this artifact filter from the `UpdateConfiguration` to `IvyActions.update` and from there to the Ivy ResolveOptions in `IvyActions.resolve`
- Change `updateClassifiers` to not filter out dependencies whose classifiers were deemed "not found" and thus excluded - they might still contain src/doc artifacts published in their ivys
- Added an include-all include filter to all the `ModuleID`s (and thus the `DependencyDescriptors` they convert to) that will allow Ivy to merge the explicitly given artifacts (where classifier=sources or javadoc) with the publications from the `ModuleDescriptor` (i.e. the artifacts published in an ivy)
- After finishing the update in `updateClassifiers`, map over all artifacts to set their classifier to either sources or javadoc, if it's not already set, according to a reverse mapping from the types in `(source|doc)ArtifactTypes` to "source" and "javadoc" respectively (well, `Artifact.SourceClassifier` and `Artifact.DocClassifier`, to be precise). This is because the artifacts retrieved from Ivy publications might well not have this attribute set, and it's the unfortunate case that currently IDE plugins depend exactly on this value to classify the artifacts.

Hopefully, after this, plugins could just look at the artifact's type and see in which of the two sets contains it. That would also resolve a great deal of pain surrounding "e:classifier". For instance, I've discovered that it's impossible to use that attribute in an ivy repository if its value is not either "sources" or "javadoc" (e.g. if it's src), because plugins expect it to be one of those two values as mentioned before.

updateClassifiers of course still works as before to retrieve sources/docs artifacts from Maven repositories.
