### PR TITLE
Fixes #856 - Store ++ scala version changes on session.

### DIFF
--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -1,4 +1,5 @@
   [413]: https://github.com/sbt/sbt/issues/413
+  [856]: https://github.com/sbt/sbt/issues/856
   [1036]: https://github.com/sbt/sbt/pull/1036
   [1059]: https://github.com/sbt/sbt/issues/1059
   [1194]: https://github.com/sbt/sbt/issues/1194
@@ -36,6 +37,8 @@
   [1486]: https://github.com/sbt/sbt/pull/1486
   [1487]: https://github.com/sbt/sbt/pull/1487
   [1488]: https://github.com/sbt/sbt/pull/1488
+  [1489]: https://github.com/sbt/sbt/pull/1489
+
   [@dansanduleac]: https://github.com/dansanduleac
   [@2m]: https://github.com/2m
   [@pvlugter]: https://github.com/pvlugter
@@ -82,6 +85,7 @@
 - Fixes sLog usage in tandem with the `set` comamnd [#1486][1486] [@jsuereth][@jsuereth]
 - Test suites with whitespace will have prettier filenames [#1487][1487] [@jsuereth][@jsuereth]
 - sbt no longer crashes when run in root directory [#1488][1488] by [@jsuereth][@jsuereth]
+- set no longer removes any `++` scala version setting.  [#856][856]/[#1489][1489] by [@jsuereth][@jsuereth]
 
 ### enablePlugins/disablePlugins
 

--- a/sbt/src/sbt-test/actions/cross/test
+++ b/sbt/src/sbt-test/actions/cross/test
@@ -1,3 +1,8 @@
 > check 2.7.7 2.9.1 2.9.0-1
 > ++ 2.8.2
 > check 2.8.2 2.8.2 2.8.1
+> ++ 2.10.4
+> set resolvers ++= Nil
+> check 2.10.4 2.10.4 2.10.4
+> session clear-all
+> check 2.7.7 2.9.1 2.9.0-1


### PR DESCRIPTION
- Ensure the ++ command stores its changes on the sbt session.
- Make sure `session clear-all` will clear out ++ changes
- Validate that `set` command doesn't undo `++` changes

Note: There is some autogenerated Setting[_] delegate optimisation
      work that could be done in the future.

Review by @eed3si9n cc @paulp 
