### PR TITLE
Add optional branch to ModuleID

### DIFF
--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -423,7 +423,7 @@ private[sbt] object IvySbt {
   def toID(m: ModuleID) =
     {
       import m._
-      ModuleRevisionId.newInstance(organization, name, revision, javaMap(extraAttributes))
+      ModuleRevisionId.newInstance(organization, name, branch.orNull, revision, javaMap(extraAttributes))
     }
 
   private def substituteCross(m: ModuleSettings): ModuleSettings =

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -423,7 +423,7 @@ private[sbt] object IvySbt {
   def toID(m: ModuleID) =
     {
       import m._
-      ModuleRevisionId.newInstance(organization, name, branch.orNull, revision, javaMap(extraAttributes))
+      ModuleRevisionId.newInstance(organization, name, branchName.orNull, revision, javaMap(extraAttributes))
     }
 
   private def substituteCross(m: ModuleSettings): ModuleSettings =
@@ -493,7 +493,7 @@ private[sbt] object IvySbt {
   private[this] def defaultInfo(module: ModuleID): scala.xml.Elem = {
     import module._
     val base = <info organisation={ organization } module={ name } revision={ revision }/>
-    branch.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
+    branchName.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
   }
   private[this] def addExtraAttributes(elem: scala.xml.Elem, extra: Map[String, String]): scala.xml.Elem =
     (elem /: extra) { case (e, (key, value)) => e % new scala.xml.UnprefixedAttribute(key, value, scala.xml.Null) }

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -492,7 +492,8 @@ private[sbt] object IvySbt {
     }
   private[this] def defaultInfo(module: ModuleID): scala.xml.Elem = {
     import module._
-    <info organisation={ organization } module={ name } revision={ revision }/>
+    val base = <info organisation={ organization } module={ name } revision={ revision }/>
+    branch.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
   }
   private[this] def addExtraAttributes(elem: scala.xml.Elem, extra: Map[String, String]): scala.xml.Elem =
     (elem /: extra) { case (e, (key, value)) => e % new scala.xml.UnprefixedAttribute(key, value, scala.xml.Null) }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -309,7 +309,7 @@ object IvyActions {
     {
       val mextra = IvySbt.javaMap(mid.extraAttributes, true)
       val aextra = IvySbt.extra(art, true)
-      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branch.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
+      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branchName.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
     }
 
   import UpdateLogging.{ Quiet, Full, DownloadOnly, Default }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -309,7 +309,7 @@ object IvyActions {
     {
       val mextra = IvySbt.javaMap(mid.extraAttributes, true)
       val aextra = IvySbt.extra(art, true)
-      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.revision, art.name, art.`type`, art.extension, conf, mextra, aextra)
+      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branch.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
     }
 
   import UpdateLogging.{ Quiet, Full, DownloadOnly, Default }

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -116,7 +116,7 @@ sealed case class ModuleID(organization: String, name: String, revision: String,
    */
   def jar() = artifacts(Artifact(name))
 
-  override val branch: Option[String] = None
+  override val branchName: Option[String] = None
 }
 
 object ModuleID {
@@ -130,18 +130,18 @@ object ModuleID {
  * This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility.
  */
 private[sbt] trait ModuleIDSetBranch { self: ModuleID =>
-  val branch: Option[String]
+  val branchName: Option[String]
 
   /**
    * Sets the Ivy branch of this module.
    */
-  def onBranch(branch: String) = new ModuleIDWithBranch(self, Some(branch))
+  def branch(branchName: String) = new ModuleIDWithBranch(self, Some(branchName))
 
-  def onBranch(branch: Option[String]) = new ModuleIDWithBranch(self, branch)
+  def branch(branchName: Option[String]) = new ModuleIDWithBranch(self, branchName)
 }
 
 /** This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility. */
-final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
+final class ModuleIDWithBranch(m: ModuleID, override val branchName: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
   override def copy(organization: String,
     name: String,
     revision: String,
@@ -153,5 +153,5 @@ final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String])
     exclusions: Seq[ExclusionRule],
     extraAttributes: Map[String, String],
     crossVersion: CrossVersion) =
-    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).onBranch(branch)
+    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).branch(branchName)
 }

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -141,4 +141,17 @@ private[sbt] trait ModuleIDSetBranch { self: ModuleID =>
 }
 
 /** This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility. */
-final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch
+final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
+  override def copy(organization: String,
+    name: String,
+    revision: String,
+    configurations: Option[String],
+    isChanging: Boolean,
+    isTransitive: Boolean,
+    isForce: Boolean,
+    explicitArtifacts: Seq[Artifact],
+    exclusions: Seq[ExclusionRule],
+    extraAttributes: Map[String, String],
+    crossVersion: CrossVersion) =
+    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).onBranch(branch)
+}

--- a/ivy/src/main/scala/sbt/ResolutionCache.scala
+++ b/ivy/src/main/scala/sbt/ResolutionCache.scala
@@ -86,5 +86,5 @@ private[sbt] object ResolutionCache {
   private val Name = "sbt-resolution-cache"
 
   // use sbt-specific extra attributes so that resolved xml files do not get overwritten when using different Scala/sbt versions
-  private val ResolvedPattern = "[organisation]/[module]/" + Resolver.PluginPattern + "[revision]/[artifact].[ext]"
+  private val ResolvedPattern = "[organisation]/[module]/" + Resolver.PluginPattern + "([branch]/)[revision]/[artifact].[ext]"
 }

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -298,7 +298,7 @@ object Resolver {
 
   def defaultPatterns = mavenStylePatterns
   def mavenStyleBasePattern = "[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]"
-  def localBasePattern = "[organisation]/[module]/" + PluginPattern + "[revision]/[type]s/[artifact](-[classifier]).[ext]"
+  def localBasePattern = "[organisation]/[module]/" + PluginPattern + "(/[branch])/[revision]/[type]s/[artifact](-[classifier]).[ext]"
   def defaultRetrievePattern = "[type]s/[organisation]/[module]/" + PluginPattern + "[artifact](-[revision])(-[classifier]).[ext]"
   final val PluginPattern = "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)"
   private[this] def mavenLocalDir: File = {


### PR DESCRIPTION
Allow an Ivy branch to be set on the project's module, as well as on dependencies.
This is a work in progress, which for now adds the `branch: Option[String]` to `ModuleID` while preserving backwards-compatibility, but the plan is to fix up the whole of sbt so that it's aware of branches where relevant.

Other changes planned:
- change the default Ivy patterns to include the `([branch]/)` after the module name
