### PR TITLE
Allow derived settings to replace previously-defined but non-default settings

### DIFF
--- a/main/settings/src/main/scala/sbt/Def.scala
+++ b/main/settings/src/main/scala/sbt/Def.scala
@@ -45,9 +45,10 @@ object Def extends Init[Scope] with TaskMacroExtra
 		s.dependencies.find(k => k.scope != ThisScope).map(k => s"Scope cannot be defined for dependency ${k.key.label} of ${definedSettingString(s)}")
 
 	override def intersect(s1: Scope, s2: Scope)(implicit delegates: Scope => Seq[Scope]): Option[Scope] =
-		if      (s2 == GlobalScope || delegates(s1).contains(s2))  Some(s1) // s1 is more specific
-		else if (s1 == GlobalScope || delegates(s2).contains(s1))  Some(s2) // s2 is more specific
-		else None
+		if      (s2 == GlobalScope)  Some(s1) // s1 is more specific
+		else if (s1 == GlobalScope)  Some(s2) // s2 is more specific
+		else super.intersect(s1, s2)
+
 
 	private[this] def definedSettingString(s: Setting[_]): String =
 		s"derived setting ${s.key.key.label}${positionString(s)}"

--- a/main/settings/src/main/scala/sbt/Def.scala
+++ b/main/settings/src/main/scala/sbt/Def.scala
@@ -3,7 +3,7 @@ package sbt
 	import Types.const
 	import complete.Parser
 	import java.io.File
-	import Scope.ThisScope
+	import Scope.{ThisScope,GlobalScope}
 	import KeyRanks.{DTask, Invisible}
 
 /** A concrete settings system that uses `sbt.Scope` for the scope type. */
@@ -43,6 +43,11 @@ object Def extends Init[Scope] with TaskMacroExtra
 		super.deriveAllowed(s, allowDynamic) orElse
 		(if(s.key.scope != ThisScope) Some(s"Scope cannot be defined for ${definedSettingString(s)}") else None ) orElse
 		s.dependencies.find(k => k.scope != ThisScope).map(k => s"Scope cannot be defined for dependency ${k.key.label} of ${definedSettingString(s)}")
+
+	override def intersect(s1: Scope, s2: Scope)(implicit delegates: Scope => Seq[Scope]): Option[Scope] =
+		if      (s2 == GlobalScope || delegates(s1).contains(s2))  Some(s1) // s1 is more specific
+		else if (s1 == GlobalScope || delegates(s2).contains(s1))  Some(s2) // s2 is more specific
+		else None
 
 	private[this] def definedSettingString(s: Setting[_]): String =
 		s"derived setting ${s.key.key.label}${positionString(s)}"

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -230,11 +230,10 @@ object Defaults extends BuildCommon
 		javacOptions :== Nil,
 		scalacOptions :== Nil,
 		scalaVersion := appConfiguration.value.provider.scalaProvider.version,
-		crossScalaVersions := Seq(scalaVersion.value)
-	)) ++ Seq(
+		crossScalaVersions := Seq(scalaVersion.value),
 		derive(compilersSetting),
 		derive(scalaBinaryVersion := binaryScalaVersion(scalaVersion.value))
-	)
+	))
 	def makeCrossTarget(t: File, sv: String, sbtv: String, plugin: Boolean, cross: Boolean): File =
 	{
 		val scalaBase = if(cross) t / ("scala-" + sv) else t
@@ -409,9 +408,9 @@ object Defaults extends BuildCommon
 		},
 		testOptions := Tests.Listeners(testListeners.value) +: (testOptions in TaskGlobal).value,
 		testExecution <<= testExecutionTask(key)
-	) ) ++ Seq(
+	) ) ++ inScope(GlobalScope)(Seq(
 		derive(testGrouping <<= singleTestGroupDefault)
-	)
+	))
 	@deprecated("Doesn't provide for closing the underlying resources.", "0.13.1")
 	def testLogger(manager: Streams, baseKey: Scoped)(tdef: TestDefinition): Logger =
 	{

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1741,5 +1741,5 @@ trait BuildCommon
 	def getPrevious[T](task: TaskKey[T]): Initialize[Task[Option[T]]] =
 		(state, resolvedScoped) map { (s, ctx) => getFromContext(task, ctx, s) }
 
-	private[sbt] def derive[T](s: Setting[T]): Setting[T] = Def.derive(s, allowDynamic=true, trigger = _ != streams.key)
+	private[sbt] def derive[T](s: Setting[T]): Setting[T] = Def.derive(s, allowDynamic=true, trigger = _ != streams.key, default = true)
 }

--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -3,7 +3,7 @@
  */
 package sbt
 
-	import Types._
+import Types._
 
 sealed trait Settings[Scope]
 {
@@ -291,6 +291,11 @@ trait Init[Scope]
 		} else ""
 	}
 
+	/**
+	 * Intersects two scopes, returning the more specific one if they intersect, or None otherwise.
+	 * Not implemented here because we want to optimise for Scope.GlobalScope which is inaccessible here. */
+	private[sbt] def intersect(s1: Scope, s2: Scope)(implicit delegates: Scope => Seq[Scope]): Option[Scope] = ???
+
 	private[this] def deriveAndLocal(init: Seq[Setting[_]])(implicit delegates: Scope => Seq[Scope], scopeLocal: ScopeLocal): Seq[Setting[_]] =
 	{
 			import collection.mutable
@@ -361,10 +366,6 @@ trait Init[Scope]
 			val scope = sk.scope
 			def localAndDerived(d: Derived): Seq[Setting[_]] = {
 				def definingScope = d.setting.key.scope
-				def intersect(s1: Scope, s2: Scope): Option[Scope] =
-					if (delegates(s1).contains(s2))       Some(s1) // s1 is more specific
-					else if (delegates(s2).contains(s1))  Some(s2) // s2 is more specific
-					else None
 				val outputScope = intersect(scope, definingScope)
 				outputScope collect { case s if !d.inScopes.contains(s) && d.setting.filter(s) =>
 					val local = d.dependencies.flatMap(dep => scopeLocal(ScopedKey(s, dep)))

--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -90,7 +90,7 @@ trait Init[Scope]
 	* Only the static dependencies are tracked, however.  Dependencies on previous values do not introduce a derived setting either. */
 	final def derive[T](s: Setting[T], allowDynamic: Boolean = false, filter: Scope => Boolean = const(true), trigger: AttributeKey[_] => Boolean = const(true)): Setting[T] = {
 		deriveAllowed(s, allowDynamic) foreach error
-		new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger, nextDefaultID())
+		new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger)
 	}
 	def deriveAllowed[T](s: Setting[T], allowDynamic: Boolean): Option[String] = s.init match {
 		case _: Bind[_,_] if !allowDynamic => Some("Cannot derive from dynamic dependencies.")
@@ -456,8 +456,8 @@ trait Init[Scope]
 		protected[sbt] def isDerived: Boolean = false
 		private[sbt] def setScope(s: Scope): Setting[T] = make(key.copy(scope = s), init.mapReferenced(mapScope(const(s))), pos)
 	}
-	private[Init] final class DerivedSetting[T](sk: ScopedKey[T], i: Initialize[T], p: SourcePosition, val filter: Scope => Boolean, val trigger: AttributeKey[_] => Boolean, id: Long) extends DefaultSetting[T](sk, i, p, id) {
-		override def make[T](key: ScopedKey[T], init: Initialize[T], pos: SourcePosition): Setting[T] = new DerivedSetting[T](key, init, pos, filter, trigger, id)
+	private[Init] final class DerivedSetting[T](sk: ScopedKey[T], i: Initialize[T], p: SourcePosition, val filter: Scope => Boolean, val trigger: AttributeKey[_] => Boolean) extends Setting[T](sk, i, p) {
+		override def make[T](key: ScopedKey[T], init: Initialize[T], pos: SourcePosition): Setting[T] = new DerivedSetting[T](key, init, pos, filter, trigger)
 		protected[sbt] override def isDerived: Boolean = true
 	}
 	// Only keep the first occurence of this setting and move it to the front so that it has lower precedence than non-defaults.

--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -90,7 +90,7 @@ trait Init[Scope]
 	* Only the static dependencies are tracked, however.  Dependencies on previous values do not introduce a derived setting either. */
 	final def derive[T](s: Setting[T], allowDynamic: Boolean = false, filter: Scope => Boolean = const(true), trigger: AttributeKey[_] => Boolean = const(true), default: Boolean = false): Setting[T] = {
 		deriveAllowed(s, allowDynamic) foreach error
-		def d = new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger)
+		val d = new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger)
 		if (default) d.default() else d
 	}
 	def deriveAllowed[T](s: Setting[T], allowDynamic: Boolean): Option[String] = s.init match {
@@ -293,8 +293,11 @@ trait Init[Scope]
 
 	/**
 	 * Intersects two scopes, returning the more specific one if they intersect, or None otherwise.
-	 * Not implemented here because we want to optimise for Scope.GlobalScope which is inaccessible here. */
-	private[sbt] def intersect(s1: Scope, s2: Scope)(implicit delegates: Scope => Seq[Scope]): Option[Scope] = ???
+	 */
+	private[sbt] def intersect(s1: Scope, s2: Scope)(implicit delegates: Scope => Seq[Scope]): Option[Scope] =
+		if      (delegates(s1).contains(s2))  Some(s1) // s1 is more specific
+		else if (delegates(s2).contains(s1))  Some(s2) // s2 is more specific
+		else None
 
 	private[this] def deriveAndLocal(init: Seq[Setting[_]])(implicit delegates: Scope => Seq[Scope], scopeLocal: ScopeLocal): Seq[Setting[_]] =
 	{

--- a/util/collection/src/test/scala/SettingsExample.scala
+++ b/util/collection/src/test/scala/SettingsExample.scala
@@ -3,7 +3,7 @@ package sbt
 /** Define our settings system */
 
 // A basic scope indexed by an integer.
-final case class Scope(index: Int)
+final case class Scope(nestIndex: Int, idAtIndex: Int = 0)
 
 // Extend the Init trait.
 //  (It is done this way because the Scope type parameter is used everywhere in Init.
@@ -14,12 +14,12 @@ object SettingsExample extends Init[Scope]
 {
 	// Provides a way of showing a Scope+AttributeKey[_]
 	val showFullKey: Show[ScopedKey[_]] = new Show[ScopedKey[_]] {
-		def apply(key: ScopedKey[_]) = key.scope.index + "/" + key.key.label
+		def apply(key: ScopedKey[_]) = s"${key.scope.nestIndex}(${key.scope.idAtIndex})/${key.key.label}"
 	}
 
 	// A sample delegation function that delegates to a Scope with a lower index.
-	val delegates: Scope => Seq[Scope] = { case s @ Scope(index) =>
-		s +: (if(index <= 0) Nil else delegates(Scope(index-1)) )
+	val delegates: Scope => Seq[Scope] = { case s @ Scope(index, proj) =>
+		s +: (if(index <= 0) Nil else { (if (proj > 0) List(Scope(index)) else Nil) ++: delegates(Scope(index-1)) })
 	}
 
 	// Not using this feature in this example.


### PR DESCRIPTION
Following #1034. It remains to update all uses of `DerivedSetting` internally so that they still get created as `DefaultSetting`s, by doing so explicitly.
