### PR TITLE
Fixes to the internal API hooks for the sbt server.

### DIFF
--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -58,16 +58,21 @@ object Compiler
 		val provider = ComponentCompiler.interfaceProvider(componentManager)
 		new AnalyzingCompiler(instance, provider, cpOptions, log)
 	}
-
-	def apply(in: Inputs, log: Logger): Analysis =
+	def apply(in: Inputs, log: Logger): Analysis = 
 	{
-			import in.compilers._
-			import in.config._
-			import in.incSetup._
-
+		import in.compilers._
+		import in.config._
+		import in.incSetup._
+		apply(in, log, new LoggerReporter(maxErrors, log, sourcePositionMapper))
+	}
+	def apply(in: Inputs, log: Logger, reporter: xsbti.Reporter): Analysis =
+	{
+		import in.compilers._
+		import in.config._
+		import in.incSetup._
 		val agg = new AggressiveCompile(cacheFile)
 		agg(scalac, javac, sources, classpath, CompileOutput(classesDirectory), cache, None, options, javacOptions,
-		    analysisMap, definesClass, new LoggerReporter(maxErrors, log, sourcePositionMapper), order, skip, incOptions)(log)
+		    analysisMap, definesClass, reporter, order, skip, incOptions)(log)
 	}
 
 	private[sbt] def foldMappers[A](mappers: Seq[A => Option[A]]) =

--- a/main/src/main/scala/sbt/Aggregation.scala
+++ b/main/src/main/scala/sbt/Aggregation.scala
@@ -59,7 +59,7 @@ final object Aggregation
 		import extracted.structure
 		val toRun = ts map { case KeyValue(k,t) => t.map(v => KeyValue(k,v)) } join;
 		val roots = ts map { case KeyValue(k,_) => k }
-		val config = extractedConfig(extracted, structure)
+		val config = extractedConfig(extracted, structure, s)
 
 		val start = System.currentTimeMillis
 		val (newS, result) = withStreams(structure, s){ str =>

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -344,8 +344,11 @@ object Keys
 
 	// wrapper to work around SI-2915
 	private[sbt] final class TaskProgress(val progress: ExecuteProgress[Task])
-	private[sbt] val executeProgress = SettingKey[TaskProgress]("executeProgress", "Experimental task execution listener.", DTask)
+	private[sbt] val executeProgress = SettingKey[State => TaskProgress]("executeProgress", "Experimental task execution listener.", DTask)
 
+	// Experimental in sbt 0.13.2 to enable grabing semantic compile failures.
+	private[sbt] val compilerReporter = TaskKey[Option[xsbti.Reporter]]("compilerReporter", "Experimental hook to listen (or send) compilation failure messages.", DTask)
+	
 	val triggeredBy = Def.triggeredBy
 	val runBefore = Def.runBefore
 


### PR DESCRIPTION
- Alter the TaskProgress listener key to be `State => TaskProgress` so it
  can be instantiated from the current server/sbt state.
- Expose the xsbti.Reporter interface for compilation through to sbt builds.
