### PR TITLE
Rename GlobalModule -> CorePlugin

### DIFF
--- a/main/src/main/scala/sbt/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/PluginDiscovery.scala
@@ -29,9 +29,9 @@ object PluginDiscovery
 		import Paths._
 		// TODO - Fix this once we can autodetect AutoPlugins defined by sbt itself.
 		val defaultAutoPlugins = Seq(
-			"sbt.plugins.IvyModule" -> sbt.plugins.IvyModule,
-			"sbt.plugins.JvmModule" -> sbt.plugins.JvmModule,
-			"sbt.plugins.GlobalModule" -> sbt.plugins.GlobalModule
+			"sbt.plugins.IvyPlugin" -> sbt.plugins.IvyPlugin,
+			"sbt.plugins.JvmPlugin" -> sbt.plugins.JvmPlugin,
+			"sbt.plugins.CorePlugin" -> sbt.plugins.CorePlugin
 		)
 		val detectedAutoPugins = discover[AutoPlugin](AutoPlugins)
 		val allAutoPlugins = (defaultAutoPlugins ++ detectedAutoPugins.modules) map { case (name, value) =>

--- a/main/src/main/scala/sbt/plugins/CorePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/CorePlugin.scala
@@ -8,7 +8,7 @@ import Def.Setting
  *
  * Can control task-level paralleism, logging, etc.
  */
-object GlobalModule extends AutoPlugin {
+object CorePlugin extends AutoPlugin {
   // This is included by default
   override def trigger = allRequirements
   

--- a/main/src/main/scala/sbt/plugins/IvyPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/IvyPlugin.scala
@@ -13,12 +13,12 @@ import Def.Setting
  * - `artifacts`
  * - `publishedArtifacts`
  */
-object IvyModule extends AutoPlugin {
+object IvyPlugin extends AutoPlugin {
   // We are automatically included on everything that has the global module,
   // which is automatically included on everything.
-  override def requires = GlobalModule
+  override def requires = CorePlugin
   override def trigger = allRequirements
-  
+
   override lazy val projectSettings: Seq[Setting[_]] = 
     Classpaths.ivyPublishSettings ++ Classpaths.ivyBaseSettings
   override lazy val globalSettings: Seq[Setting[_]] =

--- a/main/src/main/scala/sbt/plugins/JvmPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JvmPlugin.scala
@@ -14,10 +14,10 @@ import Def.Setting
  *  - `Test`
  *  - `Compile`
  */
-object JvmModule extends AutoPlugin {
+object JvmPlugin extends AutoPlugin {
   // We are automatically enabled for any IvyModule project.  We also require its settings
   // for ours to work.
-  override def requires = IvyModule
+  override def requires = IvyPlugin
   override def trigger = allRequirements
   
   override lazy val projectSettings: Seq[Setting[_]] = 

--- a/src/sphinx/Getting-Started/Using-Plugins.rst
+++ b/src/sphinx/Getting-Started/Using-Plugins.rst
@@ -35,7 +35,7 @@ Adding settings for a plugin
 
 A plugin can declare that its settings be automatically added, in which case you don't have to do anything to add them.
 
-As of sbt 0.13.2, there is a new :doc:`auto-plugins <../DetailedTopics/AutoPlugins>` feature that enables plugins
+As of sbt 0.13.5, there is a new :doc:`auto-plugins <../DetailedTopics/AutoPlugins>` feature that enables plugins
 to automatically, and safely, ensure their settings and dependencies are on a project.  Most plugins should have
 their default settings automatically, however some may require explicit enablement.
 
@@ -51,16 +51,16 @@ For example ::
 
     > plugins
     In file:/home/jsuereth/projects/sbt/test-ivy-issues/
-      sbt.plugins.IvyModule: enabled in test-ivy-issues
-      sbt.plugins.JvmModule: enabled in test-ivy-issues
-      sbt.plugins.GlobalModule: enabled in test-ivy-issues
+      sbt.plugins.IvyPlugin: enabled in test-ivy-issues
+      sbt.plugins.JvmPlugin: enabled in test-ivy-issues
+      sbt.plugins.CorePlugin: enabled in test-ivy-issues
 
 
 Here, the plugins output is showing that the sbt default plugins are all enabled.  Sbt's default settings are provided via three plugins:
 
-1. GlobalModule:  Provides the core parallelism controls for tasks
-2. IvyModule:     Provides the mechanisms to publish/resolve modules.
-3. JvmModule:     Provides the mechanisms to compile/test/run/package Java/Scala projects.
+1. CorePlugin:    Provides the core parallelism controls for tasks
+2. IvyPlugin:     Provides the mechanisms to publish/resolve modules.
+3. JvmPlugin:     Provides the mechanisms to compile/test/run/package Java/Scala projects.
 
 
 However, older plugins often required settings to be added explictly, so that :doc:`multi-project build <Multi-Project>` could have different types of projects.  The plugin documentation will indicate how to configure it, but typically for older plugins this involves adding the base settings for the plugin and customizing as necessary.


### PR DESCRIPTION
Global plugin is a term used for `~/.sbt/0.13/*`.
