### PR TITLE
Allow adding extra VersionMatchers in InlineIvyConfiguration

### DIFF
--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -31,6 +31,7 @@ import util.{Message, MessageLogger}
 import util.extendable.ExtendableItem
 
 import scala.xml.{NodeSeq, Text}
+import org.apache.ivy.plugins.version.VersionMatcher
 
 final class IvySbt(val configuration: IvyConfiguration)
 {
@@ -77,6 +78,8 @@ final class IvySbt(val configuration: IvyConfiguration)
 				IvySbt.configureCache(is, i.localOnly, i.resolutionCacheDir)
 				IvySbt.setResolvers(is, i.resolvers, i.otherResolvers, i.localOnly, configuration.log)
 				IvySbt.setModuleConfigurations(is, i.moduleConfigurations, configuration.log)
+				is.configureDefaultVersionMatcher()
+				IvySbt.addVersionMatchers(is, i.extraVersionMatchers)
 		}
 		is
 	}
@@ -301,6 +304,10 @@ private object IvySbt
 			val attributes = javaMap(Map(MODULE_KEY -> name, ORGANISATION_KEY -> organization, REVISION_KEY -> revision))
 			settings.addModuleConfiguration(attributes, settings.getMatcher(EXACT_OR_REGEXP), resolver.name, null, null, null)
 		}
+	}
+	private def addVersionMatchers(settings: IvySettings, versionMatchers: Seq[VersionMatcher])
+	{
+		versionMatchers foreach settings.addVersionMatcher
 	}
 	private def configureCache(settings: IvySettings, localOnly: Boolean, resCacheDir: Option[File])
 	{

--- a/ivy/src/main/scala/sbt/IvyCache.scala
+++ b/ivy/src/main/scala/sbt/IvyCache.scala
@@ -86,7 +86,7 @@ class IvyCache(val ivyHome: Option[File])
 	{
 		val local = Resolver.defaultLocal
 		val paths = new IvyPaths(new File("."), ivyHome)
-		val conf = new InlineIvyConfiguration(paths, Seq(local), Nil, Nil, false, lock, IvySbt.DefaultChecksums, None, log)
+		val conf = new InlineIvyConfiguration(paths, Seq(local), Nil, Nil, false, lock, IvySbt.DefaultChecksums, None, Nil, log)
 		(new IvySbt(conf), local)
 	}
 	/** Creates a default jar artifact based on the given ID.*/

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1070,7 +1070,7 @@ object Classpaths
 			val explicit = buildStructure.value.units(thisProjectRef.value.build).unit.plugins.pluginData.resolvers
 			explicit orElse bootRepositories(appConfiguration.value) getOrElse externalResolvers.value
 		},
-		ivyConfiguration := new InlineIvyConfiguration(ivyPaths.value, externalResolvers.value, Nil, Nil, offline.value, Option(lock(appConfiguration.value)), checksums.value, Some(target.value / "resolution-cache"), streams.value.log),
+		ivyConfiguration := new InlineIvyConfiguration(ivyPaths.value, externalResolvers.value, Nil, Nil, offline.value, Option(lock(appConfiguration.value)), checksums.value, Some(target.value / "resolution-cache"), Nil, streams.value.log),
 		ivySbt <<= ivySbt0,
 		classifiersModule <<= (projectID, sbtDependency, transitiveClassifiers, loadedBuild, thisProjectRef) map { ( pid, sbtDep, classifiers, lb, ref) =>
 			val pluginClasspath = lb.units(ref.build).unit.plugins.fullClasspath
@@ -1255,7 +1255,7 @@ object Classpaths
 		(fullResolvers, ivyPaths, otherResolvers, moduleConfigurations, offline, checksums in update, appConfiguration, target, streams) map { (rs, paths, other, moduleConfs, off, check, app, t, s) =>
 			warnResolversConflict(rs ++: other, s.log)
 			val resCacheDir = t / "resolution-cache"
-			new InlineIvyConfiguration(paths, rs, other, moduleConfs, off, Option(lock(app)), check, Some(resCacheDir), s.log)
+			new InlineIvyConfiguration(paths, rs, other, moduleConfs, off, Option(lock(app)), check, Some(resCacheDir), Nil, s.log)
 		}
 
 		import java.util.LinkedHashSet


### PR DESCRIPTION
It seems that currently there's no way to add additional `VersionMatcher`s to the IvySettings configuration.
I needed such a feature to add my own matcher, and did so through a new field in `InlineIvyConfiguration` called `extraVersionMatchers`. 
I don't think there's a real need to abstract an sbt class over this and later do a conversion to Ivy, which is why I didn't introduce a new setting either (anything like `SettingKey[sbt.VersionMatcher]` seemed unnecessary).

Instead, the use case for this is to just transform the `ivyConfiguration` and add some matchers:

``` scala
ivyConfiguration ~= _ map { 
  case ic: InlineIvyConfiguration => ic changeVersionMatchers (myVMatcher :: Nil)
  case c => c // or something...
}
```

Please let me know if the approach seems reasonable.
