### PR TITLE
Documentation page title width overlaps search box

### DIFF
--- a/src/sphinx/_sphinx/themes/sbt/static/docs.css
+++ b/src/sphinx/_sphinx/themes/sbt/static/docs.css
@@ -4,7 +4,7 @@ a { color: #447281; }
 a:hover { color: #73a600; text-decoration: none; }
 .navbar-logo { visibility: visible; float: left; padding-top: 6px; margin-bottom: 18px;}
 .main { position: relative; height: auto; margin-top: -18px; overflow: auto; }
-.page-title { position: relative; top: 24px; font-family: 'Exo', sans-serif; font-size: 24px; font-weight: 400; color: rgba(255, 255, 255, 1); text-shadow:0 2px 0 #000000; width: 900px; min-height: 32px; }
+.page-title { position: relative; top: 24px; font-family: 'Exo', sans-serif; font-size: 24px; font-weight: 400; color: rgba(255, 255, 255, 1); text-shadow:0 2px 0 #000000; width: 600px; min-height: 32px; }
 .main-container { background: #f2f2eb;  min-height: 600px; padding-top: 20px; margin-top: 28px; padding-bottom: 40px; }
 .container h1:first-of-type { display: none; visibility: hidden; margin-top: -36px; }
 .pdf-link { float: right; height: 40px; margin-bottom: -15px; margin-top: -5px; }


### PR DESCRIPTION
The documentation page title is set via css to 900 px. This overlaps the search box so that you cannot click on it to select it. When the screen is maxed out the last quarter to the right of the search box is selectable.

This change changes the css to 600px to reduce the title width.

Please note I do not know if there are other reasons for the width being originally set to 900px, nor do I know enough about sphinx to be sure this works as intended.
