### PR TITLE
Enable name hashing algorithm in sbt build.

### DIFF
--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -22,7 +22,8 @@ object Sbt extends Build {
     resolvers += Resolver.typesafeIvyRepo("releases"),
     concurrentRestrictions in Global += Util.testExclusiveRestriction,
     testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
-    javacOptions in compile ++= Seq("-target", "6", "-source", "6", "-Xlint", "-Xlint:-serial")
+    javacOptions in compile ++= Seq("-target", "6", "-source", "6", "-Xlint", "-Xlint:-serial"),
+    incOptions := incOptions.value.withNameHashing(true)
   )
 
   lazy val myProvided = config("provided") intransitive;


### PR DESCRIPTION
The name hashing seems to be stable enough for sbt to use it by default
now. It also greatly improves incremental compilation experience for
people working on sbt sources.
