### PR TITLE
migrates to 2.11.0-RC1

### DIFF
--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -67,6 +67,7 @@ object InputWrapper
 	def wrapImpl[T: c.WeakTypeTag, S <: AnyRef with Singleton](c: Context, s: S, wrapName: String)(ts: c.Expr[Any], pos: c.Position)(implicit it: c.TypeTag[s.type]): c.Expr[T] =
 	{
 			import c.universe.{Apply=>ApplyTree,_}
+			import compat._
 		val util = new ContextUtil[c.type](c)
 		val iw = util.singleton(s)
 		val tpe = c.weakTypeOf[T]

--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -67,7 +67,8 @@ object InputWrapper
 	def wrapImpl[T: c.WeakTypeTag, S <: AnyRef with Singleton](c: Context, s: S, wrapName: String)(ts: c.Expr[Any], pos: c.Position)(implicit it: c.TypeTag[s.type]): c.Expr[T] =
 	{
 			import c.universe.{Apply=>ApplyTree,_}
-			import compat._
+			import internal._
+			import decorators._
 		val util = new ContextUtil[c.type](c)
 		val iw = util.singleton(s)
 		val tpe = c.weakTypeOf[T]

--- a/main/settings/src/main/scala/sbt/std/KeyMacro.scala
+++ b/main/settings/src/main/scala/sbt/std/KeyMacro.scala
@@ -31,22 +31,10 @@ private[sbt] object KeyMacro
 	def definingValName(c: Context, invalidEnclosingTree: String => String): String =
 	{
 		import c.universe.{Apply=>ApplyTree,_}
-		val methodName = c.macroApplication.symbol.name
-		def processName(n: Name): String = n.decoded.trim // trim is not strictly correct, but macros don't expose the API necessary
-		def enclosingVal(trees: List[c.Tree]): String =
-		{
-			trees match {
-				case vd @ ValDef(_, name, _, _) :: ts => processName(name)
-				case (_: ApplyTree | _: Select | _: TypeApply) :: xs => enclosingVal(xs)
-					// lazy val x: X = <methodName> has this form for some reason (only when the explicit type is present, though)
-				case Block(_, _) :: DefDef(mods, name, _, _, _, _) :: xs if mods.hasFlag(Flag.LAZY) => processName(name)
-				case _ =>
-					c.error(c.enclosingPosition, invalidEnclosingTree(methodName.decoded))
-					"<error>"
-			}
-		}
-		enclosingVal(enclosingTrees(c).toList)
+		import c.internal.enclosingOwner
+		def processName(n: Name): String = n.decodedName.toString.stripSuffix(termNames.LOCAL_SUFFIX_STRING)
+		def fail() = { c.error(c.enclosingPosition, invalidEnclosingTree(c.macroApplication.symbol.name.decodedName.toString)); "<error>" }
+		if (!enclosingOwner.isTerm || enclosingOwner.name.toString.startsWith("<local ")) fail()
+		else processName(enclosingOwner.name)
 	}
-	def enclosingTrees(c: Context): Seq[c.Tree] =
-		c.asInstanceOf[reflect.macros.runtime.Context].callsiteTyper.context.enclosingContextChain.map(_.tree.asInstanceOf[c.Tree])
 }

--- a/main/settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main/settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -284,7 +284,8 @@ object TaskMacro
 	private[this] def inputTaskDynMacro0[T: c.WeakTypeTag](c: Context)(t: c.Expr[Initialize[Task[T]]]): c.Expr[Initialize[InputTask[T]]] =
 	{
 			import c.universe.{Apply=>ApplyTree,_}
-			import compat._
+			import internal._
+			import decorators._
 
 		val tag = implicitly[c.WeakTypeTag[T]]
 		val util = ContextUtil[c.type](c)

--- a/main/settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main/settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -284,6 +284,7 @@ object TaskMacro
 	private[this] def inputTaskDynMacro0[T: c.WeakTypeTag](c: Context)(t: c.Expr[Initialize[Task[T]]]): c.Expr[Initialize[InputTask[T]]] =
 	{
 			import c.universe.{Apply=>ApplyTree,_}
+			import compat._
 
 		val tag = implicitly[c.WeakTypeTag[T]]
 		val util = ContextUtil[c.type](c)

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -38,13 +38,12 @@ object ContextUtil {
 final class ContextUtil[C <: Context](val ctx: C)
 {
 		import ctx.universe.{Apply=>ApplyTree,_}
-		import internal._
+		import ctx.internal._
 		import decorators._
 
 	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
 	val global: powerContext.universe.type = powerContext.universe
 	def callsiteTyper: global.analyzer.Typer = powerContext.callsiteTyper
-	val initialOwner: Symbol = callsiteTyper.context.owner.asInstanceOf[ctx.universe.Symbol]
 
 	lazy val alistType = ctx.typeOf[AList[KList]]
 	lazy val alist: Symbol = alistType.typeSymbol.companionSymbol
@@ -163,8 +162,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 	/** Creates a Function tree using `functionSym` as the Symbol and changing `initialOwner` to `functionSym` in `body`.*/
 	def createFunction(params: List[ValDef], body: Tree, functionSym: Symbol): Tree =
 	{
-		import internal.decorators._
-		body.changeOwner(initialOwner, functionSym)
+		body.changeOwner(enclosingOwner, functionSym)
 		val f = Function(params, body)
 		setSymbol(f, functionSym)
 		f

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -117,11 +117,6 @@ final class ContextUtil[C <: Context](val ctx: C)
 	def mkTuple(args: List[Tree]): Tree =
 		global.gen.mkTuple(args.asInstanceOf[List[global.Tree]]).asInstanceOf[ctx.universe.Tree]
 
-	def setSymbol[Tree](t: Tree, sym: Symbol): Unit =
-		t.asInstanceOf[global.Tree].setSymbol(sym.asInstanceOf[global.Symbol])
-	def setInfo[Tree](sym: Symbol, tpe: Type): Unit =
-		sym.asInstanceOf[global.Symbol].setInfo(tpe.asInstanceOf[global.Type])
-
 	/** Creates a new, synthetic type variable with the specified `owner`. */
 	def newTypeVariable(owner: Symbol, prefix: String = "T0"): TypeSymbol =
 		owner.asInstanceOf[global.Symbol].newSyntheticTypeParam(prefix, 0L).asInstanceOf[ctx.universe.TypeSymbol]

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -142,7 +142,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 
 	/** Creates a new anonymous function symbol with Position `pos`. */
 	def functionSymbol(pos: Position): Symbol =
-		enclosingOwner.asInstanceOf[global.Symbol].newAnonymousFunctionValue(pos.asInstanceOf[global.Position]).asInstanceOf[ctx.universe.Symbol]
+		enclosingOwner.newTermSymbol(TermName("$anonfun"), pos, SYNTHETIC) setInfo NoType
 
 	def functionType(args: List[Type], result: Type): Type =
 		appliedType(definitions.FunctionClass(args.length), args :+ result)

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -162,25 +162,11 @@ final class ContextUtil[C <: Context](val ctx: C)
 	/** Creates a Function tree using `functionSym` as the Symbol and changing `initialOwner` to `functionSym` in `body`.*/
 	def createFunction(params: List[ValDef], body: Tree, functionSym: Symbol): Tree =
 	{
-		changeOwner(body, initialOwner, functionSym)
+		import internal.decorators._
+		body.changeOwner(initialOwner, functionSym)
 		val f = Function(params, body)
 		setSymbol(f, functionSym)
 		f
-	}
-
-	def changeOwner(tree: Tree, prev: Symbol, next: Symbol): Unit =
-		new ChangeOwnerAndModuleClassTraverser(prev.asInstanceOf[global.Symbol], next.asInstanceOf[global.Symbol]).traverse(tree.asInstanceOf[global.Tree])
-
-	// Workaround copied from scala/async:can be removed once https://github.com/scala/scala/pull/3179 is merged.
-	private[this] class ChangeOwnerAndModuleClassTraverser(oldowner: global.Symbol, newowner: global.Symbol) extends global.ChangeOwnerTraverser(oldowner, newowner)
-	{
-		override def traverse(tree: global.Tree) {
-			tree match {
-				case _: global.DefTree => change(tree.symbol.moduleClass)
-				case _ =>
-			}
-			super.traverse(tree)
-		}
 	}
 
 	/** Returns the Symbol that references the statically accessible singleton `i`. */

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -150,10 +150,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 		callsiteTyper.context.owner.newAnonymousFunctionValue(pos.asInstanceOf[global.Position]).asInstanceOf[ctx.universe.Symbol]
 
 	def functionType(args: List[Type], result: Type): Type =
-	{
-		val tpe = global.definitions.functionType(args.asInstanceOf[List[global.Type]], result.asInstanceOf[global.Type])
-		tpe.asInstanceOf[Type]
-	}
+		appliedType(definitions.FunctionClass(args.length), args :+ result)
 
 	/** Create a Tree that references the `val` represented by `vd`, copying attributes from `replaced`. */
 	def refVal(replaced: Tree, vd: ValDef): Tree =

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -115,7 +115,8 @@ final class ContextUtil[C <: Context](val ctx: C)
 
 	/** Constructs a tuple value of the right TupleN type from the provided inputs.*/
 	def mkTuple(args: List[Tree]): Tree =
-		global.gen.mkTuple(args.asInstanceOf[List[global.Tree]]).asInstanceOf[ctx.universe.Tree]
+		if (args.length == 1) args.head
+		else q"(..$args)"
 
 	/** Creates a new, synthetic type variable with the specified `owner`. */
 	def newTypeVariable(owner: Symbol, prefix: String = "T0"): TypeSymbol =

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -40,6 +40,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 		import ctx.universe.{Apply=>ApplyTree,_}
 		import ctx.internal._
 		import decorators._
+		import Flag._
 
 	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
 	val global: powerContext.universe.type = powerContext.universe
@@ -119,7 +120,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 
 	/** Creates a new, synthetic type variable with the specified `owner`. */
 	def newTypeVariable(owner: Symbol, prefix: String = "T0"): TypeSymbol =
-		owner.asInstanceOf[global.Symbol].newSyntheticTypeParam(prefix, 0L).asInstanceOf[ctx.universe.TypeSymbol]
+		owner.newTypeSymbol(newTypeName(prefix), NoPosition, PARAM | DEFERRED).setInfo(emptyTypeBounds)
 
 	/** The type representing the type constructor `[X] X` */
 	lazy val idTC: Type =

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -38,6 +38,7 @@ object ContextUtil {
 final class ContextUtil[C <: Context](val ctx: C)
 {
 		import ctx.universe.{Apply=>ApplyTree,_}
+		import compat._
 
 	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
 	val global: powerContext.universe.type = powerContext.universe

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -3,7 +3,6 @@ package appmacro
 
 	import scala.reflect._
 	import macros._
-	import scala.tools.nsc.Global
 	import ContextUtil.{DynamicDependencyError, DynamicReferenceError}
 
 object ContextUtil {
@@ -32,7 +31,7 @@ object ContextUtil {
 	def unexpectedTree[C <: Context](tree: C#Tree): Nothing = sys.error("Unexpected macro application tree (" + tree.getClass + "): " + tree)
 }
 
-/** Utility methods for macros.  Several methods assume that the context's universe is a full compiler (`scala.tools.nsc.Global`).
+/** Utility methods for macros.
 * This is not thread safe due to the underlying Context and related data structures not being thread safe.
 * Use `ContextUtil[c.type](c)` to construct. */
 final class ContextUtil[C <: Context](val ctx: C)
@@ -41,9 +40,6 @@ final class ContextUtil[C <: Context](val ctx: C)
 		import ctx.internal._
 		import decorators._
 		import Flag._
-
-	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
-	val global: powerContext.universe.type = powerContext.universe
 
 	lazy val alistType = ctx.typeOf[AList[KList]]
 	lazy val alist: Symbol = alistType.typeSymbol.companionSymbol

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -62,7 +62,6 @@ final class ContextUtil[C <: Context](val ctx: C)
 	* Position `pos`, an empty implementation (no rhs), and owned by `owner`. */
 	def freshValDef(tpe: Type, pos: Position, owner: Symbol): ValDef =
 	{
-		val SYNTHETIC = (1 << 21).toLong.asInstanceOf[FlagSet]
 		val sym = owner.newTermSymbol(freshTermName("q"), pos, SYNTHETIC)
 		sym.setInfo(tpe)
 		val vd = valDef(sym, EmptyTree)

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -38,7 +38,8 @@ object ContextUtil {
 final class ContextUtil[C <: Context](val ctx: C)
 {
 		import ctx.universe.{Apply=>ApplyTree,_}
-		import compat._
+		import internal._
+		import decorators._
 
 	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
 	val global: powerContext.universe.type = powerContext.universe
@@ -64,8 +65,8 @@ final class ContextUtil[C <: Context](val ctx: C)
 	{
 		val SYNTHETIC = (1 << 21).toLong.asInstanceOf[FlagSet]
 		val sym = owner.newTermSymbol(freshTermName("q"), pos, SYNTHETIC)
-		setInfo(sym, tpe)
-		val vd = ValDef(sym, EmptyTree)
+		sym.setInfo(tpe)
+		val vd = valDef(sym, EmptyTree)
 		vd.setPos(pos)
 		vd
 	}
@@ -139,11 +140,11 @@ final class ContextUtil[C <: Context](val ctx: C)
 	{
 		val tc = newTypeVariable(owner)
 		val arg = newTypeVariable(tc, "x")
-		tc.setTypeSignature(PolyType(arg :: Nil, emptyTypeBounds))
+		tc.setInfo(polyType(arg :: Nil, emptyTypeBounds))
 		tc
 	}
 	/** >: Nothing <: Any */
-	def emptyTypeBounds: TypeBounds = TypeBounds(definitions.NothingClass.toType, definitions.AnyClass.toType)
+	def emptyTypeBounds: TypeBounds = typeBounds(definitions.NothingClass.toType, definitions.AnyClass.toType)
 
 	/** Creates a new anonymous function symbol with Position `pos`. */
 	def functionSymbol(pos: Position): Symbol =

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -43,7 +43,6 @@ final class ContextUtil[C <: Context](val ctx: C)
 
 	val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
 	val global: powerContext.universe.type = powerContext.universe
-	def callsiteTyper: global.analyzer.Typer = powerContext.callsiteTyper
 
 	lazy val alistType = ctx.typeOf[AList[KList]]
 	lazy val alist: Symbol = alistType.typeSymbol.companionSymbol
@@ -143,7 +142,7 @@ final class ContextUtil[C <: Context](val ctx: C)
 
 	/** Creates a new anonymous function symbol with Position `pos`. */
 	def functionSymbol(pos: Position): Symbol =
-		callsiteTyper.context.owner.newAnonymousFunctionValue(pos.asInstanceOf[global.Position]).asInstanceOf[ctx.universe.Symbol]
+		enclosingOwner.asInstanceOf[global.Symbol].newAnonymousFunctionValue(pos.asInstanceOf[global.Position]).asInstanceOf[ctx.universe.Symbol]
 
 	def functionType(args: List[Type], result: Type): Type =
 		appliedType(definitions.FunctionClass(args.length), args :+ result)

--- a/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
@@ -14,6 +14,7 @@ object KListBuilder extends TupleBuilder
 		val ctx: c.type = c
 		val util = ContextUtil[c.type](c)
 			import c.universe.{Apply=>ApplyTree,_}
+			import compat._
 			import util._
 
 		val knilType = c.typeOf[KNil]

--- a/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
@@ -2,7 +2,6 @@ package sbt
 package appmacro
 
 	import Types.Id
-	import scala.tools.nsc.Global
 	import scala.reflect._
 	import macros._
 
@@ -11,34 +10,34 @@ object KListBuilder extends TupleBuilder
 {
 	def make(c: Context)(mt: c.Type, inputs: Inputs[c.universe.type]): BuilderResult[c.type] = new BuilderResult[c.type]
 	{
-		val ctx: c.type = c
+		import c.universe.{Apply=>ApplyTree,_}
+		import c.internal._
+		import decorators._
 		val util = ContextUtil[c.type](c)
-			import c.universe.{Apply=>ApplyTree,_}
-			import internal._
-			import util._
+		val ctx: c.type = c
 
 		val knilType = c.typeOf[KNil]
 		val knil = Ident(knilType.typeSymbol.companionSymbol)
 		val kconsTpe = c.typeOf[KCons[Int,KNil,List]]
 		val kcons = kconsTpe.typeSymbol.companionSymbol
-		val mTC: Type = mt.asInstanceOf[c.universe.Type]
+		val mTC: Type = mt
 		val kconsTC: Type = kconsTpe.typeConstructor
 
 		/** This is the L in the type function [L[x]] ...  */
-		val tcVariable: TypeSymbol = newTCVariable(util.initialOwner)
+		val tcVariable: TypeSymbol = util.newTCVariable(enclosingOwner)
 
 		/** Instantiates KCons[h, t <: KList[L], L], where L is the type constructor variable */
 		def kconsType(h: Type, t: Type): Type =
-			appliedType(kconsTC, h :: t :: refVar(tcVariable) :: Nil)
+			appliedType(kconsTC, h :: t :: util.refVar(tcVariable) :: Nil)
 
 		def bindKList(prev: ValDef, revBindings: List[ValDef], params: List[ValDef]): List[ValDef] =
 			params match
 			{
 				case (x @ ValDef(mods, name, tpt, _)) :: xs =>
-					val rhs = select(Ident(prev.name), "head")
+					val rhs = util.select(Ident(prev.name), "head")
 					val head = treeCopy.ValDef(x, mods, name, tpt, rhs)
-					util.setSymbol(head, x.symbol)
-					val tail = localValDef(TypeTree(), select(Ident(prev.name), "tail"))
+					head.setSymbol(x.symbol)
+					val tail = util.localValDef(TypeTree(), util.select(Ident(prev.name), "tail"))
 					val base = head :: revBindings
 					bindKList(tail, if(xs.isEmpty) base else tail :: base, xs)
 				case Nil => revBindings.reverse
@@ -61,9 +60,9 @@ object KListBuilder extends TupleBuilder
 		val klistType: Type = (inputs :\ knilType)( (in, klist) => kconsType(in.tpe, klist) )
 
 		val representationC = polyType(tcVariable :: Nil, klistType)
-		val resultType = appliedType(representationC, idTC :: Nil)
+		val resultType = appliedType(representationC, util.idTC :: Nil)
 		val input = klist
-		val alistInstance: ctx.universe.Tree = TypeApply(select(Ident(alist), "klist"), TypeTree(representationC) :: Nil)
+		val alistInstance: Tree = TypeApply(util.select(Ident(util.alist), "klist"), TypeTree(representationC) :: Nil)
 		def extract(param: ValDef) = bindKList(param, Nil, inputs.map(_.local))
 	}
 }

--- a/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/KListBuilder.scala
@@ -14,7 +14,7 @@ object KListBuilder extends TupleBuilder
 		val ctx: c.type = c
 		val util = ContextUtil[c.type](c)
 			import c.universe.{Apply=>ApplyTree,_}
-			import compat._
+			import internal._
 			import util._
 
 		val knilType = c.typeOf[KNil]
@@ -60,7 +60,7 @@ object KListBuilder extends TupleBuilder
 		* When applied to `M`, this type gives the type of the `input` KList. */
 		val klistType: Type = (inputs :\ knilType)( (in, klist) => kconsType(in.tpe, klist) )
 
-		val representationC = PolyType(tcVariable :: Nil, klistType)
+		val representationC = polyType(tcVariable :: Nil, klistType)
 		val resultType = appliedType(representationC, idTC :: Nil)
 		val input = klist
 		val alistInstance: ctx.universe.Tree = TypeApply(select(Ident(alist), "klist"), TypeTree(representationC) :: Nil)

--- a/util/appmacro/src/main/scala/sbt/appmacro/TupleBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/TupleBuilder.scala
@@ -2,11 +2,10 @@ package sbt
 package appmacro
 
 	import Types.Id
-	import scala.tools.nsc.Global
 	import scala.reflect._
 	import macros._
 
-/** 
+/**
 * A `TupleBuilder` abstracts the work of constructing a tuple data structure such as a `TupleN` or `KList`
 * and extracting values from it.  The `Instance` macro implementation will (roughly) traverse the tree of its argument
 * and ultimately obtain a list of expressions with type `M[T]` for different types `T`.

--- a/util/appmacro/src/main/scala/sbt/appmacro/TupleNBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/TupleNBuilder.scala
@@ -18,7 +18,7 @@ object TupleNBuilder extends TupleBuilder
 	{
 		val util = ContextUtil[c.type](c)
 			import c.universe.{Apply=>ApplyTree,_}
-			import compat._
+			import internal._
 			import util._
 
 		val global: Global = c.universe.asInstanceOf[Global]
@@ -29,7 +29,7 @@ object TupleNBuilder extends TupleBuilder
 			val tcVariable: Symbol = newTCVariable(util.initialOwner)
 			val tupleTypeArgs = inputs.map(in => typeRef(NoPrefix, tcVariable, in.tpe :: Nil).asInstanceOf[global.Type])
 			val tuple = global.definitions.tupleType(tupleTypeArgs)
-			PolyType(tcVariable :: Nil, tuple.asInstanceOf[Type] )
+			polyType(tcVariable :: Nil, tuple.asInstanceOf[Type] )
 		}
 		val resultType = appliedType(representationC, idTC :: Nil)
 

--- a/util/appmacro/src/main/scala/sbt/appmacro/TupleNBuilder.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/TupleNBuilder.scala
@@ -18,6 +18,7 @@ object TupleNBuilder extends TupleBuilder
 	{
 		val util = ContextUtil[c.type](c)
 			import c.universe.{Apply=>ApplyTree,_}
+			import compat._
 			import util._
 
 		val global: Global = c.universe.asInstanceOf[Global]


### PR DESCRIPTION
Migrates sbt/sbt to https://github.com/scala/scala/pull/3452 that is planned to be merged into trunk before 2.11.0-RC1. No more casts to Global. No more powerContext. /cc @retronym @harrah
