### PR TITLE
Roll back Ivy to 2.3.0 for 0.13.5 for #1356

### DIFF
--- a/project/Util.scala
+++ b/project/Util.scala
@@ -168,7 +168,7 @@ object Common
 	def lib(m: ModuleID) = libraryDependencies += m
 	lazy val jlineDep = "jline" % "jline" % "2.11"
 	lazy val jline = lib(jlineDep)
-	lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.4.0-sbt-d6fca11d63402c92e4167cdf2da91a660d043392")
+	lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0")
 	lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
 	lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive() )
 	lazy val sbinary = libraryDependencies <+= Util.nightly211(n => "org.scala-tools.sbinary" % "sbinary" % "0.4.2" cross(if(n) CrossVersion.full else CrossVersion.binary))


### PR DESCRIPTION
This is a fix for #1356.

Due to test failures at the last minute
- https://travis-ci.org/sbt/ivy/builds/25567318
- https://travis-ci.org/sbt/sbt/jobs/25567288

we might need to roll back Ivy back to 2.3.0 final. 
The reported version of sbt that worked was 0.13.2-M3, which uses Ivy 2.3.0.
