### PR TITLE
BintrayMavenRepository added

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -20,6 +20,10 @@ sealed case class MavenRepository(name: String, root: String) extends Resolver {
   override def toString = name + ": " + root
 }
 
+sealed class JCenter(isSecure: Boolean = false) extends MavenRepository("jcenter", s"http${if (isSecure) "s" else ""}://jcenter.bintray.com/")
+
+sealed class BintrayMavenRepository(subject: String, repo: String, isSecure: Boolean = false) extends MavenRepository(s"bintray$subject/$repo/", s"http${if (isSecure) "s" else ""}://dl.bintray.com/$subject/$repo/")
+
 final class Patterns(val ivyPatterns: Seq[String], val artifactPatterns: Seq[String], val isMavenCompatible: Boolean, val descriptorOptional: Boolean, val skipConsistencyCheck: Boolean) {
   private[sbt] def mavenStyle(): Patterns = Patterns(ivyPatterns, artifactPatterns, true)
   private[sbt] def withDescriptorOptional(): Patterns = Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, true, skipConsistencyCheck)
@@ -135,6 +139,7 @@ final case class SftpRepository(name: String, connection: SshConnection, pattern
 
 import Resolver._
 
+object JCenter extends JCenter(false)
 object DefaultMavenRepository extends MavenRepository("public", IBiblioResolver.DEFAULT_M2_ROOT)
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository


### PR DESCRIPTION
This PR needs some additional work. Right now trying to use sbt 0.13.6-SNAPSHOT I'm getting 

```
java.lang.NoSuchFieldError: JCenter
    at sbt.Classpaths$.sbt$Classpaths$$bootRepository(Defaults.scala:1555)
    at sbt.Classpaths$$anonfun$appRepositories$1.apply(Defaults.scala:1527)
    at sbt.Classpaths$$anonfun$appRepositories$1.apply(Defaults.scala:1527)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
    at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:34)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
    at scala.collection.AbstractTraversable.map(Traversable.scala:105)
    at sbt.Classpaths$.appRepositories(Defaults.scala:1527)
    at sbt.Classpaths$$anonfun$40.apply(Defaults.scala:1041)
    at sbt.Classpaths$$anonfun$40.apply(Defaults.scala:1041)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.EvaluateSettings$MixedNode.evaluate0(INode.scala:175)
    at sbt.EvaluateSettings$INode.evaluate(INode.scala:135)
    at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$submitEvaluate$1.apply$mcV$sp(INode.scala:69)
    at sbt.EvaluateSettings.sbt$EvaluateSettings$$run0(INode.scala:78)
    at sbt.EvaluateSettings$$anon$3.run(INode.scala:74)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
[error] java.lang.NoSuchFieldError: JCenter
```
