### PR TITLE
Rename sbtTransformHash -> e:sbtTransformHash

### DIFF
--- a/ivy/src/main/scala/sbt/CustomPomParser.scala
+++ b/ivy/src/main/scala/sbt/CustomPomParser.scala
@@ -43,7 +43,7 @@ object CustomPomParser
 	val JarPackagings = Set("eclipse-plugin", "hk2-jar", "orbit")
 	val default = new CustomPomParser(PomModuleDescriptorParser.getInstance, defaultTransform)
 
-	private[this] val TransformedHashKey = "sbtTransformHash"
+	private[this] val TransformedHashKey = "e:sbtTransformHash"
 	// A hash of the parameters transformation is based on.
 	// If a descriptor has a different hash, we need to retransform it.
 	private[this] val TransformHash: String = hash((unqualifiedKeys ++ JarPackagings).toSeq.sorted)


### PR DESCRIPTION
This way, it can be parsed by Ivy's `XmlModuleDescriptorParser`.
Fixes #1191.
