### PR TITLE
Fixes #1384. Fixes Scope.parseScopedKey

### DIFF
--- a/main/settings/src/main/scala/sbt/Scope.scala
+++ b/main/settings/src/main/scala/sbt/Scope.scala
@@ -124,12 +124,32 @@ object Scope {
 
   def parseScopedKey(command: String): (Scope, String) =
     {
-      val ScopedKeyRegex(_, projectID, _, config, key) = command
-      val pref = if (projectID eq null) This else Select(LocalProject(projectID))
-      val conf = if (config eq null) This else Select(ConfigKey(config))
-      (Scope(pref, conf, This, This), transformTaskName(key))
+      val ScopedKeyRegex2(_, uriOrNull, _, projectIdOrNull, _, configOrNull, _, inTaskOrNull, key) = command
+      val uriOpt = Option(uriOrNull) map { new URI(_) }
+      val projectIdOpt = Option(projectIdOrNull)
+      val configOpt = Option(configOrNull)
+      val inTaskOpt = Option(inTaskOrNull)
+      val DotURI = new URI(".")
+      val GlobalStr = "*"
+      val scope = (uriOpt, projectIdOpt, configOpt, inTaskOpt) match {
+        case (None, None, Some(GlobalStr), None) => GlobalScope
+        case _ =>
+          val projScope = (uriOpt, projectIdOpt) match {
+            case (Some(DotURI), Some("")) => Select(ThisBuild)
+            case (Some(uri), Some(""))    => Select(BuildRef(uri))
+            case (Some(uri), Some(p))     => Select(ProjectRef(uri, p))
+            case (None, Some(p))          => Select(LocalProject(p))
+            case _                        => This
+          }
+          val configScope = configOpt map { case c if c != GlobalStr => Select(ConfigKey(c)) } getOrElse This
+          val inTaskScope = inTaskOpt map { t => Select(AttributeKey(t)) } getOrElse This
+          Scope(projScope, configScope, inTaskScope, This)
+      }
+      (scope, transformTaskName(key))
     }
+  // TODO: Change to ScopedKeyRegex2 on sbt 1.0
   val ScopedKeyRegex = """((\w+)\/)?((\w+)\:)?([\w\-]+)""".r
+  private[sbt] val ScopedKeyRegex2 = """([{](.*?)[}])?((\w*)\/)?(([\w\*]+)\:)?(([\w\-]+)\:\:)?([\w\-]+)""".r
 
   def transformTaskName(s: String) =
     {

--- a/main/settings/src/main/scala/sbt/Scope.scala
+++ b/main/settings/src/main/scala/sbt/Scope.scala
@@ -122,8 +122,10 @@ object Scope {
   def projectPrefix(project: ScopeAxis[Reference], show: Reference => String = showProject): String = project.foldStrict(show, "*/", "./")
   def showProject = (ref: Reference) => Reference.display(ref) + "/"
 
+  @deprecated("No longer used", "0.13.6")
   def parseScopedKey(command: String): (Scope, String) =
     {
+      val ScopedKeyRegex2 = """([{](.*?)[}])?((\w*)\/)?(([\w\*]+)\:)?(([\w\-]+)\:\:)?([\w\-]+)""".r
       val ScopedKeyRegex2(_, uriOrNull, _, projectIdOrNull, _, configOrNull, _, inTaskOrNull, key) = command
       val uriOpt = Option(uriOrNull) map { new URI(_) }
       val projectIdOpt = Option(projectIdOrNull)
@@ -147,9 +149,8 @@ object Scope {
       }
       (scope, transformTaskName(key))
     }
-  // TODO: Change to ScopedKeyRegex2 on sbt 1.0
+  @deprecated("No longer used", "0.13.6")
   val ScopedKeyRegex = """((\w+)\/)?((\w+)\:)?([\w\-]+)""".r
-  private[sbt] val ScopedKeyRegex2 = """([{](.*?)[}])?((\w*)\/)?(([\w\*]+)\:)?(([\w\-]+)\:\:)?([\w\-]+)""".r
 
   def transformTaskName(s: String) =
     {

--- a/main/settings/src/test/scala/ScopedKeySpec.scala
+++ b/main/settings/src/test/scala/ScopedKeySpec.scala
@@ -1,0 +1,48 @@
+package sbt
+
+import org.specs2._
+import Scope.{ ThisScope, GlobalScope, parseScopedKey }
+import java.net.URI
+
+/**
+ * http://www.scala-sbt.org/0.13/tutorial/Scopes.html
+ */
+class ScopedKeySpec extends Specification {
+  def is = s2"""
+
+  This is a specification to check the scoped key parsing.
+
+  fullClasspath should
+    ${beParsedAs("fullClasspath", ThisScope, "fullClasspath")}
+
+  test:fullClasspath should
+    ${beParsedAs("test:fullClasspath", ThisScope in ConfigKey("test"), "fullClasspath")}
+
+  *:fullClasspath
+    ${beParsedAs("*:fullClasspath", GlobalScope, "fullClasspath")}
+
+  aea33a/test:fullClasspath   
+    ${beParsedAs("aea33a/test:fullClasspath", ThisScope in (LocalProject("aea33a"), ConfigKey("test")), "fullClasspath")}
+
+  doc::fullClasspath
+    ${beParsedAs("doc::fullClasspath", ThisScope in AttributeKey("doc"), "fullClasspath")}
+
+  {file:/hello/}aea33a/test:fullClasspath
+    ${beParsedAs("{file:/hello/}aea33a/test:fullClasspath", ThisScope in (ProjectRef(new URI("file:/hello/"), "aea33a"), ConfigKey("test")), "fullClasspath")}
+
+  {file:/hello/}/test:fullClasspath
+    ${beParsedAs("{file:/hello/}/test:fullClasspath", ThisScope in (BuildRef(new URI("file:/hello/")), ConfigKey("test")), "fullClasspath")}
+
+  {.}/test:fullClasspath
+    ${beParsedAs("{.}/test:fullClasspath", ThisScope in (ThisBuild, ConfigKey("test")), "fullClasspath")}
+
+  {file:/hello/}/compile:doc::fullClasspath
+    ${beParsedAs("{file:/hello/}/compile:doc::fullClasspath", ThisScope in (BuildRef(new URI("file:/hello/")), ConfigKey("compile"), AttributeKey("doc")), "fullClasspath")}
+                                                                """
+
+  def beParsedAs(cmd: String, scope0: Scope, key0: String) =
+    {
+      val (scope, key) = parseScopedKey(cmd)
+      (scope must_== scope0) and (key must_== key0)
+    }
+}

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -17,6 +17,7 @@
   [1367]: https://github.com/sbt/sbt/pull/1367
   [1378]: https://github.com/sbt/sbt/pull/1378
   [1383]: https://github.com/sbt/sbt/pull/1383
+  [1384]: https://github.com/sbt/sbt/issues/1384
   [1400]: https://github.com/sbt/sbt/pull/1400
   [1401]: https://github.com/sbt/sbt/pull/1401
   [1409]: https://github.com/sbt/sbt/pull/1409
@@ -91,6 +92,7 @@
 - Test suites with whitespace will have prettier filenames [#1487][1487] [@jsuereth][@jsuereth]
 - sbt no longer crashes when run in root directory [#1488][1488] by [@jsuereth][@jsuereth]
 - set no longer removes any `++` scala version setting.  [#856][856]/[#1489][1489] by [@jsuereth][@jsuereth]
+- Fixes `Scope.parseScopedKey`. [#1384][1384] by [@eed3si9n][@eed3si9n]
 
 ### enablePlugins/disablePlugins
 


### PR DESCRIPTION
Fixes #1384.

`Scope.parseScopedKey` now supports full range of legal keys described in the documentation including {.} and other notation for `ProjectRef`, `BuildRef`, and `ThisBuild`.
Just in case any plugin is using `val ScopedKeyRegex = """((\w+)\/)?((\w+)\:)?([\w\-]+)""".r`, I'm leaving that old regex as is and added `ScopedKeyRegex2` in `private[sbt]`.
