### PR TITLE
Add link to sbt-sonatype plugin

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -158,6 +158,8 @@ Release plugins
    https://github.com/sbt/sbt-start-script
 -  sbt-native-packager:
    https://github.com/sbt/sbt-native-packager
+-  sbt-sonatype-plugin (releases to Sonatype Nexus repository)
+   https://github.com/xerial/sbt-sonatype
 
 System plugins
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
I created sbt-sonatype plugin https://github.com/xerial/sbt-sonatype that simplifies release processes at Sonatype Nexus repository. Please add a link to this plugin.

Thanks in advance.
