### PR TITLE
Do not attempt to publish if no artifacts are present

### DIFF
--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -255,16 +255,18 @@ object IvyActions
 
 	def publish(module: ModuleDescriptor, artifacts: Seq[(IArtifact, File)], resolver: DependencyResolver, overwrite: Boolean): Unit =
 	{
-		checkFilesPresent(artifacts)
-		try {
-			resolver.beginPublishTransaction(module.getModuleRevisionId(), overwrite);
-			for( (artifact, file) <- artifacts)
-				resolver.publish(artifact, file, overwrite)
-			resolver.commitPublishTransaction()
-		} catch {
-			case e: Throwable =>
-				try { resolver.abortPublishTransaction() }
-				finally { throw e }
+		if (artifacts.nonEmpty) {
+			checkFilesPresent(artifacts)
+			try {
+				resolver.beginPublishTransaction(module.getModuleRevisionId(), overwrite);
+				for( (artifact, file) <- artifacts)
+					resolver.publish(artifact, file, overwrite)
+				resolver.commitPublishTransaction()
+			} catch {
+				case e: Throwable =>
+					try { resolver.abortPublishTransaction() }
+					finally { throw e }
+			}
 		}
 	}
 	private[this] def checkFilesPresent(artifacts: Seq[(IArtifact, File)])


### PR DESCRIPTION
Ivy transactional publishing will abort if no artifacts
are published, either because the temporary directory is
not being created, or because Ivy will detect an anomalous
condition.

Therefore, skip publishing altogether if there is
nothing to publish to begin with.

Fixes #1281
