### PR TITLE
Documentation : use isSnapshot setting instead of "version.value.trim.endsWith("SNAPSHOT")"

### DIFF
--- a/src/sphinx/Community/Using-Sonatype.rst
+++ b/src/sphinx/Community/Using-Sonatype.rst
@@ -33,7 +33,7 @@ the same URLs for everyone:
 
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (version.value.trim.endsWith("SNAPSHOT"))
+      if (isSnapshot.value)
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")
@@ -223,7 +223,7 @@ others:
 
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (version.value.trim.endsWith("SNAPSHOT"))
+      if (isSnapshot.value)
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases" at nexus + "service/local/staging/deploy/maven2")


### PR DESCRIPTION
Since SBT provides the `isSnapshot` setting to check whether the current version is a snapshot version or not, I thought it could be nice to use it here instead of reimplementing it :)
