### PR TITLE
fixes #1196

### DIFF
--- a/main/actions/src/main/scala/sbt/Tests.scala
+++ b/main/actions/src/main/scala/sbt/Tests.scala
@@ -220,7 +220,9 @@ object Tests
 	def processResults(results: Iterable[(String, SuiteResult)]): Output =
 		Output(overall(results.map(_._2.result)), results.toMap, Iterable.empty)
 	def foldTasks(results: Seq[Task[Output]], parallel: Boolean): Task[Output] = 
-		if (parallel)
+                if (results.isEmpty)
+                        task { Output(TestResult.Passed, Map.empty, Nil) } 
+		else if (parallel)
 			reduced(results.toIndexedSeq, {
 				case (Output(v1, m1, _), Output(v2, m2, _)) => Output(if (v1.id < v2.id) v2 else v1, m1 ++ m2, Iterable.empty)
 			})


### PR DESCRIPTION
Added missing fork for empty results sequence in foldTasks method, Tests.scala
