### PR TITLE
Remove work-arounds for Scala 2.11 problematic dependencies

### DIFF
--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -276,7 +276,7 @@ object Sbt extends Build
 		artifact in (Compile, packageSrc) := Artifact(srcID).copy(configurations = Compile :: Nil).extra("e:component" -> srcID)
 	)
 	def compilerSettings = Seq(
-		libraryDependencies <+= scalaVersion( "org.scala-lang" % "scala-compiler" % _ % "test" excludeAll(ExclusionRule(organization = "org.scala-lang.modules"))),
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test"),
 		unmanagedJars in Test <<= (packageSrc in compileInterfaceSub in Compile).map(x => Seq(x).classpath)
 	)
 	def precompiled(scalav: String): Project = baseProject(compilePath / "interface", "Precompiled " + scalav.replace('.', '_')) dependsOn(interfaceSub) settings(precompiledSettings : _*) settings(
@@ -290,6 +290,6 @@ object Sbt extends Build
 		sources in Test := Nil
 	)
 	def ioSettings: Seq[Setting[_]] = Seq(
-		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test" excludeAll(ExclusionRule(organization = "org.scala-lang.modules")))
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _ % "test")
 	)
 }

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -172,8 +172,7 @@ object Common
 	lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
 	lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive() )
 	lazy val sbinary = libraryDependencies <+= Util.nightly211(n => "org.scala-tools.sbinary" % "sbinary" % "0.4.2" cross(if(n) CrossVersion.full else CrossVersion.binary))
-	lazy val scalaCompiler = libraryDependencies <+= scalaVersion(
-		sv => "org.scala-lang" % "scala-compiler" % sv excludeAll(ExclusionRule(organization = "org.scala-lang.modules")))
+	lazy val scalaCompiler = libraryDependencies <+= scalaVersion(sv => "org.scala-lang" % "scala-compiler" % sv)
 	lazy val testInterface = lib("org.scala-sbt" % "test-interface" % "1.0")
 	private def scala211Module(name: String, moduleVersion: String) =
 		libraryDependencies <++= (scalaVersion)( scalaVersion =>


### PR DESCRIPTION
The ff0fd6eec658502f276f89c46f4aba0e0e268ddc introduced some exclusions
that were necessary for getting sbt to resolve dependencies properly
against Scala 2.11.0-M7.

Scala 2.11.0-M8 fixed its dependency structure so we can get rid of those
exclusions now.
