### PR TITLE
Read stderr from server for a short time before exiting

### DIFF
--- a/launch/src/main/scala/xsbt/boot/ServerApplication.scala
+++ b/launch/src/main/scala/xsbt/boot/ServerApplication.scala
@@ -115,7 +115,7 @@ class StreamDumper(in: java.io.BufferedReader, out: java.io.PrintStream) extends
       endTime.set(System.currentTimeMillis + 2000)
       // at this point we'd rather the dumper thread run
       // before we check whether to sleep
-      Thread.yield()
+      Thread.`yield`()
       // let ourselves read more (thread should exit on earlier of endTime or EOF)
       while (isAlive() && (endTime.get > System.currentTimeMillis))
         Thread.sleep(50)

--- a/launch/src/main/scala/xsbt/boot/ServerApplication.scala
+++ b/launch/src/main/scala/xsbt/boot/ServerApplication.scala
@@ -113,6 +113,9 @@ class StreamDumper(in: java.io.BufferedReader, out: java.io.PrintStream) extends
     // any stuff.
     if (waitForErrors) {
       endTime.set(System.currentTimeMillis + 2000)
+      // at this point we'd rather the dumper thread run
+      // before we check whether to sleep
+      Thread.yield()
       // let ourselves read more (thread should exit on earlier of endTime or EOF)
       while (isAlive() && (endTime.get > System.currentTimeMillis))
         Thread.sleep(50)


### PR DESCRIPTION
Previously we exited immediately without waiting to get any
error output.

This patch also adds the command line and directory to the
exception message on failure, in case the failure is due to
getting one of those wrong, for example.
