### PR TITLE
Use the correct state in buildPluginDefinition()

### DIFF
--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -612,7 +612,7 @@ object Load
 	{
 		val (eval,pluginDef) = apply(dir, s, config)
 		val pluginState = Project.setProject(Load.initialSession(pluginDef, eval), pluginDef, s)
-		config.evalPluginDef(pluginDef, pluginState)
+		config.evalPluginDef(Project.structure(pluginState), pluginState)
 	}
 
 	@deprecated("Use ModuleUtilities.getCheckedObjects[Build].", "0.13.2")


### PR DESCRIPTION
Within buildPluginDefinition(), the call to setProject() can
(and usually will) return a modified structure together with
the new state.

The subsequent call to evalPluginDef() should use the updated
structure, rather the old stucture that was present before
the setProject() ("pluginDef"); if that is not the case,
the code called by evalPluginDef() will find an inconsistent
structure/state combination, and behave in bizarre ways as
a result.

More in general, it is a bit dangerous to pass to routines
in parallel the two separate state and structure, as the
two may easily inadvertently fall out of alignment, as in this
case.

This patch should be applied to both the 0.13 branch as well
as to a future 0.12.5 release (the corresponding file there
is ./main/Load.scala).
