### PR TITLE
Fix #1136 - Ivy's + dependency ranges not converted appropriately to maven.

### DIFF
--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -188,13 +188,32 @@ class MakePom(val log: Logger)
 		<dependency>
 			<groupId>{mrid.getOrganisation}</groupId>
 			<artifactId>{mrid.getName}</artifactId>
-			<version>{mrid.getRevision}</version>
+			<version>{makeDependencyVersion(mrid.getRevision)}</version>
 			{ scopeElem(scope) }
 			{ optionalElem(optional) }
 			{ classifierElem(classifier) }
 			{ typeElem(tpe) }
 			{ exclusions(dependency) }
 		</dependency>
+	}
+
+
+
+	def makeDependencyVersion(revision: String): String = {
+		if(revision endsWith "+") try {
+			// TODO - this is the slowest possible implementation.
+			val beforePlus = revision.reverse.dropWhile(_ != '.').drop(1).reverse
+			val lastVersion = beforePlus.reverse.takeWhile(_ != '.').reverse
+			val lastVersionInt = lastVersion.toInt
+			val prefixVersion = beforePlus.reverse.dropWhile(_ != '.').drop(1).reverse
+			s"[$beforePlus, ${prefixVersion}.${lastVersionInt+1})"
+		} catch {
+			case e: NumberFormatException => 
+			  // TODO - if the version deosn't meet our expectations, maybe we just issue a hard
+			  //        error instead of softly ignoring the attempt to rewrite.
+			  //sys.error(s"Could not fix version [$revision] into maven style version")
+			  revision
+		} else revision
 	}
 
 	@deprecated("No longer used and will be removed.", "0.12.1")

--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -200,20 +200,39 @@ class MakePom(val log: Logger)
 
 
 	def makeDependencyVersion(revision: String): String = {
-		if(revision endsWith "+") try {
-			// TODO - this is the slowest possible implementation.
-			val beforePlus = revision.reverse.dropWhile(_ != '.').drop(1).reverse
-			val lastVersion = beforePlus.reverse.takeWhile(_ != '.').reverse
+		def plusRange(s:String, shift:Int = 0) = {
+			def pow(i:Int):Int = if (i>0) 10 * pow(i-1) else 1
+			val (prefixVersion, lastVersion) = (s+"0"*shift).reverse.split("\\.",2) match {
+				case Array(revLast,revRest) =>
+					( revRest.reverse + ".", revLast.reverse )
+				case Array(revLast) => ("", revLast.reverse)
+			}
 			val lastVersionInt = lastVersion.toInt
-			val prefixVersion = beforePlus.reverse.dropWhile(_ != '.').drop(1).reverse
-			s"[$beforePlus, ${prefixVersion}.${lastVersionInt+1})"
+			s"[${prefixVersion}${lastVersion},${prefixVersion}${lastVersionInt+pow(shift)})"
+		}
+		val startSym=Set(']','[','(')
+		val stopSym=Set(']','[',')')
+		try {
+			if (revision endsWith ".+") {
+				plusRange(revision.substring(0,revision.length-2))
+			} else if (revision endsWith "+") {
+				val base = revision.take(revision.length-1)
+				// This is a heuristic.  Maven just doesn't support Ivy's notions of 1+, so
+				// we assume version ranges never go beyond 5 siginificant digits.
+				(0 to 5).map(plusRange(base,_)).mkString(",")
+			} else if (startSym(revision(0)) && stopSym(revision(revision.length-1))) {
+				val start = revision(0)
+				val stop = revision(revision.length-1)
+      			val mid = revision.substring(1,revision.length-1)
+      			(if (start == ']') "(" else start) + mid + (if (stop == '[') ")" else stop)
+    		} else revision
 		} catch {
-			case e: NumberFormatException => 
-			  // TODO - if the version deosn't meet our expectations, maybe we just issue a hard
-			  //        error instead of softly ignoring the attempt to rewrite.
-			  //sys.error(s"Could not fix version [$revision] into maven style version")
-			  revision
-		} else revision
+    		case e: NumberFormatException =>
+    		// TODO - if the version doesn't meet our expectations, maybe we just issue a hard
+    		//        error instead of softly ignoring the attempt to rewrite.
+    		//sys.error(s"Could not fix version [$revision] into maven style version")
+    		revision
+		}	
 	}
 
 	@deprecated("No longer used and will be removed.", "0.12.1")

--- a/ivy/src/test/scala/MakePomTest.scala
+++ b/ivy/src/test/scala/MakePomTest.scala
@@ -1,0 +1,29 @@
+package sbt
+
+import java.io.File
+import org.specs2._
+import mutable.Specification
+
+object MakePomTest extends Specification
+{
+	val mp = new MakePom(ConsoleLogger())
+	import mp.{makeDependencyVersion=>v}
+	"MakePom makeDependencyVersion" should {
+		"Handle .+ in versions" in {
+			v("1.+") must_== "[1,2)"
+            v("1.2.3.4.+") must_== "[1.2.3.4,1.2.3.5)"
+			v("12.31.42.+") must_== "[12.31.42,12.31.43)"
+		}
+		/* TODO - do we care about this case?
+         * 1+ --> [1,2),[10,20),[100,200),[1000,2000),[10000,20000),[100000,200000)
+         */
+		"Handle ]* bracket in version ranges" in {
+			v("]1,3]") must_== "(1,3]"
+			v("]1.1,1.3]") must_== "(1.1,1.3]"
+		}
+		"Handle *[ bracket in version ranges" in {
+			v("[1,3[") must_== "[1,3)"
+			v("[1.1,1.3[") must_== "[1.1,1.3)"
+		}
+	}
+}

--- a/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
+++ b/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
@@ -40,7 +40,7 @@ object MakePomTest extends Build
 		for {
 			dep <- pomXml \ "dependencies" \ "dependency"
 			if (dep \ "artifactId").text == "jsr305"
-			if (dep \ "version").text contains "+"
+			if (dep \ "version").text != "[1.3, 1.4)"
 		} sys.error(s"Found dependency with invalid maven version: $dep")
 		()
 	}

--- a/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
+++ b/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
@@ -40,7 +40,8 @@ object MakePomTest extends Build
 		for {
 			dep <- pomXml \ "dependencies" \ "dependency"
 			if (dep \ "artifactId").text == "jsr305"
-			if (dep \ "version").text != "[1.3, 1.4)"
+			// TODO - Ignore space here.
+			if (dep \ "version").text != "[1.3,1.4)"
 		} sys.error(s"Found dependency with invalid maven version: $dep")
 		()
 	}

--- a/sbt/src/sbt-test/dependency-management/make-pom/test
+++ b/sbt/src/sbt-test/dependency-management/make-pom/test
@@ -1,2 +1,3 @@
 > check-pom
 > check-extra
+> check-version-plus-mapping


### PR DESCRIPTION
Fix pom creation to handle Ivy's version ranges, in semi-popular usage.

Review @eed3si9n 
