### PR TITLE
Fix saving session settings

### DIFF
--- a/main/src/main/scala/sbt/SessionSettings.scala
+++ b/main/src/main/scala/sbt/SessionSettings.scala
@@ -128,7 +128,7 @@ object SessionSettings
 		}
 		val exist = tmpLines.reverse
 		val adjusted = if(!newSettings.isEmpty && needsTrailingBlank(exist)) exist :+ "" else exist
-		val lines = adjusted ++ newSettings.map(_._2).flatten.flatMap(_ :: "" :: Nil)
+		val lines = adjusted ++ newSettings.flatMap(_._2 ::: "" :: Nil)
 		IO.writeLines(writeTo, lines)
 		val (newWithPos, _) = ((List[SessionSetting](), adjusted.size + 1) /: newSettings) {
 			case ((acc, line), (s, newLines)) => 


### PR DESCRIPTION
As it stands, writing back _new_ session settings that span more than 1 line will "double-space" each line inside the setting, not just between settings.
So something like 

``` scala
val s: Setting[_]
val ss: SessionSettings.SessionSetting = (s, List(
  "libraryDependencies ++= Seq(",
  "  something,",
  "  something else",
  ")"
))
```

will end up written as

``` scala
 libraryDependencies ++= Seq(

  something,

  something else

)
```

This fixes it to only add double-space _between_ individual `SessionSetting`s.
