### PR TITLE
SI-7788 Adapt to renamed implict Predef.conforms

### DIFF
--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -3,7 +3,7 @@
  */
 package sbt
 
-	import Predef.{conforms => _, _}
+	import Predef.{Map, Set, implicitly} // excludes *both 2.10.x conforms and 2.11.x $conforms in source compatible manner.
 
 	import FileInfo.{exists, hash}
 	import java.io.File


### PR DESCRIPTION
In 2.11, the implicit version is named `$conforms` so as to avoid
accidental shadowing by user code, which renders methods using
views and subtype bounds inexplicable unusable.

But, SBT intentionally needs to hide it to make the implicits
in this file line up.

This commit opts-in the the required identifiers from Predef,
rather than opting out of conforms. This makes the same code
source compatible with 2.10 and 2.11.

Review by @jsuereth @adriaanm
