### PR TITLE
Pick the right overload in EvaluateTask.runTask

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -292,7 +292,7 @@ object EvaluateTask
     def runTask[T](root: Task[T], state: State, streams: Streams, triggers: Triggers[Task], config: EvaluateConfig)(implicit taskToNode: NodeView[Task]): (State, Result[T]) =
     {
     	val newConfig = EvaluateTaskConfig(config)
-    	runTask(root, state, streams, triggers, config)(taskToNode)
+    	runTask(root, state, streams, triggers, newConfig)(taskToNode)
     }
 	def runTask[T](root: Task[T], state: State, streams: Streams, triggers: Triggers[Task], config: EvaluateTaskConfig)(implicit taskToNode: NodeView[Task]): (State, Result[T]) =
 	{


### PR DESCRIPTION
The deprecated method should forward to the other overloaded alternative
but it recursed instead.

This kind of mistake would be easily caught by linter warning about
unused `newConfig` local variable. I hope we'll get there some day.

Fixes #1251
