### PR TITLE
Fix AutoPlugins declared at top-level

### DIFF
--- a/main/src/main/scala/sbt/BuildStructure.scala
+++ b/main/src/main/scala/sbt/BuildStructure.scala
@@ -100,15 +100,24 @@ case class DetectedAutoPlugin(val name: String, val value: AutoPlugin, val hasAu
 final class DetectedPlugins(val plugins: DetectedModules[Plugin], val autoPlugins: Seq[DetectedAutoPlugin], val builds: DetectedModules[Build])
 {
 	/** Sequence of import expressions for the build definition.  This includes the names of the [[Plugin]], [[Build]], and [[AutoImport]] modules, but not the [[AutoPlugin]] modules. */
-	lazy val imports: Seq[String] = BuildUtil.getImports(plugins.names ++ builds.names ++
-		(autoPlugins flatMap { case DetectedAutoPlugin(name, ap, hasAutoImport) =>
-			if (hasAutoImport) Some(name + ".autoImport")
-			else None
-		})) ++
-		BuildUtil.importNamesRoot(autoPlugins map { _.name })
+	lazy val imports: Seq[String] = BuildUtil.getImports(plugins.names ++ builds.names) ++
+		BuildUtil.importAllRoot(autoImports(autoPluginAutoImports)) ++
+		BuildUtil.importAll(autoImports(topLevelAutoPluginAutoImports)) ++
+		BuildUtil.importNamesRoot(autoPlugins.map(_.name).filter(nonTopLevelPlugin))
+
+	private[this] lazy val (autoPluginAutoImports, topLevelAutoPluginAutoImports) =
+    autoPlugins.flatMap { case DetectedAutoPlugin(name, ap, hasAutoImport) =>
+      if (hasAutoImport) Some(name)
+      else None
+    }.partition(nonTopLevelPlugin)
 
 	/** A function to select the right [[AutoPlugin]]s from [[autoPlugins]] for a [[Project]]. */
 	lazy val deducePlugins: (Plugins, Logger) => Seq[AutoPlugin] = Plugins.deducer(autoPlugins.toList map {_.value})
+
+	private[this] def autoImports(pluginNames: Seq[String]) = pluginNames.map(_ + ".autoImport")
+
+  private[this] def nonTopLevelPlugin(name: String) = name.contains('.')
+
 }
 
 /** The built and loaded build definition project.

--- a/sbt/src/sbt-test/project/auto-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins/build.sbt
@@ -13,6 +13,15 @@ lazy val projD = project
 // with S selected, Q is loaded automatically, which in turn selects R
 lazy val projE = project.enablePlugins(S)
 
+// with X enabled, TopA is loaded automatically
+lazy val projF = project.enablePlugins(X)
+
+// only TopB should be enabled
+lazy val projG = project.enablePlugins(TopB)
+
+// enables TopC, which declares topLevelKeyTest
+lazy val projH = project.enablePlugins(TopC)
+
 check := {
 	val adel = (del in projA).?.value // should be None
 	same(adel, None, "del in projA")
@@ -31,9 +40,20 @@ check := {
 	same(qValue, " Q R", "del in projC in q")
 	val optInValue = (del in projE in q).value
 	same(optInValue, " Q S R", "del in projE in q")
+// tests for top level plugins
+  val topLevelAValueF = (topLevelDemo in projF).value
+  same(topLevelAValueF, "TopA: topLevelDemo project projF", "topLevelDemo in projF")
+  val demoValueF = (demo in projF).value
+  same(demoValueF, "TopA: demo project projF", "demo in projF")
+  val topLevelBValueG = (topLevelDemo in projG).value
+  same(topLevelBValueG, "TopB: topLevelDemo project projG", "topLevelDemo in projG")
+  val gdel = (del in projG).?.value
+  same(gdel, None, "del in projG")
 }
 
 keyTest := "foo"
+
+topLevelKeyTest := "bar"
 
 def same[T](actual: T, expected: T, label: String) {
 	assert(actual == expected, s"Expected '$expected' for `$label`, got '$actual'")

--- a/sbt/src/sbt-test/project/auto-plugins/project/A.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/A.scala
@@ -1,0 +1,47 @@
+// no package
+// plugins declared within no package should be visible to other plugins in the _root_ package
+
+import sbt._
+import sbt.Keys._
+
+object TopLevelImports {
+  lazy val topLevelDemo = settingKey[String]("A top level demo setting.")
+}
+
+object TopA extends AutoPlugin {
+
+  import TopLevelImports._
+  import sbttest.Imports._
+
+  val autoImport = TopLevelImports
+
+  override def requires = sbttest.X
+
+  override def trigger = AllRequirements
+
+  override def projectSettings: scala.Seq[sbt.Setting[_]] = Seq(
+    topLevelDemo := s"TopA: topLevelDemo project ${name.value}",
+    demo := s"TopA: demo project ${name.value}"
+  )
+
+}
+
+object TopB extends AutoPlugin {
+
+  import TopLevelImports._
+
+  val autoImport = TopLevelImports
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    topLevelDemo := s"TopB: topLevelDemo project ${name.value}"
+  )
+
+}
+
+object TopC extends AutoPlugin {
+
+  object autoImport {
+    lazy val topLevelKeyTest = settingKey[String]("A top level setting declared in a plugin.")
+  }
+
+}

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/D.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/D.scala
@@ -1,0 +1,11 @@
+// no package declaration
+
+import sbt._
+
+object D extends AutoPlugin {
+
+  object autoImport {
+    lazy val dKey = settingKey[String]("Test key")
+  }
+
+}

--- a/sbt/src/sbt-test/project/binary-plugin/test
+++ b/sbt/src/sbt-test/project/binary-plugin/test
@@ -1,12 +1,13 @@
 # First we define the plugin project and publish it
 $ copy-file changes/define/build.sbt build.sbt
 $ copy-file changes/define/A.scala A.scala
+$ copy-file changes/define/D.scala D.scala
 
 # reload implied
 > publishLocal
 
 # Now we remove the source code and define a project which uses the build.
-$ delete build.sbt A.scala
+$ delete build.sbt A.scala D.scala
 $ copy-file changes/use/plugins.sbt project/plugins.sbt
 > reload
 > check


### PR DESCRIPTION
When having `AutoPlugin` declared as top-level classes, an exception is thrown during build load. This pull request is an attempt to fix it. 

The top-level `AutoPlugin` classes are not imported any more, and `autoImport` statements of top level plugins are not prefixed with `_root_`.

The issue happens on sbt 0.13.5-RC5.

```
import _root_.sbt.plugins.IvyPlugin, _root_.sbt.plugins.JvmPlugin, _root_.sbt.plugins.CorePlugin, _root_.sbt.plugins.JUnitXmlReportPlugin, MyPlugin
                                                                                                                                                   ^
sbt.compiler.EvalException: Error parsing imports for expression.
    at sbt.compiler.Eval.checkError(Eval.scala:343)
    at sbt.compiler.Eval.sbt$compiler$Eval$$parseImport(Eval.scala:295)
    at sbt.compiler.Eval$$anonfun$parseImports$1.apply(Eval.scala:289)
    at sbt.compiler.Eval$$anonfun$parseImports$1.apply(Eval.scala:289)
    at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
    at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
```
