### PR TITLE
Fix AutoPlugins declared at top-level

### DIFF
--- a/sbt/src/sbt-test/project/auto-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins/build.sbt
@@ -15,6 +15,16 @@ lazy val projE = project.enablePlugins(S)
 
 lazy val projF = project
 
+// with X enabled, TopA is loaded automatically
+lazy val projG = project.enablePlugins(X)
+
+// only TopB should be enabled
+lazy val projH = project.enablePlugins(TopB)
+
+// enables TopC, which declares topLevelKeyTest
+lazy val projI = project.enablePlugins(TopC)
+
+
 disablePlugins(plugins.IvyPlugin)
 
 check := {
@@ -49,9 +59,20 @@ check := {
 	same(optInValue, " Q S R", "del in projE in q")
 	val overrideOrgValue = (organization in projE).value
 	same(overrideOrgValue, "S", "organization in projE")
+// tests for top level plugins
+  val topLevelAValueG = (topLevelDemo in projG).value
+  same(topLevelAValueG, "TopA: topLevelDemo project projG", "topLevelDemo in projG")
+  val demoValueG = (demo in projG).value
+  same(demoValueG, "TopA: demo project projG", "demo in projG")
+  val topLevelBValueH = (topLevelDemo in projH).value
+  same(topLevelBValueH, "TopB: topLevelDemo project projH", "topLevelDemo in projH")
+  val hdel = (del in projH).?.value
+  same(hdel, None, "del in projH")
 }
 
 keyTest := "foo"
+
+topLevelKeyTest := "bar"
 
 def same[T](actual: T, expected: T, label: String) {
 	assert(actual == expected, s"Expected '$expected' for `$label`, got '$actual'")

--- a/sbt/src/sbt-test/project/auto-plugins/project/A.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/A.scala
@@ -1,0 +1,47 @@
+// no package
+// plugins declared within no package should be visible to other plugins in the _root_ package
+
+import sbt._
+import sbt.Keys._
+
+object TopLevelImports {
+  lazy val topLevelDemo = settingKey[String]("A top level demo setting.")
+}
+
+object TopA extends AutoPlugin {
+
+  import TopLevelImports._
+  import sbttest.Imports._
+
+  val autoImport = TopLevelImports
+
+  override def requires = sbttest.X
+
+  override def trigger = AllRequirements
+
+  override def projectSettings: scala.Seq[sbt.Setting[_]] = Seq(
+    topLevelDemo := s"TopA: topLevelDemo project ${name.value}",
+    demo := s"TopA: demo project ${name.value}"
+  )
+
+}
+
+object TopB extends AutoPlugin {
+
+  import TopLevelImports._
+
+  val autoImport = TopLevelImports
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    topLevelDemo := s"TopB: topLevelDemo project ${name.value}"
+  )
+
+}
+
+object TopC extends AutoPlugin {
+
+  object autoImport {
+    lazy val topLevelKeyTest = settingKey[String]("A top level setting declared in a plugin.")
+  }
+
+}

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/D.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/D.scala
@@ -1,0 +1,11 @@
+// no package declaration
+
+import sbt._
+
+object D extends AutoPlugin {
+
+  object autoImport {
+    lazy val dKey = settingKey[String]("Test key")
+  }
+
+}

--- a/sbt/src/sbt-test/project/binary-plugin/test
+++ b/sbt/src/sbt-test/project/binary-plugin/test
@@ -1,12 +1,13 @@
 # First we define the plugin project and publish it
 $ copy-file changes/define/build.sbt build.sbt
 $ copy-file changes/define/A.scala A.scala
+$ copy-file changes/define/D.scala D.scala
 
 # reload implied
 > publishLocal
 
 # Now we remove the source code and define a project which uses the build.
-$ delete build.sbt A.scala
+$ delete build.sbt A.scala D.scala
 $ copy-file changes/use/plugins.sbt project/plugins.sbt
 > reload
 > check


### PR DESCRIPTION
When having `AutoPlugin` declared as top-level classes, an exception is thrown during build load. This pull request is an attempt to fix it. 

The top-level `AutoPlugin` classes are not imported any more, and `autoImport` statements of top level plugins are not prefixed with `_root_`.

```
import _root_.sbt.plugins.IvyPlugin, _root_.sbt.plugins.JvmPlugin, _root_.sbt.plugins.CorePlugin, _root_.sbt.plugins.JUnitXmlReportPlugin, MyPlugin
                                                                                                                                                   ^
sbt.compiler.EvalException: Error parsing imports for expression.
    at sbt.compiler.Eval.checkError(Eval.scala:343)
    at sbt.compiler.Eval.sbt$compiler$Eval$$parseImport(Eval.scala:295)
    at sbt.compiler.Eval$$anonfun$parseImports$1.apply(Eval.scala:289)
    at sbt.compiler.Eval$$anonfun$parseImports$1.apply(Eval.scala:289)
    at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
    at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
```

This is a resend of #1365.
