### PR TITLE
Abstract over dependency contexts

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Compile.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Compile.scala
@@ -175,10 +175,11 @@ private final class AnalysisCallback(internalMap: File => Option[File], external
         val info = SourceInfos.makeInfo(getOrNil(reporteds, src), getOrNil(unreporteds, src))
         val direct = sourceDeps.getOrElse(src, Nil: Iterable[File])
         val publicInherited = inheritedSourceDeps.getOrElse(src, Nil: Iterable[File])
-        a.addSource(src, s, stamp, direct, publicInherited, info)
+        val allDeps = direct.map((_, DependencyByMemberRef)) ++ publicInherited.map((_, DependencyByInheritance))
+        a.addSource(src, s, stamp, allDeps, info)
     }
   def getOrNil[A, B](m: collection.Map[A, Seq[B]], a: A): Seq[B] = m.get(a).toList.flatten
-  def addExternals(base: Analysis): Analysis = (base /: extSrcDeps) { case (a, (source, name, api, inherited)) => a.addExternalDep(source, name, api, inherited) }
+  def addExternals(base: Analysis): Analysis = (base /: extSrcDeps) { case (a, (source, name, api, inherited)) => a.addExternalDep(source, name, api, if (inherited) DependencyByInheritance else DependencyByMemberRef) }
   def addCompilation(base: Analysis): Analysis = base.copy(compilations = base.compilations.add(compilation))
   def addUsedNames(base: Analysis): Analysis = (base /: usedNames) {
     case (a, (src, names)) =>

--- a/compile/inc/src/main/scala/sbt/inc/Dependency.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Dependency.scala
@@ -1,0 +1,16 @@
+package sbt.inc
+
+/**
+ * Represents contextual information about particular depedency edge. See comments in
+ * subtypes for examples of particular contexts.
+ */
+private[inc] sealed abstract class DependencyContext
+/**
+ * Marks dependency edge introduced by referring to a class through inheritance as in
+ *
+ *   class A extends B
+ *
+ * Each dependency by inheritance introduces corresponding dependency by member reference.
+ */
+private[inc] final case object DependencyByInheritance extends DependencyContext
+private[inc] final case object DependencyByMemberRef extends DependencyContext


### PR DESCRIPTION
The current implementation of Analysis and Relations expect to receive
information about the context in which a dependency has been collected
as a boolean value simply indicating whether the dependency comes from
an inheritance relationship or from a member reference.

Unfortunately, adding a new kind of dependency context (for instance,
dependencies coming from a macro expansion) requires to change the
signature of many methods in these classes, and can lead to
inconsistencies.

Since the number of dependency contexts is expected to grow,
abstracting over the dependency contexts permits to stabilize the
signature of these methods.

This pull request is a follow up from sbt/sbt#1340, which came from this discussion : https://groups.google.com/forum/#!topic/sbt-dev/clIbzCp9VX8

This implement the idea from @gkossakowski that we should only abstract over dependency contexts instead of over the whole dependency kind for now.

/cc @xeno-by
