### PR TITLE
Add caching around dependency exclude rule evaluation

### DIFF
--- a/ivy/src/main/scala/sbt/UpdateReport.scala
+++ b/ivy/src/main/scala/sbt/UpdateReport.scala
@@ -47,8 +47,7 @@ final class ConfigurationReport(
     val configuration: String,
     val modules: Seq[ModuleReport],
     val details: Seq[ModuleDetailReport],
-    @deprecated("Use details instead to get better eviction info.", "0.13.6")
-    val evicted: Seq[ModuleID]) {
+    @deprecated("Use details instead to get better eviction info.", "0.13.6") val evicted: Seq[ModuleID]) {
   def this(configuration: String, modules: Seq[ModuleReport], evicted: Seq[ModuleID]) =
     this(configuration, modules, Nil, evicted)
 

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -63,6 +63,7 @@
 - Selects the first test fingerprint for a test name for forked tests. [#1450][1450] by [@pvlugter][@pvlugter]
 - Allows default auto plugins to be disabled. [#1451][1451] by [@jsuereth][@jsuereth]
 - Allows keys defined inside `build.sbt` to be used from sbt shell. [#1059][1059]/[#1456][1456]
+- Updates internal Ivy instance to cache the results of dependency exclusion rules. by [@eed3si9n][@eed3si9n]
 
 ### Bug fixes
 

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -2,6 +2,7 @@ import sbt._
 import Keys._
 import Status.{ publishStatus }
 import org.apache.ivy.util.url.CredentialsStore
+import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
 
 object Release extends Build {
   lazy val remoteBase = SettingKey[String]("remote-base")
@@ -57,4 +58,8 @@ object Release extends Build {
         case None        => error("No credentials defined for " + PublishRepoHost)
       }
     }
+
+  def javaVersionCheckSettings = Seq(
+    javaVersionPrefix in javaVersionCheck := Some("1.6")
+  )
 }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -31,7 +31,7 @@ object Release extends Build {
       // Note - This will eitehr issue a failure or succeed.
       getCredentials(credentials.value, streams.value.log)
     }
-  ) ++ lameCredentialSettings
+  ) ++ lameCredentialSettings ++ javaVersionCheckSettings
 
   def snapshotPattern(version: String) = Resolver.localBasePattern.replaceAll("""\[revision\]""", version)
   def publishResolver: Project.Initialize[Option[Resolver]] = (remoteID, remoteBase) { (id, base) =>

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -290,7 +290,7 @@ object Sbt extends Build {
   def releaseSettings = Release.settings(nonRoots, proguard in Proguard)
   def rootSettings = releaseSettings ++ fullDocSettings ++ LaunchProguard.settings ++ LaunchProguard.specific(launchSub) ++
     Util.publishPomSettings ++ otherRootSettings ++ proguardedLauncherSettings ++ Formatting.sbtFilesSettings ++
-    Transform.conscriptSettings(launchSub) ++ Release.javaVersionCheckSettings
+    Transform.conscriptSettings(launchSub)
   def otherRootSettings = Seq(
     scripted <<= scriptedTask,
     scriptedUnpublished <<= scriptedUnpublishedTask,

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -290,7 +290,7 @@ object Sbt extends Build {
   def releaseSettings = Release.settings(nonRoots, proguard in Proguard)
   def rootSettings = releaseSettings ++ fullDocSettings ++ LaunchProguard.settings ++ LaunchProguard.specific(launchSub) ++
     Util.publishPomSettings ++ otherRootSettings ++ proguardedLauncherSettings ++ Formatting.sbtFilesSettings ++
-    Transform.conscriptSettings(launchSub)
+    Transform.conscriptSettings(launchSub) ++ Release.javaVersionCheckSettings
   def otherRootSettings = Seq(
     scripted <<= scriptedTask,
     scriptedUnpublished <<= scriptedUnpublishedTask,

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -174,7 +174,7 @@ object Common {
   def lib(m: ModuleID) = libraryDependencies += m
   lazy val jlineDep = "jline" % "jline" % "2.11"
   lazy val jline = lib(jlineDep)
-  lazy val ivy = lib("org.apache.ivy" % "ivy" % "2.3.0")
+  lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-fac2aaab6f982c4424b47e6b190190bef50a6f59")
   lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
   lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive ())
   lazy val sbinary = libraryDependencies += "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -41,7 +41,7 @@ object Util {
     name := nameString,
     resolvers += Resolver.typesafeIvyRepo("releases")
   )
-  def minProject(path: File, nameString: String) = Project(normalize(nameString), path) settings (commonSettings(nameString) ++ publishPomSettings: _*)
+  def minProject(path: File, nameString: String) = Project(normalize(nameString), path) settings (commonSettings(nameString) ++ publishPomSettings ++ Release.javaVersionCheckSettings: _*)
   def baseProject(path: File, nameString: String) = minProject(path, nameString) settings (base: _*)
   def testedBaseProject(path: File, nameString: String) = baseProject(path, nameString) settings (testDependencies)
 
@@ -174,7 +174,7 @@ object Common {
   def lib(m: ModuleID) = libraryDependencies += m
   lazy val jlineDep = "jline" % "jline" % "2.11"
   lazy val jline = lib(jlineDep)
-  lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-fac2aaab6f982c4424b47e6b190190bef50a6f59")
+  lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-14d4d23e25f354cd296c73bfff405544434d5f80")
   lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
   lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive ())
   lazy val sbinary = libraryDependencies += "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"

--- a/project/p.sbt
+++ b/project/p.sbt
@@ -10,3 +10,5 @@ resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")


### PR DESCRIPTION
Updates internal Ivy to 2.3.0-sbt-fac2aaab6f982c4424b47e6b190190bef50a6f59. See sbt/ivy#10.
