### PR TITLE
Change "Not a simple type" warning to log message

### DIFF
--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -149,7 +149,7 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
   private def simpleType(in: Symbol, t: Type): SimpleType =
     processType(in, t) match {
       case s: SimpleType => s
-      case x             => warning("Not a simple type:\n\tType: " + t + " (" + t.getClass + ")\n\tTransformed: " + x.getClass); Constants.emptyType
+      case x             => log("Not a simple type:\n\tType: " + t + " (" + t.getClass + ")\n\tTransformed: " + x.getClass); Constants.emptyType
     }
   private def types(in: Symbol, t: List[Type]): Array[xsbti.api.Type] = t.toArray[Type].map(processType(in, _))
   private def projectionType(in: Symbol, pre: Type, sym: Symbol) =


### PR DESCRIPTION
Workaround for -Xfatal-warnings being triggered because of #830.
