### PR TITLE
Fix NPE in task macro accessing q"{...}".symbol.pos

### DIFF
--- a/sbt/src/sbt-test/project/setting-macro/build.sbt
+++ b/sbt/src/sbt-test/project/setting-macro/build.sbt
@@ -27,3 +27,8 @@ key1 := {
 	)
   ()
 }
+
+// https://github.com/sbt/sbt/issues/1107
+def appcfgTask(a: String, b: String) = Def.task("")
+
+TaskKey[Unit]("test") := appcfgTask(b = "", a = "").value

--- a/util/appmacro/src/main/scala/sbt/appmacro/Instance.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/Instance.scala
@@ -167,7 +167,7 @@ object Instance
 		def addType(tpe: Type, qual: Tree, selection: Tree): Tree =
 		{
 			qual.foreach(checkQual)
-			val vd = util.freshValDef(tpe, qual.symbol.pos, functionSym)
+			val vd = util.freshValDef(tpe, qual.pos, functionSym)
 			inputs ::= new Input(tpe, qual, vd)
 			util.refVal(selection, vd)
 		}


### PR DESCRIPTION
We shouldn't assume that the qualifier of a `Select` is a
`SymTree`; it may be a `Block`. One place that happens
is after the transformation of named/defaults applications.
That causes the reported `NullPointerException'.

In any case, using `qual.symbol.pos` sense here; it yields the
position of the defintions _referred to_ by `qual`, not the
position of `qual` itself.

Both problems are easily fixed: use `qual.pos` instead.

Fixes #1107

Review by @jsuereth
