### PR TITLE
Fix formatting of inline code samples which are pluralized

### DIFF
--- a/src/sphinx/Getting-Started/Basic-Def.rst
+++ b/src/sphinx/Getting-Started/Basic-Def.rst
@@ -48,7 +48,7 @@ becomes sbt's new map.
 To create the map, sbt first sorts the list of settings so that all
 changes to the same key are made together, and values that depend on
 other keys are processed after the keys they depend on. Then sbt walks
-over the sorted list of `Setting`s and applies each one to the map in
+over the sorted list of `Setting`\ s and applies each one to the map in
 turn.
 
 Summary: A build definition defines a list of `Setting[T]`, where a
@@ -77,8 +77,8 @@ Here's an example:
 Each `Setting` is defined with a Scala expression.
 The expressions in `build.sbt` are independent of one another, and
 they are expressions, rather than complete Scala statements.  These
-expressions may be interspersed with `val`s, `lazy val`s, and `def`s.
-Top-level `object`s and `class`es are not allowed in `build.sbt`.
+expressions may be interspersed with `val`\ s, `lazy val`\ s, and `def`\ s.
+Top-level `object`\ s and `class`\ es are not allowed in `build.sbt`.
 Those should go in the `project/` directory as full Scala source files.
 
 On the left, :key:`name`, :key:`version`, and :key:`scalaVersion` are *keys*. A

--- a/src/sphinx/Howto/runningcommands.rst
+++ b/src/sphinx/Howto/runningcommands.rst
@@ -84,5 +84,5 @@ For example,
     > eval 2+2
     4: Int
 
-Variables defined by an `eval` are not visible to subsequent `eval`s, although changes to system properties persist and affect the JVM that is running sbt.
+Variables defined by an `eval` are not visible to subsequent `eval`\ s, although changes to system properties persist and affect the JVM that is running sbt.
 Use the Scala REPL (:key:`console` and related commands) for full support for evaluating Scala code interactively.


### PR DESCRIPTION
The docs contain some inline code samples whose formatting is broken, for example on the [Build Definition page](http://www.scala-sbt.org/release/docs/Getting-Started/Basic-Def.html):

![screen shot 2014-02-06 at 01 11 25](https://f.cloud.github.com/assets/754712/2094402/b3658f86-8ecb-11e3-9417-99ea8bc43c0d.png)

I'm pretty sure this is because [Sphinx requires inline markup to be surrounded by spaces](http://sphinx-doc.org/rest.html?highlight=backquote#inline-markup), which can be worked around by adding an escaped space. In the example above, the plural terms like "`class`es" don't have this escaped space.

I used `\ `[^`]+`[A-Za-z]` to find any other occurrences and fixed those as well.
