### PR TITLE
Allow end users to add Plugins, not just AutoPlugins

### DIFF
--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -36,11 +36,11 @@ Steps for users:
 
 For example, given plugins Web and Javascript (perhaps provided by plugins added with addSbtPlugin),
 
-  <Project>.plugins( Web && Javascript )
+  <Project>.addPlugins( Web && Javascript )
 
 will activate `MyPlugin` defined above and have its settings automatically added.  If the user instead defines
 
-  <Project>.plugins( Web && Javascript && !MyPlugin)
+  <Project>.addPlugins( Web && Javascript ).disablePlugins(MyPlugin)
 
 then the `MyPlugin` settings (and anything that activates only when `MyPlugin` is activated) will not be added.
 */
@@ -186,7 +186,7 @@ object Plugins
 			if(removed.isEmpty) Empty else And(removed)
 	}
 
-	/** Defines a clause for `ap` such that the [[AutPlugin]] provided by `ap` is the head and the selector for `ap` is the body. */
+	/** Defines a clause for `ap` such that the [[AutoPlugin]] provided by `ap` is the head and the selector for `ap` is the body. */
 	private[sbt] def asClause(ap: AutoPlugin): Clause =
 		Clause( convert(ap.select), Set(Atom(ap.label)) )
 

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -138,7 +138,7 @@ sealed trait Project extends ProjectDefinition[ProjectReference]
 
 	/** Sets the [[AutoPlugin]]s of this project.
 	A [[AutoPlugin]] is a common label that is used by plugins to determine what settings, if any, to add to a project. */
-	def addPlugins(ns: AutoPlugin*): Project = setPlugins(Plugins.and(plugins, Plugins.And(ns.toList)))
+	def addPlugins(ns: Plugins*): Project = setPlugins(ns.foldLeft(plugins)(Plugins.and))
 
 	/** Disable the given plugins on this project. */
 	def disablePlugins(ps: AutoPlugin*): Project =


### PR DESCRIPTION
This allows plugins to define a Plugins instance that captures both the plugin and its required dependencies.

Also fixed up some scaladocs that were wrong.
