### PR TITLE
Improve error handling in incremental compiler

### DIFF
--- a/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/IncrementalCompiler.scala
@@ -46,5 +46,12 @@ object IC extends IncrementalCompiler[Analysis, AnalyzingCompiler]
 		}
 
 	def readCacheUncaught(file: File): (Analysis, CompileSetup) =
-    Using.fileReader(IO.utf8)(file) { reader => TextAnalysisFormat.read(reader) }
+		Using.fileReader(IO.utf8)(file) { reader =>
+			try {
+				TextAnalysisFormat.read(reader)
+			} catch {
+				case ex: sbt.inc.ReadException =>
+					throw new java.io.IOException(s"Error while reading $file", ex)
+			}
+		}
 }

--- a/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
+++ b/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
@@ -225,8 +225,8 @@ object TextAnalysisFormat {
 			if (nameHashing)
 				Relations.make(srcProd, binaryDep, memberRefSrcDeps, inheritanceSrcDeps, classes, names)
 			else {
-				assert(names.all.isEmpty, s"When `nameHashing` is disabled `names` relation " +
-					"should be empty: $names")
+				assert(names.all.isEmpty, "When `nameHashing` is disabled `names` relation " +
+					s"should be empty: $names")
 				Relations.make(srcProd, binaryDep, directSrcDeps, publicInheritedSrcDeps, classes)
 			}
 		}


### PR DESCRIPTION
Record more information in case we fail to parse analysis file.

Motivated by: https://groups.google.com/d/msg/sbt-dev/KmGEhFTMve0/1MwyZsjWQDQJ
