### PR TITLE
FIx configuration ordering issues in sbt 0.13.5

### DIFF
--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -469,7 +469,7 @@ object Load
 			val autoConfigs = autoPlugins.flatMap(_.projectConfigurations)
 			val loadedSbtFiles = loadSbtFiles(project.auto, project.base, autoPlugins, project.settings)
 			// add the automatically selected settings, record the selected AutoPlugins, and register the automatically selected configurations
-			val transformed = project.copy(settings = loadedSbtFiles.settings).setAutoPlugins(autoPlugins).overrideConfigs(autoConfigs : _*)
+			val transformed = project.copy(settings = loadedSbtFiles.settings).setAutoPlugins(autoPlugins).prefixConfigs(autoConfigs : _*)
 			(transformed, loadedSbtFiles.projects)
 		}
 		def defaultLoad = loadSbtFiles(AddSettings.defaultSbtFiles, buildBase, Nil, Nil).projects

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -109,6 +109,11 @@ sealed trait Project extends ProjectDefinition[ProjectReference]
 	/** Adds configurations to this project.  Added configurations replace existing configurations with the same name.*/
 	def overrideConfigs(cs: Configuration*): Project = copy(configurations = Defaults.overrideConfigs(cs : _*)(configurations))
 
+    /** Adds configuration at the *start* of the configuration list for this rpoject.  Prevous configurations replace this prefix
+     * list with the same name. 
+     */
+    def prefixConfigs(cs: Configuration*): Project = copy(configurations = Defaults.overrideConfigs(configurations : _*)(cs))
+
 	/** Adds new configurations directly to this project.  To override an existing configuration, use `overrideConfigs`. */
 	def configs(cs: Configuration*): Project = copy(configurations = configurations ++ cs)
 

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -112,7 +112,7 @@ sealed trait Project extends ProjectDefinition[ProjectReference]
     /** Adds configuration at the *start* of the configuration list for this rpoject.  Prevous configurations replace this prefix
      * list with the same name. 
      */
-    def prefixConfigs(cs: Configuration*): Project = copy(configurations = Defaults.overrideConfigs(configurations : _*)(cs))
+    private[sbt] def prefixConfigs(cs: Configuration*): Project = copy(configurations = Defaults.overrideConfigs(configurations : _*)(cs))
 
 	/** Adds new configurations directly to this project.  To override an existing configuration, use `overrideConfigs`. */
 	def configs(cs: Configuration*): Project = copy(configurations = configurations ++ cs)

--- a/sbt/src/sbt-test/actions/configuration-delegation/build.sbt
+++ b/sbt/src/sbt-test/actions/configuration-delegation/build.sbt
@@ -1,0 +1,17 @@
+lazy val foo = taskKey[Unit]("Runs the foo task")
+
+lazy val bar = taskKey[Unit]("Runs the bar task")
+
+def makeFoo(config: Configuration): Setting[_] = 
+  foo in config := IO.write(file(s"${config.name}-foo"), "foo")
+
+lazy val PerformanceTest = (config("pt") extend Test)
+
+lazy val root = (
+  (project in file("."))
+  .configs(PerformanceTest)
+  .settings(Seq(Compile, Test, Runtime, PerformanceTest).map(makeFoo) :_*)
+  .settings(
+     bar in PerformanceTest := IO.write(file("pt-bar"), "bar")
+  )
+)

--- a/sbt/src/sbt-test/actions/configuration-delegation/test
+++ b/sbt/src/sbt-test/actions/configuration-delegation/test
@@ -1,0 +1,8 @@
+# First make sure a task just on the new config delegates.
+> bar
+$ exists pt-bar
+
+
+# Now make sure compile is the default configuration
+> foo
+$ exists compile-foo


### PR DESCRIPTION
The autoplugin configurations represent the new "default project" so they must come first.   The previous mechanism of specifying configurations can override autoplugins, but must be injected _after_ the default configurations.

Review by @eed3si9n or @gkossakowski cc> @jroper
