### PR TITLE
Documentation default paths filtering resources use unmanagedResources (0.13.1)

### DIFF
--- a/src/sphinx/Howto/defaultpaths.rst
+++ b/src/sphinx/Howto/defaultpaths.rst
@@ -173,13 +173,13 @@ When sbt traverses :key:`unmanagedResourceDirectories` for resources, it only in
 :key:`includeFilter` and :key:`excludeFilter` have type `java.io.FileFilter` and sbt :ref:`provides some useful combinators <file-filter>` for constructing a `FileFilter`.
 For example, in addition to the default hidden files exclusion, the following also ignores files containing `impl` in their name, ::
 
-    excludeFilter in unmanagedSources := HiddenFileFilter || "*impl*"
+    excludeFilter in unmanagedResources := HiddenFileFilter || "*impl*"
 
 To have different filters for main and test libraries, configure `Compile` and `Test` separately: ::
 
-    includeFilter in (Compile, unmanagedSources) := "*.txt"
+    includeFilter in (Compile, unmanagedResources) := "*.txt"
 
-    includeFilter in (Test, unmanagedSources) := "*.html"
+    includeFilter in (Test, unmanagedResources) := "*.html"
 
 .. note::
 


### PR DESCRIPTION
Correct target branch for previous pull request https://github.com/sbt/sbt/pull/1182

In the documentation filtering resources should use unmanagedResources and not unmanagedSources.
