### PR TITLE
fix the "fork in [T]est" documentation

### DIFF
--- a/src/sphinx/Detailed-Topics/Forking.rst
+++ b/src/sphinx/Detailed-Topics/Forking.rst
@@ -48,7 +48,7 @@ the :key:`test` scope:
 
 ::
 
-    fork in test := true
+    fork in Test := true
 
 See :doc:`Testing` for more control over how tests are assigned to JVMs and
 what options to pass to each group.


### PR DESCRIPTION
"fork in test" doesn't work with sbt 0.13.2
