### PR TITLE
Make incremental compiler compatible with Scala 2.11.

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -39,10 +39,17 @@ abstract class Compat
 		def unapply(t: Type): Option[Type] = None
 	}
 
-	// before 2.10, sym.moduleSuffix doesn't exist, but genJVM.moduleSuffix does
-	private[this] implicit def symbolCompat(sym: Symbol): SymbolCompat = new SymbolCompat(sym)
-	private[this] final class SymbolCompat(sym: Symbol) {
+	protected implicit def symbolCompat(sym: Symbol): SymbolCompat = new SymbolCompat(sym)
+	protected final class SymbolCompat(sym: Symbol) {
+		// before 2.10, sym.moduleSuffix doesn't exist, but genJVM.moduleSuffix does
 		def moduleSuffix = global.genJVM.moduleSuffix(sym)
+		def enclosingTopLevelClass: Symbol = sym.toplevelClass
+		// this for compatibility with Scala 2.11 where Symbol.enclosingTopLevelClass method exist
+		// so we won't be ever calling SymbolCompat.enclosingTopLevelClass but we need to compile
+		// it hence we need dummy forwarder target, the `toplevelClass` method defined
+		// in Scala 2.9 and 2.10 the `Symbol.toplevelClass` exists so the dummy forwarder target
+		// won't be used
+		def toplevelClass: Symbol = throw new UnsupportedOperationException("We should never have gotten here")
 	}
 
 

--- a/compile/interface/src/main/scala/xsbt/Dependency.scala
+++ b/compile/interface/src/main/scala/xsbt/Dependency.scala
@@ -156,9 +156,7 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile
 		val traverser = new ExtractDependenciesByMemberRefTraverser
 		traverser.traverse(unit.body)
 		val dependencies = traverser.dependencies
-		// we capture enclosing classes only because that's what CompilationUnit.depends does and we don't want
-		// to deviate from old behaviour too much for now
-		dependencies.map(_.toplevelClass)
+		dependencies.map(enclosingTopLevelClass)
 	}
 
 	/** Copied straight from Scala 2.10 as it does not exist in Scala 2.9 compiler */
@@ -184,7 +182,15 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile
 		val traverser = new ExtractDependenciesByInheritanceTraverser
 		traverser.traverse(unit.body)
 		val dependencies = traverser.dependencies
-		dependencies.map(_.toplevelClass)
+		dependencies.map(enclosingTopLevelClass)
 	}
+
+	/**
+	 * We capture enclosing classes only because that's what CompilationUnit.depends does and we don't want
+	 * to deviate from old behaviour too much for now.
+	 */
+	private def enclosingTopLevelClass(sym: Symbol): Symbol =
+		// for Scala 2.8 and 2.9 this method is provided through SymbolCompat
+		sym.enclosingTopLevelClass
 
 }


### PR DESCRIPTION
The scala/scala@2d4f0f1859b957b744f9b9f222dec8e8c478a4a8 removes the
`toplevelClass` method. The recent change from
aac19fd02be94f4ef6ba98187c9cbbc2b66a60f9 introduces dependency on that
method. Combination of both changes makes incremental compiler incompatible
with Scala 2.11.

This change introduces a compatibility hack that brings back source
compatibility of incremental compiler with Scala 2.8, 2.9, 2.10 and 2.11.

The compatibility hack is making clever use implicit conversions that
can provide dummy method definitions for methods removed from Scala
compiler.

Also, the code that depends on `enclosingTopLevelClass` has been refactored
so the dependency is more centralized.
