### PR TITLE
`DefaultOptions` for resolvers should not resets existing values.

### DIFF
--- a/main/src/main/scala/sbt/Opts.scala
+++ b/main/src/main/scala/sbt/Opts.scala
@@ -52,8 +52,8 @@ object DefaultOptions {
 	def pluginResolvers(plugin: Boolean, snapshot: Boolean): Seq[Resolver] = {
 		if (plugin && snapshot) Seq(Classpaths.typesafeSnapshots, Classpaths.sbtPluginSnapshots) else Nil
 	}
-	def addResolvers: Setting[_] = Keys.resolvers <<= Keys.isSnapshot apply resolvers
-	def addPluginResolvers: Setting[_] = Keys.resolvers <<= (Keys.sbtPlugin, Keys.isSnapshot) apply pluginResolvers
+	def addResolvers: Setting[_] = Keys.resolvers <++= Keys.isSnapshot apply resolvers
+	def addPluginResolvers: Setting[_] = Keys.resolvers <++= (Keys.sbtPlugin, Keys.isSnapshot) apply pluginResolvers
 
 	@deprecated("Use `credentials(State)` instead to make use of configuration path dynamically configured via `Keys.globalSettingsDirectory`; relying on ~/.ivy2 is not recommended anymore.", "0.12.0")
 	def credentials: Credentials = Credentials(userHome / ".ivy2" / ".credentials")


### PR DESCRIPTION
`DefaultOptions.addResolvers` and `DefaultOptions.addPluginResolvers`
should not reset the existing value while adding the new ones. The
names are prefixed with _add_ afterall.
