### PR TITLE
Fix task macro's handling of Symbol owners in <qual>.value

### DIFF
--- a/sbt/src/sbt-test/project/setting-macro/build.sbt
+++ b/sbt/src/sbt-test/project/setting-macro/build.sbt
@@ -15,3 +15,12 @@ demo := {
   val (n, s) = parser.parsed
   s * n
 }
+
+// Tests for correct Symbol owner structure in the lifted qualifiers of
+// the `.value` macro within a task macro. (#1150)
+val touchIfChanged = taskKey[Unit]("")
+
+touchIfChanged := { 
+  val foo = (sourceDirectory in Compile).apply(base => base).value.get
+  ()
+}


### PR DESCRIPTION
The qualifier of the `.value` call may contain `DefTree`s (e.g.
vals, defs) or `Function` trees. When we snip them out of the
tree and graft them into a new context, we must also call
`changeOwner`, so that the symbol owner structure and the tree
structure are coherent.

Failure to do so resulted in a crash in the compiler backend.

Fixes #1150

Review by @jsuereth @gkossakowski
