### PR TITLE
add precompiled 2.11.0

### DIFF
--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -102,6 +102,7 @@ object Sbt extends Build
 	lazy val precompiled282 = precompiled("2.8.2")
 	lazy val precompiled292 = precompiled("2.9.2")
 	lazy val precompiled293 = precompiled("2.9.3")
+	lazy val precompiled2110 = precompiled("2.11.0")
 
 		// Implements the core functionality of detecting and propagating changes incrementally.
 		//   Defines the data structures for representing file fingerprints and relationships and the overall source analysis
@@ -137,7 +138,7 @@ object Sbt extends Build
 		// Strictly for bringing implicits and aliases from subsystems into the top-level sbt namespace through a single package object
 		//  technically, we need a dependency on all of mainSub's dependencies, but we don't do that since this is strictly an integration project
 		//  with the sole purpose of providing certain identifiers without qualification (with a package object)
-	lazy val sbtSub = baseProject(sbtPath, "sbt") dependsOn(mainSub, compileInterfaceSub, precompiled282, precompiled292, precompiled293, scriptedSbtSub % "test->test") settings(sbtSettings : _*)
+	lazy val sbtSub = baseProject(sbtPath, "sbt") dependsOn(mainSub, compileInterfaceSub, precompiled282, precompiled292, precompiled293, precompiled2110, scriptedSbtSub % "test->test") settings(sbtSettings : _*)
 
 		/* Nested subproject paths */
 	def sbtPath = file("sbt")


### PR DESCRIPTION
## what this changes

Adds Scala 2.11.0 to the precompiled.
## expectations

The benefit is that the projects using 2.11.0 would boot up faster.
