### PR TITLE
When fragmenting Defaults, we mixed back settings in the wrong order.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -971,7 +971,7 @@ object Classpaths
 		publishM2 <<= publishTask(publishM2Configuration, deliverLocal)
 	)
 	@deprecated("0.13.2", "This has been split into jvmIvySettings and ivyPublishSettings.")
-	val publishSettings: Seq[Setting[_]] = jvmPublishSettings ++ ivyPublishSettings
+	val publishSettings: Seq[Setting[_]] = ivyPublishSettings ++ jvmPublishSettings
 
 	private[this] def baseGlobalDefaults = Defaults.globalDefaults(Seq(
 		conflictWarning :== ConflictWarning.default("global"),

--- a/sbt/src/sbt-test/project/default-settings/build.sbt
+++ b/sbt/src/sbt-test/project/default-settings/build.sbt
@@ -1,0 +1,8 @@
+
+val root = Project("root", file("."), settings=Defaults.defaultSettings)
+
+
+TaskKey[Unit]("checkArtifacts", "test") := {
+	val arts = packagedArtifacts.value
+	assert(!arts.isEmpty, "Packaged artifacts must not be empty!")
+}

--- a/sbt/src/sbt-test/project/default-settings/test
+++ b/sbt/src/sbt-test/project/default-settings/test
@@ -1,0 +1,1 @@
+> checkArtifacts


### PR DESCRIPTION
- packageArtifacts is not cleared by defautlSettings
- Added a test for this behavior (this one test should ensure the ordering for most settings is correct.)

Fixes #1176 

Review by @havocp cc> @patriknw
