### PR TITLE
Remove line of dead code.

### DIFF
--- a/main/command/src/main/scala/sbt/State.scala
+++ b/main/command/src/main/scala/sbt/State.scala
@@ -183,7 +183,6 @@ object State {
           log.debug(s"> $x")
           f(x, s.copy(remainingCommands = xs, history = x :: s.history))
       }
-    s.copy(remainingCommands = s.remainingCommands.drop(1))
     def :::(newCommands: Seq[String]): State = s.copy(remainingCommands = newCommands ++ s.remainingCommands)
     def ::(command: String): State = (command :: Nil) ::: this
     def ++(newCommands: Seq[Command]): State = s.copy(definedCommands = (s.definedCommands ++ newCommands).distinct)


### PR DESCRIPTION
Unmoored expression in constructor does nothing except pack
on a few micros.
