### PR TITLE
Update broken links on the Community Plugins documentation page

### DIFF
--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -115,8 +115,8 @@ Release plugins
 -  sbt-signer-plugin: https://github.com/rossabaker/sbt-signer-plugin
 -  sbt-izpack (generates IzPack an installer):
    http://software.clapper.org/sbt-izpack/
--  sbt-ghpages-plugin (publishes generated site and api):
-   https://github.com/jsuereth/xsbt-ghpages-plugin
+-  sbt-ghpages (publishes generated site and api):
+   https://github.com/sbt/sbt-ghpages
 -  sbt-pgp (PGP signing plugin, can generate keys too):
    https://github.com/sbt/sbt-pgp
 -  sbt-release (customizable release process):

--- a/src/sphinx/Community/Community-Plugins.rst
+++ b/src/sphinx/Community/Community-Plugins.rst
@@ -63,8 +63,6 @@ Test plugins
    https://github.com/typesafehub/sbt-multi-jvm
 -  sbt-testng-interface:
    https://github.com/sbt/sbt-testng-interface
--  schoir (Distributed testing plugin):
-   https://github.com/typesafehub/schoir
 
 Static Code Analysis plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A couple of basic fixes to the documentation:
- The sbt-ghpages repo has moved and the old one is no longer accessible, so the link has been updated.
- The Schoir plugin is not longer accessible in the typesafe github area, and it seems to have disappeared without trace, so I have removed it.
