### PR TITLE
Add task cancellation hooks into the build definition.

### DIFF
--- a/main/src/main/scala/sbt/Aggregation.scala
+++ b/main/src/main/scala/sbt/Aggregation.scala
@@ -59,7 +59,7 @@ final object Aggregation
 		import extracted.structure
 		val toRun = ts map { case KeyValue(k,t) => t.map(v => KeyValue(k,v)) } join;
 		val roots = ts map { case KeyValue(k,_) => k }
-		val config = extractedConfig(extracted, structure, s)
+		val config = extractedTaskConfig(extracted, structure, s)
 
 		val start = System.currentTimeMillis
 		val (newS, result) = withStreams(structure, s){ str =>

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -120,9 +120,9 @@ object Defaults extends BuildCommon
 		trapExit :== true,
 		connectInput :== false,
 		cancelable :== false,
-		taskCancelHandler := { state: State => 
-			if(cancelable.value) TaskEvaluationCancelHandler.Signal
-			else TaskEvaluationCancelHandler.Null
+		taskCancelStrategy := { state: State => 
+			if(cancelable.value) TaskCancellationStrategy.Signal
+			else TaskCancellationStrategy.Null
 		},
 		envVars :== Map.empty,
 		sbtVersion := appConfiguration.value.provider.id.version,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -120,6 +120,10 @@ object Defaults extends BuildCommon
 		trapExit :== true,
 		connectInput :== false,
 		cancelable :== false,
+		taskCancelHandler := { state: State => 
+			if(cancelable.value) TaskEvaluationCancelHandler.Signal
+			else TaskEvaluationCancelHandler.Null
+		},
 		envVars :== Map.empty,
 		sbtVersion := appConfiguration.value.provider.id.version,
 		sbtBinaryVersion := binarySbtVersion(sbtVersion.value),

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -14,7 +14,7 @@ package sbt
 	import std.Transform.{DummyTaskMap,TaskAndValue}
 	import TaskName._
 
-@deprecated("Use EvaluateTaskConfig instead.", "0.13.2")
+@deprecated("Use EvaluateTaskConfig instead.", "0.13.5")
 final case class EvaluateConfig(cancelable: Boolean, restrictions: Seq[Tags.Rule], checkCycles: Boolean = false, progress: ExecuteProgress[Task] = EvaluateTask.defaultProgress)
 
 
@@ -242,7 +242,7 @@ object EvaluateTask
 	def nodeView[HL <: HList](state: State, streams: Streams, roots: Seq[ScopedKey[_]], dummies: DummyTaskMap = DummyTaskMap(Nil)): NodeView[Task] =
 		Transform((dummyRoots, roots) :: (dummyStreamsManager, streams) :: (dummyState, state) :: dummies )
 
-	@deprecated("Use new EvalauteTaskConfig option to runTask", "0.13.2")
+	@deprecated("Use new EvalauteTaskConfig option to runTask", "0.13.5")
     def runTask[T](root: Task[T], state: State, streams: Streams, triggers: Triggers[Task], config: EvaluateConfig)(implicit taskToNode: NodeView[Task]): (State, Result[T]) =
     {
     	val newConfig = EvaluateTaskConfig(config)

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -19,20 +19,34 @@ final case class EvaluateConfig(cancelable: Boolean, restrictions: Seq[Tags.Rule
 
 
 
-/** Represents something that can be cancelled. */
+/** Represents something that can be cancelled. 
+ *  For example, this is implemented by the TaskEngine; invoking `cancel()` allows you
+ *  to cancel the current task exeuction.   A `TaskCancel` is passed to the 
+ *  [[TaskEvalautionCancelHandler]] which is responsible for calling `cancel()` when
+ *  appropriate.
+ */
 trait TaskCancel {
 	/** cancels whatever this points at. */
 	def cancel(): Unit
 }
-/** A handler for registering/remmoving listeners that allow you to cancel tasks. */
+/** 
+ * A handler for registering/remmoving listeners that allow you to cancel task
+ * execution.
+ *
+ * Implementations of this trait determine what will trigger `cancel()` for
+ * the task engine, providing in the `start` method.
+ */
 trait TaskEvaluationCancelHandler {
-  /* Evaluation is starting, here's a mechanism to cancel things. */
+  /** Called when task evaluation starts.
+   *
+   * @param canceller An object that can cancel the current task evaluation session.
+   */
   def start(canceller: TaskCancel): Unit
-  /* Task Evaluation is complete, whether success or failure. */
+  /** Called when task evaluation completes, either in success or failure. */
   def finish(): Unit
 }
 object TaskEvaluationCancelHandler {
-   /** An empty handler that does nothing. */
+   /** An empty handler that does not cancel tasks. */
    object Null extends TaskEvaluationCancelHandler {
    	  def start(canceller: TaskCancel): Unit = ()
       def finish(): Unit = ()

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -346,6 +346,7 @@ object Keys
 	// wrapper to work around SI-2915
 	private[sbt] final class TaskProgress(val progress: ExecuteProgress[Task])
 	private[sbt] val executeProgress = SettingKey[State => TaskProgress]("executeProgress", "Experimental task execution listener.", DTask)
+    private[sbt] val taskCancelHandler = SettingKey[State => TaskEvaluationCancelHandler]("taskCancelHandler", "Experimental task cancellation handler.", DTask)	
 
 	// Experimental in sbt 0.13.2 to enable grabing semantic compile failures.
 	private[sbt] val compilerReporter = TaskKey[Option[xsbti.Reporter]]("compilerReporter", "Experimental hook to listen (or send) compilation failure messages.", DTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -346,7 +346,7 @@ object Keys
 	// wrapper to work around SI-2915
 	private[sbt] final class TaskProgress(val progress: ExecuteProgress[Task])
 	private[sbt] val executeProgress = SettingKey[State => TaskProgress]("executeProgress", "Experimental task execution listener.", DTask)
-    private[sbt] val taskCancelHandler = SettingKey[State => TaskEvaluationCancelHandler]("taskCancelHandler", "Experimental task cancellation handler.", DTask)	
+    private[sbt] val taskCancelStrategy = SettingKey[State => TaskCancellationStrategy]("taskCancelStrategy", "Experimental task cancellation handler.", DTask)	
 
 	// Experimental in sbt 0.13.2 to enable grabing semantic compile failures.
 	private[sbt] val compilerReporter = TaskKey[Option[xsbti.Reporter]]("compilerReporter", "Experimental hook to listen (or send) compilation failure messages.", DTask)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -502,7 +502,7 @@ object Project extends ProjectExtra
 	def runTask[T](taskKey: ScopedKey[Task[T]], state: State, checkCycles: Boolean = false): Option[(State, Result[T])] =
 	{
 		val extracted = Project.extract(state)
-		val ch = EvaluateTask.cancelHandler(extracted, extracted.structure, state)
+		val ch = EvaluateTask.cancelStrategy(extracted, extracted.structure, state)
 		val p = EvaluateTask.executeProgress(extracted, extracted.structure, state)
 		val r = EvaluateTask.restrictions(state)
 		runTask(taskKey, state, EvaluateTaskConfig(r, checkCycles, p, ch))

--- a/sbt/src/sbt-test/actions/task-cancel/build.sbt
+++ b/sbt/src/sbt-test/actions/task-cancel/build.sbt
@@ -1,0 +1,8 @@
+import sbt.ExposeYourself._
+
+taskCancelHandler := { (state: State) =>
+  new TaskEvaluationCancelHandler {
+    override def start(canceller: TaskCancel): Unit = canceller.cancel()
+    override def finish(): Unit = ()
+  }
+}

--- a/sbt/src/sbt-test/actions/task-cancel/build.sbt
+++ b/sbt/src/sbt-test/actions/task-cancel/build.sbt
@@ -2,7 +2,8 @@ import sbt.ExposeYourself._
 
 taskCancelHandler := { (state: State) =>
   new TaskEvaluationCancelHandler {
-    override def start(canceller: TaskCancel): Unit = canceller.cancel()
-    override def finish(): Unit = ()
+    type State = Unit
+    override def onTaskEngineStart(canceller: TaskCancel): Unit = canceller.cancel()
+    override def finish(result: Unit): Unit = ()
   }
 }

--- a/sbt/src/sbt-test/actions/task-cancel/project/Build.scala
+++ b/sbt/src/sbt-test/actions/task-cancel/project/Build.scala
@@ -1,0 +1,5 @@
+package sbt  // this API is private[sbt], so only exposed for trusted clients and folks who like breaking.
+
+object ExposeYourself {
+	val taskCancelHandler = sbt.Keys.taskCancelHandler
+}

--- a/sbt/src/sbt-test/actions/task-cancel/src/main/scala/test.scala
+++ b/sbt/src/sbt-test/actions/task-cancel/src/main/scala/test.scala
@@ -1,0 +1,5 @@
+import scala
+
+object Foo {
+	val x = "this should be long to compile or the test may fail."
+}

--- a/sbt/src/sbt-test/actions/task-cancel/test
+++ b/sbt/src/sbt-test/actions/task-cancel/test
@@ -1,0 +1,3 @@
+# All tasks should fail.
+-> compile
+-> test


### PR DESCRIPTION
This enables configurable strategies for non-CLI clients to register for all task evaluations.
- Mini TaskCancel library
- Deprecate existing EvaluateConfig case class in favor of EvaluateTaskConfig trait (which is
  easier to evolve in BC way)
- Move all methods taking EvaluateConfig into methods taking EvaluateTaskConfig.
- Add hooks in build for cancel handlers
- Expose hooks in Signal library for non-ARM usage

Review by @eed3si9n & @havocp cc @skyluc
