### PR TITLE
Fixes #1478 - Append new sLog when reloading in set command.

### DIFF
--- a/main/src/main/scala/sbt/LogManager.scala
+++ b/main/src/main/scala/sbt/LogManager.scala
@@ -105,8 +105,8 @@ object LogManager {
   // construct a Logger that delegates to the global logger, but only holds a weak reference
   //  this is an approximation to the ideal that would invalidate the delegate after loading completes
   private[this] def globalWrapper(s: State): Logger = {
-    val ref = new java.lang.ref.WeakReference(s.globalLogging.full)
     new Logger {
+      private[this] val ref = new java.lang.ref.WeakReference(s.globalLogging.full)
       private[this] def slog: Logger = Option(ref.get) getOrElse sys.error("Settings logger used after project was loaded.")
 
       override val ansiCodesSupported = slog.ansiCodesSupported

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -227,7 +227,10 @@ object BuiltinCommands {
   def reapply(newSession: SessionSettings, structure: BuildStructure, s: State): State =
     {
       s.log.info("Reapplying settings...")
-      val newStructure = Load.reapply(newSession.mergeSettings, structure)(Project.showContextKey(newSession, structure))
+      // Here, for correct behavior, we also need to re-inject a settings logger, as we'll be re-evaluating settings.
+      val loggerInject = LogManager.settingsLogger(s)
+      val withLogger = newSession.appendRaw(loggerInject :: Nil)
+      val newStructure = Load.reapply(withLogger.mergeSettings, structure)(Project.showContextKey(newSession, structure))
       Project.setProject(newSession, newStructure, s)
     }
   def set = Command(SetCommand, setBrief, setDetailed)(setParser) {

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -33,6 +33,7 @@
   [1467]: https://github.com/sbt/sbt/pull/1467
   [1476]: https://github.com/sbt/sbt/pull/1476
   [1477]: https://github.com/sbt/sbt/pull/1477
+  [1486]: https://github.com/sbt/sbt/pull/1486
   [@dansanduleac]: https://github.com/dansanduleac
   [@2m]: https://github.com/2m
   [@pvlugter]: https://github.com/pvlugter
@@ -76,6 +77,7 @@
 - Adds `scala-jar` to the list of jar artifacts recognized by CustomPomParser. [#1400][1400] by [@dpratt][@dpratt]
 - Fixes cross versioning to recognize version number with mutiple -tags. [#1433][1433] by [@henrikengstrom][@henrikengstrom]
 - Works around "Not a simple type" breaking `-Xfatal-warnings`. [#1477][1477] by [@puffnfresh][@puffnfresh]
+- Fixes sLog usage in tandem with the `set` comamnd [#1486][1486] [@jsuereth][@jsuereth]
 
 ### enablePlugins/disablePlugins
 

--- a/sbt/src/sbt-test/actions/reload/log-in-setting.sbt
+++ b/sbt/src/sbt-test/actions/reload/log-in-setting.sbt
@@ -1,0 +1,15 @@
+
+version := {
+  sLog.value.info("Version is initializing")
+  version.value
+}
+
+TaskKey[Unit]("evil-clear-logger") := {
+  val logger = sLog.value
+  val cls = logger.getClass
+  val field = cls.getDeclaredField("ref")
+  field.setAccessible(true)
+  val ref = field.get(logger).asInstanceOf[java.lang.ref.WeakReference[_]]
+  // MUHAHAHHAHAHAHAHHAHA, I am de evil GC, I clear things.
+  ref.clear()
+}

--- a/sbt/src/sbt-test/actions/reload/test
+++ b/sbt/src/sbt-test/actions/reload/test
@@ -1,3 +1,6 @@
+# Note: We aren't actively running this test, but it checks to make sure the setting-level logger is ok across reloads.
+# > evil-clear-logger
+# > reload
 -> f
 > project sub
 > f

--- a/sbt/src/sbt-test/actions/set/build.sbt
+++ b/sbt/src/sbt-test/actions/set/build.sbt
@@ -9,6 +9,16 @@ TaskKey[Unit]("checkBuildSbtDefined", "") := {
 	assert(notExistingThing.?.value == Some(5), "Failed to set a settingKey defined in build.sbt")
 }
 
+TaskKey[Unit]("evil-clear-logger") := {
+  val logger = sLog.value
+  val cls = logger.getClass
+  val field = cls.getDeclaredField("ref")
+  field.setAccessible(true)
+  val ref = field.get(logger).asInstanceOf[java.lang.ref.WeakReference[_]]
+  // MUHAHAHHAHAHAHAHHAHA, I am de evil GC, I clear things.
+  ref.clear()
+}
+
 commands ++= Seq(
   Command.command("helloWorldTest") { state: State =>
      """set name := "hello-world"""" ::

--- a/sbt/src/sbt-test/actions/set/test
+++ b/sbt/src/sbt-test/actions/set/test
@@ -1,2 +1,4 @@
 > helloWorldTest
 > buildSbtTest
+> evil-clear-logger
+> set version := { sLog.value.info("yo"); version.value }


### PR DESCRIPTION
- Migrate weak reference into logger class so we can test clearing it.
- Ensure new state.log is propoagted into settings on `set` command.
- Fix set test so that it ensures the sLog is relatively stable when
  reloading on set command.

Review by @eed3si9n 
