### PR TITLE
Implement name hashing algorithm in incremental compiler

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Analysis.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Analysis.scala
@@ -56,6 +56,8 @@ trait Analysis
 object Analysis
 {
 	lazy val Empty: Analysis = new MAnalysis(Stamps.empty, APIs.empty, Relations.empty, SourceInfos.empty, Compilations.empty)
+	private[sbt] def empty(nameHashing: Boolean): Analysis = new MAnalysis(Stamps.empty, APIs.empty,
+		Relations.empty(nameHashing = nameHashing), SourceInfos.empty, Compilations.empty)
 
 	/** Merge multiple analysis objects into one. Deps will be internalized as needed. */
 	def merge(analyses: Traversable[Analysis]): Analysis = {

--- a/compile/inc/src/main/scala/sbt/inc/Changes.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Changes.scala
@@ -22,14 +22,14 @@ sealed abstract class APIChange[T](val modified: T)
  * api has changed. The reason is that there's no way to determine if changes to macros implementation
  * are affecting its users or not. Therefore we err on the side of caution.
  */
-case class APIChangeDueToMacroDefinition[T](modified0: T) extends APIChange(modified0)
-case class SourceAPIChange[T](modified0: T) extends APIChange(modified0)
+final case class APIChangeDueToMacroDefinition[T](modified0: T) extends APIChange(modified0)
+final case class SourceAPIChange[T](modified0: T) extends APIChange(modified0)
 /**
  * An APIChange that carries information about modified names.
  *
  * This class is used only when name hashing algorithm is enabled.
  */
-case class NamesChange[T](modified0: T, modifiedNames: ModifiedNames) extends APIChange(modified0)
+final case class NamesChange[T](modified0: T, modifiedNames: ModifiedNames) extends APIChange(modified0)
 
 /**
  * ModifiedNames are determined by comparing name hashes in two versions of an API representation.
@@ -39,7 +39,7 @@ case class NamesChange[T](modified0: T, modifiedNames: ModifiedNames) extends AP
  * on whether modified name is implicit or not. Implicit names are much more difficult to handle
  * due to difficulty of reasoning about the implicit scope.
  */
-case class ModifiedNames(regularNames: Set[String], implicitNames: Set[String]) {
+final case class ModifiedNames(regularNames: Set[String], implicitNames: Set[String]) {
 	override def toString: String =
 		s"ModifiedNames(regularNames = ${regularNames mkString ", "}, implicitNames = ${implicitNames mkString ", "})"
 }

--- a/compile/inc/src/main/scala/sbt/inc/Changes.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Changes.scala
@@ -6,6 +6,8 @@ package inc
 
 import xsbt.api.NameChanges
 import java.io.File
+import xsbti.api.{_internalOnly_NameHashes => NameHashes}
+import xsbti.api.{_internalOnly_NameHash => NameHash}
 
 final case class InitialChanges(internalSrc: Changes[File], removedProducts: Set[File], binaryDeps: Set[File], external: APIChanges[String])
 final class APIChanges[T](val apiChanges: Iterable[APIChange[T]])
@@ -22,6 +24,37 @@ sealed abstract class APIChange[T](val modified: T)
  */
 case class APIChangeDueToMacroDefinition[T](modified0: T) extends APIChange(modified0)
 case class SourceAPIChange[T](modified0: T) extends APIChange(modified0)
+/**
+ * An APIChange that carries information about modified names.
+ *
+ * This class is used only when name hashing algorithm is enabled.
+ */
+case class NamesChange[T](modified0: T, modifiedNames: ModifiedNames) extends APIChange(modified0)
+
+/**
+ * ModifiedNames are determined by comparing name hashes in two versions of an API representation.
+ *
+ * Note that we distinguish between sets of regular (non-implicit) and implicit modified names.
+ * This distinction is needed because the name hashing algorithm makes different decisions based
+ * on whether modified name is implicit or not. Implicit names are much more difficult to handle
+ * due to difficulty of reasoning about the implicit scope.
+ */
+case class ModifiedNames(regularNames: Set[String], implicitNames: Set[String]) {
+	override def toString: String =
+		s"ModifiedNames(regularNames = ${regularNames mkString ", "}, implicitNames = ${implicitNames mkString ", "})"
+}
+object ModifiedNames {
+	def compareTwoNameHashes(a: NameHashes, b: NameHashes): ModifiedNames = {
+		val modifiedRegularNames = calculateModifiedNames(a.regularMembers.toSet, b.regularMembers.toSet)
+		val modifiedImplicitNames = calculateModifiedNames(a.implicitMembers.toSet, b.implicitMembers.toSet)
+		ModifiedNames(modifiedRegularNames, modifiedImplicitNames)
+	}
+	private def calculateModifiedNames(xs: Set[NameHash], ys: Set[NameHash]): Set[String] = {
+	  val differentNameHashes = (xs union ys) diff (xs intersect ys)
+	  differentNameHashes.map(_.name)
+	}
+}
+
 
 trait Changes[A]
 {

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -157,9 +157,9 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 
 	def usedName(sourceFile: File, name: String) = add(usedNames, sourceFile, name)
 
-	def nameHashing: Boolean = false // TODO: define the flag in IncOptions which controls this
+	def nameHashing: Boolean = options.nameHashing
 
-	def get: Analysis = addUsedNames( addCompilation( addExternals( addBinaries( addProducts( addSources(Analysis.Empty) ) ) ) ) )
+	def get: Analysis = addUsedNames( addCompilation( addExternals( addBinaries( addProducts( addSources(Analysis.empty(nameHashing = nameHashing)) ) ) ) ) )
 	def addProducts(base: Analysis): Analysis = addAll(base, classes) { case (a, src, (prod, name)) => a.addProduct(src, prod, current product prod, name ) }
 	def addBinaries(base: Analysis): Analysis = addAll(base, binaryDeps)( (a, src, bin) => a.addBinaryDep(src, bin, binaryClassName(bin), current binary bin) )
 	def addSources(base: Analysis): Analysis =

--- a/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
@@ -112,14 +112,14 @@ final class IncOptions(
 			 apiDumpDirectory: Option[java.io.File] = this.apiDumpDirectory,
 			 newClassfileManager: () => ClassfileManager = this.newClassfileManager): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
 	}
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
 	override def productPrefix: String = "IncOptions"
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
-	def productArity: Int = 7
+	def productArity: Int = 8
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
 	def productElement(x$1: Int): Any = x$1 match {
@@ -130,6 +130,7 @@ final class IncOptions(
 		case 4 => IncOptions.this.apiDiffContextSize
 		case 5 => IncOptions.this.apiDumpDirectory
 		case 6 => IncOptions.this.newClassfileManager
+		case 7 => IncOptions.this.recompileOnMacroDef
 		case _ => throw new IndexOutOfBoundsException(x$1.toString())
 	}
 
@@ -149,7 +150,8 @@ final class IncOptions(
       acc = Statics.mix(acc, apiDiffContextSize)
       acc = Statics.mix(acc, Statics.anyHash(apiDumpDirectory))
       acc = Statics.mix(acc, Statics.anyHash(newClassfileManager))
-      Statics.finalizeHash(acc, 7)
+      acc = Statics.mix(acc, if (recompileOnMacroDef) 1231 else 1237)
+      Statics.finalizeHash(acc, 8)
     }
 
    override def toString(): String = scala.runtime.ScalaRunTime._toString(IncOptions.this)
@@ -160,7 +162,8 @@ final class IncOptions(
         transitiveStep == IncOptions$1.transitiveStep && recompileAllFraction == IncOptions$1.recompileAllFraction &&
         relationsDebug == IncOptions$1.relationsDebug && apiDebug == IncOptions$1.apiDebug  &&
         apiDiffContextSize == IncOptions$1.apiDiffContextSize && apiDumpDirectory == IncOptions$1.apiDumpDirectory &&
-        newClassfileManager == IncOptions$1.newClassfileManager
+        newClassfileManager == IncOptions$1.newClassfileManager &&
+        recompileOnMacroDef == IncOptions$1.recompileOnMacroDef
       }))
     }
     //- EXPANDED CASE CLASS METHOD END -//
@@ -217,7 +220,7 @@ object IncOptions extends Serializable {
 	private val apiDebugKey             = "apiDebug"
 	private val apiDumpDirectoryKey     = "apiDumpDirectory"
 	private val apiDiffContextSizeKey   = "apiDiffContextSize"
-	private val recompileOnMacroDefKey  = "recompileOnMacroDefKey"
+	private val recompileOnMacroDefKey  = "recompileOnMacroDef"
 
 	def fromStringMap(m: java.util.Map[String, String]): IncOptions = {
 		// all the code below doesn't look like idiomatic Scala for a good reason: we are working with Java API

--- a/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
@@ -51,57 +51,76 @@ final class IncOptions(
 	 * Determines whether incremental compiler should recompile all dependencies of a file
 	 * that contains a macro definition.
 	 */
-	val recompileOnMacroDef: Boolean
+	val recompileOnMacroDef: Boolean,
+	/**
+	 * Determines whether incremental compiler uses the new algorithm known as name hashing.
+	 *
+	 * This flag is disabled by default so incremental compiler's behavior is the same as in sbt 0.13.0.
+	 *
+	 * IMPLEMENTATION NOTE:
+	 * Enabling this flag enables a few additional functionalities that are needed by the name hashing algorithm:
+	 *
+	 *   1. New dependency source tracking is used. See `sbt.inc.Relations` for details.
+	 *   2. Used names extraction and tracking is enabled. See `sbt.inc.Relations` for details as well.
+	 *   3. Hashing of public names is enabled. See `sbt.inc.AnalysisCallback` for details.
+	 *
+	 */
+	val nameHashing: Boolean
 ) extends Product with Serializable {
 
 	/**
 	 * Secondary constructor introduced to make IncOptions to be binary compatible with version that didn't have
-	 * `recompileOnMacroDef` filed defined.
+	 * `recompileOnMacroDef` and `nameHashing` fields defined.
 	 */
 	def this(transitiveStep: Int, recompileAllFraction: Double, relationsDebug: Boolean, apiDebug: Boolean,
 			 apiDiffContextSize: Int, apiDumpDirectory: Option[java.io.File], newClassfileManager: () => ClassfileManager) = {
 		this(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-		     apiDumpDirectory, newClassfileManager, IncOptions.recompileOnMacroDefDefault)
+		     apiDumpDirectory, newClassfileManager, IncOptions.recompileOnMacroDefDefault, IncOptions.nameHashingDefault)
 	}
 
 	def withTransitiveStep(transitiveStep: Int): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withRecompileAllFraction(recompileAllFraction: Double): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withRelationsDebug(relationsDebug: Boolean): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withApiDebug(apiDebug: Boolean): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withApiDiffContextSize(apiDiffContextSize: Int): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withApiDumpDirectory(apiDumpDirectory: Option[File]): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withNewClassfileManager(newClassfileManager: () => ClassfileManager): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	def withRecompileOnMacroDef(recompileOnMacroDef: Boolean): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
+	}
+
+	def withNameHashing(nameHashing: Boolean): IncOptions = {
+		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	//- EXPANDED CASE CLASS METHOD BEGIN -//
@@ -112,14 +131,14 @@ final class IncOptions(
 			 apiDumpDirectory: Option[java.io.File] = this.apiDumpDirectory,
 			 newClassfileManager: () => ClassfileManager = this.newClassfileManager): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
 	override def productPrefix: String = "IncOptions"
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
-	def productArity: Int = 8
+	def productArity: Int = 9
 
 	@deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
 	def productElement(x$1: Int): Any = x$1 match {
@@ -131,6 +150,7 @@ final class IncOptions(
 		case 5 => IncOptions.this.apiDumpDirectory
 		case 6 => IncOptions.this.newClassfileManager
 		case 7 => IncOptions.this.recompileOnMacroDef
+		case 8 => IncOptions.this.nameHashing
 		case _ => throw new IndexOutOfBoundsException(x$1.toString())
 	}
 
@@ -151,7 +171,8 @@ final class IncOptions(
       acc = Statics.mix(acc, Statics.anyHash(apiDumpDirectory))
       acc = Statics.mix(acc, Statics.anyHash(newClassfileManager))
       acc = Statics.mix(acc, if (recompileOnMacroDef) 1231 else 1237)
-      Statics.finalizeHash(acc, 8)
+      acc = Statics.mix(acc, if (nameHashing) 1231 else 1237)
+      Statics.finalizeHash(acc, 9)
     }
 
    override def toString(): String = scala.runtime.ScalaRunTime._toString(IncOptions.this)
@@ -163,7 +184,7 @@ final class IncOptions(
         relationsDebug == IncOptions$1.relationsDebug && apiDebug == IncOptions$1.apiDebug  &&
         apiDiffContextSize == IncOptions$1.apiDiffContextSize && apiDumpDirectory == IncOptions$1.apiDumpDirectory &&
         newClassfileManager == IncOptions$1.newClassfileManager &&
-        recompileOnMacroDef == IncOptions$1.recompileOnMacroDef
+        recompileOnMacroDef == IncOptions$1.recompileOnMacroDef && nameHashing == IncOptions$1.nameHashing
       }))
     }
     //- EXPANDED CASE CLASS METHOD END -//
@@ -171,6 +192,7 @@ final class IncOptions(
 
 object IncOptions extends Serializable {
 	private val recompileOnMacroDefDefault: Boolean = true
+	private val nameHashingDefault: Boolean = false
 	val Default = IncOptions(
 		//    1. recompile changed sources
 		// 2(3). recompile direct dependencies and transitive public inheritance dependencies of sources with API changes in 1(2).
@@ -182,7 +204,8 @@ object IncOptions extends Serializable {
 		apiDiffContextSize = 5,
 		apiDumpDirectory = None,
 		newClassfileManager = ClassfileManager.deleteImmediately,
-		recompileOnMacroDef = recompileOnMacroDefDefault
+		recompileOnMacroDef = recompileOnMacroDefDefault,
+		nameHashing = nameHashingDefault
 	)
 	//- EXPANDED CASE CLASS METHOD BEGIN -//
 	final override def toString(): String = "IncOptions"
@@ -195,9 +218,10 @@ object IncOptions extends Serializable {
 	}
 	def apply(transitiveStep: Int, recompileAllFraction: Double, relationsDebug: Boolean, apiDebug: Boolean,
 			  apiDiffContextSize: Int, apiDumpDirectory: Option[java.io.File],
-			  newClassfileManager: () => ClassfileManager, recompileOnMacroDef: Boolean): IncOptions = {
+			  newClassfileManager: () => ClassfileManager, recompileOnMacroDef: Boolean,
+			  nameHashing: Boolean): IncOptions = {
 		new IncOptions(transitiveStep, recompileAllFraction, relationsDebug, apiDebug, apiDiffContextSize,
-			apiDumpDirectory, newClassfileManager, recompileOnMacroDef)
+			apiDumpDirectory, newClassfileManager, recompileOnMacroDef, nameHashing)
 	}
     @deprecated("Methods generated for case class will be removed in the future.", "0.13.2")
 	def unapply(x$0: IncOptions): Option[(Int, Double, Boolean, Boolean, Int, Option[java.io.File], () => AnyRef)] = {
@@ -221,6 +245,7 @@ object IncOptions extends Serializable {
 	private val apiDumpDirectoryKey     = "apiDumpDirectory"
 	private val apiDiffContextSizeKey   = "apiDiffContextSize"
 	private val recompileOnMacroDefKey  = "recompileOnMacroDef"
+	private val nameHashingKey          = "nameHashing"
 
 	def fromStringMap(m: java.util.Map[String, String]): IncOptions = {
 		// all the code below doesn't look like idiomatic Scala for a good reason: we are working with Java API
@@ -254,9 +279,13 @@ object IncOptions extends Serializable {
 			val k = recompileOnMacroDefKey
 			if (m.containsKey(k)) m.get(k).toBoolean else Default.recompileOnMacroDef
 		}
+		def getNameHashing: Boolean = {
+			val k = nameHashingKey
+			if (m.containsKey(k)) m.get(k).toBoolean else Default.nameHashing
+		}
 
 		new IncOptions(getTransitiveStep, getRecompileAllFraction, getRelationsDebug, getApiDebug, getApiDiffContextSize,
-			getApiDumpDirectory, ClassfileManager.deleteImmediately, getRecompileOnMacroDef)
+			getApiDumpDirectory, ClassfileManager.deleteImmediately, getRecompileOnMacroDef, getNameHashing)
 	}
 
 	def toStringMap(o: IncOptions): java.util.Map[String, String] = {
@@ -268,6 +297,7 @@ object IncOptions extends Serializable {
 		o.apiDumpDirectory.foreach(f => m.put(apiDumpDirectoryKey, f.toString))
 		m.put(apiDiffContextSizeKey, o.apiDiffContextSize.toString)
 		m.put(recompileOnMacroDefKey, o.recompileOnMacroDef.toString)
+		m.put(nameHashingKey, o.nameHashing.toString)
 		m
 	}
 }

--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -21,6 +21,7 @@ object Incremental
 		log: Logger,
 		options: IncOptions)(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
 	{
+		assert(!options.nameHashing, "We don't support name hashing algorithm yet.")
 		val incremental = new IncrementalDefaultImpl(log, options)
 		val initialChanges = incremental.changedInitial(entry, sources, previous, current, forEntry)
 		val binaryChanges = new DependencyChanges {

--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -21,7 +21,7 @@ object Incremental
 		log: Logger,
 		options: IncOptions)(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
 	{
-		val incremental = new Incremental(log, options)
+		val incremental = new IncrementalDefaultImpl(log, options)
 		val initialChanges = incremental.changedInitial(entry, sources, previous, current, forEntry)
 		val binaryChanges = new DependencyChanges {
 			val modifiedBinaries = initialChanges.binaryDeps.toArray
@@ -62,7 +62,7 @@ object Incremental
 }
 
 
-private class Incremental(log: Logger, options: IncOptions) {
+private abstract class IncrementalCommon(log: Logger, options: IncOptions) {
 
 	val incDebugProp = "xsbt.inc.debug"
 	private def incDebug(options: IncOptions): Boolean = options.relationsDebug || java.lang.Boolean.getBoolean(incDebugProp)
@@ -449,3 +449,5 @@ private class Incremental(log: Logger, options: IncOptions) {
 	def properSubPkg(testParent: Seq[String], testSub: Seq[String]) = testParent.length < testSub.length && testSub.startsWith(testParent)
 	def pkgs(api: Source) = names(api :: Nil).map(pkg)*/
 }
+
+private final class IncrementalDefaultImpl(log: Logger, options: IncOptions) extends IncrementalCommon(log, options)

--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -21,8 +21,11 @@ object Incremental
 		log: Logger,
 		options: IncOptions)(implicit equivS: Equiv[Stamp]): (Boolean, Analysis) =
 	{
-		assert(!options.nameHashing, "We don't support name hashing algorithm yet.")
-		val incremental = new IncrementalDefaultImpl(log, options)
+		val incremental: IncrementalCommon =
+			if (!options.nameHashing)
+				new IncrementalDefaultImpl(log, options)
+			else
+				new IncrementalNameHashing(log, options)
 		val initialChanges = incremental.changedInitial(entry, sources, previous, current, forEntry)
 		val binaryChanges = new DependencyChanges {
 			val modifiedBinaries = initialChanges.binaryDeps.toArray
@@ -128,7 +131,8 @@ private abstract class IncrementalCommon(log: Logger, options: IncOptions) {
 			apiChanges foreach {
 				case APIChangeDueToMacroDefinition(src) =>
 					log.debug(s"Public API is considered to be changed because $src contains a macro definition.")
-				case SourceAPIChange(src) =>
+				case apiChange@(_: SourceAPIChange[T] | _: NamesChange[T]) =>
+					val src = apiChange.modified
 					val oldApi = oldAPIMapping(src)
 					val newApi = newAPIMapping(src)
 					val apiUnifiedPatch = apiDiff.generateApiDiff(src.toString, oldApi.api, newApi.api, contextSize)
@@ -176,7 +180,7 @@ private abstract class IncrementalCommon(log: Logger, options: IncOptions) {
 		}
 	}
 
-	protected def sameAPI[T](src: T, a: Source, b: Source): Option[SourceAPIChange[T]]
+	protected def sameAPI[T](src: T, a: Source, b: Source): Option[APIChange[T]]
 
 	def shortcutSameSource(a: Source, b: Source): Boolean  =  !a.hash.isEmpty && !b.hash.isEmpty && sameCompilation(a.compilation, b.compilation) && (a.hash.deep equals b.hash.deep)
 	def sameCompilation(a: Compilation, b: Compilation): Boolean  =  a.startTime == b.startTime && a.outputs.corresponds(b.outputs){
@@ -475,11 +479,90 @@ private final class IncrementalDefaultImpl(log: Logger, options: IncOptions) ext
 		log.debug("Invalidated by transitive public inheritance: " + transitiveInherited)
 		val direct = transitiveInherited flatMap directDeps
 		log.debug("Invalidated by direct dependency: " + direct)
-		val all = transitiveInherited ++ direct
-		all
+		transitiveInherited ++ direct
 	}
 
 	override protected def allDeps(relations: Relations): File => Set[File] =
 		f => relations.direct.internal.reverse(f)
+
+}
+
+/**
+ * Implementation of incremental algorithm known as "name hashing". It differs from the default implementation
+ * by applying pruning (filter) of member reference dependencies based on used and modified simple names.
+ *
+ * See MemberReferenceInvalidationStrategy for some more information.
+ */
+private final class IncrementalNameHashing(log: Logger, options: IncOptions) extends IncrementalCommon(log, options) {
+
+	private val memberRefInvalidator = new MemberRefInvalidator(log)
+
+	// Package objects are fragile: if they inherit from an invalidated source, get "class file needed by package is missing" error
+	//  This might be too conservative: we probably only need package objects for packages of invalidated sources.
+	override protected def invalidatedPackageObjects(invalidated: Set[File], relations: Relations): Set[File] =
+		invalidated flatMap relations.inheritance.internal.reverse filter { _.getName == "package.scala" }
+
+	override protected def sameAPI[T](src: T, a: Source, b: Source): Option[APIChange[T]] = {
+		if (SameAPI(a,b))
+			None
+		else {
+			val aNameHashes = a._internalOnly_nameHashes
+			val bNameHashes = b._internalOnly_nameHashes
+			val modifiedNames = ModifiedNames.compareTwoNameHashes(aNameHashes, bNameHashes)
+			val apiChange = NamesChange(src, modifiedNames)
+			Some(apiChange)
+		}
+	}
+
+	/** Invalidates sources based on initially detected 'changes' to the sources, products, and dependencies.*/
+	override protected def invalidateByExternal(relations: Relations, externalAPIChange: APIChange[String]): Set[File] = {
+		val modified = externalAPIChange.modified
+		val invalidationReason = memberRefInvalidator.invalidationReason(externalAPIChange)
+		log.debug(s"$invalidationReason\nAll member reference dependencies will be considered within this context.")
+		// Propagate inheritance dependencies transitively.
+		// This differs from normal because we need the initial crossing from externals to sources in this project.
+		val externalInheritanceR = relations.inheritance.external
+		val byExternalInheritance = externalInheritanceR.reverse(modified)
+		log.debug(s"Files invalidated by inheriting from (external) $modified: $byExternalInheritance; now invalidating by inheritance (internally).")
+		val transitiveInheritance = byExternalInheritance flatMap { file =>
+			invalidateByInheritance(relations, file)
+		}
+		val memberRefInvalidationInternal = memberRefInvalidator.get(relations.memberRef.internal,
+			relations.names, externalAPIChange)
+        val memberRefInvalidationExternal = memberRefInvalidator.get(relations.memberRef.external,
+			relations.names, externalAPIChange)
+
+		// Get the member reference dependencies of all sources transitively invalidated by inheritance
+        log.debug("Getting direct dependencies of all sources transitively invalidated by inheritance.")
+		val memberRefA = transitiveInheritance flatMap memberRefInvalidationInternal
+		// Get the sources that depend on externals by member reference.
+		// This includes non-inheritance dependencies and is not transitive.
+		log.debug(s"Getting sources that directly depend on (external) $modified.")
+		val memberRefB = memberRefInvalidationExternal(modified)
+		transitiveInheritance ++ memberRefA ++ memberRefB
+	}
+
+	private def invalidateByInheritance(relations: Relations, modified: File): Set[File] = {
+		val inheritanceDeps = relations.inheritance.internal.reverse _
+		log.debug(s"Invalidating (transitively) by inheritance from $modified...")
+		val transitiveInheritance = transitiveDeps(Set(modified))(inheritanceDeps)
+		log.debug("Invalidated by transitive inheritance dependency: " + transitiveInheritance)
+		transitiveInheritance
+	}
+
+	override protected def invalidateSource(relations: Relations, change: APIChange[File]): Set[File] = {
+		log.debug(s"Invalidating ${change.modified}...")
+		val transitiveInheritance = invalidateByInheritance(relations, change.modified)
+		val reasonForInvalidation = memberRefInvalidator.invalidationReason(change)
+		log.debug(s"$reasonForInvalidation\nAll member reference dependencies will be considered within this context.")
+		val memberRefInvalidation = memberRefInvalidator.get(relations.memberRef.internal,
+			relations.names, change)
+		val memberRef = transitiveInheritance flatMap memberRefInvalidation
+		val all = transitiveInheritance ++ memberRef
+		all
+	}
+
+	override protected def allDeps(relations: Relations): File => Set[File] =
+		f => relations.memberRef.internal.reverse(f)
 
 }

--- a/compile/inc/src/main/scala/sbt/inc/MemberRefInvalidator.scala
+++ b/compile/inc/src/main/scala/sbt/inc/MemberRefInvalidator.scala
@@ -1,0 +1,124 @@
+package sbt.inc
+
+import sbt.Relation
+import java.io.File
+import sbt.Logger
+import xsbt.api.APIUtil
+
+/**
+ * Implements various strategies for invalidating dependencies introduced by member reference.
+ *
+ * The strategy is represented as function T => Set[File] where T is a source file that other
+ * source files depend on. When you apply that function to given element `src` you get set of
+ * files that depend on `src` by member reference and should be invalidated due to api change
+ * that was passed to a method constructing that function. There are two questions that arise:
+ *
+ *    1. Why is signature T => Set[File] and not T => Set[T] or File => Set[File]?
+ *    2. Why would we apply that function to any other `src` that then one that got modified
+ *       and the modification is described by APIChange?
+ *
+ * Let's address the second question with the following example of source code structure:
+ *
+ * // A.scala
+ * class A
+ *
+ * // B.scala
+ * class B extends A
+ *
+ * // C.scala
+ * class C { def foo(a: A) = ??? }
+ *
+ * // D.scala
+ * class D { def bar(b: B) = ??? }
+ *
+ * Member reference dependencies on A.scala are B.scala, C.scala. When the api of A changes
+ * then we would consider B and C for invalidation. However, B is also a dependency by inheritance
+ * so we always invalidate it. The api change to A is relevant when B is considered (because
+ * of how inheritance works) so we would invalidate B by inheritance and then we would like to
+ * invalidate member reference dependencies of B as well. In other words, we have a function
+ * because we want to apply it (with the same api change in mind) to all src files invalidated
+ * by inheritance of the originally modified file.
+ *
+ * The first question is a bit more straightforward to answer. We always invalidate internal
+ * source files (in given project) that are represented as File but they might depend either on
+ * internal source files (then T=File) or they can depend on external class name (then T=String).
+ *
+ * The specific invalidation strategy is determined based on APIChange that describes a change to api
+ * of a single source file.
+ *
+ * For example, if we get APIChangeDueToMacroDefinition then we invalidate all member reference
+ * dependencies unconditionally. On the other hand, if api change is due to modified name hashes
+ * of regular members then we'll invalidate sources that use those names.
+ */
+private[inc] class MemberRefInvalidator(log: Logger) {
+	def get[T](memberRef: Relation[File, T], usedNames: Relation[File, String], apiChange: APIChange[_]):
+		T => Set[File] = apiChange match {
+			case _: APIChangeDueToMacroDefinition[_] =>
+				new InvalidateUnconditionally(memberRef)
+			case NamesChange(_, modifiedNames) if !modifiedNames.implicitNames.isEmpty =>
+				new InvalidateUnconditionally(memberRef)
+			case NamesChange(modifiedSrcFile, modifiedNames) =>
+				new NameHashFilteredInvalidator[T](usedNames, memberRef, modifiedNames.regularNames)
+			case _: SourceAPIChange[_] =>
+				sys.error(wrongAPIChangeMsg)
+		}
+
+	def invalidationReason(apiChange: APIChange[_]): String = apiChange match {
+		case APIChangeDueToMacroDefinition(modifiedSrcFile) =>
+			s"The $modifiedSrcFile source file declares a macro."
+		case NamesChange(modifiedSrcFile, modifiedNames) if !modifiedNames.implicitNames.isEmpty =>
+			s"""|The $modifiedSrcFile source file has the following implicit definitions changed:
+				|\t${modifiedNames.implicitNames.mkString(", ")}.""".stripMargin
+		case NamesChange(modifiedSrcFile, modifiedNames) =>
+			s"""|The $modifiedSrcFile source file has the following regular definitions changed:
+				|\t${modifiedNames.regularNames.mkString(", ")}.""".stripMargin
+		case _: SourceAPIChange[_] =>
+			sys.error(wrongAPIChangeMsg)
+	}
+
+	private val wrongAPIChangeMsg =
+		"MemberReferenceInvalidator.get should be called when name hashing is enabled " +
+			"and in that case we shouldn't have SourceAPIChange as an api change."
+
+	private class InvalidateUnconditionally[T](memberRef: Relation[File, T]) extends (T => Set[File]) {
+		def apply(from: T): Set[File] = {
+			val invalidated = memberRef.reverse(from)
+			if (!invalidated.isEmpty)
+				log.debug(s"The following member ref dependencies of $from are invalidated:\n" +
+					formatInvalidated(invalidated))
+			invalidated
+		}
+		private def formatInvalidated(invalidated: Set[File]): String = {
+			val sortedFiles = invalidated.toSeq.sortBy(_.getAbsolutePath)
+			sortedFiles.map(file => "\t"+file).mkString("\n")
+		}
+	}
+
+	private class NameHashFilteredInvalidator[T](
+		usedNames: Relation[File, String],
+		memberRef: Relation[File, T],
+		modifiedNames: Set[String]) extends (T => Set[File]) {
+
+		def apply(to: T): Set[File] = {
+			val dependent = memberRef.reverse(to)
+			filteredDependencies(dependent)
+		}
+		private def filteredDependencies(dependent: Set[File]): Set[File] = {
+			dependent.filter {
+				case from if APIUtil.isScalaSourceName(from.getName) =>
+					val usedNamesInDependent = usedNames.forward(from)
+					val modifiedAndUsedNames = modifiedNames intersect usedNamesInDependent
+					if (modifiedAndUsedNames.isEmpty) {
+						log.debug(s"None of the modified names appears in $from. This dependency is not being considered for invalidation.")
+						false
+					} else {
+						log.debug(s"The following modified names cause invalidation of $from: $modifiedAndUsedNames")
+						true
+					}
+				case from =>
+					log.debug(s"Name hashing optimization doesn't apply to non-Scala dependency: $from")
+					true
+			}
+		}
+	}
+}

--- a/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
@@ -61,7 +61,7 @@ class AggressiveCompile(cacheFile: File)
 		cache: GlobalsCache,
 		incrementalCompilerOptions: IncOptions)(implicit log: Logger): Analysis =
 	{
-		val (previousAnalysis, previousSetup) = extract(store.get())
+		val (previousAnalysis, previousSetup) = extract(store.get(), incrementalCompilerOptions)
 		if(skip)
 			previousAnalysis
 		else {
@@ -169,11 +169,11 @@ class AggressiveCompile(cacheFile: File)
 		if(!combined.isEmpty)
 			log.info(combined.mkString("Compiling ", " and ", " to " + outputDirs.map(_.getAbsolutePath).mkString(",") + "..."))
 	}
-	private def extract(previous: Option[(Analysis, CompileSetup)]): (Analysis, Option[CompileSetup]) =
+	private def extract(previous: Option[(Analysis, CompileSetup)], incOptions: IncOptions): (Analysis, Option[CompileSetup]) =
 		previous match
 		{
 			case Some((an, setup)) => (an, Some(setup))
-			case None => (Analysis.Empty, None)
+			case None => (Analysis.empty(nameHashing = incOptions.nameHashing), None)
 		}
 	def javaOnly(f: File) = f.getName.endsWith(".java")
 

--- a/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
@@ -36,8 +36,14 @@ object IC extends IncrementalCompiler[Analysis, AnalyzingCompiler]
 	def readCache(file: File): Maybe[(Analysis, CompileSetup)] =
 		try { Maybe.just(readCacheUncaught(file)) } catch { case _: Exception => Maybe.nothing() }
 
+	@deprecated("Use overloaded variant which takes `IncOptions` as parameter.", "0.13.2")
 	def readAnalysis(file: File): Analysis =
 		try { readCacheUncaught(file)._1 } catch { case _: Exception => Analysis.Empty }
+
+	def readAnalysis(file: File, incOptions: IncOptions): Analysis =
+		try { readCacheUncaught(file)._1 } catch {
+			case _: Exception => Analysis.empty(nameHashing = incOptions.nameHashing)
+		}
 
 	def readCacheUncaught(file: File): (Analysis, CompileSetup) =
     Using.fileReader(IO.utf8)(file) { reader => TextAnalysisFormat.read(reader) }

--- a/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/A.scala
@@ -1,0 +1,3 @@
+object A {
+   def `=` = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/B.scala
@@ -1,0 +1,3 @@
+object B extends App {
+   println(A.`=`)
+}

--- a/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+   def asdf = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/test
+++ b/sbt/src/sbt-test/source-dependencies/backtick-quoted-names/test
@@ -1,0 +1,7 @@
+> compile
+
+# rename def with symbolic name (`=`)
+$ copy-file changes/A.scala A.scala
+
+# Both A.scala and B.scala should be recompiled, producing a compile error
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/constants-name-hashing/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/constants-name-hashing/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/A1.scala
+++ b/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/A1.scala
@@ -1,0 +1,1 @@
+object A { final val x = 1 }

--- a/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/A2.scala
+++ b/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/A2.scala
@@ -1,0 +1,1 @@
+object A { final val x = 2 }

--- a/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/constants-name-hashing/changes/B.scala
@@ -1,0 +1,4 @@
+object B
+{
+	def main(args: Array[String]) = assert(args(0).toInt == A.x )
+}

--- a/sbt/src/sbt-test/source-dependencies/constants-name-hashing/pending
+++ b/sbt/src/sbt-test/source-dependencies/constants-name-hashing/pending
@@ -1,0 +1,11 @@
+# Tests if source dependencies are tracked properly
+# for compile-time constants (like final vals in top-level objects)
+# see https://issues.scala-lang.org/browse/SI-7173 for details
+# why compile-time constants can be tricky to track due to early inlining
+
+$ copy-file changes/B.scala B.scala
+
+$ copy-file changes/A1.scala A.scala
+> run 1
+$ copy-file changes/A2.scala A.scala
+> run 2

--- a/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/A.scala
@@ -1,0 +1,3 @@
+package a
+
+class A

--- a/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/B.scala
@@ -1,0 +1,1 @@
+import a.A

--- a/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/changes/A.scala
@@ -1,0 +1,1 @@
+package a

--- a/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/test
+++ b/sbt/src/sbt-test/source-dependencies/import-class-name-hashing/test
@@ -1,0 +1,8 @@
+> compile
+
+# remove class a.A
+$ copy-file changes/A.scala A.scala
+
+# 'import a.A' should now fail in B.scala
+# succeeds because scalac doesn't track this dependency
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/J1.java
+++ b/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/J1.java
@@ -1,0 +1,4 @@
+public class J
+{
+	public static final int x = 3;
+}

--- a/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/J2.java
+++ b/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/J2.java
@@ -1,0 +1,4 @@
+public class J
+{
+	public static final String x = "3";
+}

--- a/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/S.scala
+++ b/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/changes/S.scala
@@ -1,0 +1,4 @@
+object S
+{
+	val y: Int = J.x
+}

--- a/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/pending
+++ b/sbt/src/sbt-test/source-dependencies/java-static-name-hashing/pending
@@ -1,0 +1,24 @@
+# When a Java class is loaded from a class file and not parsed from a source file, scalac reports
+#    the statics as an object without a file and so the Analyzer must know to look for the
+#    object's linked class.
+# This test verifies this happens.
+# The test compiles a Java class with a static field. 
+# It then adds a Scala object that references the static field.  Because the object only depends on a
+#   static member and because the Java source is not included in the compilation (since it didn't change),
+#   this triggers the special case above.
+
+# add and compile the Java source
+$ copy-file changes/J1.java src/main/java/J.java
+> compile
+
+# add and compile the Scala source
+$ copy-file changes/S.scala src/main/scala/S.scala
+> compile
+
+# change the Java source so that a compile error should occur if S.scala is also recompiled (which will happen if the dependency was properly recorded)
+$ copy-file changes/J2.java src/main/java/J.java
+-> compile
+
+# verify it should have failed by doing a full recompilation
+> clean
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-client/Client.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-client/Client.scala
@@ -1,0 +1,5 @@
+package macro
+
+object Client {
+	Provider.tree(0)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-provider/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-provider/Provider.scala
@@ -1,0 +1,8 @@
+package macro
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+	def tree(args: Any) = macro treeImpl
+	def treeImpl(c: Context)(args: c.Expr[Any]) = c.universe.reify(args.splice)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-provider/changes/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-name-hashing/macro-provider/changes/Provider.scala
@@ -1,0 +1,8 @@
+package macro
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+	def tree(args: Any) = macro treeImpl
+	def treeImpl(c: Context)(args: c.Expr[Any]) = sys.error("no macro for you!")
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-name-hashing/pending
+++ b/sbt/src/sbt-test/source-dependencies/macro-name-hashing/pending
@@ -1,0 +1,13 @@
+> compile
+
+# replace macro with one that throws an error
+
+$ copy-file macro-provider/changes/Provider.scala macro-provider/Provider.scala
+
+> macro-provider/compile
+
+-> macro-client/compile
+
+> clean
+
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/macro-name-hashing/project/build.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-name-hashing/project/build.scala
@@ -1,0 +1,29 @@
+import sbt._
+import Keys._
+
+object build extends Build {
+	val defaultSettings = Seq(
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ ),
+		incOptions := incOptions.value.withNameHashing(true)
+	)
+
+	lazy val root = Project(
+	   base = file("."),
+	   id = "macro",
+	   aggregate = Seq(macroProvider, macroClient),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroProvider = Project(
+	   base = file("macro-provider"),
+	   id = "macro-provider",
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroClient = Project(
+	   base = file("macro-client"),
+	   id = "macro-client",
+	   dependencies = Seq(macroProvider),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+}

--- a/sbt/src/sbt-test/source-dependencies/same-file-used-names/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/same-file-used-names/A.scala
@@ -1,0 +1,8 @@
+object A {
+   def x = 3
+
+   def y = {
+     import B._
+     x
+   }
+}

--- a/sbt/src/sbt-test/source-dependencies/same-file-used-names/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/same-file-used-names/B.scala
@@ -1,0 +1,3 @@
+object B {
+//   def x = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/same-file-used-names/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/same-file-used-names/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/same-file-used-names/changes/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/same-file-used-names/changes/B.scala
@@ -1,0 +1,3 @@
+object B {
+  def x = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/same-file-used-names/test
+++ b/sbt/src/sbt-test/source-dependencies/same-file-used-names/test
@@ -1,0 +1,7 @@
+> compile
+
+# uncomment definition of `x` that leads to ambiguity error in A
+$ copy-file changes/B.scala B.scala
+
+# Both A.scala and B.scala should be recompiled, producing a compile error
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/A.scala
@@ -1,0 +1,3 @@
+object A {
+	def x: Int = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/B.scala
@@ -1,0 +1,4 @@
+object B {
+	def onX(m: { def x: Int } ) =
+		m.x
+}

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/C.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/C.scala
@@ -1,0 +1,4 @@
+object C {
+	def main(args: Array[String]) =
+		println(B.onX(A))
+}

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/build.sbt
@@ -1,0 +1,1 @@
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+	def x: Byte = 3
+}

--- a/sbt/src/sbt-test/source-dependencies/struct-name-hashing/pending
+++ b/sbt/src/sbt-test/source-dependencies/struct-name-hashing/pending
@@ -1,0 +1,6 @@
+> compile
+
+# modify A.scala so that it does not conform to the structural type in B.scala
+$ copy-file changes/A.scala A.scala
+
+-> compile

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/build.sbt
@@ -1,0 +1,36 @@
+logLevel := Level.Debug
+
+// disable sbt's heauristic which recompiles everything in case
+// some fraction (e.g. 50%) of files is scheduled to be recompiled
+// in this test we want precise information about recompiled files
+// which that heuristic would distort
+incOptions := incOptions.value.copy(recompileAllFraction = 1.0)
+
+/* Performs checks related to compilations:
+ *  a) checks in which compilation given set of files was recompiled
+ *  b) checks overall number of compilations performed
+ */
+TaskKey[Unit]("check-compilations") <<= (compile in Compile, scalaSource in Compile) map { (a: sbt.inc.Analysis, src: java.io.File) =>
+  def relative(f: java.io.File): java.io.File =  f.relativeTo(src) getOrElse f
+  val allCompilations = a.compilations.allCompilations
+  val recompiledFiles: Seq[Set[java.io.File]] = allCompilations map { c =>
+    val recompiledFiles = a.apis.internal.collect {
+      case (file, api) if api.compilation.startTime == c.startTime => relative(file)
+    }
+    recompiledFiles.toSet
+  }
+  def recompiledFilesInIteration(iteration: Int, fileNames: Set[String]) = {
+    val files = fileNames.map(new java.io.File(_))
+    assert(recompiledFiles(iteration) == files, "%s != %s".format(recompiledFiles(iteration), files))
+  }
+  // Y.scala is compiled only at the beginning as changes to A.scala do not affect it
+  recompiledFilesInIteration(0, Set("Y.scala"))
+  // A.scala is changed and recompiled
+  recompiledFilesInIteration(1, Set("A.scala"))
+  // change in A.scala causes recompilation of B.scala, C.scala, D.scala which depend on transtiviely
+  // and by inheritance on A.scala
+  // X.scala is also recompiled because it depends by member reference on B.scala
+  // Note that Y.scala is not recompiled because it depends just on X through member reference dependency
+  recompiledFilesInIteration(2, Set("B.scala", "C.scala", "D.scala", "X.scala"))
+  assert(allCompilations.size == 3)
+}

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/build.sbt
@@ -1,5 +1,7 @@
 logLevel := Level.Debug
 
+incOptions := incOptions.value.withNameHashing(true)
+
 // disable sbt's heauristic which recompiles everything in case
 // some fraction (e.g. 50%) of files is scheduled to be recompiled
 // in this test we want precise information about recompiled files
@@ -24,13 +26,13 @@ TaskKey[Unit]("check-compilations") <<= (compile in Compile, scalaSource in Comp
     assert(recompiledFiles(iteration) == files, "%s != %s".format(recompiledFiles(iteration), files))
   }
   // Y.scala is compiled only at the beginning as changes to A.scala do not affect it
-  recompiledFilesInIteration(0, Set("Y.scala"))
+  recompiledFilesInIteration(0, Set("X.scala", "Y.scala"))
   // A.scala is changed and recompiled
   recompiledFilesInIteration(1, Set("A.scala"))
   // change in A.scala causes recompilation of B.scala, C.scala, D.scala which depend on transtiviely
   // and by inheritance on A.scala
   // X.scala is also recompiled because it depends by member reference on B.scala
   // Note that Y.scala is not recompiled because it depends just on X through member reference dependency
-  recompiledFilesInIteration(2, Set("B.scala", "C.scala", "D.scala", "X.scala"))
+  recompiledFilesInIteration(2, Set("B.scala", "C.scala", "D.scala"))
   assert(allCompilations.size == 3)
 }

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/changes/A1.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/changes/A1.scala
@@ -1,0 +1,5 @@
+package test
+
+class A {
+	def foo: Int = 23
+}

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/A.scala
@@ -1,0 +1,3 @@
+package test
+
+class A

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/B.scala
@@ -1,0 +1,3 @@
+package test
+
+class B extends A

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/C.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/C.scala
@@ -1,0 +1,3 @@
+package test
+
+class C extends B

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/D.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/D.scala
@@ -1,0 +1,3 @@
+package test
+
+class D extends C

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/X.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/X.scala
@@ -1,0 +1,5 @@
+package test
+
+class X {
+	def bar(b: B) = b
+}

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/Y.scala
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/src/main/scala/Y.scala
@@ -1,0 +1,5 @@
+package test
+
+class Y {
+	def baz(x: X) = x
+}

--- a/sbt/src/sbt-test/source-dependencies/transitive-memberRef/test
+++ b/sbt/src/sbt-test/source-dependencies/transitive-memberRef/test
@@ -1,0 +1,11 @@
+# introduces first compile iteration
+> compile
+# adds a new method to A which will cause transitive invalidation
+# of all source files that inherit from it
+# also, all direct dependencies of files that inherit from A will
+# be invalidated (in our case that's X.scala)
+$ copy-file changes/A1.scala src/main/scala/A.scala
+# second iteration
+> compile
+# check in which compile iteration given source file got recompiled
+> check-compilations

--- a/sbt/src/sbt-test/source-dependencies/type-alias/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/type-alias/A.scala
@@ -1,0 +1,4 @@
+object A {
+  type X = Option[Int]
+}
+

--- a/sbt/src/sbt-test/source-dependencies/type-alias/B.scala
+++ b/sbt/src/sbt-test/source-dependencies/type-alias/B.scala
@@ -1,0 +1,3 @@
+object B {
+	def y: A.X = Option(3)
+}

--- a/sbt/src/sbt-test/source-dependencies/type-alias/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/type-alias/build.sbt
@@ -1,0 +1,3 @@
+logLevel in compile := Level.Debug
+
+incOptions := incOptions.value.withNameHashing(true)

--- a/sbt/src/sbt-test/source-dependencies/type-alias/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/type-alias/changes/A.scala
@@ -1,0 +1,3 @@
+object A {
+  type X = Int
+}

--- a/sbt/src/sbt-test/source-dependencies/type-alias/test
+++ b/sbt/src/sbt-test/source-dependencies/type-alias/test
@@ -1,0 +1,7 @@
+> compile
+
+# change type alias
+$ copy-file changes/A.scala A.scala
+
+# Both A.scala and B.scala should be recompiled, producing a compile error
+-> compile


### PR DESCRIPTION
This PR implements the name hashing algorithm.

It starts with number of commits that are refactorings of existing functionality. Those changes structure the core of incremental compiler in a way that is makes it easier to plug an alternative (name hashing) implementation of the invalidation logic. Then we have the main commit 729cc41 which provides the implementation (see the description below). Finally, we have two commits that show what's the difference in behavior between the new and old algorithm when it comes to existing test suite. Here comes description of the main commit:

---

Provide implementation of invalidation logic that takes computed name hashes into account. The implementation is spread amongst two classes:
1. `IncrementalNameHashing` which implements a variant of incremental compilation algorithm that computes modified
    names and delegates to `MemberReferenceInvalidationStrategy` when invalidating member reference dependencies
2. `MemberReferenceInvalidationStrategy` which implements the core logic of dealing with dependencies introduced by member reference. See documentation of that class for details.

The name hashing optimization is applied when invalidating source files having both internal and external dependencies (in initial iteration), check `invalidateByExternal` and `invalidateSource` methods for details.

As seen in implementation of `MemberReferenceInvalidationStrategy` the name hashing optimization is not applied when implicit members change.

NOTE: All functionality introduced in this commit is enabled only when `IncOptions.nameHashing` flag is set to true.

The `source-dependencies/transitive-memberRef` test has been changed to test name hashing variant of incremental compilation. The change to invalidated files reflects the difference between the old and the new algorithm.

Also, there a few new tests added that cover issues previously found while testing name hashing algorithm and are fixed in this commit. Each paragraph describes a single test.

Add a test case which shows that detect properly changes to type aliases in the name hashing algorithm. See gkossakowski/sbt#6 for details.

Add test covering bug with use of symbolic names (issue gkossakowski/sbt#5).

Add a test which covers the case where we refer to a name that is declared in the same file. See issue gkossakowski/sbt#3 for details.
