### PR TITLE
Improve resolve exception

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -17,7 +17,7 @@ object Release extends Build {
 
   // Add credentials if they exist.
   def lameCredentialSettings: Seq[Setting[_]] =
-    if(CredentialsFile.exists) Seq(credentials in ThisBuild += Credentials(CredentialsFile)) 
+    if (CredentialsFile.exists) Seq(credentials in ThisBuild += Credentials(CredentialsFile))
     else Nil
   def releaseSettings(nonRoots: => Seq[ProjectReference], launcher: TaskKey[File]): Seq[Setting[_]] = Seq(
     publishTo in ThisBuild <<= publishResolver,

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -14,7 +14,7 @@ object Sbt extends Build {
 
   // Aggregate task for 2.11
   private def lameAgregateTask(task: String): String =
-        s"all control/$task collections/$task io/$task completion/$task"
+    s"all control/$task collections/$task io/$task completion/$task"
   def buildSettings = Seq(
     organization := "org.scala-sbt",
     version := "0.13.6-SNAPSHOT",
@@ -57,15 +57,15 @@ object Sbt extends Build {
     },
     commands += Command.command("release-sbt-local") { state =>
       "publishLocal" ::
-      "setupBuildScala211" ::
-      lameAgregateTask("publishLocal") ::
-      "reload" ::
-      state
+        "setupBuildScala211" ::
+        lameAgregateTask("publishLocal") ::
+        "reload" ::
+        state
     },
     commands += Command.command("release-sbt") { state =>
       // TODO - Any sort of validation
       "checkCredentials" ::
-      "publishSigned" ::
+        "publishSigned" ::
         "publishLauncher" ::
         "release-libs-211" ::
         state


### PR DESCRIPTION
fixes #1422, #381 
## steps

``` scala
lazy val d = project.
  settings(
    libraryDependencies += "org.apache.cayenne.plugins" % "maven-cayenne-plugin" % "3.0.2"
  )
```
## problem

You have no idea which transitive deps path failed.
## what this changes

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: foundrylogic.vpp#vpp;2.2.1: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]      foundrylogic.vpp:vpp:2.2.1
[warn]        +- org.apache.cayenne:cayenne-tools:3.0.2
[warn]        +- org.apache.cayenne.plugins:maven-cayenne-plugin:3.0.2
[warn]        +- d:d_2.10:0.1-SNAPSHOT
```
