### PR TITLE
Upgrade sbt plugins and version with sbt-git.

### DIFF
--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -8,13 +8,13 @@
 	import Licensed._
 	import Scope.ThisScope
 	import LaunchProguard.{proguard, Proguard}
+	import com.typesafe.sbt.SbtGit.{git, versionWithGit}
 
 object Sbt extends Build
 {
-	override lazy val settings = super.settings ++ buildSettings ++ Status.settings ++ nightlySettings
+	override lazy val settings = super.settings ++ versionWithGit ++ buildSettings ++ Status.settings ++ nightlySettings
 	def buildSettings = Seq(
 		organization := "org.scala-sbt",
-		version := "0.13.5-SNAPSHOT",
 		publishArtifact in packageDoc := false,
 		scalaVersion := "2.10.4",
 		publishMavenStyle := false,

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -41,7 +41,7 @@ object Util
 	lazy val javaOnly = Seq[Setting[_]](/*crossPaths := false, */compileOrder := CompileOrder.JavaThenScala, unmanagedSourceDirectories in Compile <<= Seq(javaSource in Compile).join)
 	lazy val base: Seq[Setting[_]] = Seq(projectComponent) ++ baseScalacOptions ++ Licensed.settings
 	lazy val baseScalacOptions = Seq(
-		scalacOptions ++= Seq("-Xelide-below", "0"),
+		scalacOptions ++= Seq("-Xelide-below", "0", "-deprecation"),
 		scalacOptions <++= scalaVersion map CrossVersion.partialVersion map {
 			case Some((2, 9)) => Nil // support 2.9 for some subprojects for the Scala Eclipse IDE
 			case _ => Seq("-feature", "-language:implicitConversions", "-language:postfixOps", "-language:higherKinds", "-language:existentials")

--- a/project/p.sbt
+++ b/project/p.sbt
@@ -3,8 +3,10 @@ libraryDependencies ++= Seq(
 	"org.jsoup" % "jsoup" % "1.7.1"
 )
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.2")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,2 @@
+// TODO - This should be automaticlaly updated or pulled from the upstream branch.
+git.baseVersion := "0.13.5"


### PR DESCRIPTION
- Version number now includes git SHA for snapshots, or the tag.
- Version base string now encoded in `version.sbt`
- Upgrade to latest sbt-site, sbt-git, sbt-ghpages.
- Show deprecation warnings when building sbt.

Review by @eed3si9n 
