### PR TITLE
Fixed SessionSettings replacing existing setting

### DIFF
--- a/main/src/main/scala/sbt/SessionSettings.scala
+++ b/main/src/main/scala/sbt/SessionSettings.scala
@@ -110,7 +110,7 @@ object SessionSettings
 				val RangePosition(_, r@LineRange(start, end)) = s.pos
 				settings find (_._1.key == s.key) match {
 					case Some(ss@(ns, newLines)) if !ns.init.dependencies.contains(ns.key) =>
-						val shifted = ns withPos RangePosition(path, LineRange(start - offs, start - offs + 1))
+						val shifted = ns withPos RangePosition(path, LineRange(start - offs, start - offs + newLines.size))
 						(offs + end - start - newLines.size, shifted::olds, ss::repl, lineMap + (start -> (end, newLines)))
 					case _ =>
 						val shifted = s withPos RangePosition(path, r shift -offs)

--- a/sbt/src/sbt-test/project/session-update-from-cmd/build.check.1
+++ b/sbt/src/sbt-test/project/session-update-from-cmd/build.check.1
@@ -1,0 +1,10 @@
+name := "projectName"
+
+k1 := {
+//
+//
+}
+
+k2 := {
+  println("This is k2")
+}

--- a/sbt/src/sbt-test/project/session-update-from-cmd/build.sbt
+++ b/sbt/src/sbt-test/project/session-update-from-cmd/build.sbt
@@ -1,0 +1,7 @@
+name := "projectName"
+
+k1 := {}
+
+k2 := {
+  println("This is k2")
+}

--- a/sbt/src/sbt-test/project/session-update-from-cmd/project/build.scala
+++ b/sbt/src/sbt-test/project/session-update-from-cmd/project/build.scala
@@ -1,0 +1,25 @@
+import sbt._
+import Keys._
+
+object build extends Build {
+  lazy val k1 = taskKey[Unit]("")
+  lazy val k2 = taskKey[Unit]("")
+
+  val UpdateK1 = Command.command("UpdateK1") { st: State =>
+    val ex = Project extract st
+    import ex._
+    val session2 = BuiltinCommands.setThis(st, ex, Seq(k1 := {}), """k1 := {
+    |//
+    |//
+    |}""".stripMargin).session
+    val st1 = BuiltinCommands.reapply(session2, structure, st)
+    // SessionSettings.writeSettings(ex.currentRef, session2, ex.session.original, ex.structure)
+    SessionSettings.saveAllSettings(st1)
+  }
+
+	lazy val root = Project("root", file(".")) settings(
+    commands += UpdateK1
+  )
+}
+
+// vim: set ts=4 sw=4 et:

--- a/sbt/src/sbt-test/project/session-update-from-cmd/test
+++ b/sbt/src/sbt-test/project/session-update-from-cmd/test
@@ -1,0 +1,4 @@
+> UpdateK1
+$ must-mirror build.sbt build.check.1
+> UpdateK1
+$ must-mirror build.sbt build.check.1


### PR DESCRIPTION
Another bug in session settings: replacing an existing setting incorrectly sets its new range to end after 1 line, whereas it should set it to end after the number of `newLines` that the replacing setting has.
Currently, this messes up the state of that `Def.Setting` and will corrupt the file if you choose to write the same setting again without first `reload`ing.
