### PR TITLE
Override certain SecurityManager methods to avoid filesystem performance hit

### DIFF
--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -413,6 +413,15 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
 	private def isRealExit(element: StackTraceElement): Boolean =
 		element.getClassName == "java.lang.Runtime" && element.getMethodName == "exit"
 
+	// These are overridden to do nothing because there is a substantial filesystem performance penalty
+	// when there is a SecurityManager defined.  The default implementations of these construct a
+	// FilePermission, and its initialization involves canonicalization, which is expensive.
+	override def checkRead(file: String) {}
+	override def checkRead(file: String, context: AnyRef) {}
+	override def checkWrite(file: String) {}
+	override def checkDelete(file: String) {}
+	override def checkExec(cmd: String) {}
+
 	override def checkPermission(perm: Permission)
 	{
 		if(delegateManager ne null)


### PR DESCRIPTION
Further explanation in the comment in the code.  This was discovered while investigating a major performance reduction using sbt-assembly 0.9.2 with sbt 0.12 and 0.13.  When used with sbt 0.13, the `assembly` time was much slower.  This patch will probably speed up other tasks that touch many files, like `clean`.  (To be clear, it will probably restore them to 0.12 speeds.)
