### PR TITLE
Remove whitespaces at the end of Google Group URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-  [sbt-dev]: https://groups.google.com/d/forum/sbt-dev‎
+  [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
   [StackOverflow]: http://stackoverflow.com/tags/sbt  
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [Issues]: https://github.com/sbt/sbt/issues


### PR DESCRIPTION
The Google Group URL was pointing to `https://groups.google.com/forum/#!forum/sbt-dev%E2%80%8E` instead of `https://groups.google.com/forum/#!forum/sbt-dev` - this fixes it.

(Hint: You can only see the change in the diff, not the white space that was removed itself)
