### PR TITLE
Completed a full example of forked tests with grouping

### DIFF
--- a/src/sphinx/Detailed-Topics/Testing.rst
+++ b/src/sphinx/Detailed-Topics/Testing.rst
@@ -204,7 +204,7 @@ available with :key:`testGrouping` key. For example:
       def groupByFirst(tests: Seq[TestDefinition]) =
         tests groupBy (_.name(0)) map {
           case (letter, tests) => new Group(letter.toString, tests, SubProcess(Seq("-Dfirst.letter"+letter)))
-        } toSeq;
+        } toSeq
 
       lazy val root = Project("root", file("."), settings = defaultSettings ++  Seq(
         scalaVersion := "2.10.3",

--- a/src/sphinx/Detailed-Topics/Testing.rst
+++ b/src/sphinx/Detailed-Topics/Testing.rst
@@ -191,26 +191,19 @@ The setting:
 specifies that all tests will be executed in a single external JVM. See
 :doc:`Forking` for configuring standard options for forking. More control
 over how tests are assigned to JVMs and what options to pass to those is
-available with :key:`testGrouping` key. For example:
+available with :key:`testGrouping` key. For example in build.sbt:
 
 ::
 
-    import sbt._
-    import Keys._
     import Tests._
-    import Defaults._
 
-    object ForkTestsBuild extends Build {
+    {
       def groupByFirst(tests: Seq[TestDefinition]) =
         tests groupBy (_.name(0)) map {
           case (letter, tests) => new Group(letter.toString, tests, SubProcess(Seq("-Dfirst.letter"+letter)))
         } toSeq
 
-      lazy val root = Project("root", file("."), settings = defaultSettings ++  Seq(
-        scalaVersion := "2.10.3",
-        testGrouping in Test := groupByFirst( (definedTests in Test).value ),
-        libraryDependencies += "org.scalatest" %% "scalatest" % "2.0" % "test"
-      ))
+        testGrouping in Test <<= groupByFirst( (definedTests in Test).value )
     }
 
 The tests in a single group are run sequentially. Control the number

--- a/src/sphinx/Detailed-Topics/Testing.rst
+++ b/src/sphinx/Detailed-Topics/Testing.rst
@@ -195,14 +195,22 @@ available with :key:`testGrouping` key. For example:
 
 ::
 
+    import sbt._
+    import Keys._
     import Tests._
+    import Defaults._
 
-    {
+    object ForkTestsBuild extends Build {
       def groupByFirst(tests: Seq[TestDefinition]) =
         tests groupBy (_.name(0)) map {
           case (letter, tests) => new Group(letter.toString, tests, SubProcess(Seq("-Dfirst.letter"+letter)))
         } toSeq;
-      testGrouping := groupByFirst( (definedTests in Test).value )
+
+      lazy val root = Project("root", file("."), settings = defaultSettings ++  Seq(
+        scalaVersion := "2.10.3",
+        testGrouping in Test := groupByFirst( (definedTests in Test).value ),
+        libraryDependencies += "org.scalatest" %% "scalatest" % "2.0" % "test"
+      ))
     }
 
 The tests in a single group are run sequentially. Control the number


### PR DESCRIPTION
The previous example of how to fork group of tests in different
JVMs was incomplete and not fully working.

a) The "testGrouping in Test" is needed, otherwise the grouping is
   not known to which phase to apply
b) Added a more complete Project definition to explain what the curly
   brackets section refers to and where the settings need to be included

The new complete example works out of the box :-)
