### PR TITLE
Fixes issue with deadlocking server discovery on windows.

### DIFF
--- a/launch/src/main/scala/xsbt/boot/ServerApplication.scala
+++ b/launch/src/main/scala/xsbt/boot/ServerApplication.scala
@@ -150,7 +150,12 @@ object ServerLauncher {
     } finally {
       errorDumper.close()
       stdout.close()
-      stderr.close()
+      // Note:  Closing this causes windows to block waiting for the server
+      // to close, but it ne'er will, as it is obstinate, and not designed
+      // to close immediately, unlike this process.
+      // We leave it open because this JVM shold be shut down soon anyway,
+      // and that will clean up al this memory.
+      //stderr.close()
     }
   }
   


### PR DESCRIPTION
It turns out windows blocks until a process is finished when
you try to close the stderr handle, but not stdout.  Therefore,
we leave stderr open when we shut down, which lets the server
continue to run on windows.

Review by @havocp cc @eed3si9n 
