### PR TITLE
Automatically run GC/finalization after each task execution.

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -325,6 +325,7 @@ object Keys
 	val tags = SettingKey[Seq[(Tags.Tag,Int)]]("tags", ConcurrentRestrictions.tagsKey.label, BSetting)
 	val concurrentRestrictions = SettingKey[Seq[Tags.Rule]]("concurrent-restrictions", "Rules describing restrictions on concurrent task execution.", BSetting)
 	val cancelable = SettingKey[Boolean]("cancelable", "Enables (true) or disables (false) the ability to interrupt task execution with CTRL+C.", BMinusSetting)
+	val forcegc = SettingKey[Boolean]("forcegc", "Enables (true) or disables (false) forcing garbage collection after each task run.", BMinusSetting)
 	val settingsData = std.FullInstance.settingsData
 	val streams = TaskKey[TaskStreams]("streams", "Provides streams for logging and persisting data.", DTask)
 	val taskDefinitionKey = Def.taskDefinitionKey

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -510,7 +510,8 @@ object Project extends ProjectExtra
 		val ch = EvaluateTask.cancelStrategy(extracted, extracted.structure, state)
 		val p = EvaluateTask.executeProgress(extracted, extracted.structure, state)
 		val r = EvaluateTask.restrictions(state)
-		runTask(taskKey, state, EvaluateTaskConfig(r, checkCycles, p, ch))
+		val fgc = EvaluateTask.forcegc(extracted, extracted.structure)
+		runTask(taskKey, state, EvaluateTaskConfig(r, checkCycles, p, ch, fgc))
 	}
     @deprecated("Use EvalauteTaskConfig option instead.", "0.13.5")
 	def runTask[T](taskKey: ScopedKey[Task[T]], state: State, config: EvaluateConfig): Option[(State, Result[T])] =


### PR DESCRIPTION
Fixes #1223.
- Add a new key to disable forcing the garbage collector to run
  after each task-executioin
- Add a new flag to disable forcing the garbage collector to run
  after each task-exeuction
- Add a hook into EvalauteTask to run System.gc/System.runFinalization
  after each task execution

Review by @eed3si9n
