### PR TITLE
Include value of `nameHashing` flag in `CompileSetup`.

### DIFF
--- a/compile/inc/src/main/scala/sbt/CompileSetup.scala
+++ b/compile/inc/src/main/scala/sbt/CompileSetup.scala
@@ -11,7 +11,8 @@ package sbt
 //    because complexity(Equiv[Seq[String]]) > complexity(Equiv[CompileSetup])
 //     (6 > 4)
 final class CompileOptions(val options: Seq[String], val javacOptions: Seq[String])
-final class CompileSetup(val output: APIOutput, val options: CompileOptions, val compilerVersion: String, val order: CompileOrder)
+final class CompileSetup(val output: APIOutput, val options: CompileOptions, val compilerVersion: String,
+	val order: CompileOrder, val nameHashing: Boolean)
 
 object CompileSetup
 {
@@ -21,7 +22,8 @@ object CompileSetup
 			equivOutput.equiv(a.output, b.output) &&
 			equivOpts.equiv(a.options, b.options) &&
 			equivComp.equiv(a.compilerVersion, b.compilerVersion) &&
-			a.order == b.order // equivOrder.equiv(a.order, b.order)
+			a.order == b.order && // equivOrder.equiv(a.order, b.order)
+			a.nameHashing == b.nameHashing
 	}
 	implicit val equivFile: Equiv[File] = new Equiv[File] {
 		def equiv(a: File, b: File) = a.getAbsoluteFile == b.getAbsoluteFile
@@ -32,7 +34,7 @@ object CompileSetup
 			case (m1: MultipleOutput, m2: MultipleOutput) =>
 				(m1.outputGroups.length == m2.outputGroups.length) &&
 				(m1.outputGroups.sorted zip m2.outputGroups.sorted forall {
-					case (a,b) => 
+					case (a,b) =>
 						equivFile.equiv(a.sourceDirectory, b.sourceDirectory) && equivFile.equiv(a.outputDirectory, b.outputDirectory)
 				})
 			case (s1: SingleOutput, s2: SingleOutput) => equivFile.equiv(s1.outputDirectory, s2.outputDirectory)
@@ -42,12 +44,12 @@ object CompileSetup
 	implicit val equivOpts: Equiv[CompileOptions] = new Equiv[CompileOptions] {
 		def equiv(a: CompileOptions, b: CompileOptions) =
 			(a.options sameElements b.options) &&
-			(a.javacOptions sameElements b.javacOptions) 
+			(a.javacOptions sameElements b.javacOptions)
 	}
 	implicit val equivCompilerVersion: Equiv[String] = new Equiv[String] {
 		def equiv(a: String, b: String) = a == b
 	}
-	
+
 	implicit val equivOrder: Equiv[CompileOrder] = new Equiv[CompileOrder] {
 		def equiv(a: CompileOrder, b: CompileOrder) = a == b
 	}

--- a/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/AggressiveCompile.scala
@@ -41,7 +41,8 @@ class AggressiveCompile(cacheFile: File)
 	    skip: Boolean = false,
 	    incrementalCompilerOptions: IncOptions)(implicit log: Logger): Analysis =
 	{
-		val setup = new CompileSetup(output, new CompileOptions(options, javacOptions), compiler.scalaInstance.actualVersion, compileOrder)
+		val setup = new CompileSetup(output, new CompileOptions(options, javacOptions),
+			compiler.scalaInstance.actualVersion, compileOrder, incrementalCompilerOptions.nameHashing)
 		compile1(sources, classpath, setup, progress, store, analysisMap, definesClass,
 		    compiler, javac, reporter, skip, cache, incrementalCompilerOptions)
 	}
@@ -144,6 +145,12 @@ class AggressiveCompile(cacheFile: File)
 
 		val sourcesSet = sources.toSet
 		val analysis = previousSetup match {
+			case Some(previous) if previous.nameHashing != currentSetup.nameHashing =>
+				// if the value of `nameHashing` flag has changed we have to throw away
+				// previous Analysis completely and start with empty Analysis object
+				// that supports the particular value of the `nameHashing` flag.
+				// Otherwise we'll be getting UnsupportedOperationExceptions
+				Analysis.empty(currentSetup.nameHashing)
 			case Some(previous) if equiv.equiv(previous, currentSetup) => previousAnalysis
 			case _ => Incremental.prune(sourcesSet, previousAnalysis)
 		}

--- a/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
+++ b/compile/persist/src/main/scala/sbt/inc/AnalysisFormats.scala
@@ -73,8 +73,8 @@ object AnalysisFormats
 		wrap[Severity, Byte]( _.ordinal.toByte, b => Severity.values.apply(b.toInt) )
 
 
-	implicit def setupFormat(implicit outputF: Format[APIOutput], optionF: Format[CompileOptions], compilerVersion: Format[String], orderF: Format[CompileOrder]): Format[CompileSetup] =
-		asProduct4[CompileSetup, APIOutput, CompileOptions, String, CompileOrder]( (a,b,c,d) => new CompileSetup(a,b,c,d) )(s => (s.output, s.options, s.compilerVersion, s.order))(outputF, optionF, compilerVersion, orderF)
+	implicit def setupFormat(implicit outputF: Format[APIOutput], optionF: Format[CompileOptions], compilerVersion: Format[String], orderF: Format[CompileOrder], nameHashingF: Format[Boolean]): Format[CompileSetup] =
+		asProduct5[CompileSetup, APIOutput, CompileOptions, String, CompileOrder, Boolean]( (a,b,c,d,e) => new CompileSetup(a,b,c,d,e) )(s => (s.output, s.options, s.compilerVersion, s.order, s.nameHashing))(outputF, optionF, compilerVersion, orderF, nameHashingF)
 
 	implicit val outputGroupFormat: Format[OutputGroup] =
 		asProduct2((a: File,b: File) => new OutputGroup{def sourceDirectory = a; def outputDirectory = b}) { out => (out.sourceDirectory, out.outputDirectory) }(fileFormat, fileFormat)


### PR DESCRIPTION
The CompileSetup class is being used to detect changes to arguments of
incremental compiler that affect result of compilation and trigger
recompilation. Examples of such arguments include, the target (output)
directory, Scala compiler options, Scala compiler version, etc.

By adding `nameHashing` to CompileSetup we have a chance to handle change
to that flag smoothly by throwing away old Analysis object and starting
with an empty one. That's implemented in AggressiveComile by extending
the logic that was responsible for detection of changes to CompileSetup
values. Thanks to this change we fix #1081.

Analysis formats has been updated to support persisting of newly added
value in CompileSetup. We used to not store the value of `nameHashing`
flag in persisted Analysis file and infer it from contents of relations
but that leads to issue #1071 when empty relations are involved. Given
the fact that CompileSetup stores `nameHashing` value now, we can just
use it when reading relations and fix #1071. This requires reading/writing
compile setup before reading relations. I decided to make that change even
if there's a comment saying that reading/writing relations first was done
intentionally.
