### PR TITLE
Roll back aggressive deletion of cache. Fixes #1091.

### DIFF
--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -7,7 +7,6 @@ import Resolver.PluginPattern
 
 import java.io.File
 import java.net.URI
-import java.text.ParseException
 import java.util.concurrent.Callable
 import java.util.{Collection, Collections => CS}
 import CS.singleton
@@ -24,9 +23,7 @@ import core.settings.IvySettings
 import plugins.latest.LatestRevisionStrategy
 import plugins.matcher.PatternMatcher
 import plugins.parser.m2.PomModuleDescriptorParser
-import plugins.repository.ResourceDownloader
 import plugins.resolver.{ChainResolver, DependencyResolver}
-import plugins.resolver.util.ResolvedResource
 import util.{Message, MessageLogger}
 import util.extendable.ExtendableItem
 
@@ -358,41 +355,8 @@ private object IvySbt
 				case pr: ProjectResolver => true
 				case _ => false
 			}
-			/** This is overridden to delete outofdate artifacts of changing modules that are not listed in the metadata.
-			* This occurs for artifacts with classifiers, for example. */
-			@throws(classOf[ParseException])
-			override def cacheModuleDescriptor(resolver: DependencyResolver, mdRef: ResolvedResource, dd: DependencyDescriptor, moduleArtifact: IArtifact, downloader: ResourceDownloader, options: CacheMetadataOptions): ResolvedModuleRevision =
-			{
-				val rmrRaw = super.cacheModuleDescriptor(null, mdRef, dd, moduleArtifact, downloader, options)
-				val rmr = resetArtifactResolver(rmrRaw)
-				val mrid = moduleArtifact.getModuleRevisionId
-				def shouldClear(): Boolean = rmr != null &&
-					( (rmr.getReport != null && rmr.getReport.isSearched && isChanging(dd, mrid)) ||
-						isProjectResolver(rmr.getResolver) )
-				// only handle changing modules whose metadata actually changed.
-				// Typically, the publication date in the metadata has to change to get here.
-				if(shouldClear()) {
-					// this is the locally cached metadata as originally retrieved (e.g. the pom)
-					val original = rmr.getReport.getOriginalLocalFile
-					if(original != null) {
-						// delete all files in subdirectories that are older than the original metadata file's publication date
-						//  The publication date is used because the metadata will be redownloaded for changing files,
-						//  so the last modified time changes, but the publication date doesn't
-						val pubDate = rmrRaw.getPublicationDate
-						val lm = if(pubDate eq null) original.lastModified else pubDate.getTime
-						val indirectFiles = PathFinder(original.getParentFile).*(DirectoryFilter).**(-DirectoryFilter).get.toList
-						val older = indirectFiles.filter(f => f.lastModified < lm).toList
-						Message.verbose("Deleting additional old artifacts from cache for changed module " + mrid + older.mkString(":\n\t", "\n\t", ""))
-						IO.delete(older)
-					}
-				}
-				rmr
-			}
 			// ignore the original resolver wherever possible to avoid issues like #704
 			override def saveResolvers(descriptor: ModuleDescriptor, metadataResolverName: String, artifactResolverName: String) {}
-
-			def isChanging(dd: DependencyDescriptor, requestedRevisionId: ModuleRevisionId): Boolean =
-				!localOnly && (dd.isChanging || requestedRevisionId.getRevision.contains("-SNAPSHOT"))
 		}
 		manager.setArtifactPattern(PluginPattern + manager.getArtifactPattern)
 		manager.setDataFilePattern(PluginPattern + manager.getDataFilePattern)


### PR DESCRIPTION
- sbt 0.12.3 introduced 482f9905235217c339934d8a7a560aae13b7f296 (aggressive deletion of cache) to fix #637 and #641.
- The underlying issue of #641 was an incorrect classifier, and it was
  fixed in 718fa9177254e6067cafdc1ee6a744ba5c325921 for #683 and shipped as sbt 0.13.0.

We should roll back 482f9905235217c339934d8a7a560aae13b7f296 to fix #1091 (re-download of SNAPSHOTs). Rolling it back should not cause regression of #641 as confirmed by the scripted test `scripted dependency-management/cache-classifiers` and its externalized version [eed3si9n/test-sbt-641](https://github.com/eed3si9n/test-sbt-641).
