### PR TITLE
Extra tweak for making the forkGroup work on build.sbt

### DIFF
--- a/src/sphinx/Detailed-Topics/Testing.rst
+++ b/src/sphinx/Detailed-Topics/Testing.rst
@@ -201,9 +201,8 @@ available with :key:`testGrouping` key. For example in build.sbt:
       def groupByFirst(tests: Seq[TestDefinition]) =
         tests groupBy (_.name(0)) map {
           case (letter, tests) => new Group(letter.toString, tests, SubProcess(Seq("-Dfirst.letter"+letter)))
-        } toSeq
-
-        testGrouping in Test <<= groupByFirst( (definedTests in Test).value )
+        } toSeq;
+        testGrouping in Test := groupByFirst( (definedTests in Test).value )
     }
 
 The tests in a single group are run sequentially. Control the number


### PR DESCRIPTION
When the fork grouping definition is on build.sbt, extra rules
apply, such as the line taken as separator between settings.
It seems as well that the ';' to terminate the def function is needed
to isolate it from the setting definition itself.
