### PR TITLE
Use dedicated api for lastCompilationTime in build definition

### DIFF
--- a/project/Util.scala
+++ b/project/Util.scala
@@ -82,8 +82,8 @@ object Util
 	}
 	def lastCompilationTime(analysis: sbt.inc.Analysis): Long =
 	{
-		val times = analysis.apis.internal.values.map(_.compilation.startTime)
-		if(times.isEmpty) 0L else times.max
+		val lastCompilation = analysis.compilations.allCompilations.lastOption
+		lastCompilation.map(_.startTime) getOrElse 0L
 	}
 	def generateVersionFile(version: String, dir: File, s: TaskStreams, analysis: sbt.inc.Analysis): Seq[File] =
 	{


### PR DESCRIPTION
Since sbt 0.13.0, we have dedicated API in Analysis that gives access to information about all compilations performed since the last time clean was ran.

By looking at at last compilation we can determine lastCompilationTime value.

Fixes #1272
