### PR TITLE
Fixed a typo

### DIFF
--- a/src/sphinx/Extending/Plugins.rst
+++ b/src/sphinx/Extending/Plugins.rst
@@ -269,7 +269,7 @@ An example of a typical plugin:
 
     object Plugin extends AutoPlugin
     {
-        // by definging autoImport, these are automatically imported into user's `*.sbt`
+        // by defining autoImport, these are automatically imported into user's `*.sbt`
         object autoImport
         {
             // configuration points, like the built in `version`, `libraryDependencies`, or `compile`


### PR DESCRIPTION
This patch fixes a typo in a comment of a plugin implementation example.
