### PR TITLE
Add a warning if the build scala version is evicted for another.

### DIFF
--- a/ivy/src/main/scala/sbt/IvyConflcitReport.scala
+++ b/ivy/src/main/scala/sbt/IvyConflcitReport.scala
@@ -1,0 +1,54 @@
+package sbt
+
+import java.io.File
+
+
+/** Represents that one module ousted others. */
+final case class DependencyEviction(val chosen: ModuleID, val evicted: Seq[ModuleID]) {
+	override def toString = s"${chosen} -> ${evicted.map(_.revision).mkString("(", ", ", ")")}"
+}
+final case class CrossVersionConflict(organization: String, rawName: String, crossVersions: Set[String]) {
+	override def toString = s"${organization}:${rawName} -> ${crossVersions.mkString("(", ", ", ")")}"
+}
+/** represents the evictions for a given configuration (duplicated data from UpdateReport). */
+final case class ConfigurationEvictions(config: String, evictions: Seq[DependencyEviction]) {
+	override def toString = 
+       if(evictions.isEmpty) s"[evictions - $config]"
+	   else s"[evictions - $config]\n${evictions.mkString("* ", "\n* ", "")}"
+}
+/** A report of all eviction/conflicts within the previous update. */
+final case class ConflictReport private (configurations: Seq[ConfigurationEvictions], crossVersions: Seq[CrossVersionConflict]) {
+	private[this] def crossVersionToString: String = 
+	  s"[scala binary conflicts]${if(crossVersions.isEmpty) "" else crossVersions.mkString("\n* ", "\n* ", "")}"
+	override def toString = s"-- ConflictReport --\n${crossVersionToString}\n${configurations mkString "\n"}"
+}
+
+object ConflictReport {
+	def makeConflictReport(report: UpdateReport): ConflictReport = {
+		def key(m: ModuleID): String = s"${m.organization}:${m.name}"
+		def evictionsForConfig(c: ConfigurationReport): Iterable[DependencyEviction] = {
+			def chosen(mkey: String): Option[ModuleID] =
+			  c.modules map (_.module) find { m => key(m) == mkey }
+			c.evicted groupBy key flatMap {
+				case (mkey, evicted) =>
+				  chosen(mkey) match {
+				  	case Some(m) => DependencyEviction(m, evicted) :: Nil
+				  	case None => Nil
+				  }
+			}
+		}
+		val crossConflicts = 
+			for( ((org,rawName), fullNames) <- ConflictWarning.crossVersionMismatches(report) ) 
+			yield {
+				val suffixes = fullNames map ConflictWarning.getCrossSuffix
+				CrossVersionConflict(org, rawName, suffixes)
+			}
+
+		ConflictReport(report.configurations map { configReport =>
+			ConfigurationEvictions(
+				configReport.configuration,
+				evictionsForConfig(configReport).toSeq
+			)
+		}, crossConflicts.toSeq)
+	}
+}

--- a/ivy/src/main/scala/sbt/UpdateReport.scala
+++ b/ivy/src/main/scala/sbt/UpdateReport.scala
@@ -32,6 +32,9 @@ final class UpdateReport(val cachedDescriptor: File, val configurations: Seq[Con
 
 	/** Gets the names of all resolved configurations.  This `UpdateReport` contains one `ConfigurationReport` for each configuration in this list. */
 	def allConfigurations: Seq[String] = configurations.map(_.configuration)
+
+	/** A faster index to conflicts/evictions in this update report. */
+	lazy val conflicts: ConflictReport = ConflictReport.makeConflictReport(this)
 }
 
 /** Provides information about resolution of a single configuration.

--- a/main/src/main/scala/sbt/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/GlobalPlugin.scala
@@ -9,6 +9,9 @@ package sbt
 	import org.apache.ivy.core.module.{descriptor, id}
 	import descriptor.ModuleDescriptor, id.ModuleRevisionId
 
+/**
+ * This object knows how to load ~/.sbt/<version> projects and their settings.
+ */
 object GlobalPlugin
 {
 		// constructs a sequence of settings that may be appended to a project's settings to

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -245,6 +245,7 @@ object Keys
 	val ivySbt = TaskKey[IvySbt]("ivy-sbt", "Provides the sbt interface to Ivy.", CTask)
 	val ivyModule = TaskKey[IvySbt#Module]("ivy-module", "Provides the sbt interface to a configured Ivy module.", CTask)
 	val update = TaskKey[UpdateReport]("update", "Resolves and optionally retrieves dependencies, producing a report.", ATask)
+	val updateConflictReport = TaskKey[ConflictReport]("updateConflictReport", "The configuration used to issue a conflict report on update..", CTask)
 	val transitiveUpdate = TaskKey[Seq[UpdateReport]]("transitive-update", "UpdateReports for the internal dependencies of this project.", DTask)
 	val updateClassifiers = TaskKey[UpdateReport]("update-classifiers", "Resolves and optionally retrieves classified artifacts, such as javadocs and sources, for dependency definitions, transitively.", BPlusTask, update)
 	val transitiveClassifiers = SettingKey[Seq[String]]("transitive-classifiers", "List of classifiers used for transitively obtaining extra artifacts for sbt or declared dependencies.", BSetting)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -482,7 +482,7 @@ object Project extends ProjectExtra
 	def projectReturn(s: State): List[File] = getOrNil(s, ProjectReturn)
 	def inPluginProject(s: State): Boolean = projectReturn(s).toList.length > 1
 	def setProjectReturn(s: State, pr: List[File]): State = s.copy(attributes = s.attributes.put( ProjectReturn, pr) )
-	def loadAction(s: State, action: LoadAction.Value) = action match {
+	def loadAction(s: State, action: LoadAction.Value): (State, File) = action match {
 		case Return =>
 			projectReturn(s) match
 			{


### PR DESCRIPTION
- Add new ConflictReport helper to build to display only conflict information
- Add hook to issue warnings if the scalaVersion isn't the one resolved
- Update documentation to reflect these changes.

Review by @eed3si9n 
