### PR TITLE
Remove second invalid URL reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
   [StackOverflow]: http://stackoverflow.com/tags/sbt  
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [Issues]: https://github.com/sbt/sbt/issues
-  [sbt-dev]: https://groups.google.com/d/forum/sbt-dev‎
   [subscriptions]: http://typesafe.com/how/subscription
   [327]: https://github.com/sbt/sbt/issues/327
 


### PR DESCRIPTION
There was a duplicate entry for the Google Groups URL and it had whitespace at the end.
This is related to #1482
