### PR TITLE
Fixes missing tests from autoplugins feature.

### DIFF
--- a/sbt/src/sbt-test/project/auto-settings/project/P.scala
+++ b/sbt/src/sbt-test/project/auto-settings/project/P.scala
@@ -6,22 +6,22 @@
 object B extends Build
 {
 	// version should be from explicit/a.txt
-	lazy val root = project("root", "1.4") autoSettings( userSettings, sbtFiles(file("explicit/a.txt")) )
+	lazy val root = project("root", "1.4") autoSettings( projectSettings,userSettings, sbtFiles(file("explicit/a.txt")) )
 
 	// version should be from global/user.sbt
-	lazy val a = project("a", "1.1") autoSettings( userSettings )
+	lazy val a = project("a", "1.1") autoSettings( projectSettings, userSettings )
 
 	// version should be the default 0.1-SNAPSHOT
-	lazy val b = project("b", "0.1-SNAPSHOT") autoSettings()
+	lazy val b = project("b", "0.1-SNAPSHOT") autoSettings(projectSettings)
 
 	// version should be from the explicit settings call
-	lazy val c = project("c", "0.9") settings(version := "0.9") autoSettings()
+	lazy val c = project("c", "0.9") settings(version := "0.9") autoSettings(projectSettings)
 
 	// version should be from d/build.sbt
-	lazy val d = project("d", "1.3") settings(version := "0.9") autoSettings( defaultSbtFiles )
+	lazy val d = project("d", "1.3") settings(version := "0.9") autoSettings( projectSettings, defaultSbtFiles )
 
 	// version should be from global/user.sbt
-	lazy val e = project("e", "1.1") settings(version := "0.9") autoSettings( defaultSbtFiles, sbtFiles(file("../explicit/a.txt")), userSettings )
+	lazy val e = project("e", "1.1") settings(version := "0.9") autoSettings( projectSettings, defaultSbtFiles, sbtFiles(file("../explicit/a.txt")), userSettings )
 
 	def project(id: String, expectedVersion: String): Project = Project(id, if(id == "root") file(".") else file(id)) settings(
 		TaskKey[Unit]("check") <<= version map { v =>

--- a/sbt/src/sbt-test/project/auto-settings/test
+++ b/sbt/src/sbt-test/project/auto-settings/test
@@ -1,3 +1,5 @@
+> plugins
+
 > root/check
 
 > a/check

--- a/sbt/src/sbt-test/project/delegate_config/project/Build.scala
+++ b/sbt/src/sbt-test/project/delegate_config/project/Build.scala
@@ -1,6 +1,7 @@
 import sbt._
 import complete.DefaultParsers._
 import Keys._
+import AddSettings._
 
 object B extends Build
 {
@@ -11,8 +12,11 @@ object B extends Build
 	val sample = SettingKey[Int]("sample")
 	val check = TaskKey[Unit]("check")
 	
-	lazy val root = Project("root", file("."), settings = Nil)
-	lazy val sub = Project("sub", file("."), delegates = root :: Nil, configurations = newConfig :: Nil, settings = incSample :: checkTask(4) :: Nil)
+	lazy val root = Project("root", file("."), settings = Nil).autoSettings()
+	lazy val sub = Project("sub", file("."), 
+		delegates = root :: Nil, 
+		configurations = newConfig :: Nil, 
+		settings = incSample :: checkTask(4) :: Nil).autoSettings(projectSettings)
 	override lazy val settings =
 		(sample in newConfig := 3) ::
 		checkTask(3) ::

--- a/sbt/src/sbt-test/project/multi/changes/Build1.scala
+++ b/sbt/src/sbt-test/project/multi/changes/Build1.scala
@@ -1,5 +1,6 @@
 import sbt._
 import Keys.name
+import AddSettings._
 
 object TestBuild extends Build
 {
@@ -7,5 +8,5 @@ object TestBuild extends Build
 		proj("a", "."),
 		proj("b", "b")
 	)
-	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) )
+	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).autoSettings(projectSettings)
 }

--- a/sbt/src/sbt-test/project/multi/changes/Build2.scala
+++ b/sbt/src/sbt-test/project/multi/changes/Build2.scala
@@ -11,5 +11,6 @@ object SecondBuild extends MakeBuild
 }
 trait MakeBuild extends Build
 {
-	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) )
+	import AddSettings._
+	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).autoSettings(projectSettings, defaultSbtFiles)
 }

--- a/sbt/src/sbt-test/project/sbt-file-projects/build.sbt
+++ b/sbt/src/sbt-test/project/sbt-file-projects/build.sbt
@@ -2,7 +2,7 @@ val a = "a"
 val f = file("a")
 val g = taskKey[Unit]("A task in the root project")
 
-val p = Project(a, f).autoSettings(AddSettings.sbtFiles( file("a.sbt") ))
+val p = Project(a, f).autoSettings(AddSettings.autoPlugins, AddSettings.sbtFiles( file("a.sbt") ))
 
 val b = Project("b", file("b"))
 

--- a/sbt/src/sbt-test/project/sbt-file-projects/changes/Restricted.scala
+++ b/sbt/src/sbt-test/project/sbt-file-projects/changes/Restricted.scala
@@ -3,5 +3,6 @@ import Keys._
 
 object B extends Build {
 	lazy val root = Project("root", file(".")).autoSettings(
+		AddSettings.autoPlugins,
 		AddSettings.sbtFiles( file("other.sbt") )) // ignore build.sbt
 }


### PR DESCRIPTION
For some reason, autoSettings fixes for tests disappeared.
- Fixes setting orderings now that defaults come from autoPlugins
- Removes autoPlugin settings where expected.

Review by @havocp (note, these are going in the migration guide)
