### PR TITLE
Select the first test fingerprint for a test name for forked tests

### DIFF
--- a/main/actions/src/main/scala/sbt/Tests.scala
+++ b/main/actions/src/main/scala/sbt/Tests.scala
@@ -150,7 +150,14 @@ object Tests {
       def includeTest(test: TestDefinition) = !excludeTestsSet.contains(test.name) && testFilters.forall(filter => filter(test.name))
       val filtered0 = discovered.filter(includeTest).toList.distinct
       val tests = if (orderedFilters.isEmpty) filtered0 else orderedFilters.flatMap(f => filtered0.filter(d => f(d.name))).toList.distinct
-      new ProcessedOptions(tests, setup.toList, cleanup.toList, testListeners.toList)
+      val uniqueTests = distinctBy(tests)(_.name)
+      new ProcessedOptions(uniqueTests, setup.toList, cleanup.toList, testListeners.toList)
+    }
+
+  private[this] def distinctBy[T, K](in: Seq[T])(f: T => K): Seq[T] =
+    {
+      val seen = new collection.mutable.HashSet[K]
+      in.filter(t => seen.add(f(t)))
     }
 
   def apply(frameworks: Map[TestFramework, Framework], testLoader: ClassLoader, runners: Map[TestFramework, Runner], discovered: Seq[TestDefinition], config: Execution, log: Logger): Task[Output] =

--- a/sbt/src/sbt-test/tests/one-class-multi-framework/test
+++ b/sbt/src/sbt-test/tests/one-class-multi-framework/test
@@ -6,3 +6,7 @@ $ absent succeed
 # it will fail if run via junit and succeed if run via specs
 $ touch succeed
 > test
+
+# also run with forked tests
+> set fork in Test := true
+> test

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -131,19 +131,13 @@ object TestFramework {
     log: Logger,
     listeners: Seq[TestReportListener]): (() => Unit, Seq[(String, TestFunction)], TestResult.Value => () => Unit) =
     {
-      val unique = distinctBy(tests)(_.name)
-      val mappedTests = testMap(frameworks.values.toSeq, unique)
+      val mappedTests = testMap(frameworks.values.toSeq, tests)
       if (mappedTests.isEmpty)
         (() => (), Nil, _ => () => ())
       else
-        createTestTasks(testLoader, runners.map { case (tf, r) => (frameworks(tf), new TestRunner(r, listeners, log)) }, mappedTests, unique, log, listeners)
+        createTestTasks(testLoader, runners.map { case (tf, r) => (frameworks(tf), new TestRunner(r, listeners, log)) }, mappedTests, tests, log, listeners)
     }
 
-  private[this] def distinctBy[T, K](in: Seq[T])(f: T => K): Seq[T] =
-    {
-      val seen = new collection.mutable.HashSet[K]
-      in.filter(t => seen.add(f(t)))
-    }
   private[this] def order(mapped: Map[String, TestFunction], inputs: Seq[TestDefinition]): Seq[(String, TestFunction)] =
     for (d <- inputs; act <- mapped.get(d.name)) yield (d.name, act)
 


### PR DESCRIPTION
This takes the 'distinct by name' filtering which is applied to in-process tests and makes it available to forked tests (by moving it to Tests.processOptions which is used in both in-process and forked).

The test from the original commit for the filtering (https://github.com/sbt/sbt/commit/a0e301e) is extended to also test when forked, and this test fails without the other changes.

This resolves junit tests being run twice as reported in https://github.com/sbt/junit-interface/issues/14, for at least some of the test samples.
