### PR TITLE
Removing deprecated "re-publish release artifacts" behavior from tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: scala
 script:
-  - sbt scripted 
+  - sbt "scripted $SCRIPTED_TEST"
+env:
+  - SCRIPTED_TEST=actions/*
+  - SCRIPTED_TEST=api/*
+  - SCRIPTED_TEST=compiler-project/*
+  - SCRIPTED_TEST=dependency-management/*
+  - SCRIPTED_TEST=java/*
+  - SCRIPTED_TEST=package/*
+  - SCRIPTED_TEST=reporter/*
+  - SCRIPTED_TEST=run/*
+  - SCRIPTED_TEST=source-dependencies/*
+  - SCRIPTED_TEST=tests/*
 jdk:
   - openjdk6
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: scala
+script:
+  - sbt launcher/test actions/test api/test apply-macro/test cache/test classfile/test classpath/test collections/test command/test compile/test completion/test contorl/test cross/test incremental-compiler/test io/test ivy/test logic/test main/test main-settings/test persist/test relation/test run/test tasks/test test-agent/test tracking/test testing/test
+  - sbt scripted 
+jdk:
+  - openjdk6
+notifications:
+  email:
+    - qbranch@typesafe.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 script:
-  - sbt launcher/test actions/test api/test apply-macro/test cache/test classfile/test classpath/test collections/test command/test compile/test completion/test contorl/test cross/test incremental-compiler/test io/test ivy/test logic/test main/test main-settings/test persist/test relation/test run/test tasks/test test-agent/test tracking/test testing/test
   - sbt scripted 
 jdk:
   - openjdk6

--- a/sbt/src/sbt-test/dependency-management/cache-resolver/changes/def/Build.scala
+++ b/sbt/src/sbt-test/dependency-management/cache-resolver/changes/def/Build.scala
@@ -5,7 +5,7 @@ object B extends Build {
 
 	override def settings = super.settings ++ Seq(
 		organization := "org.example",
-		version := "2.0"
+		version := "2.0-SNAPSHOT"
 	)
 
 	lazy val root = proj("root", ".") aggregate(a,b)

--- a/sbt/src/sbt-test/dependency-management/cache-resolver/changes/use/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-resolver/changes/use/build.sbt
@@ -4,6 +4,6 @@ organization := "org.example"
 
 version := "1.0"
 
-libraryDependencies += "org.example" % "b" % "2.0"
+libraryDependencies += "org.example" % "b" % "2.0-SNAPSHOT"
 
 ivyPaths <<= ivyPaths in ThisBuild


### PR DESCRIPTION
In sbt 1.0 republishing released artifacts will be removed, causing these tests
to fail.  We migrate to SNAPSHOT version now, to prevent surprises.

Review by @dansanduleac
