### PR TITLE
Deprecate autoSettings, Rename ProjectSettings => BuildScalaFiles

### DIFF
--- a/main/src/main/scala/sbt/AddSettings.scala
+++ b/main/src/main/scala/sbt/AddSettings.scala
@@ -15,8 +15,7 @@ object AddSettings
 	private[sbt] final class AutoPlugins(val include: AutoPlugin => Boolean) extends AddSettings
 	private[sbt] final class DefaultSbtFiles(val include: File => Boolean) extends AddSettings
 	private[sbt] final class SbtFiles(val files: Seq[File]) extends AddSettings
-	// Settings created with the Project().settings() commands in build.scala files.
-	private[sbt] final object ProjectSettings extends AddSettings
+	private[sbt] final object BuildScalaFiles extends AddSettings
 
 	/** Adds all settings from autoplugins. */
 	val autoPlugins: AddSettings = new AutoPlugins(const(true))  // Note: We do not expose fine-grained autoplugins because
@@ -27,7 +26,7 @@ object AddSettings
 	                                                             // in place.
 
 	/** Settings specified in Build.scala `Project` constructors. */
-	val projectSettings: AddSettings = ProjectSettings
+	val buildScalaFiles: AddSettings = BuildScalaFiles
 
     /** All plugins that aren't auto plugins. */
 	val nonAutoPlugins: AddSettings = plugins(const(true))
@@ -51,7 +50,7 @@ object AddSettings
 	def seq(autos: AddSettings*): AddSettings = new Sequence(autos)
 
     /** The default inclusion of settings. */
-	val allDefaults: AddSettings = seq(autoPlugins, projectSettings, userSettings, nonAutoPlugins, defaultSbtFiles)
+	val allDefaults: AddSettings = seq(autoPlugins, buildScalaFiles, userSettings, nonAutoPlugins, defaultSbtFiles)
 
 	/** Combines two automatic setting configurations. */
 	def append(a: AddSettings, b: AddSettings): AddSettings = (a,b) match {

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -125,8 +125,11 @@ sealed trait Project extends ProjectDefinition[ProjectReference]
 	/** Appends settings to the current settings sequence for this project. */
 	def settings(ss: Setting[_]*): Project = copy(settings = (settings: Seq[Setting[_]]) ++ ss)
 
+	@deprecated("Use settingSets method.", "0.13.5")
+	def autoSettings(select: AddSettings*): Project = settingSets(select.toSeq: _*)
+
 	/** Configures how settings from other sources, such as .sbt files, are appended to the explicitly specified settings for this project. */
-	def autoSettings(select: AddSettings*): Project = copy(auto = AddSettings.seq(select : _*))
+	def settingSets(select: AddSettings*): Project = copy(auto = AddSettings.seq(select : _*))
 
 	/** Adds a list of .sbt files whose settings will be appended to the settings of this project.
 	* They will be appended after the explicit settings and already defined automatic settings sources. */

--- a/sbt/src/sbt-test/project/auto-settings/project/P.scala
+++ b/sbt/src/sbt-test/project/auto-settings/project/P.scala
@@ -6,22 +6,22 @@
 object B extends Build
 {
 	// version should be from explicit/a.txt
-	lazy val root = project("root", "1.4") autoSettings( projectSettings,userSettings, sbtFiles(file("explicit/a.txt")) )
+	lazy val root = project("root", "1.4") settingSets( buildScalaFiles, userSettings, sbtFiles(file("explicit/a.txt")) )
 
 	// version should be from global/user.sbt
-	lazy val a = project("a", "1.1") autoSettings( projectSettings, userSettings )
+	lazy val a = project("a", "1.1") settingSets( buildScalaFiles, userSettings )
 
 	// version should be the default 0.1-SNAPSHOT
-	lazy val b = project("b", "0.1-SNAPSHOT") autoSettings(projectSettings)
+	lazy val b = project("b", "0.1-SNAPSHOT") settingSets(buildScalaFiles)
 
 	// version should be from the explicit settings call
-	lazy val c = project("c", "0.9") settings(version := "0.9") autoSettings(projectSettings)
+	lazy val c = project("c", "0.9") settings(version := "0.9") settingSets(buildScalaFiles)
 
 	// version should be from d/build.sbt
-	lazy val d = project("d", "1.3") settings(version := "0.9") autoSettings( projectSettings, defaultSbtFiles )
+	lazy val d = project("d", "1.3") settings(version := "0.9") settingSets( buildScalaFiles, defaultSbtFiles )
 
 	// version should be from global/user.sbt
-	lazy val e = project("e", "1.1") settings(version := "0.9") autoSettings( projectSettings, defaultSbtFiles, sbtFiles(file("../explicit/a.txt")), userSettings )
+	lazy val e = project("e", "1.1") settings(version := "0.9") settingSets( buildScalaFiles, defaultSbtFiles, sbtFiles(file("../explicit/a.txt")), userSettings )
 
 	def project(id: String, expectedVersion: String): Project = Project(id, if(id == "root") file(".") else file(id)) settings(
 		TaskKey[Unit]("check") <<= version map { v =>

--- a/sbt/src/sbt-test/project/delegate_config/project/Build.scala
+++ b/sbt/src/sbt-test/project/delegate_config/project/Build.scala
@@ -12,11 +12,11 @@ object B extends Build
 	val sample = SettingKey[Int]("sample")
 	val check = TaskKey[Unit]("check")
 	
-	lazy val root = Project("root", file("."), settings = Nil).autoSettings()
+	lazy val root = Project("root", file("."), settings = Nil).settingSets()
 	lazy val sub = Project("sub", file("."), 
 		delegates = root :: Nil, 
 		configurations = newConfig :: Nil, 
-		settings = incSample :: checkTask(4) :: Nil).autoSettings(projectSettings)
+		settings = incSample :: checkTask(4) :: Nil).settingSets(buildScalaFiles)
 	override lazy val settings =
 		(sample in newConfig := 3) ::
 		checkTask(3) ::

--- a/sbt/src/sbt-test/project/multi/changes/Build1.scala
+++ b/sbt/src/sbt-test/project/multi/changes/Build1.scala
@@ -8,5 +8,5 @@ object TestBuild extends Build
 		proj("a", "."),
 		proj("b", "b")
 	)
-	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).autoSettings(projectSettings)
+	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).settingSets(buildScalaFiles)
 }

--- a/sbt/src/sbt-test/project/multi/changes/Build2.scala
+++ b/sbt/src/sbt-test/project/multi/changes/Build2.scala
@@ -12,5 +12,5 @@ object SecondBuild extends MakeBuild
 trait MakeBuild extends Build
 {
 	import AddSettings._
-	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).autoSettings(projectSettings, defaultSbtFiles)
+	def proj(id: String, dir: String) = Project(id, file(dir), settings = Seq( name := id ) ).settingSets(buildScalaFiles, defaultSbtFiles)
 }

--- a/sbt/src/sbt-test/project/sbt-file-projects/build.sbt
+++ b/sbt/src/sbt-test/project/sbt-file-projects/build.sbt
@@ -2,7 +2,7 @@ val a = "a"
 val f = file("a")
 val g = taskKey[Unit]("A task in the root project")
 
-val p = Project(a, f).autoSettings(AddSettings.autoPlugins, AddSettings.sbtFiles( file("a.sbt") ))
+val p = Project(a, f).settingSets(AddSettings.autoPlugins, AddSettings.sbtFiles( file("a.sbt") ))
 
 val b = Project("b", file("b"))
 

--- a/sbt/src/sbt-test/project/sbt-file-projects/changes/Restricted.scala
+++ b/sbt/src/sbt-test/project/sbt-file-projects/changes/Restricted.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object B extends Build {
-	lazy val root = Project("root", file(".")).autoSettings(
+	lazy val root = Project("root", file(".")).settingSets(
 		AddSettings.autoPlugins,
 		AddSettings.sbtFiles( file("other.sbt") )) // ignore build.sbt
 }

--- a/src/sphinx/Architecture/Setting-Initialization.rst
+++ b/src/sphinx/Architecture/Setting-Initialization.rst
@@ -74,7 +74,7 @@ To do so, use the ``AddSettings`` class ::
 
     object MyOwnOrder extends Build {
 	  // here we load config from a txt file.
-	  lazy val root = project.in(file(".")).autoSettings( autoPlugins, projectSettings, sbtFiles(file("silly.txt")) )
+	  lazy val root = project.in(file(".")).settingSets( autoPlugins, buildScalaFiles, sbtFiles(file("silly.txt")) )
 	}
 
 In the above project, we've modified the order of settings to be:
@@ -92,7 +92,7 @@ The AddSettings object provides the following "groups" of settings you can use f
 
 ``autoPlugins``
   All the ordered settings of plugins after they've gone through dependency resolution
-``projectSettings``
+``buildScalaFiles``
   The full sequence of settings defined directly in ``project/*.scala`` builds.
 ``sbtFiles(*)``
   Specifies the exact setting DSL files to include (files must use the ``.sbt`` file format)
@@ -104,7 +104,7 @@ The AddSettings object provides the following "groups" of settings you can use f
 
 *Note: Be very careful when reordering settings.  It's easy to accidentally remove core functionality.*
 
-For example, let's see what happens if we move the ``build.sbt`` files *before* the ``projectSettings``.
+For example, let's see what happens if we move the ``build.sbt`` files *before* the ``buildScalaFile``.
 
 Let's create an example project the following defintiion:
 
@@ -112,7 +112,7 @@ Let's create an example project the following defintiion:
 
   object MyTestBuild extends Build {
 
-    val testProject = project.in(file(".")).autoSettings(autoPlugins, defaultSbtFiles, projectSettings).settings(
+    val testProject = project.in(file(".")).settingSets(autoPlugins, defaultSbtFiles, buildScalaFile).settings(
       version := scalaBinaryVersion.value match {
         case "2.10" => "1.0-SNAPSHOT"
         case v => "1.0-for-${v}-SNAPSHOT"


### PR DESCRIPTION
- `autoSettings` is renamed to `settingSets`. Since this was part of 0.13.0 we need to deprecate it first.
- `ProjectSettings` is not out yet, so we can rename this to `BuildScalaFiles`
