### PR TITLE
Added community plugins page link to fm-sbt-s3-resolver (S3 Resolver/Publishing support for SBT)

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -258,6 +258,8 @@ Utility plugins
    https://github.com/jozic/sbt-about-plugins
 -  sbt-git-stamp (include git metadata in MANIFEST.MF file in artifact):
    https://bitbucket.org/pkaeding/sbt-git-stamp
+-  fm-sbt-s3-resolver (Resolve and Publish using Amazon S3):
+   https://github.com/frugalmechanic/fm-sbt-s3-resolver
 
 Code coverage plugins
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Replacement pull request for https://github.com/sbt/sbt/pull/1310 that is based on the 0.13.2b branch
