### PR TITLE
Accumulate Test Count

### DIFF
--- a/testing/src/main/scala/sbt/TestReportListener.scala
+++ b/testing/src/main/scala/sbt/TestReportListener.scala
@@ -28,9 +28,21 @@ trait TestsListener extends TestReportListener {
 
 /** Provides the overall `result` of a group of tests (a suite) and test counts for each result type. */
 final class SuiteResult(
-  val result: TestResult.Value,
-  val passedCount: Int, val failureCount: Int, val errorCount: Int,
-  val skippedCount: Int, val ignoredCount: Int, val canceledCount: Int, val pendingCount: Int)
+    val result: TestResult.Value,
+    val passedCount: Int, val failureCount: Int, val errorCount: Int,
+    val skippedCount: Int, val ignoredCount: Int, val canceledCount: Int, val pendingCount: Int) {
+  def +(other: SuiteResult): SuiteResult = {
+    val combinedTestResult =
+      (result, other.result) match {
+        case (TestResult.Passed, TestResult.Passed) => TestResult.Passed
+        case (_, TestResult.Error)                  => TestResult.Error
+        case (TestResult.Error, _)                  => TestResult.Error
+        case _                                      => TestResult.Failed
+      }
+    new SuiteResult(combinedTestResult, passedCount + other.passedCount, failureCount + other.failureCount, errorCount + other.errorCount, skippedCount + other.skippedCount,
+      ignoredCount + other.ignoredCount, canceledCount + other.canceledCount, pendingCount + other.pendingCount)
+  }
+}
 
 object SuiteResult {
   /** Computes the overall result and counts for a suite with individual test results in `events`. */


### PR DESCRIPTION
Changed to combine SuiteResult with same name, instead of replacing with latest one. This solves the test result count problem when a Suite is executed more than 1 time due to being returned as nested suites (sub-task).

This solves incorrect test count problem when a suite in ScalaTest is executed more than one time as nested suites, current code simply replace the old count with the new count, this changes will add them up instead.

The following is an issue reported in ScalaTest that drive this request:

https://github.com/scalatest/scalatest/issues/167 
