### PR TITLE
Separate location of analysis cache if we're cross compiling scala.

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -142,6 +142,7 @@ object Keys
 	val consoleProject = TaskKey[Unit]("console-project", "Starts the Scala interpreter with the sbt and the build definition on the classpath and useful imports.", AMinusTask)
 	val compile = TaskKey[Analysis]("compile", "Compiles sources.", APlusTask)
 	val compilers = TaskKey[Compiler.Compilers]("compilers", "Defines the Scala and Java compilers to use for compilation.", DTask)
+	val compileAnalysisFilename = TaskKey[String]("compileAnalysisFilename", "Defines the filename used to store the incremental compiler analysis file (inside the streams cacheDirectory).", DTask)
 	val compileIncSetup = TaskKey[Compiler.IncSetup]("inc-compile-setup", "Configures aspects of incremental compilation.", DTask)
 	val compilerCache = TaskKey[GlobalsCache]("compiler-cache", "Cache of scala.tools.nsc.Global instances.  This should typically be cached so that it isn't recreated every task run.", DTask)
 	val stateCompilerCache = AttributeKey[GlobalsCache]("compiler-cache", "Internal use: Global cache.")

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
@@ -1,0 +1,12 @@
+name := "foo"
+
+scalaVersion := "2.10.4"
+
+crossScalaVersions := List("2.10.4", "2.11.0")
+
+incOptions := incOptions.value.withNewClassfileManager(
+  sbt.inc.ClassfileManager.transactional(
+    crossTarget.value / "classes.bak",
+    (streams in (Compile, compile)).value.log
+  )
+)

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/foo.scala
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/foo.scala
@@ -1,0 +1,6 @@
+package foo
+
+object Foo extends App {
+  println("yay")
+}
+

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/test
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/test
@@ -1,0 +1,3 @@
+> + compile
+$ exists target/scala-2.10
+$ exists target/scala-2.11


### PR DESCRIPTION
- Add task to determine file-name of analysis cache
- If crossPaths := true, then add scala binary version to the analysis cache name.

This makes it possible to leverage incremental compilation with the `+` command.

Fixes #1267 

Review by @gkossakowski  cc> @eed3si9n 
