### PR TITLE
"Use HTTPS for downloading artifacts from Maven Central" + disable flag

### DIFF
--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -307,7 +307,7 @@ class MakePom(val log: Logger) {
       val repositories = if (includeAll) allResolvers(settings) else resolvers(settings.getDefaultResolver)
       val mavenRepositories =
         repositories.flatMap {
-          case m: IBiblioResolver if m.isM2compatible && m.getRoot != IBiblioResolver.DEFAULT_M2_ROOT =>
+          case m: IBiblioResolver if m.isM2compatible && m.getRoot != DefaultMavenRepository.root =>
             MavenRepository(m.getName, m.getRoot) :: Nil
           case _ => Nil
         }

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -6,7 +6,7 @@ package sbt
 import java.io.File
 import java.net.URL
 import scala.xml.NodeSeq
-import org.apache.ivy.plugins.resolver.{ DependencyResolver, IBiblioResolver }
+import org.apache.ivy.plugins.resolver.DependencyResolver
 
 sealed trait Resolver {
   def name: String
@@ -135,7 +135,7 @@ final case class SftpRepository(name: String, connection: SshConnection, pattern
 
 import Resolver._
 
-object DefaultMavenRepository extends MavenRepository("public", IBiblioResolver.DEFAULT_M2_ROOT)
+object DefaultMavenRepository extends MavenRepository("public", DefaultMavenRepositoryRoot)
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JCenterRepository extends MavenRepository(JCenterRepositoryName, JCenterRepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository
@@ -151,6 +151,7 @@ object Resolver {
   val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
   val JCenterRepositoryName = "jcenter"
   val JCenterRepositoryRoot = "https://jcenter.bintray.com/"
+  val DefaultMavenRepositoryRoot = "https://repo1.maven.org/maven2/"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -135,7 +135,7 @@ final case class SftpRepository(name: String, connection: SshConnection, pattern
 
 import Resolver._
 
-object DefaultMavenRepository extends MavenRepository("public", DefaultMavenRepositoryRoot)
+object DefaultMavenRepository extends MavenRepository("public", centralRepositoryRoot(useSecureResolvers))
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JCenterRepository extends MavenRepository(JCenterRepositoryName, JCenterRepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository
@@ -144,6 +144,8 @@ sealed trait JavaNet1Repository extends Resolver {
 }
 
 object Resolver {
+  private[sbt] def useSecureResolvers = sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
+
   val TypesafeRepositoryRoot = "http://repo.typesafe.com/typesafe"
   val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
@@ -152,6 +154,7 @@ object Resolver {
   val JCenterRepositoryName = "jcenter"
   val JCenterRepositoryRoot = "https://jcenter.bintray.com/"
   val DefaultMavenRepositoryRoot = "https://repo1.maven.org/maven2/"
+  private[sbt] def centralRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo1.maven.org/maven2/"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"

--- a/launch/src/test/scala/ConfigurationParserTest.scala
+++ b/launch/src/test/scala/ConfigurationParserTest.scala
@@ -21,64 +21,64 @@ object ConfigurationParserTest extends Specification {
         Repository.Predefined("local", false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org""".stripMargin,
-        Repository.Maven("id", new URL("http://repo1.maven.org"), false))
+                                            |  id: https://repo1.maven.org""".stripMargin,
+        Repository.Maven("id", new URL("https://repo1.maven.org"), false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, bootOnly""".stripMargin,
-        Repository.Maven("id", new URL("http://repo1.maven.org"), true))
+                                            |  id: https://repo1.maven.org, bootOnly""".stripMargin,
+        Repository.Maven("id", new URL("https://repo1.maven.org"), true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath]""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false))
+                                            |  id: https://repo1.maven.org, [orgPath]""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false))
+                                            |  id: https://repo1.maven.org, [orgPath], mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], bootOnly, mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true))
+                                            |  id: https://repo1.maven.org, [orgPath], bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[orgPath]", false, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath]""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, false))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], descriptorOptional""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, false))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], descriptorOptional, skipConsistencyCheck""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], descriptorOptional, skipConsistencyCheck""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, false, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional, mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true, true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], skipConsistencyCheck, descriptorOptional, mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true, true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", false, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], bootOnly, mavenCompatible""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
 
       repoFileContains("""|[repositories]
-                                            |  id: http://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
-        Repository.Ivy("id", new URL("http://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
+                                            |  id: https://repo1.maven.org, [orgPath], [artPath], mavenCompatible, bootOnly""".stripMargin,
+        Repository.Ivy("id", new URL("https://repo1.maven.org"), "[orgPath]", "[artPath]", true, true))
 
     }
   }

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -42,6 +42,7 @@
   [1487]: https://github.com/sbt/sbt/pull/1487
   [1488]: https://github.com/sbt/sbt/pull/1488
   [1489]: https://github.com/sbt/sbt/pull/1489
+  [1494]: https://github.com/sbt/sbt/pull/1494
 
   [@dansanduleac]: https://github.com/dansanduleac
   [@2m]: https://github.com/2m
@@ -57,6 +58,7 @@
   [@dpratt]: https://github.com/dpratt
   [@henrikengstrom]: https://github.com/henrikengstrom
   [@puffnfresh]: https://github.com/puffnfresh
+  [@rtyley]: https://github.com/rtyley
 
 ### Changes since 0.13.6-M1
 
@@ -64,6 +66,7 @@
 
 ### Fixes with compatibility implications
 
+- Maven Central Repository now defaults to HTTPS. [#1494][1494] by [@rtyley][@rtyley]
 - `ThisProject` used to resolve to the root project in a build even when it's place in `subproj/build.sbt`. sbt 0.13.6 fixes it to resolve to the sub project. [#1194][1194]/[#1358][1358] by [@dansanduleac][@dansanduleac]
 - Global plugins classpath used to be injected into every build. This will no longer be the case. [#1347][1347]/[#1352][1352] by [@dansanduleac][@dansanduleac]
 - Fixes `newer` command in scripted. [#1419][1419] by [@jroper][@jroper]
@@ -98,6 +101,14 @@
 - set no longer removes any `++` scala version setting.  [#856][856]/[#1489][1489] by [@jsuereth][@jsuereth]
 - Fixes `Scope.parseScopedKey`. [#1384][1384] by [@eed3si9n][@eed3si9n]
 - Fixes `build.sbt` errors causing `ArrayIndexOutOfBoundsException` due to invalid source in position. [#1181][1181] by [@eed3si9n][@eed3si9n]
+
+### Maven Central Repository defaults to HTTPS
+
+Thanks to Sonatype, HTTPS access to Maven Central Repository is available to public. This is now enabled by default, but if HTTP is required for some reason the following system properties can be used:
+
+    -Dsbt.repository.secure=false
+
+[#1494][1494] by [@rtyley][@rtyley]
 
 ### enablePlugins/disablePlugins
 

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -1,12 +1,12 @@
 import sbt._
 import Keys._
 import Status.publishStatus
-import com.typesafe.sbt.{SbtGhPages,SbtGit,SbtSite,site=>sbtsite}
-import SbtSite.{site, SiteKeys}
-import SbtGhPages.{ghpages, GhPagesKeys => ghkeys}
-import SbtGit.{git, GitKeys}
+import com.typesafe.sbt.{ SbtGhPages, SbtGit, SbtSite, site => sbtsite }
+import SbtSite.{ site, SiteKeys }
+import SbtGhPages.{ ghpages, GhPagesKeys => ghkeys }
+import SbtGit.{ git, GitKeys }
 import sbtsite.SphinxSupport
-import SiteKeys.{makeSite,siteMappings}
+import SiteKeys.{ makeSite, siteMappings }
 import Sxr.sxr
 import SiteMap.Entry
 
@@ -16,9 +16,9 @@ object Docs {
 
   def settings: Seq[Setting[_]] =
     site.settings ++
-    site.includeScaladoc("api") ++
-    siteIncludeSxr("sxr") ++
-    ghPagesSettings
+      site.includeScaladoc("api") ++
+      siteIncludeSxr("sxr") ++
+      ghPagesSettings
 
   def ghPagesSettings = ghpages.settings ++ Seq(
     git.remoteRepo := "git@github.com:sbt/sbt.github.com.git",
@@ -27,11 +27,10 @@ object Docs {
     GitKeys.gitBranch in ghkeys.updatedRepository := Some("master")
   )
 
-
   def localRepoDirectory = ghkeys.repository := {
     // distinguish between building to update the site or not so that CI jobs 
     //  that don't commit+publish don't leave uncommitted changes in the working directory
-    val status = if(isSnapshot.value) "snapshot" else "public"
+    val status = if (isSnapshot.value) "snapshot" else "public"
     Path.userHome / ".sbt" / "ghpages" / status / organization.value / name.value
   }
 
@@ -42,11 +41,11 @@ object Docs {
 
   def synchLocalImpl = (ghkeys.privateMappings, ghkeys.updatedRepository, version, streams) map {
     (mappings, repo, v, s) =>
-    val versioned = repo / v
-    IO.delete(versioned / "sxr")
-    IO.delete(versioned / "api")
-    val toCopy = for( (file, target) <- mappings if siteInclude(file) ) yield (file, versioned / target)
-    IO.copy(toCopy)
-    repo
+      val versioned = repo / v
+      IO.delete(versioned / "sxr")
+      IO.delete(versioned / "api")
+      val toCopy = for ((file, target) <- mappings if siteInclude(file)) yield (file, versioned / target)
+      IO.copy(toCopy)
+      repo
   }
 }


### PR DESCRIPTION
This is an amendment to #1494. HTTPS will be enabled by default, but can be turned off using the following flag:

```
-Dsbt.repository.secure=false
```
