### PR TITLE
Check for object autoImport in auto plugins. 

### DIFF
--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -319,9 +319,9 @@ ${listConflicts(conflicting)}""")
 		val hasGetterOpt = catching(classOf[ScalaReflectionException]) opt {
 			im.symbol.asType.toType.declaration(ru.newTermName("autoImport")) match {
 				case ru.NoSymbol => false
-				case sym => sym.asTerm.isGetter
+				case sym => sym.asTerm.isGetter || sym.asTerm.isModule
 			}
 		}
 		hasGetterOpt getOrElse false
-	} 
+	}
 }

--- a/sbt/src/sbt-test/project/auto-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins/build.sbt
@@ -33,6 +33,8 @@ check := {
 	same(optInValue, " Q S R", "del in projE in q")
 }
 
+keyTest := "foo"
+
 def same[T](actual: T, expected: T, label: String) {
 	assert(actual == expected, s"Expected '$expected' for `$label`, got '$actual'")
 }

--- a/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
@@ -28,6 +28,10 @@ object X extends AutoPlugin {
 object D extends AutoPlugin {
 	override def requires: Plugins = E
 	override def trigger = allRequirements
+
+	object autoImport {
+		lazy val keyTest = settingKey[String]("Another demo setting.")
+	}
 }
 
 object Q extends AutoPlugin


### PR DESCRIPTION
Fixes #1314 
## what this changes

Apparently when I was coding this I had intended to work only for `val` and `lazy val`. Later we included `object autoImport` as a use case but apparently did not check. Now we have the support for `object autoImport` and test to confirm it.
