### PR TITLE
HTTPS: Use HTTPS for downloading artifacts from Maven Central

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -6,7 +6,7 @@ package sbt
 import java.io.File
 import java.net.URL
 import scala.xml.NodeSeq
-import org.apache.ivy.plugins.resolver.{ DependencyResolver, IBiblioResolver }
+import org.apache.ivy.plugins.resolver.DependencyResolver
 
 sealed trait Resolver {
   def name: String
@@ -135,7 +135,7 @@ final case class SftpRepository(name: String, connection: SshConnection, pattern
 
 import Resolver._
 
-object DefaultMavenRepository extends MavenRepository("public", IBiblioResolver.DEFAULT_M2_ROOT)
+object DefaultMavenRepository extends MavenRepository("public", DefaultMavenRepositoryRoot)
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository
 sealed trait JavaNet1Repository extends Resolver {
@@ -146,6 +146,7 @@ object Resolver {
   val TypesafeRepositoryRoot = "http://repo.typesafe.com/typesafe"
   val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
+  val DefaultMavenRepositoryRoot = "https://repo1.maven.org/maven2/"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"

--- a/launch/src/test/scala/ConfigurationParserTest.scala
+++ b/launch/src/test/scala/ConfigurationParserTest.scala
@@ -21,64 +21,64 @@ object ConfigurationParserTest extends Specification {
         Repository.Predefined("local", false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org""".stripMargin,
-        Repository.Maven("id", new URL("http://repo1.maven.org"), false))
+                                            |  id: https://repo1.maven.org""".stripMargin,
+        Repository.Maven("id", new URL("https://repo1.maven.org"), false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, bootOnly""".stripMargin,
-        Repository.Maven("id", new URL("http://repo1.maven.org"), true))
+                                            |  id: https://repo1.maven.org, bootOnly""".stripMargin,
+        Repository.Maven("id", new URL("https://repo1.maven.org"), true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath]""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false))
+                                            |  id: https://repo1.maven.org, [orgPath]""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false))
+                                            |  id: https://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true))
+                                            |  id: https://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, false))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], descriptorOptional""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional, skipConsistencyCheck""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], descriptorOptional, skipConsistencyCheck""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional, mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional, mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
 
     }
   }

--- a/src/sphinx/Detailed-Topics/Resolvers.rst
+++ b/src/sphinx/Detailed-Topics/Resolvers.rst
@@ -21,7 +21,7 @@ Predefined
 A few predefined repositories are available and are listed below
 
 -  `DefaultMavenRepository` This is the main Maven repository at
-   http://repo1.maven.org/maven2/ and is included by default
+   https://repo1.maven.org/maven2/ and is included by default
 -  `JavaNet1Repository` This is the Maven 1 repository at
    http://download.java.net/maven/1/
 

--- a/src/sphinx/faq.rst
+++ b/src/sphinx/faq.rst
@@ -491,7 +491,7 @@ as a jar or pom.xml. An example of such an error is:
 ::
 
     [warn]  problem while downloading module descriptor:
-    http://repo1.maven.org/maven2/commons-fileupload/commons-fileupload/1.2.2/commons-fileupload-1.2.2.pom:
+    https://repo1.maven.org/maven2/commons-fileupload/commons-fileupload/1.2.2/commons-fileupload-1.2.2.pom:
     invalid sha1: expected=ad3fda4adc95eb0d061341228cc94845ddb9a6fe computed=0ce5d4a03b07c8b00ab60252e5cacdc708a4e6d8 (1070ms)
 
 The invalid checksum should generally be reported to the repository


### PR DESCRIPTION
Sonatype have enabled HTTPS access for Maven Central:

http://central.sonatype.org/articles/2014/Aug/03/https-support-launching-now/

Note that the Ivy class IBiblioResolver contains the old http url (ie `DEFAULT_M2_ROOT="http://repo1.maven.org/maven2/"`):

http://svn.apache.org/viewvc/ant/ivy/core/trunk/src/java/org/apache/ivy/plugins/resolver/IBiblioResolver.java?revision=1557968&view=markup#l72

An alternative to this PR would be to wait for that artifact to update, but I can't think of any reason to not just include the url directly, as done with the other repository roots.
