### PR TITLE
Record dependencies on macro arguments

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Dependency.scala
+++ b/compile/interface/src/main/scala/xsbt/Dependency.scala
@@ -146,6 +146,8 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile
 					deps.foreach(addDependency)
 				case Template(parents, self, body) =>
 					traverseTrees(body)
+				case MacroExpansionOf(original) =>
+					this.traverse(original)
 				case other => ()
 			}
 			super.traverse(tree)

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/Client.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/Client.scala
@@ -1,0 +1,5 @@
+package macro
+
+object Client {
+	Provider.printTree(Provider.printTree(Foo.str))
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/Foo.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/Foo.scala
@@ -1,0 +1,5 @@
+package macro
+
+object Foo {
+  def str: String = "abc"
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/changes/Foo.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-client/changes/Foo.scala
@@ -1,0 +1,3 @@
+package macro
+object Foo {
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-provider/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/macro-provider/Provider.scala
@@ -1,0 +1,12 @@
+package macro
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+	def printTree(arg: Any) = macro printTreeImpl
+	def printTreeImpl(c: Context)(arg: c.Expr[Any]): c.Expr[String] = {
+	  val argStr = arg.tree.toString
+	  val literalStr = c.universe.Literal(c.universe.Constant(argStr))
+	  c.Expr[String](literalStr)
+	}
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/project/build.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/project/build.scala
@@ -1,0 +1,29 @@
+import sbt._
+import Keys._
+
+object build extends Build {
+	val defaultSettings = Seq(
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ ),
+		incOptions := incOptions.value.withNameHashing(true)
+	)
+
+	lazy val root = Project(
+	   base = file("."),
+	   id = "macro",
+	   aggregate = Seq(macroProvider, macroClient),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroProvider = Project(
+	   base = file("macro-provider"),
+	   id = "macro-provider",
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroClient = Project(
+	   base = file("macro-client"),
+	   id = "macro-client",
+	   dependencies = Seq(macroProvider),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/test
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/test
@@ -1,6 +1,7 @@
 > compile
 
 # remove `Foo.str` which is an argument to a macro
+# (this macro itself that is an argument to another macro)
 $ copy-file macro-client/changes/Foo.scala macro-client/Foo.scala
 
 # we should recompile Foo.scala first and then fail to compile Client.scala due to missing

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/Client.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/Client.scala
@@ -1,0 +1,5 @@
+package macro
+
+object Client {
+	Provider.printTree(Foo.str)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/Foo.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/Foo.scala
@@ -1,0 +1,5 @@
+package macro
+
+object Foo {
+  def str: String = "abc"
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/changes/Foo.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-client/changes/Foo.scala
@@ -1,0 +1,3 @@
+package macro
+object Foo {
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-provider/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/macro-provider/Provider.scala
@@ -1,0 +1,12 @@
+package macro
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+	def printTree(arg: Any) = macro printTreeImpl
+	def printTreeImpl(c: Context)(arg: c.Expr[Any]): c.Expr[String] = {
+	  val argStr = arg.tree.toString
+	  val literalStr = c.universe.Literal(c.universe.Constant(argStr))
+	  c.Expr[String](literalStr)
+	}
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/project/build.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/project/build.scala
@@ -1,0 +1,29 @@
+import sbt._
+import Keys._
+
+object build extends Build {
+	val defaultSettings = Seq(
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ ),
+		incOptions := incOptions.value.withNameHashing(true)
+	)
+
+	lazy val root = Project(
+	   base = file("."),
+	   id = "macro",
+	   aggregate = Seq(macroProvider, macroClient),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroProvider = Project(
+	   base = file("macro-provider"),
+	   id = "macro-provider",
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroClient = Project(
+	   base = file("macro-client"),
+	   id = "macro-client",
+	   dependencies = Seq(macroProvider),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/test
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/test
@@ -1,0 +1,15 @@
+> compile
+
+# remove `Foo.str` which is an argument to a macro that incremental compiler doesn't see in
+# Client.scala because macro has been already expanded
+
+$ copy-file macro-client/changes/Foo.scala macro-client/Foo.scala
+
+# we should recompile Foo.scala first and then fail to compile Client.scala due to missing
+# `Foo.str`; however recompilation of Client.scala is never triggered due to missing
+# dependency
+-> macro-client/compile
+
+> clean
+
+-> compile


### PR DESCRIPTION
> Macros take arguments as trees and return some other trees; both of them have dependencies but we see trees only after expansion and recorded only those dependencies.

(from [this discussion in sbt-dev](https://groups.google.com/d/msg/sbt-dev/zDOIFDSNRrk/_YTVn7bRJb0J)).

This pull request solves this problem by looking into the attachments of the trees that are supposed to contain originals of macro expansions and recording dependencies of the macro before its expansion.
