### PR TITLE
Make change to CompileSetup backwards compatible.

### DIFF
--- a/compile/inc/src/main/scala/sbt/CompileSetup.scala
+++ b/compile/inc/src/main/scala/sbt/CompileSetup.scala
@@ -12,7 +12,12 @@ package sbt
 //     (6 > 4)
 final class CompileOptions(val options: Seq[String], val javacOptions: Seq[String])
 final class CompileSetup(val output: APIOutput, val options: CompileOptions, val compilerVersion: String,
-	val order: CompileOrder, val nameHashing: Boolean)
+	val order: CompileOrder, val nameHashing: Boolean) {
+	@deprecated("Use the other overloaded variant of the constructor that takes `nameHashing` value, instead.", "0.13.2")
+	def this(output: APIOutput, options: CompileOptions, compilerVersion: String, order: CompileOrder) = {
+		this(output, options, compilerVersion, order, false)
+	}
+}
 
 object CompileSetup
 {


### PR DESCRIPTION
The c7f435026ff8591085f427b8ee4d192e1f10f783 introduced a new parameter
to the constructor of `CompileSetup` but it turns out that this class
is being used in zinc. Introduce an overloaded variant of that constructor
that preserves backwards compatibility.
