### PR TITLE
Sort setting key names in the inspect tree view

### DIFF
--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -45,7 +45,7 @@ case class SettingGraph(name: String,
     } getOrElse { "" }
 
   def dependsAscii: String = Graph.toAscii(this,
-    (x: SettingGraph) => x.depends.toSeq,
+    (x: SettingGraph) => x.depends.toSeq.sortBy(_.name),
     (x: SettingGraph) => "%s = %s" format (x.definedIn getOrElse { "" }, x.dataString))
 }
 


### PR DESCRIPTION
This little add-on helps quite a lot when comparing two dependency trees, i.e. after and before a change in the build.
