### PR TITLE
Ensure sequences in analysis files are read in order.

### DIFF
--- a/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
+++ b/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
@@ -436,7 +436,7 @@ object TextAnalysisFormat {
   }
 
   private[this] def readSeq[T](in: BufferedReader)(expectedHeader: String, s2t: String => T): Seq[T] =
-    (readPairs(in)(expectedHeader, identity[String], s2t) map (_._2)).toSeq
+    (readPairs(in)(expectedHeader, identity[String], s2t).toSeq.sortBy(_._1) map (_._2))
 
   private[this] def writeMap[K, V](out: Writer)(header: String, m: Map[K, V], v2s: V => String, inlineVals: Boolean = true)(implicit ord: Ordering[K]) {
     writeHeader(out, header)


### PR DESCRIPTION
For various reasons, we serialize sequences as:

0 -> foo
1 -> bar
...

Until now we were implicitly relying on the sequences being in order.
However external code may end up (due to bugs or otherwise) messing
with the ordering:

1 -> bar
0 -> foo
...

This change ensures that we don't get confused by that. Although
it's best if external code doesn't mess up the ordering, it's still
a good idea to be defensive about this.

Note that the sequences we serialize are short, so the extra sort
is not a performance concern.
