### PR TITLE
Launcher to retrieve dynamic app versions correctly

### DIFF
--- a/launch/src/main/scala/xsbt/boot/ModuleDefinition.scala
+++ b/launch/src/main/scala/xsbt/boot/ModuleDefinition.scala
@@ -13,8 +13,12 @@ final class ModuleDefinition(val configuration: UpdateConfiguration, val extraCl
 	private def versionString: String = target match { case _: UpdateScala => configuration.getScalaVersion; case a: UpdateApp => Value.get(a.id.version) }
 }
 
-final class RetrievedModule(val fresh: Boolean, val definition: ModuleDefinition, val detectedScalaVersion: Option[String], val baseDirectories: List[File])
+final class RetrievedModule(val fresh: Boolean, val definition: ModuleDefinition, val detectedScalaVersion: Option[String], val resolvedAppVersion: Option[String], val baseDirectories: List[File])
 {
+	/** Use this constructor only when the module exists already, or when its version is not dynamic (so its resolved version would be the same) */
+	def this(fresh: Boolean, definition: ModuleDefinition, detectedScalaVersion: Option[String], baseDirectories: List[File]) =
+		this(fresh, definition, detectedScalaVersion, None, baseDirectories)
+
 	lazy val classpath: Array[File] = getJars(baseDirectories)
 	lazy val fullClasspath: Array[File] = concat(classpath, definition.extraClasspath)
 


### PR DESCRIPTION
Currently, if in a launcher specification you use a dynamic ivy revision for the version, Ivy will comply, but that exact same text propagates into the `AppProvider` that the app sees, hence the app won't know what version of itself was actually retrieved.
In sbt, for a version such as `0.13.+`, this leads to sbtBinaryVersion becoming `0.13.+` (taken directly from `AppProvider.id()`), as well as the artifacts being retrieved to an incorrect boot directory: `~/.sbt/boot/scala-2.10.3/org.scala-sbt/sbt/0.13.+`. 

This pull request fixes that by looking at Ivy's ResolveReport upon resolving the app, figuring out the resolved version, and using that for:
- the destination artifact pattern (download location) for when `Update.retrieve` downloads the artifacts
- the `ApplicationID` referenced in the `AppProvider`, which will mention the resolved version

This way, sbt and (I believe) other apps too will be able to have dynamic versions specified in their launcher config, and still be presented with correct information upon launch.
