### PR TITLE
IncludeRule / ExcludeRule aliases for InclExclRule

### DIFF
--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -44,4 +44,9 @@ package object sbt extends sbt.std.TaskExtra with sbt.Types with sbt.ProcessExtr
 	def settingKey[T](description: String): SettingKey[T] = macro std.KeyMacro.settingKeyImpl[T]
 	def taskKey[T](description: String): TaskKey[T] = macro std.KeyMacro.taskKeyImpl[T]
 	def inputKey[T](description: String): InputKey[T] = macro std.KeyMacro.inputKeyImpl[T]
+
+	type ExcludeRule = InclExclRule
+	final val ExcludeRule = InclExclRule
+	type IncludeRule = InclExclRule
+	final val IncludeRule = InclExclRule
 }


### PR DESCRIPTION
In #1016 I've changed `ExcludeRule` to `InclExclRule` for reuse between the two types of rules. This would break existing projects which use `ExcludeRule` so I've added aliases for `IncludeRule` and `ExcludeRule` to point to `InclExclRule`.
