### PR TITLE
SettingsTest: Don't allow generated strings (key names) to be empty

### DIFF
--- a/util/collection/src/test/scala/SettingsTest.scala
+++ b/util/collection/src/test/scala/SettingsTest.scala
@@ -61,9 +61,12 @@ object SettingsTest extends Properties("settings") {
 
   private def mkAttrKeys[T](nr: Int)(implicit mf: Manifest[T]): Gen[List[AttributeKey[T]]] =
     {
-      val alphaStr = Gen.alphaStr
+      import Gen._
+      val nonEmptyAlphaStr =
+        nonEmptyListOf(alphaChar).map(_.mkString).suchThat(_.forall(_.isLetter))
+
       for {
-        list <- Gen.listOfN(nr, alphaStr) suchThat (l => l.size == l.distinct.size)
+        list <- Gen.listOfN(nr, nonEmptyAlphaStr) suchThat (l => l.size == l.distinct.size)
         item <- list
       } yield AttributeKey[T](item)
     }


### PR DESCRIPTION
Sometimes the derived settings tests fail, I presume because of empty string identifiers. 
I'm not 100% sure that's the cause, because the error isn't very clear, but hopefully this will prevent those transient failures.

Example:

```
[info] ! settings.Derived setting chain depending on (prev derived, normal setting): Exception raised on property evaluation.
[info] > ARG_0: 51
[info] > ARG_1: List()
[info] > ARG_1_ORIGINAL: List("ScopedKey(Scope(0,0),ch)", "ScopedKey(Scope(0,0),fhki)", "ScopedKey(Scope(0,0),bleceeSipekAseelQqeiejdalgh)", "ScopedKey(Scope(0,0),Wleoitjyxdz)", "ScopedKey(Scope(0,0),fgjMqoveadido)", "ScopedKey(Scope(0,0),xhfdg)", "ScopedKey(Scope(0,0),ugz)", "ScopedKey(Scope(0,0),PFcywfdxkpodNybcgjqfpybjfv)", "ScopedKey(Scope(0,0),fb)", "ScopedKey(Scope(0,0),jhrjdndmzvfmx)", "ScopedKey(Scope(0,0),slKxntqpoyloHoxdgzpud)", "ScopedKey(Scope(0,0),QwzorxTblgvPzerpalownfdgDscp)", "ScopedKey(Scope(0,0),hmkuuhjKfotzfuzryev)", "ScopedKey(Scope(0,0),wEjfuazlqacqmivrhkuzaeokccv)", "ScopedKey(Scope(0,0),vjrskeWrlpsgycrWDfLqzbbtag)", "ScopedKey(Scope(0,0),zvLtwmlNokatjXighVctUt)", "ScopedKey(Scope(0,0),ikrMhincvpkmWOhfttjsCtwtpdZajag)", "ScopedKey(Scope(0,0),qphwincdboafmfeSnpyiezLemppCowDe)", "ScopedKey(Scope(0,0),neeZukxhvtudknygfwecyjpvr)", "ScopedKey(Scope(0,0),emycvmvkawfzvzkorwbzzwqn)", "ScopedKey(Scope(0,0),udouyluhxqvfzwypeqxwtyepyqvxlkol)", "ScopedKey(Scope(0,0),gBjqavfwvkxwyvrqBpyiosWrqtxvs)", "ScopedKey(Scope(0,0),vjvlkXarq)", "ScopedKey(Scope(0,0),gwDqc)", "ScopedKey(Scope(0,0),kUhmzyp)", "ScopedKey(Scope(0,0),hvtjmmadtdhdqjfiaxwqmhuapuMhosa)", "ScopedKey(Scope(0,0),y)", "ScopedKey(Scope(0,0),zxmysmugzkHzuwnxodsfhbggljxZPdl)", "ScopedKey(Scope(0,0),vGqfdqeKlovvUg)", "ScopedKey(Scope(0,0),wjgf)", "ScopedKey(Scope(0,0),FktvsCd)", "ScopedKey(Scope(0,0),WchjqhUlxi)", "ScopedKey(Scope(0,0),mbrxeTp)", "ScopedKey(Scope(0,0),CFtyqswdmq)", "ScopedKey(Scope(0,0),nksxcfA)", "ScopedKey(Scope(0,0),gfjkHtseuUufnNjU)", "ScopedKey(Scope(0,0),um)", "ScopedKey(Scope(0,0),p)", "ScopedKey(Scope(0,0),yxtkwfombtnvuxwcvrfox)", "ScopedKey(Scope(0,0),lkixfjfqaygYyblgioikL)", "ScopedKey(Scope(0,0),Xcpntmilap)", "ScopedKey(Scope(0,0),sedRlvZqo)", "ScopedKey(Scope(0,0),)", "ScopedKey(Scope(0,0),xo)", "ScopedKey(Scope(0,0),ksZnf)", "ScopedKey(Scope(0,0),jcfsokSwajukyIkgiqpBlt)", "ScopedKey(Scope(0,0),xyeqcjrfzkytoziIirGghkgRznjeibq)", "ScopedKey(Scope(0,0),ghljMM)", "ScopedKey(Scope(0,0),xcxm)", "ScopedKey(Scope(0,0),lkzbmlKfdhOokIkwqva)", "ScopedKey(Scope(0,0),xmqP)")
[info] > Exception: java.util.NoSuchElementException: null
...
[error] Error: Total 11, Failed 0, Errors 1, Passed 10
[error] Error during tests:
[error]     sbt.SettingsTest
```
