### PR TITLE
Move NameHashing from incremental to api subproject.

### DIFF
--- a/compile/api/src/main/scala/xsbt/api/NameHashing.scala
+++ b/compile/api/src/main/scala/xsbt/api/NameHashing.scala
@@ -1,4 +1,4 @@
-package sbt.inc
+package xsbt.api
 
 import xsbti.api.SourceAPI
 import xsbti.api.Definition
@@ -6,7 +6,10 @@ import xsbti.api.DefinitionType
 import xsbti.api.ClassLike
 import xsbti.api._internalOnly_NameHash
 import xsbti.api._internalOnly_NameHashes
-import xsbt.api.Visit
+import xsbti.api.DefinitionType.ClassDef
+import xsbti.api.DefinitionType.Module
+import xsbti.api.DefinitionType.PackageModule
+import xsbti.api.DefinitionType.Trait
 
 /**
  * A class that computes hashes for each group of definitions grouped by a simple name.

--- a/compile/api/src/test/scala/xsbt/api/NameHashingSpecification.scala
+++ b/compile/api/src/test/scala/xsbt/api/NameHashingSpecification.scala
@@ -1,8 +1,7 @@
-package sbt.inc
+package xsbt.api
 
 import org.junit.runner.RunWith
 import xsbti.api._
-import xsbt.api.HashAPI
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 

--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -154,7 +154,7 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
 		if (APIUtil.isScalaSourceName(sourceFile.getName) && APIUtil.hasMacro(source)) macroSources += sourceFile
 		publicNameHashes(sourceFile) = {
 			if (nameHashing)
-				(new NameHashing).nameHashes(source)
+				(new xsbt.api.NameHashing).nameHashes(source)
 			else
 				emptyNameHashes
 		}


### PR DESCRIPTION
It should have been there from the beginning because NameHashing is tied
to internals of the API subproject.

It was added to incremental subproject by mistake.
