### PR TITLE
Unifies AutoPlugin and AutoImport. Fixes #1188 (resend)

### DIFF
--- a/main/src/main/scala/sbt/BuildStructure.scala
+++ b/main/src/main/scala/sbt/BuildStructure.scala
@@ -90,7 +90,7 @@ final class DetectedModules[T](val modules: Seq[(String, T)])
 }
 
 /** Auto-detected auto plugin. */
-case class DetectedAutoPlugin(val name: String, val value: AutoPlugin, val hasStableAutoImport: Boolean)
+case class DetectedAutoPlugin(val name: String, val value: AutoPlugin, val hasAutoImport: Boolean)
 
 /** Auto-discovered modules for the build definition project.  These include modules defined in build definition sources
 * as well as modules in binary dependencies.
@@ -105,6 +105,7 @@ final class DetectedPlugins(val plugins: DetectedModules[Plugin], val autoPlugin
 			if (hasAutoImport) Some(name + ".autoImport")
 			else None
 		}))
+
 	/** A function to select the right [[AutoPlugin]]s from [[autoPlugins]] for a [[Project]]. */
 	lazy val deducePlugins: (Plugins, Logger) => Seq[AutoPlugin] = Plugins.deducer(autoPlugins.toList map {_.value})
 }

--- a/main/src/main/scala/sbt/BuildStructure.scala
+++ b/main/src/main/scala/sbt/BuildStructure.scala
@@ -106,7 +106,7 @@ final class DetectedPlugins(val plugins: DetectedModules[Plugin], val autoPlugin
 			else None
 		}))
 	/** A function to select the right [[AutoPlugin]]s from [[autoPlugins]] for a [[Project]]. */
-	lazy val deducePlugins: (Plugins, Logger) => Seq[AutoPlugin] = Plugins.deducer(autoPlugins.values.toList)
+	lazy val deducePlugins: (Plugins, Logger) => Seq[AutoPlugin] = Plugins.deducer(autoPlugins.toList map {_.value})
 }
 
 /** The built and loaded build definition project.

--- a/main/src/main/scala/sbt/BuildStructure.scala
+++ b/main/src/main/scala/sbt/BuildStructure.scala
@@ -89,16 +89,22 @@ final class DetectedModules[T](val modules: Seq[(String, T)])
 	def values: Seq[T] = modules.map(_._2)
 }
 
+/** Auto-detected auto plugin. */
+case class DetectedAutoPlugin(val name: String, val value: AutoPlugin, val hasStableAutoImport: Boolean)
+
 /** Auto-discovered modules for the build definition project.  These include modules defined in build definition sources
 * as well as modules in binary dependencies.
 *
 * @param builds The [[Build]]s detected in the build definition.  This does not include the default [[Build]] that sbt creates if none is defined.
 */
-final class DetectedPlugins(val plugins: DetectedModules[Plugin], val autoImports: DetectedModules[AutoImport], val autoPlugins: DetectedModules[AutoPlugin], val builds: DetectedModules[Build])
+final class DetectedPlugins(val plugins: DetectedModules[Plugin], val autoPlugins: Seq[DetectedAutoPlugin], val builds: DetectedModules[Build])
 {
 	/** Sequence of import expressions for the build definition.  This includes the names of the [[Plugin]], [[Build]], and [[AutoImport]] modules, but not the [[AutoPlugin]] modules. */
-	lazy val imports: Seq[String] = BuildUtil.getImports(plugins.names ++ builds.names ++ autoImports.names)
-
+	lazy val imports: Seq[String] = BuildUtil.getImports(plugins.names ++ builds.names ++
+		(autoPlugins flatMap { case DetectedAutoPlugin(name, ap, hasAutoImport) =>
+			if (hasAutoImport) Some(name + ".autoImport")
+			else None
+		}))
 	/** A function to select the right [[AutoPlugin]]s from [[autoPlugins]] for a [[Project]]. */
 	lazy val deducePlugins: (Plugins, Logger) => Seq[AutoPlugin] = Plugins.deducer(autoPlugins.values.toList)
 }
@@ -115,7 +121,7 @@ final class LoadedPlugins(val base: File, val pluginData: PluginData, val loader
 	@deprecated("Use the primary constructor.", "0.13.2")
 	def this(base: File, pluginData: PluginData, loader: ClassLoader, plugins: Seq[Plugin], pluginNames: Seq[String]) =
 		this(base, pluginData, loader,
-			new DetectedPlugins(new DetectedModules(pluginNames zip plugins), new DetectedModules(Nil), new DetectedModules(Nil), new DetectedModules(Nil))
+			new DetectedPlugins(new DetectedModules(pluginNames zip plugins), Nil, new DetectedModules(Nil))
 		)
 
 	@deprecated("Use detected.plugins.values.", "0.13.2")

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -131,7 +131,7 @@ object Keys
 	val crossVersion = SettingKey[CrossVersion]("cross-version", "Configures handling of the Scala version when cross-building.", CSetting)
 	val classpathOptions = SettingKey[ClasspathOptions]("classpath-options", "Configures handling of Scala classpaths.", DSetting)
 	val definedSbtPlugins = TaskKey[Set[String]]("defined-sbt-plugins", "The set of names of Plugin implementations defined by this project.", CTask)
-	val discoveredSbtPlugins = TaskKey[PluginDiscovery.DiscoveredNames]("discovered-sbt-plugins", "The names of sbt plugin-related modules (modules that extend Build, Plugin, AutoImport, AutoPlugin) defined by this project.", CTask)
+	val discoveredSbtPlugins = TaskKey[PluginDiscovery.DiscoveredNames]("discovered-sbt-plugins", "The names of sbt plugin-related modules (modules that extend Build, Plugin, AutoPlugin) defined by this project.", CTask)
 	val sbtPlugin = SettingKey[Boolean]("sbt-plugin", "If true, enables adding sbt as a dependency and auto-generation of the plugin descriptor file.", BMinusSetting)
 	val printWarnings = TaskKey[Unit]("print-warnings", "Shows warnings from compilation, including ones that weren't printed initially.", BPlusTask)
 	val fileInputOptions = SettingKey[Seq[String]]("file-input-options", "Options that take file input, which may invalidate the cache.", CSetting)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -125,7 +125,7 @@ object BuiltinCommands
 
 	def aboutPlugins(e: Extracted): String =
 	{
-		def list(b: BuildUnit) = b.plugins.detected.autoPlugins.values.map(_.label) ++ b.plugins.detected.plugins.names
+		def list(b: BuildUnit) = b.plugins.detected.autoPlugins.map(_.value.label) ++ b.plugins.detected.plugins.names
 		val allPluginNames = e.structure.units.values.flatMap(u => list(u.unit)).toSeq.distinct
 		if(allPluginNames.isEmpty) "" else allPluginNames.mkString("Available Plugins: ", ", ", "")
 	}

--- a/main/src/main/scala/sbt/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/PluginDiscovery.scala
@@ -35,7 +35,7 @@ object PluginDiscovery
 		)
 		val detectedAutoPugins = discover[AutoPlugin](AutoPlugins)
 		val allAutoPlugins = (defaultAutoPlugins ++ detectedAutoPugins.modules) map { case (name, value) =>
-			DetectedAutoPlugin(name, value, sbt.Plugins.hasStableAutoImport(value, loader))
+			DetectedAutoPlugin(name, value, sbt.Plugins.hasAutoImportGetter(value, loader))
 		}
 		new DetectedPlugins(discover[Plugin](Plugins), allAutoPlugins, discover[Build](Builds))
 	}

--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -11,9 +11,6 @@ TODO:
 	import Plugins._
 	import annotation.tailrec
 
-/** Marks a top-level object so that sbt will wildcard import it for .sbt files, `consoleProject`, and `set`. */
-trait AutoImport
-
 /**
 An AutoPlugin defines a group of settings and the conditions where the settings are automatically added to a build (called "activation").
 The `requires` and `trigger` methods together define the conditions, and a method like `projectSettings` defines the settings to add.
@@ -65,6 +62,10 @@ abstract class AutoPlugin extends Plugins.Basic with PluginsFunctions
 	val label: String = getClass.getName.stripSuffix("$")
 
 	override def toString: String = label
+
+	/** When this method is overridden with a val or a lazy val, `autoImport._` is automatically
+	 * imported to *.sbt scripts. */
+	def autoImport: Any = ()
 
 	/** The [[Configuration]]s to add to each project that activates this AutoPlugin.*/
 	def projectConfigurations: Seq[Configuration] = Nil
@@ -307,4 +308,16 @@ ${listConflicts(conflicting)}""")
 			case Exclude(a) => !model(a)
 			case ap: AutoPlugin => model(ap)
 		}
+
+	private[sbt] def hasStableAutoImport(ap: AutoPlugin, loader: ClassLoader): Boolean = {
+		import reflect.runtime.{universe => ru}
+		import util.control.Exception.catching
+		val m = ru.runtimeMirror(loader)
+		val im = m.reflect(ap)
+		val fmOpt = catching(classOf[ScalaReflectionException]) opt {
+			val autoImportSym = im.symbol.asType.toType.declaration(ru.newTermName("autoImport")).asTerm
+			im.reflectField(autoImportSym)
+		}
+		fmOpt.isDefined
+	} 
 }

--- a/main/src/main/scala/sbt/PluginsDebug.scala
+++ b/main/src/main/scala/sbt/PluginsDebug.scala
@@ -108,7 +108,7 @@ private[sbt] object PluginsDebug
 		structure.units.values.toList.flatMap(availableAutoPlugins).map(plugin => (plugin.label, plugin)).toMap
 	}
 	private[this] def availableAutoPlugins(build: LoadedBuildUnit): Seq[AutoPlugin] =
-		build.unit.plugins.detected.autoPlugins.values
+		build.unit.plugins.detected.autoPlugins map {_.value}
 
 	def help(plugin: AutoPlugin, s: State): String =
 	{

--- a/sbt/src/sbt-test/project/auto-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins/build.sbt
@@ -1,4 +1,4 @@
-import sbttest.{Q}
+import sbttest.{Q, S}
 
 // disablePlugins(Q) will prevent R from being auto-added
 lazy val projA = project.addPlugins(A, B).disablePlugins(Q)

--- a/sbt/src/sbt-test/project/auto-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins/build.sbt
@@ -1,3 +1,5 @@
+import sbttest.{Q}
+
 // disablePlugins(Q) will prevent R from being auto-added
 lazy val projA = project.addPlugins(A, B).disablePlugins(Q)
 

--- a/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
@@ -25,7 +25,8 @@ object Imports
 
 object X extends AutoPlugin {
 	override lazy val autoImport = Imports
-	def select = Plugins.empty
+	def requires = Plugins.empty
+	def trigger = noTrigger
 }
 
 	import Imports._

--- a/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
@@ -1,8 +1,10 @@
+package sbttest // you need package http://stackoverflow.com/questions/9822008/
+
 	import sbt._
 	import sbt.Keys.{name, resolvedScoped}
 	import java.util.concurrent.atomic.{AtomicInteger => AInt}
 
-object AI extends AutoImport
+object Imports
 {
 	trait EmptyAutoPlugin extends AutoPlugin {
 		def requires = empty
@@ -21,7 +23,12 @@ object AI extends AutoImport
 	lazy val check = settingKey[Unit]("Verifies settings are as they should be.")
 }
 
-	import AI._
+object X extends AutoPlugin {
+	override lazy val autoImport = Imports
+	def select = Plugins.empty
+}
+
+	import Imports._
 
 object D extends AutoPlugin {
 	def requires: Plugins = E

--- a/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
@@ -24,7 +24,7 @@ object Imports
 }
 
 object X extends AutoPlugin {
-	override lazy val autoImport = Imports
+	val autoImport = Imports
 	def requires = Plugins.empty
 	def trigger = noTrigger
 }

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
@@ -13,7 +13,8 @@ object Imports {
 
 object C extends AutoPlugin {
 	override lazy val autoImport = Imports
-	def select = Plugins.empty
+	def requires = empty
+	def trigger = noTrigger
 }
 
 	import Imports._

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
@@ -1,16 +1,22 @@
+package sbttest // you need package http://stackoverflow.com/questions/9822008/
+
 import sbt._
 import Keys._
 
-
-object C extends AutoImport {
+object Imports {
 	object bN extends AutoPlugin {
 		def requires = empty
 		def trigger = allRequirements
 	}
-	lazy val check = taskKey[Unit]("Checks that the AutoPlugin and Build are automatically added.")
+	lazy val check = taskKey[Unit]("Checks that the AutoPlugin and Build are automatically added.")	
 }
 
-	import C._
+object C extends AutoPlugin {
+	override lazy val autoImport = Imports
+	def select = Plugins.empty
+}
+
+	import Imports._
 
 object A extends AutoPlugin {
 	def requires = bN

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
@@ -3,21 +3,19 @@ package sbttest // you need package http://stackoverflow.com/questions/9822008/
 import sbt._
 import Keys._
 
-object Imports {
-	object bN extends AutoPlugin {
-		def requires = empty
-		def trigger = allRequirements
-	}
-	lazy val check = taskKey[Unit]("Checks that the AutoPlugin and Build are automatically added.")	
-}
-
 object C extends AutoPlugin {
-	override lazy val autoImport = Imports
+	object autoImport {
+		object bN extends AutoPlugin {
+			def requires = empty
+			def trigger = allRequirements
+		}
+		lazy val check = taskKey[Unit]("Checks that the AutoPlugin and Build are automatically added.")			
+	}
 	def requires = empty
 	def trigger = noTrigger
 }
 
-	import Imports._
+	import C.autoImport._
 
 object A extends AutoPlugin {
 	def requires = bN

--- a/src/main/conscript/sbt/launchconfig
+++ b/src/main/conscript/sbt/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.2-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.3-SNAPSHOT]}
   class: sbt.xMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}

--- a/src/main/conscript/scalas/launchconfig
+++ b/src/main/conscript/scalas/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.2-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.3-SNAPSHOT]}
   class: sbt.ScriptMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}

--- a/src/main/conscript/screpl/launchconfig
+++ b/src/main/conscript/screpl/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.2-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.3-SNAPSHOT]}
   class: sbt.ConsoleMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}


### PR DESCRIPTION
I'm resending #1198 since target branch needs to be changed to 0.13.

See #1188 for details. This pull req implements @jroper's `def autoImport: Any` idea. 
- `trait AutoImport` is subsumed by `def autoImport` method under `AutoPlugin`.
- When `def autoImport` is overridden by a `lazy val` or a `val`, `*.sbt` automatically imports `autoImport._`.
