### PR TITLE
Merge 0.13.5 into 0.13

### DIFF
--- a/ivy/src/main/scala/sbt/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/ConvertResolver.scala
@@ -9,10 +9,10 @@ import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.apache.ivy.core.module.descriptor.DependencyDescriptor
 import org.apache.ivy.core.resolve.ResolveData
 import org.apache.ivy.core.settings.IvySettings
-import org.apache.ivy.plugins.resolver.{BasicResolver, DependencyResolver, IBiblioResolver, RepositoryResolver}
-import org.apache.ivy.plugins.resolver.{AbstractPatternsBasedResolver, AbstractSshBasedResolver, FileSystemResolver, SFTPResolver, SshResolver, URLResolver}
-import org.apache.ivy.plugins.repository.url.{URLRepository => URLRepo}
-import org.apache.ivy.plugins.repository.file.{FileRepository => FileRepo, FileResource}
+import org.apache.ivy.plugins.resolver.{ BasicResolver, DependencyResolver, IBiblioResolver, RepositoryResolver }
+import org.apache.ivy.plugins.resolver.{ AbstractPatternsBasedResolver, AbstractSshBasedResolver, FileSystemResolver, SFTPResolver, SshResolver, URLResolver }
+import org.apache.ivy.plugins.repository.url.{ URLRepository => URLRepo }
+import org.apache.ivy.plugins.repository.file.{ FileRepository => FileRepo, FileResource }
 import java.io.File
 import org.apache.ivy.util.ChecksumHelper
 import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact }

--- a/ivy/src/main/scala/sbt/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/ConvertResolver.scala
@@ -5,15 +5,14 @@ package sbt
 
 import java.net.URL
 import java.util.Collections
-import org.apache.ivy.{core,plugins}
-import core.module.id.ModuleRevisionId
-import core.module.descriptor.DependencyDescriptor
-import core.resolve.ResolveData
-import core.settings.IvySettings
-import plugins.resolver.{BasicResolver, DependencyResolver, IBiblioResolver, RepositoryResolver}
-import plugins.resolver.{AbstractPatternsBasedResolver, AbstractSshBasedResolver, FileSystemResolver, SFTPResolver, SshResolver, URLResolver}
-import plugins.repository.url.{URLRepository => URLRepo}
-import plugins.repository.file.{FileRepository => FileRepo, FileResource}
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.module.descriptor.DependencyDescriptor
+import org.apache.ivy.core.resolve.ResolveData
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.resolver.{BasicResolver, DependencyResolver, IBiblioResolver, RepositoryResolver}
+import org.apache.ivy.plugins.resolver.{AbstractPatternsBasedResolver, AbstractSshBasedResolver, FileSystemResolver, SFTPResolver, SshResolver, URLResolver}
+import org.apache.ivy.plugins.repository.url.{URLRepository => URLRepo}
+import org.apache.ivy.plugins.repository.file.{FileRepository => FileRepo, FileResource}
 import java.io.File
 import org.apache.ivy.util.ChecksumHelper
 import org.apache.ivy.core.module.descriptor.{Artifact=>IArtifact}

--- a/ivy/src/main/scala/sbt/CustomPomParser.scala
+++ b/ivy/src/main/scala/sbt/CustomPomParser.scala
@@ -1,13 +1,13 @@
 package sbt
 
-	import org.apache.ivy.core.module.id.ModuleRevisionId
-	import org.apache.ivy.core.module.descriptor.{DefaultArtifact, DefaultExtendsDescriptor, DefaultModuleDescriptor, ModuleDescriptor}
-	import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DependencyDescriptor}
-	import org.apache.ivy.plugins.parser.{ModuleDescriptorParser, ModuleDescriptorParserRegistry, ParserSettings}
-	import org.apache.ivy.plugins.parser.m2.{PomModuleDescriptorBuilder, PomModuleDescriptorParser}
-	import org.apache.ivy.plugins.repository.Resource
-	import org.apache.ivy.plugins.namespace.NamespaceTransformer
-	import org.apache.ivy.util.extendable.ExtendableItem
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.module.descriptor.{ DefaultArtifact, DefaultExtendsDescriptor, DefaultModuleDescriptor, ModuleDescriptor }
+import org.apache.ivy.core.module.descriptor.{ DefaultDependencyDescriptor, DependencyDescriptor }
+import org.apache.ivy.plugins.parser.{ ModuleDescriptorParser, ModuleDescriptorParserRegistry, ParserSettings }
+import org.apache.ivy.plugins.parser.m2.{ PomModuleDescriptorBuilder, PomModuleDescriptorParser }
+import org.apache.ivy.plugins.repository.Resource
+import org.apache.ivy.plugins.namespace.NamespaceTransformer
+import org.apache.ivy.util.extendable.ExtendableItem
 
 import java.io.{ File, InputStream }
 import java.net.URL

--- a/ivy/src/main/scala/sbt/CustomPomParser.scala
+++ b/ivy/src/main/scala/sbt/CustomPomParser.scala
@@ -1,14 +1,13 @@
 package sbt
 
-	import org.apache.ivy.{core, plugins, util}
-	import core.module.id.ModuleRevisionId
-	import core.module.descriptor.{DefaultArtifact, DefaultExtendsDescriptor, DefaultModuleDescriptor, ModuleDescriptor}
-	import core.module.descriptor.{DefaultDependencyDescriptor, DependencyDescriptor}
-	import plugins.parser.{m2, ModuleDescriptorParser, ModuleDescriptorParserRegistry, ParserSettings}
-	import m2.{PomModuleDescriptorBuilder, PomModuleDescriptorParser}
-	import plugins.repository.Resource
-	import plugins.namespace.NamespaceTransformer
-	import util.extendable.ExtendableItem
+	import org.apache.ivy.core.module.id.ModuleRevisionId
+	import org.apache.ivy.core.module.descriptor.{DefaultArtifact, DefaultExtendsDescriptor, DefaultModuleDescriptor, ModuleDescriptor}
+	import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DependencyDescriptor}
+	import org.apache.ivy.plugins.parser.{ModuleDescriptorParser, ModuleDescriptorParserRegistry, ParserSettings}
+	import org.apache.ivy.plugins.parser.m2.{PomModuleDescriptorBuilder, PomModuleDescriptorParser}
+	import org.apache.ivy.plugins.repository.Resource
+	import org.apache.ivy.plugins.namespace.NamespaceTransformer
+	import org.apache.ivy.util.extendable.ExtendableItem
 
 	import java.io.{File, InputStream}
 	import java.net.URL

--- a/ivy/src/main/scala/sbt/CustomXmlParser.scala
+++ b/ivy/src/main/scala/sbt/CustomXmlParser.scala
@@ -6,12 +6,11 @@ package sbt
 import java.io.ByteArrayInputStream
 import java.net.URL
 
-import org.apache.ivy.{core, plugins}
-import core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor}
-import core.settings.IvySettings
-import plugins.parser.xml.XmlModuleDescriptorParser
-import plugins.repository.Resource
-import plugins.repository.url.URLResource
+import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser
+import org.apache.ivy.plugins.repository.Resource
+import org.apache.ivy.plugins.repository.url.URLResource
 
 /** Subclasses the default Ivy file parser in order to provide access to protected methods.*/
 private[sbt] object CustomXmlParser extends XmlModuleDescriptorParser

--- a/ivy/src/main/scala/sbt/CustomXmlParser.scala
+++ b/ivy/src/main/scala/sbt/CustomXmlParser.scala
@@ -6,7 +6,7 @@ package sbt
 import java.io.ByteArrayInputStream
 import java.net.URL
 
-import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.module.descriptor.{ DefaultDependencyDescriptor, DefaultModuleDescriptor }
 import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.plugins.parser.xml.XmlModuleDescriptorParser
 import org.apache.ivy.plugins.repository.Resource

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -12,19 +12,19 @@ import java.util.{ Collection, Collections => CS }
 import CS.singleton
 
 import org.apache.ivy.Ivy
-import org.apache.ivy.core.{IvyPatternHelper, LogOptions}
-import org.apache.ivy.core.cache.{CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter}
-import org.apache.ivy.core.module.descriptor.{Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact}
-import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License}
-import org.apache.ivy.core.module.descriptor.{OverrideDependencyDescriptorMediator}
-import org.apache.ivy.core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
-import org.apache.ivy.core.resolve.{IvyNode, ResolveData, ResolvedModuleRevision}
+import org.apache.ivy.core.{ IvyPatternHelper, LogOptions }
+import org.apache.ivy.core.cache.{ CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter }
+import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact }
+import org.apache.ivy.core.module.descriptor.{ DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License }
+import org.apache.ivy.core.module.descriptor.{ OverrideDependencyDescriptorMediator }
+import org.apache.ivy.core.module.id.{ ArtifactId, ModuleId, ModuleRevisionId }
+import org.apache.ivy.core.resolve.{ IvyNode, ResolveData, ResolvedModuleRevision }
 import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.plugins.latest.LatestRevisionStrategy
 import org.apache.ivy.plugins.matcher.PatternMatcher
 import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorParser
-import org.apache.ivy.plugins.resolver.{ChainResolver, DependencyResolver}
-import org.apache.ivy.util.{Message, MessageLogger}
+import org.apache.ivy.plugins.resolver.{ ChainResolver, DependencyResolver }
+import org.apache.ivy.util.{ Message, MessageLogger }
 import org.apache.ivy.util.extendable.ExtendableItem
 
 import scala.xml.{ NodeSeq, Text }

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -11,21 +11,21 @@ import java.util.concurrent.Callable
 import java.util.{Collection, Collections => CS}
 import CS.singleton
 
-import org.apache.ivy.{core, plugins, util, Ivy}
-import core.{IvyPatternHelper, LogOptions}
-import core.cache.{CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter}
-import core.module.descriptor.{Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact}
-import core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License}
-import core.module.descriptor.{OverrideDependencyDescriptorMediator}
-import core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
-import core.resolve.{IvyNode, ResolveData, ResolvedModuleRevision}
-import core.settings.IvySettings
-import plugins.latest.LatestRevisionStrategy
-import plugins.matcher.PatternMatcher
-import plugins.parser.m2.PomModuleDescriptorParser
-import plugins.resolver.{ChainResolver, DependencyResolver}
-import util.{Message, MessageLogger}
-import util.extendable.ExtendableItem
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.{IvyPatternHelper, LogOptions}
+import org.apache.ivy.core.cache.{CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter}
+import org.apache.ivy.core.module.descriptor.{Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact}
+import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License}
+import org.apache.ivy.core.module.descriptor.{OverrideDependencyDescriptorMediator}
+import org.apache.ivy.core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
+import org.apache.ivy.core.resolve.{IvyNode, ResolveData, ResolvedModuleRevision}
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.latest.LatestRevisionStrategy
+import org.apache.ivy.plugins.matcher.PatternMatcher
+import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorParser
+import org.apache.ivy.plugins.resolver.{ChainResolver, DependencyResolver}
+import org.apache.ivy.util.{Message, MessageLogger}
+import org.apache.ivy.util.extendable.ExtendableItem
 
 import scala.xml.{NodeSeq, Text}
 

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -7,13 +7,13 @@ import java.io.File
 import scala.xml.{ Node => XNode, NodeSeq }
 
 import org.apache.ivy.Ivy
-import org.apache.ivy.core.{IvyPatternHelper, LogOptions}
+import org.apache.ivy.core.{ IvyPatternHelper, LogOptions }
 import org.apache.ivy.core.deliver.DeliverOptions
 import org.apache.ivy.core.install.InstallOptions
-import org.apache.ivy.core.module.descriptor.{Artifact => IArtifact, MDArtifact, ModuleDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact, MDArtifact, ModuleDescriptor, DefaultModuleDescriptor }
 import org.apache.ivy.core.report.ResolveReport
 import org.apache.ivy.core.resolve.ResolveOptions
-import org.apache.ivy.plugins.resolver.{BasicResolver, DependencyResolver}
+import org.apache.ivy.plugins.resolver.{ BasicResolver, DependencyResolver }
 
 final class DeliverConfiguration(val deliverIvyPattern: String, val status: String, val configurations: Option[Seq[Configuration]], val logging: UpdateLogging.Value)
 final class PublishConfiguration(val ivyFile: Option[File], val resolverName: String, val artifacts: Map[Artifact, File], val checksums: Seq[String], val logging: UpdateLogging.Value,

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -6,14 +6,14 @@ package sbt
 import java.io.File
 import scala.xml.{Node => XNode, NodeSeq}
 
-import org.apache.ivy.{core, plugins, Ivy}
-import core.{IvyPatternHelper, LogOptions}
-import core.deliver.DeliverOptions
-import core.install.InstallOptions
-import core.module.descriptor.{Artifact => IArtifact, MDArtifact, ModuleDescriptor, DefaultModuleDescriptor}
-import core.report.ResolveReport
-import core.resolve.ResolveOptions
-import plugins.resolver.{BasicResolver, DependencyResolver}
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.{IvyPatternHelper, LogOptions}
+import org.apache.ivy.core.deliver.DeliverOptions
+import org.apache.ivy.core.install.InstallOptions
+import org.apache.ivy.core.module.descriptor.{Artifact => IArtifact, MDArtifact, ModuleDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.report.ResolveReport
+import org.apache.ivy.core.resolve.ResolveOptions
+import org.apache.ivy.plugins.resolver.{BasicResolver, DependencyResolver}
 
 final class DeliverConfiguration(val deliverIvyPattern: String, val status: String, val configurations: Option[Seq[Configuration]], val logging: UpdateLogging.Value)
 final class PublishConfiguration(val ivyFile: Option[File], val resolverName: String, val artifacts: Map[Artifact, File], val checksums: Seq[String], val logging: UpdateLogging.Value,

--- a/ivy/src/main/scala/sbt/IvyCache.scala
+++ b/ivy/src/main/scala/sbt/IvyCache.scala
@@ -6,10 +6,10 @@ package sbt
 import java.io.File
 import java.net.URL
 
-import org.apache.ivy.core.cache.{ArtifactOrigin, CacheDownloadOptions, DefaultRepositoryCacheManager}
-import org.apache.ivy.core.module.descriptor.{Artifact => IvyArtifact, DefaultArtifact}
-import org.apache.ivy.plugins.repository.file.{FileRepository=>IvyFileRepository, FileResource}
-import org.apache.ivy.plugins.repository.{ArtifactResourceResolver, Resource, ResourceDownloader}
+import org.apache.ivy.core.cache.{ ArtifactOrigin, CacheDownloadOptions, DefaultRepositoryCacheManager }
+import org.apache.ivy.core.module.descriptor.{ Artifact => IvyArtifact, DefaultArtifact }
+import org.apache.ivy.plugins.repository.file.{ FileRepository => IvyFileRepository, FileResource }
+import org.apache.ivy.plugins.repository.{ ArtifactResourceResolver, Resource, ResourceDownloader }
 import org.apache.ivy.plugins.resolver.util.ResolvedResource
 import org.apache.ivy.util.FileUtil
 

--- a/ivy/src/main/scala/sbt/IvyCache.scala
+++ b/ivy/src/main/scala/sbt/IvyCache.scala
@@ -6,13 +6,12 @@ package sbt
 import java.io.File
 import java.net.URL
 
-import org.apache.ivy.{core, plugins, util}
-import core.cache.{ArtifactOrigin, CacheDownloadOptions, DefaultRepositoryCacheManager}
-import core.module.descriptor.{Artifact => IvyArtifact, DefaultArtifact}
-import plugins.repository.file.{FileRepository=>IvyFileRepository, FileResource}
-import plugins.repository.{ArtifactResourceResolver, Resource, ResourceDownloader}
-import plugins.resolver.util.ResolvedResource
-import util.FileUtil
+import org.apache.ivy.core.cache.{ArtifactOrigin, CacheDownloadOptions, DefaultRepositoryCacheManager}
+import org.apache.ivy.core.module.descriptor.{Artifact => IvyArtifact, DefaultArtifact}
+import org.apache.ivy.plugins.repository.file.{FileRepository=>IvyFileRepository, FileResource}
+import org.apache.ivy.plugins.repository.{ArtifactResourceResolver, Resource, ResourceDownloader}
+import org.apache.ivy.plugins.resolver.util.ResolvedResource
+import org.apache.ivy.util.FileUtil
 
 class NotInCache(val id: ModuleID, cause: Throwable)
 	extends RuntimeException(NotInCache(id, cause), cause)

--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -6,11 +6,10 @@ package sbt
 import java.util.Collections.emptyMap
 import scala.collection.mutable.HashSet
 
-import org.apache.ivy.{core, plugins}
-import core.module.descriptor.{DefaultExcludeRule, ExcludeRule}
-import core.module.descriptor.{DependencyDescriptor, DefaultModuleDescriptor, ModuleDescriptor, OverrideDependencyDescriptorMediator}
-import core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
-import plugins.matcher.ExactPatternMatcher
+import org.apache.ivy.core.module.descriptor.{DefaultExcludeRule, ExcludeRule}
+import org.apache.ivy.core.module.descriptor.{DependencyDescriptor, DefaultModuleDescriptor, ModuleDescriptor, OverrideDependencyDescriptorMediator}
+import org.apache.ivy.core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
+import org.apache.ivy.plugins.matcher.ExactPatternMatcher
 
 object ScalaArtifacts
 {

--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -6,9 +6,9 @@ package sbt
 import java.util.Collections.emptyMap
 import scala.collection.mutable.HashSet
 
-import org.apache.ivy.core.module.descriptor.{DefaultExcludeRule, ExcludeRule}
-import org.apache.ivy.core.module.descriptor.{DependencyDescriptor, DefaultModuleDescriptor, ModuleDescriptor, OverrideDependencyDescriptorMediator}
-import org.apache.ivy.core.module.id.{ArtifactId,ModuleId, ModuleRevisionId}
+import org.apache.ivy.core.module.descriptor.{ DefaultExcludeRule, ExcludeRule }
+import org.apache.ivy.core.module.descriptor.{ DependencyDescriptor, DefaultModuleDescriptor, ModuleDescriptor, OverrideDependencyDescriptorMediator }
+import org.apache.ivy.core.module.id.{ ArtifactId, ModuleId, ModuleRevisionId }
 import org.apache.ivy.plugins.matcher.ExactPatternMatcher
 
 object ScalaArtifacts {

--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -15,8 +15,8 @@ import Configurations.Optional
 
 import org.apache.ivy.Ivy
 import org.apache.ivy.core.settings.IvySettings
-import org.apache.ivy.core.module.descriptor.{DependencyArtifactDescriptor, DependencyDescriptor, License, ModuleDescriptor, ExcludeRule}
-import org.apache.ivy.plugins.resolver.{ChainResolver, DependencyResolver, IBiblioResolver}
+import org.apache.ivy.core.module.descriptor.{ DependencyArtifactDescriptor, DependencyDescriptor, License, ModuleDescriptor, ExcludeRule }
+import org.apache.ivy.plugins.resolver.{ ChainResolver, DependencyResolver, IBiblioResolver }
 
 class MakePom(val log: Logger) {
   @deprecated("Use `write(Ivy, ModuleDescriptor, ModuleInfo, Option[Iterable[Configuration]], Set[String], NodeSeq, XNode => XNode, MavenRepository => Boolean, Boolean, File)` instead", "0.11.2")

--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -13,10 +13,10 @@ import java.io.File
 import scala.xml.{Elem, Node => XNode, NodeSeq, PrettyPrinter, PrefixedAttribute}
 import Configurations.Optional
 
-import org.apache.ivy.{core, plugins, Ivy}
-import core.settings.IvySettings
-import core.module.descriptor.{DependencyArtifactDescriptor, DependencyDescriptor, License, ModuleDescriptor, ExcludeRule}
-import plugins.resolver.{ChainResolver, DependencyResolver, IBiblioResolver}
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.core.module.descriptor.{DependencyArtifactDescriptor, DependencyDescriptor, License, ModuleDescriptor, ExcludeRule}
+import org.apache.ivy.plugins.resolver.{ChainResolver, DependencyResolver, IBiblioResolver}
 
 class MakePom(val log: Logger)
 {

--- a/ivy/src/main/scala/sbt/ProjectResolver.scala
+++ b/ivy/src/main/scala/sbt/ProjectResolver.scala
@@ -6,14 +6,13 @@ package sbt
 	import java.io.File
 	import java.util.Date
 
-	import org.apache.ivy.{core,plugins}
-	import core.{cache,module, report, resolve,search}
+	import org.apache.ivy.core.{cache,module, report, resolve,search}
 	import cache.{ArtifactOrigin,RepositoryCacheManager}
 	import search.{ModuleEntry, OrganisationEntry, RevisionEntry}
 	import module.id.ModuleRevisionId
 	import module.descriptor.{Artifact => IArtifact, DefaultArtifact, DependencyDescriptor, ModuleDescriptor}
-	import plugins.namespace.Namespace
-	import plugins.resolver.{DependencyResolver,ResolverSettings}
+	import org.apache.ivy.plugins.namespace.Namespace
+	import org.apache.ivy.plugins.resolver.{DependencyResolver,ResolverSettings}
 	import report.{ArtifactDownloadReport, DownloadReport, DownloadStatus, MetadataArtifactDownloadReport}
 	import resolve.{DownloadOptions, ResolveData, ResolvedModuleRevision}
 

--- a/ivy/src/main/scala/sbt/ProjectResolver.scala
+++ b/ivy/src/main/scala/sbt/ProjectResolver.scala
@@ -6,13 +6,13 @@ package sbt
 import java.io.File
 import java.util.Date
 
-	import org.apache.ivy.core.{cache,module, report, resolve,search}
+import org.apache.ivy.core.{ cache, module, report, resolve, search }
 import cache.{ ArtifactOrigin, RepositoryCacheManager }
 import search.{ ModuleEntry, OrganisationEntry, RevisionEntry }
 import module.id.ModuleRevisionId
 import module.descriptor.{ Artifact => IArtifact, DefaultArtifact, DependencyDescriptor, ModuleDescriptor }
-	import org.apache.ivy.plugins.namespace.Namespace
-	import org.apache.ivy.plugins.resolver.{DependencyResolver,ResolverSettings}
+import org.apache.ivy.plugins.namespace.Namespace
+import org.apache.ivy.plugins.resolver.{ DependencyResolver, ResolverSettings }
 import report.{ ArtifactDownloadReport, DownloadReport, DownloadStatus, MetadataArtifactDownloadReport }
 import resolve.{ DownloadOptions, ResolveData, ResolvedModuleRevision }
 

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -14,7 +14,7 @@ object Sbt extends Build
 	override lazy val settings = super.settings ++ buildSettings ++ Status.settings ++ nightlySettings
 	def buildSettings = Seq(
 		organization := "org.scala-sbt",
-		version := "0.13.5-SNAPSHOT",
+		version := "0.13.5",
 		publishArtifact in packageDoc := false,
 		scalaVersion := "2.10.4",
 		publishMavenStyle := false,

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -39,23 +39,23 @@ object Sbt extends Build {
     },
     // TODO - To some extent these should take args to figure out what to do.
     commands += Command.command("release-libs-211") { state =>
-      def lameAgregateTask(task: String): String = 
-        s"all control/$task collectoins/$task io/$task"  
+      def lameAgregateTask(task: String): String =
+        s"all control/$task collectoins/$task io/$task"
       // TODO - Pull scala version from setting somewhere useful
       "++ 2.11.0" ::
-      /// First test
-      lameAgregateTask("test") ::
-      // Note: You need the sbt-pgp plugin installed to release.
-      lameAgregateTask("publishSigned") ::
-      // Now restore the defaults.
-      "reload" :: state
+        /// First test
+        lameAgregateTask("test") ::
+        // Note: You need the sbt-pgp plugin installed to release.
+        lameAgregateTask("publishSigned") ::
+        // Now restore the defaults.
+        "reload" :: state
     },
     commands += Command.command("release-sbt") { state =>
       // TODO - Any sort of validation
-      "publishSigned" :: 
-      "publishLauncher" ::
-      "release-libs-211" ::
-      state
+      "publishSigned" ::
+        "publishLauncher" ::
+        "release-libs-211" ::
+        state
     }
   )
 
@@ -85,13 +85,13 @@ object Sbt extends Build {
 
   /* **** Utilities **** */
 
-  lazy val controlSub = baseProject(utilPath / "control", "Control") settings (Util.crossBuild:_*)
-  lazy val collectionSub = testedBaseProject(utilPath / "collection", "Collections") settings (Util.keywordsSettings: _*) settings (Util.crossBuild:_*)
+  lazy val controlSub = baseProject(utilPath / "control", "Control") settings (Util.crossBuild: _*)
+  lazy val collectionSub = testedBaseProject(utilPath / "collection", "Collections") settings (Util.keywordsSettings: _*) settings (Util.crossBuild: _*)
   lazy val applyMacroSub = testedBaseProject(utilPath / "appmacro", "Apply Macro") dependsOn (collectionSub) settings (scalaCompiler)
   // The API for forking, combining, and doing I/O with system processes
   lazy val processSub = baseProject(utilPath / "process", "Process") dependsOn (ioSub % "test->test") settings (scalaXml)
   // Path, IO (formerly FileUtilities), NameFilter and other I/O utility classes
-  lazy val ioSub = testedBaseProject(utilPath / "io", "IO") dependsOn (controlSub) settings (ioSettings: _*) settings (Util.crossBuild:_*)
+  lazy val ioSub = testedBaseProject(utilPath / "io", "IO") dependsOn (controlSub) settings (ioSettings: _*) settings (Util.crossBuild: _*)
   // Utilities related to reflection, managing Scala versions, and custom class loaders
   lazy val classpathSub = testedBaseProject(utilPath / "classpath", "Classpath") dependsOn (launchInterfaceSub, interfaceSub, ioSub) settings (scalaCompiler)
   // Command line-related utilities.

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -168,7 +168,7 @@ object Common
 	def lib(m: ModuleID) = libraryDependencies += m
 	lazy val jlineDep = "jline" % "jline" % "2.11"
 	lazy val jline = lib(jlineDep)
-	lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.4.0-sbt-d6fca11d63402c92e4167cdf2da91a660d043392")
+	lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0")
 	lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
 	lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive() )
 	lazy val sbinary = libraryDependencies <+= Util.nightly211(n => "org.scala-tools.sbinary" % "sbinary" % "0.4.2" cross(if(n) CrossVersion.full else CrossVersion.binary))

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -29,11 +29,11 @@ object Util {
     nightly211 <<= scalaVersion(_.startsWith("2.11.")),
     includeTestDependencies <<= nightly211(x => !x)
   )
-  def crossBuild: Seq[Setting[_]] = 
+  def crossBuild: Seq[Setting[_]] =
     Seq(
       crossPaths := (scalaBinaryVersion.value match {
         case "2.11" => true
-        case _ => false
+        case _      => false
       })
     )
   def commonSettings(nameString: String) = Seq(
@@ -174,7 +174,7 @@ object Common {
   def lib(m: ModuleID) = libraryDependencies += m
   lazy val jlineDep = "jline" % "jline" % "2.11"
   lazy val jline = lib(jlineDep)
-	lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0")
+  lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0")
   lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
   lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive ())
   lazy val sbinary = libraryDependencies += "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.5

--- a/src/main/conscript/sbt/launchconfig
+++ b/src/main/conscript/sbt/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.5-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.5]}
   class: sbt.xMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}
@@ -13,7 +13,6 @@
 [repositories]
   local
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  typesafe-ivy-snapshots: http://repo.typesafe.com/typesafe/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]

--- a/src/main/conscript/scalas/launchconfig
+++ b/src/main/conscript/scalas/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.5-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.5]}
   class: sbt.ScriptMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}
@@ -13,7 +13,6 @@
 [repositories]
   local
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  typesafe-ivy-snapshots: http://repo.typesafe.com/typesafe/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]

--- a/src/main/conscript/screpl/launchconfig
+++ b/src/main/conscript/screpl/launchconfig
@@ -4,7 +4,7 @@
 [app]
   org: ${sbt.organization-org.scala-sbt}
   name: sbt
-  version: ${sbt.version-read(sbt.version)[0.13.5-SNAPSHOT]}
+  version: ${sbt.version-read(sbt.version)[0.13.5]}
   class: sbt.ConsoleMain
   components: xsbti,extra
   cross-versioned: ${sbt.cross.versioned-false}
@@ -13,7 +13,6 @@
 [repositories]
   local
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  typesafe-ivy-snapshots: http://repo.typesafe.com/typesafe/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -4,7 +4,7 @@ import java.io.{ StringWriter, PrintWriter, File }
 import java.net.InetAddress
 import scala.collection.mutable.ListBuffer
 import scala.util.DynamicVariable
-import scala.xml.{Elem, Node=>XNode, XML}
+import scala.xml.{ Elem, Node => XNode, XML }
 import testing.{ Event => TEvent, Status => TStatus, OptionalThrowable, TestSelector }
 
 /**
@@ -23,7 +23,7 @@ class JUnitXmlTestsListener(val outputDir: String) extends TestsListener {
     <properties>
       {
         val iter = System.getProperties.entrySet.iterator
-            val props:ListBuffer[XNode] = new ListBuffer()
+        val props: ListBuffer[XNode] = new ListBuffer()
         while (iter.hasNext) {
           val next = iter.next
           props += <property name={ next.getKey.toString } value={ next.getValue.toString }/>

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -4,7 +4,7 @@ import java.io.{StringWriter, PrintWriter, File}
 import java.net.InetAddress
 import scala.collection.mutable.ListBuffer
 import scala.util.DynamicVariable
-import scala.xml.{Elem, Node, XML}
+import scala.xml.{Elem, Node=>XNode, XML}
 import testing.{Event => TEvent, Status => TStatus, OptionalThrowable, TestSelector}
 
 /**
@@ -23,7 +23,7 @@ class JUnitXmlTestsListener(val outputDir:String) extends TestsListener
     val properties =
         <properties> {
             val iter = System.getProperties.entrySet.iterator
-            val props:ListBuffer[Node] = new ListBuffer()
+            val props:ListBuffer[XNode] = new ListBuffer()
             while (iter.hasNext) {
                 val next = iter.next
                 props += <property name={next.getKey.toString} value={next.getValue.toString} />


### PR DESCRIPTION
Missing fixes:
- Rolls ivy back to 2.3.0
- Fixes import issues with sxr/scaladoc generation
- Bump to sbt 0.13.5 for building sbt.
