### PR TITLE
Implemented the fileParser and added DynamicExamples.

### DIFF
--- a/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
+++ b/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
@@ -1,0 +1,49 @@
+package sbt.complete
+
+import java.io.File
+
+/**
+ * These sources of examples are used in parsers for user input completion. An example of such a source is the
+ * [[sbt.complete.FileExamples]] class, which provides a list of suggested files to the user as they press the
+ * TAB key in the console.
+ */
+trait ExampleSource
+{
+  /**
+   * @return a (possibly lazy) list of completion example strings. These strings are continuations of user's input. The
+   *         user's input is incremented with calls to [[withAddedPrefix]].
+   */
+  def apply(): Iterable[String]
+
+  /**
+   * @param addedPrefix a string that just typed in by the user.
+   * @return a new source of only those examples that start with the string typed by the user so far (with addition of
+   *         the just added prefix).
+   */
+  def withAddedPrefix(addedPrefix: String): ExampleSource
+}
+
+/**
+ * Provides path completion examples based on files in the base directory.
+ * @param base the directory within which this class will search for completion examples.
+ * @param prefix the part of the path already written by the user.
+ */
+class FileExamples(base: File, prefix: String = "") extends ExampleSource {
+  private val relativizedPrefix: String = "." + File.separator + prefix
+
+  override def apply(): Iterable[String] = files(base).map(_.toString.substring(relativizedPrefix.length))
+
+  override def withAddedPrefix(addedPrefix: String): FileExamples = new FileExamples(base, prefix + addedPrefix)
+
+  protected def fileStartsWithPrefix(path: File): Boolean = path.toString.startsWith(relativizedPrefix)
+
+  protected def directoryStartsWithPrefix(path: File): Boolean = {
+    val pathString = path.toString
+    pathString.startsWith(relativizedPrefix) || relativizedPrefix.startsWith(pathString)
+  }
+
+  protected def files(directory: File): Iterable[File] = {
+    val (subDirectories, filesOnly) = directory.listFiles().toStream.partition(_.isDirectory)
+    filesOnly.filter(fileStartsWithPrefix) ++ subDirectories.filter(directoryStartsWithPrefix).flatMap(files)
+  }
+}

--- a/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
+++ b/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
@@ -24,7 +24,8 @@ trait ExampleSource
 }
 
 /**
- * @param examples the source of examples that will be displayed to the user when they press the TAB key.
+ * A convenience example source that wraps any collection of strings into a source of examples.
+ * @param examples the examples that will be displayed to the user when they press the TAB key.
  */
 sealed case class FixedSetExamples(examples: Iterable[String]) extends ExampleSource {
 	override def withAddedPrefix(addedPrefix: String): ExampleSource = FixedSetExamples(examplesWithRemovedPrefix(addedPrefix))

--- a/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
+++ b/util/complete/src/main/scala/sbt/complete/ExampleSource.scala
@@ -9,18 +9,29 @@ import java.io.File
  */
 trait ExampleSource
 {
-  /**
-   * @return a (possibly lazy) list of completion example strings. These strings are continuations of user's input. The
-   *         user's input is incremented with calls to [[withAddedPrefix]].
-   */
-  def apply(): Iterable[String]
+	/**
+	 * @return a (possibly lazy) list of completion example strings. These strings are continuations of user's input. The
+	 *         user's input is incremented with calls to [[withAddedPrefix]].
+	 */
+	def apply(): Iterable[String]
 
-  /**
-   * @param addedPrefix a string that just typed in by the user.
-   * @return a new source of only those examples that start with the string typed by the user so far (with addition of
-   *         the just added prefix).
-   */
-  def withAddedPrefix(addedPrefix: String): ExampleSource
+	/**
+	 * @param addedPrefix a string that just typed in by the user.
+	 * @return a new source of only those examples that start with the string typed by the user so far (with addition of
+	 *         the just added prefix).
+	 */
+	def withAddedPrefix(addedPrefix: String): ExampleSource
+}
+
+/**
+ * @param examples the source of examples that will be displayed to the user when they press the TAB key.
+ */
+sealed case class FixedSetExamples(examples: Iterable[String]) extends ExampleSource {
+	override def withAddedPrefix(addedPrefix: String): ExampleSource = FixedSetExamples(examplesWithRemovedPrefix(addedPrefix))
+
+	override def apply(): Iterable[String] = examples
+
+	private def examplesWithRemovedPrefix(prefix: String) = examples.collect { case example if example startsWith prefix => example substring prefix.length }
 }
 
 /**
@@ -29,21 +40,21 @@ trait ExampleSource
  * @param prefix the part of the path already written by the user.
  */
 class FileExamples(base: File, prefix: String = "") extends ExampleSource {
-  private val relativizedPrefix: String = "." + File.separator + prefix
+	private val relativizedPrefix: String = "." + File.separator + prefix
 
-  override def apply(): Iterable[String] = files(base).map(_.toString.substring(relativizedPrefix.length))
+	override def apply(): Iterable[String] = files(base).map(_.toString.substring(relativizedPrefix.length))
 
-  override def withAddedPrefix(addedPrefix: String): FileExamples = new FileExamples(base, prefix + addedPrefix)
+	override def withAddedPrefix(addedPrefix: String): FileExamples = new FileExamples(base, prefix + addedPrefix)
 
-  protected def fileStartsWithPrefix(path: File): Boolean = path.toString.startsWith(relativizedPrefix)
+	protected def fileStartsWithPrefix(path: File): Boolean = path.toString.startsWith(relativizedPrefix)
 
-  protected def directoryStartsWithPrefix(path: File): Boolean = {
-    val pathString = path.toString
-    pathString.startsWith(relativizedPrefix) || relativizedPrefix.startsWith(pathString)
-  }
+	protected def directoryStartsWithPrefix(path: File): Boolean = {
+		val pathString = path.toString
+		pathString.startsWith(relativizedPrefix) || relativizedPrefix.startsWith(pathString)
+	}
 
-  protected def files(directory: File): Iterable[File] = {
-    val (subDirectories, filesOnly) = directory.listFiles().toStream.partition(_.isDirectory)
-    filesOnly.filter(fileStartsWithPrefix) ++ subDirectories.filter(directoryStartsWithPrefix).flatMap(files)
-  }
+	protected def files(directory: File): Iterable[File] = {
+		val (subDirectories, filesOnly) = directory.listFiles().toStream.partition(_.isDirectory)
+		filesOnly.filter(fileStartsWithPrefix) ++ subDirectories.filter(directoryStartsWithPrefix).flatMap(files)
+	}
 }

--- a/util/complete/src/main/scala/sbt/complete/Parser.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parser.scala
@@ -744,6 +744,22 @@ private final class Examples[T](delegate: Parser[T], fixed: Set[String]) extends
 			Completions(fixed map(f => Completion.suggestion(f)) )
 	override def toString = "examples(" + delegate + ", " + fixed.take(2) + ")"
 }
+
+/**
+ * This class wraps an existing parser (the delegate), and replaces the delegate's completions with examples from
+ * the given example source.
+ *
+ * This class asks the example source for a limited amount of examples (to prevent lengthy and expensive
+ * computations and large amounts of allocated data). It then passes these examples on to the UI.
+ *
+ * @param delegate the parser to decorate with completion examples (i.e., completion of user input).
+ * @param exampleSource the source from which this class will take examples (potentially filter them with the delegate
+ *                      parser), and pass them to the UI.
+ * @param maxNumberOfExamples the maximum number of completions to read from the example source and pass to the UI. This
+ *                            limit prevents lengthy example generation and allocation of large amounts of memory.
+ * @param removeInvalidExamples indicates whether to remove examples that are deemed invalid by the delegate parser.
+ * @tparam T the type of value produced by the parser.
+ */
 private final class DynamicExamples[T](delegate: Parser[T], exampleSource: ExampleSource, maxNumberOfExamples: Int, removeInvalidExamples: Boolean) extends ValidParser[T]
 {
 	def derive(c: Char) = examples(delegate derive c, exampleSource.withAddedPrefix(c.toString), maxNumberOfExamples, removeInvalidExamples)

--- a/util/complete/src/main/scala/sbt/complete/Parser.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parser.scala
@@ -718,27 +718,6 @@ private final class Examples[T](delegate: Parser[T], fixed: Set[String]) extends
 			Completions(fixed map(f => Completion.suggestion(f)) )
 	override def toString = "examples(" + delegate + ", " + fixed.take(2) + ")"
 }
-
-/**
- * These sources of examples are used in parsers for user input completion. An example of such a source is the
- * [[sbt.complete.Parsers.FileExamples]] class, which provides a list of suggested files to the user as they press the
- * TAB key in the console.
- */
-abstract class ExampleSource
-{
-  /**
-   * @return a (possibly lazy) list of completion example strings. These strings are continuations of user's input. The
-   *         user's input is incremented with calls to [[withAddedPrefix]].
-   */
-	def apply(): Iterable[String]
-
-  /**
-   * @param addedPrefix a string that just typed in by the user.
-   * @return a new source of only those examples that start with the string typed by the user so far (with addition of
-   *         the just added prefix).
-   */
-	def withAddedPrefix(addedPrefix: String): ExampleSource
-}
 private final class DynamicExamples[T](delegate: Parser[T], exampleSource: ExampleSource, maxNumberOfExamples: Int) extends ValidParser[T]
 {
 	def derive(c: Char) = examples(delegate derive c, exampleSource.withAddedPrefix(c.toString), maxNumberOfExamples)

--- a/util/complete/src/main/scala/sbt/complete/Parser.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parser.scala
@@ -752,7 +752,7 @@ private final class ParserWithExamples[T](delegate: Parser[T], exampleSource: Ex
 	}
 
 	private def isExampleValid(example: String): Boolean = {
-		apply(delegate)(example).resultEmpty.isFailure
+		apply(delegate)(example).resultEmpty.isValid
 	}
 }
 private final class StringLiteral(str: String, start: Int) extends ValidParser[String]

--- a/util/complete/src/main/scala/sbt/complete/Parsers.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parsers.scala
@@ -128,7 +128,12 @@ trait Parsers
 	/** Returns true if `c` is an ASCII letter or digit. */
 	def alphanum(c: Char) = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
 
-	class FileExamples(base: File, prefix: String = "") extends SourceOfExamples {
+  /**
+   * Provides path completion examples based on files in the base directory.
+   * @param base the directory within which this class will search for completion examples.
+   * @param prefix the part of the path already written by the user.
+   */
+	class FileExamples(base: File, prefix: String = "") extends ExampleSource {
 		private val relativizedPrefix: String = "." + File.separator + prefix
 
 		override def apply(): Iterable[String] = files(base).map(_.toString.substring(relativizedPrefix.length))
@@ -148,10 +153,20 @@ trait Parsers
 		}
 	}
 
-	def fileParser(base: File, maxNumberOfExamples: Int = 25): Parser[File] =
+  /**
+   * @param base the directory used for completion proposals (when the user presses the TAB key). Only paths under this
+   *             directory will be proposed.
+   * @return the file that was parsed from the input string. The returned path may or may not exist.
+   */
+	def fileParser(base: File, maxNumberOfExamples: Int): Parser[File] =
 		OptSpace ~> StringBasic
 			.examples(new FileExamples(base), maxNumberOfExamples)
 			.map(new File(_))
+
+  /**
+   * See the overloaded [[fileParser]] method.
+   */
+	def fileParser(base: File): Parser[File] = fileParser(base, 25)
 
 	/** Parses a port number.  Currently, this accepts any integer and presents a tab completion suggestion of `<port>`. */
 	lazy val Port = token(IntBasic, "<port>")

--- a/util/complete/src/main/scala/sbt/complete/Parsers.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parsers.scala
@@ -129,31 +129,6 @@ trait Parsers
 	def alphanum(c: Char) = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
 
   /**
-   * Provides path completion examples based on files in the base directory.
-   * @param base the directory within which this class will search for completion examples.
-   * @param prefix the part of the path already written by the user.
-   */
-	class FileExamples(base: File, prefix: String = "") extends ExampleSource {
-		private val relativizedPrefix: String = "." + File.separator + prefix
-
-		override def apply(): Iterable[String] = files(base).map(_.toString.substring(relativizedPrefix.length))
-
-		override def withAddedPrefix(addedPrefix: String): FileExamples = new FileExamples(base, prefix + addedPrefix)
-
-		protected def fileStartsWithPrefix(path: File): Boolean = path.toString.startsWith(relativizedPrefix)
-
-		protected def directoryStartsWithPrefix(path: File): Boolean = {
-			val pathString = path.toString
-			pathString.startsWith(relativizedPrefix) || relativizedPrefix.startsWith(pathString)
-		}
-
-		protected def files(directory: File): Iterable[File] = {
-			val (subDirectories, filesOnly) = directory.listFiles().toStream.partition(_.isDirectory)
-			filesOnly.filter(fileStartsWithPrefix) ++ subDirectories.filter(directoryStartsWithPrefix).flatMap(files)
-		}
-	}
-
-  /**
    * @param base the directory used for completion proposals (when the user presses the TAB key). Only paths under this
    *             directory will be proposed.
    * @return the file that was parsed from the input string. The returned path may or may not exist.

--- a/util/complete/src/main/scala/sbt/complete/Parsers.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parsers.scala
@@ -128,20 +128,15 @@ trait Parsers
 	/** Returns true if `c` is an ASCII letter or digit. */
 	def alphanum(c: Char) = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
 
-  /**
-   * @param base the directory used for completion proposals (when the user presses the TAB key). Only paths under this
-   *             directory will be proposed.
-   * @return the file that was parsed from the input string. The returned path may or may not exist.
-   */
-	def fileParser(base: File, maxNumberOfExamples: Int): Parser[File] =
+	/**
+	 * @param base the directory used for completion proposals (when the user presses the TAB key). Only paths under this
+	 *             directory will be proposed.
+	 * @return the file that was parsed from the input string. The returned path may or may not exist.
+	 */
+	def fileParser(base: File): Parser[File] =
 		OptSpace ~> StringBasic
-			.examples(new FileExamples(base), maxNumberOfExamples)
+			.examples(new FileExamples(base))
 			.map(new File(_))
-
-  /**
-   * See the overloaded [[fileParser]] method.
-   */
-	def fileParser(base: File): Parser[File] = fileParser(base, 25)
 
 	/** Parses a port number.  Currently, this accepts any integer and presents a tab completion suggestion of `<port>`. */
 	lazy val Port = token(IntBasic, "<port>")

--- a/util/complete/src/test/scala/ParserTest.scala
+++ b/util/complete/src/test/scala/ParserTest.scala
@@ -118,7 +118,8 @@ object ParserExample
 
 	val name = token("test")
 	val options = (ws ~> token("quick" | "failed" | "new") )*
-	val include = (ws ~> token(examples(notws.string, Set("am", "is", "are", "was", "were") )) )*
+	val exampleSet = Set("am", "is", "are", "was", "were")
+	val include = (ws ~> token(examples(notws.string, new FixedSetExamples(exampleSet), exampleSet.size, false )) )*
 
 	val t = name ~ options ~ include
 

--- a/util/complete/src/test/scala/sbt/complete/FileExamplesTest.scala
+++ b/util/complete/src/test/scala/sbt/complete/FileExamplesTest.scala
@@ -1,0 +1,92 @@
+package sbt.complete
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import sbt.IO.withTemporaryDirectory
+import java.io.File
+import sbt.IO._
+
+class FileExamplesTest extends Specification
+{
+
+	"listing all files in an absolute base directory" should {
+		"produce the entire base directory's contents" in new directoryStructure {
+			fileExamples().toList should containTheSameElementsAs(allRelativizedPaths)
+		}
+	}
+
+	"listing files with a prefix that matches none" should {
+		"produce an empty list" in new directoryStructure(withCompletionPrefix = "z") {
+			fileExamples().toList should beEmpty
+		}
+	}
+
+	"listing single-character prefixed files" should {
+		"produce matching paths only" in new directoryStructure(withCompletionPrefix = "f") {
+			fileExamples().toList should containTheSameElementsAs(prefixedPathsOnly)
+		}
+	}
+
+	"listing directory-prefixed files" should {
+		"produce matching paths only" in new directoryStructure(withCompletionPrefix = "far") {
+			fileExamples().toList should containTheSameElementsAs(prefixedPathsOnly)
+		}
+
+		"produce sub-dir contents only when appending a file separator to the directory" in new directoryStructure(withCompletionPrefix = "far" + File.separator) {
+			fileExamples().toList should containTheSameElementsAs(prefixedPathsOnly)
+		}
+	}
+
+	"listing files with a sub-path prefix" should {
+		"produce matching paths only" in new directoryStructure(withCompletionPrefix = "far" + File.separator + "ba") {
+			fileExamples().toList should containTheSameElementsAs(prefixedPathsOnly)
+		}
+	}
+
+	"completing a full path" should {
+		"produce a list with an empty string" in new directoryStructure(withCompletionPrefix = "bazaar") {
+			fileExamples().toList shouldEqual List("")
+		}
+	}
+
+	class directoryStructure(withCompletionPrefix: String = "") extends Scope with DelayedInit
+	{
+		var fileExamples: FileExamples = _
+		var baseDir: File = _
+		var childFiles: List[File] = _
+		var childDirectories: List[File] = _
+		var nestedFiles: List[File] = _
+		var nestedDirectories: List[File] = _
+
+		def allRelativizedPaths: List[String] =
+			(childFiles ++ childDirectories ++ nestedFiles ++ nestedDirectories).map(relativize(baseDir, _).get)
+
+		def prefixedPathsOnly: List[String] =
+			allRelativizedPaths.filter(_ startsWith withCompletionPrefix).map(_ substring withCompletionPrefix.length)
+
+		override def delayedInit(testBody: => Unit): Unit = {
+			withTemporaryDirectory {
+				tempDir =>
+					createSampleDirStructure(tempDir)
+					fileExamples = new FileExamples(baseDir, withCompletionPrefix)
+					testBody
+			}
+		}
+
+		private def createSampleDirStructure(tempDir: File): Unit = {
+			childFiles = toChildFiles(tempDir, List("foo", "bar", "bazaar"))
+			childDirectories = toChildFiles(tempDir, List("moo", "far"))
+			nestedFiles = toChildFiles(childDirectories(1), List("farfile1", "barfile2"))
+			nestedDirectories = toChildFiles(childDirectories(1), List("fardir1", "bardir2"))
+
+			(childDirectories ++ nestedDirectories).map(_.mkdirs())
+			(childFiles ++ nestedFiles).map(_.createNewFile())
+
+			// NOTE: Creating a new file here because `tempDir.listFiles()` returned an empty list.
+			baseDir = new File(tempDir.getCanonicalPath)
+		}
+
+		private def toChildFiles(baseDir: File, files: List[String]): List[File] = files.map(new File(baseDir, _))
+	}
+
+}

--- a/util/complete/src/test/scala/sbt/complete/FixedSetExamplesTest.scala
+++ b/util/complete/src/test/scala/sbt/complete/FixedSetExamplesTest.scala
@@ -1,0 +1,26 @@
+package sbt.complete
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+class FixedSetExamplesTest extends Specification {
+
+	"adding a prefix" should {
+		"produce a smaller set of examples with the prefix removed" in new examples {
+			fixedSetExamples.withAddedPrefix("f")() must containTheSameElementsAs(List("oo", "ool", "u"))
+			fixedSetExamples.withAddedPrefix("fo")() must containTheSameElementsAs(List("o", "ol"))
+			fixedSetExamples.withAddedPrefix("b")() must containTheSameElementsAs(List("ar"))
+		}
+	}
+
+	"without a prefix" should {
+		"produce the original set" in new examples {
+			fixedSetExamples() mustEqual exampleSet
+		}
+	}
+
+	trait examples extends Scope {
+		val exampleSet = List("foo", "bar", "fool", "fu")
+		val fixedSetExamples = FixedSetExamples(exampleSet)
+	}
+}

--- a/util/complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
+++ b/util/complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
@@ -1,0 +1,93 @@
+package sbt.complete
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import Completion._
+
+class ParserWithExamplesTest extends Specification {
+
+	"listing a limited number of completions" should {
+		"grab only the needed number of elements the iterable source of examples" in new parserWithLazyExamples {
+			parserWithExamples.completions(0)
+			examples.size shouldEqual maxNumberOfExamples
+		}
+	}
+
+	"listing only valid completions" should {
+		"remove invalid examples" in new parserWithValidExamples {
+			val validCompletions = Completions(Set(
+				suggestion("blue"),
+				suggestion("red")
+			))
+			parserWithExamples.completions(0) shouldEqual validCompletions
+		}
+	}
+
+	"listing completions in a derived parser" should {
+		"produce only examples that match the derivation" in new parserWithValidExamples {
+			val derivedCompletions = Completions(Set(
+				suggestion("lue")
+			))
+			parserWithExamples.derive('b').completions(0) shouldEqual derivedCompletions
+		}
+	}
+
+	"listing unfiltered completions" should {
+		"produce all examples" in new parserWithAllExamples {
+			val completions = Completions(examples.map(suggestion(_)).toSet)
+			parserWithExamples.completions(0) shouldEqual completions
+		}
+	}
+
+	"listing completions in a derived parser" should {
+		"produce only examples that match the derivation" in new parserWithAllExamples {
+			val derivedCompletions = Completions(Set(
+				suggestion("lue"),
+				suggestion("lock")
+			))
+			parserWithExamples.derive('b').completions(0) shouldEqual derivedCompletions
+		}
+	}
+
+	class parserWithLazyExamples extends parser(GrowableSourceOfExamples(), maxNumberOfExamples = 5, removeInvalidExamples = false)
+
+	class parserWithValidExamples extends parser(removeInvalidExamples = true)
+
+	class parserWithAllExamples extends parser(removeInvalidExamples = false)
+
+	case class parser(examples: Iterable[String] = Set("blue", "yellow", "greeen", "block", "red"),
+										maxNumberOfExamples: Int = 25,
+										removeInvalidExamples: Boolean) extends Scope {
+
+		import DefaultParsers._
+
+		val colorParser = "blue" | "green" | "black" | "red"
+		val parserWithExamples = new ParserWithExamples[String](
+			colorParser,
+			FixedSetExamples(examples),
+			maxNumberOfExamples,
+			removeInvalidExamples
+		)
+	}
+
+	case class GrowableSourceOfExamples() extends Iterable[String] {
+		var numberOfIteratedElements: Int = 0
+
+		override def iterator: Iterator[String] = {
+			new Iterator[String] {
+				var currentElement = 0
+
+				override def next(): String = {
+					currentElement += 1
+					numberOfIteratedElements = Math.max(currentElement, numberOfIteratedElements)
+					numberOfIteratedElements.toString
+				}
+
+				override def hasNext: Boolean = true
+			}
+		}
+
+		override def size: Int = numberOfIteratedElements
+	}
+
+}

--- a/util/complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
+++ b/util/complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
@@ -7,14 +7,14 @@ import Completion._
 class ParserWithExamplesTest extends Specification {
 
 	"listing a limited number of completions" should {
-		"grab only the needed number of elements the iterable source of examples" in new parserWithLazyExamples {
+		"grab only the needed number of elements from the iterable source of examples" in new parserWithLazyExamples {
 			parserWithExamples.completions(0)
 			examples.size shouldEqual maxNumberOfExamples
 		}
 	}
 
 	"listing only valid completions" should {
-		"remove invalid examples" in new parserWithValidExamples {
+		"use the delegate parser to remove invalid examples" in new parserWithValidExamples {
 			val validCompletions = Completions(Set(
 				suggestion("blue"),
 				suggestion("red")
@@ -23,8 +23,8 @@ class ParserWithExamplesTest extends Specification {
 		}
 	}
 
-	"listing completions in a derived parser" should {
-		"produce only examples that match the derivation" in new parserWithValidExamples {
+	"listing valid completions in a derived parser" should {
+		"produce only valid examples that start with the character of the derivation" in new parserWithValidExamples {
 			val derivedCompletions = Completions(Set(
 				suggestion("lue")
 			))
@@ -32,15 +32,15 @@ class ParserWithExamplesTest extends Specification {
 		}
 	}
 
-	"listing unfiltered completions" should {
-		"produce all examples" in new parserWithAllExamples {
+	"listing valid and invalid completions" should {
+		"produce the entire source of examples" in new parserWithAllExamples {
 			val completions = Completions(examples.map(suggestion(_)).toSet)
 			parserWithExamples.completions(0) shouldEqual completions
 		}
 	}
 
-	"listing completions in a derived parser" should {
-		"produce only examples that match the derivation" in new parserWithAllExamples {
+	"listing valid and invalid completions in a derived parser" should {
+		"produce only examples that start with the character of the derivation" in new parserWithAllExamples {
 			val derivedCompletions = Completions(Set(
 				suggestion("lue"),
 				suggestion("lock")
@@ -62,7 +62,7 @@ class ParserWithExamplesTest extends Specification {
 		import DefaultParsers._
 
 		val colorParser = "blue" | "green" | "black" | "red"
-		val parserWithExamples = new ParserWithExamples[String](
+		val parserWithExamples: Parser[String] = new ParserWithExamples[String](
 			colorParser,
 			FixedSetExamples(examples),
 			maxNumberOfExamples,
@@ -71,7 +71,7 @@ class ParserWithExamplesTest extends Specification {
 	}
 
 	case class GrowableSourceOfExamples() extends Iterable[String] {
-		var numberOfIteratedElements: Int = 0
+		private var numberOfIteratedElements: Int = 0
 
 		override def iterator: Iterator[String] = {
 			new Iterator[String] {


### PR DESCRIPTION
Main additions:
- Implemented `Parsers.fileParser` (removes a TODO)
- Added `Parser.DynamicExamples` (lazily generates/regenerates completions; especially useful for file completions if there are a lot of files in subdirectories)
- Added `Parser.SourceOfExamples` (an abstraction of the set of examples; allows lazy listing of examples; the only alternative before this was `Set[String]`, which cannot be lazy; `SourceOfExamples` is used by `DynamicExamples`)
- Added `Parsers.FileExamples` (searches for files/directories recursively; it should be fairly efficient, as it lazily traverses only the path with the user's prefix; if there's no prefix, then only a limited number of files are displayed&mdash;this avoids long recursive traversals)
