### PR TITLE
Fixed project/derived test to pass

### DIFF
--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -536,7 +536,7 @@ object Load {
             case DiscoveredProjects(Some(root), discovered, files) =>
               log.debug(s"[Loading] Found root project ${root.id} w/ remaining ${discovered.map(_.id).mkString(",")}")
               val finalRoot = finalizeProject(root, files)
-              loadTransitive(discovered, buildBase, plugins, eval, injectSettings, acc :+ finalRoot, memoSettings, log, false, buildUri, context)
+              loadTransitive(discovered, buildBase, plugins, eval, injectSettings, finalRoot +: acc, memoSettings, log, false, buildUri, context)
             // Here we need to create a root project...
             case DiscoveredProjects(None, discovered, files) =>
               log.debug(s"[Loading] Found non-root projects ${discovered.map(_.id).mkString(",")}")
@@ -546,7 +546,7 @@ object Load {
               val refs = existingIds map (id => ProjectRef(buildUri, id))
               val defaultID = autoID(buildBase, context, existingIds)
               val root = finalizeProject(Build.defaultAggregatedProject(defaultID, buildBase, refs), files)
-              val result = (acc ++ otherProjects) :+ root
+              val result = root +: (acc ++ otherProjects)
               log.debug(s"[Loading] Done in ${buildBase}, returning: ${result.map(_.id).mkString("(", ", ", ")")}")
               result
           }


### PR DESCRIPTION
Review by @eed3si9n cc @dansanduleac

Basically, the type of derived setting test which is now failing is the following:

``` scala
Def.derive(customC := s"${organization.value}-${customC.value}-${version.value}")
```

Also, derived settings must _explicitly_ be placed in the global scope to be able to derive them into projects now.   All the default sbt derived settings had this in place, it's only the tests that needed to be updated.

In general, @dansanduleac's changes bring more "stability" and regularity to derived settings, the issue remains that I have no idea what the above setting _should_ do.  For now, we'll leave the behavior unspecified, as all tests are passing and we don't really document/recommend derived settings for users yet.
