### PR TITLE
Moves JCenter and Bintray repo into object Resolver. #1405

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -20,10 +20,6 @@ sealed case class MavenRepository(name: String, root: String) extends Resolver {
   override def toString = name + ": " + root
 }
 
-sealed class JCenter(isSecure: Boolean = false) extends MavenRepository("jcenter", s"http${if (isSecure) "s" else ""}://jcenter.bintray.com/")
-
-sealed class BintrayMavenRepository(subject: String, repo: String, isSecure: Boolean = false) extends MavenRepository(s"bintray$subject/$repo/", s"http${if (isSecure) "s" else ""}://dl.bintray.com/$subject/$repo/")
-
 final class Patterns(val ivyPatterns: Seq[String], val artifactPatterns: Seq[String], val isMavenCompatible: Boolean, val descriptorOptional: Boolean, val skipConsistencyCheck: Boolean) {
   private[sbt] def mavenStyle(): Patterns = Patterns(ivyPatterns, artifactPatterns, true)
   private[sbt] def withDescriptorOptional(): Patterns = Patterns(ivyPatterns, artifactPatterns, isMavenCompatible, true, skipConsistencyCheck)
@@ -139,9 +135,9 @@ final case class SftpRepository(name: String, connection: SshConnection, pattern
 
 import Resolver._
 
-object JCenter extends JCenter(false)
 object DefaultMavenRepository extends MavenRepository("public", IBiblioResolver.DEFAULT_M2_ROOT)
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
+object JCenterRepository extends MavenRepository(JCenterRepositoryName, JCenterRepositoryRoot)
 object JavaNet1Repository extends JavaNet1Repository
 sealed trait JavaNet1Repository extends Resolver {
   def name = "java.net Maven1 Repository"
@@ -151,6 +147,10 @@ object Resolver {
   val TypesafeRepositoryRoot = "http://repo.typesafe.com/typesafe"
   val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
+  val JavaNet2RepositoryName = "java.net Maven2 Repository"
+  val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
+  val JCenterRepositoryName = "jcenter"
+  val JCenterRepositoryRoot = "https://jcenter.bintray.com/"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"
@@ -160,13 +160,12 @@ object Resolver {
   private[sbt] val ScalaToolsReleases = new MavenRepository(ScalaToolsReleasesName, ScalaToolsReleasesRoot)
   private[sbt] val ScalaToolsSnapshots = new MavenRepository(ScalaToolsSnapshotsName, ScalaToolsSnapshotsRoot)
 
-  val JavaNet2RepositoryName = "java.net Maven2 Repository"
-  val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
-
   def typesafeRepo(status: String) = new MavenRepository("typesafe-" + status, TypesafeRepositoryRoot + "/" + status)
   def typesafeIvyRepo(status: String) = url("typesafe-ivy-" + status, new URL(TypesafeRepositoryRoot + "/ivy-" + status + "/"))(ivyStylePatterns)
   def sbtPluginRepo(status: String) = url("sbt-plugin-" + status, new URL(SbtPluginRepositoryRoot + "/sbt-plugin-" + status + "/"))(ivyStylePatterns)
   def sonatypeRepo(status: String) = new MavenRepository("sonatype-" + status, SonatypeRepositoryRoot + "/" + status)
+  def bintrayRepo(owner: String, repo: String) = new MavenRepository(s"bintray-$owner-$repo", s"https://dl.bintray.com/$owner/$repo/")
+  def jcenterRepo = JCenterRepository
 
   /** Add the local and Maven Central repositories to the user repositories.  */
   def withDefaultResolvers(userResolvers: Seq[Resolver]): Seq[Resolver] =

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -20,6 +20,7 @@
   [1384]: https://github.com/sbt/sbt/issues/1384
   [1400]: https://github.com/sbt/sbt/pull/1400
   [1401]: https://github.com/sbt/sbt/pull/1401
+  [1405]: https://github.com/sbt/sbt/pull/1405
   [1409]: https://github.com/sbt/sbt/pull/1409
   [1416]: https://github.com/sbt/sbt/issues/1416
   [1419]: https://github.com/sbt/sbt/pull/1419
@@ -45,6 +46,7 @@
   [@2m]: https://github.com/2m
   [@pvlugter]: https://github.com/pvlugter
   [@eed3si9n]: https://github.com/eed3si9n
+  [@evgeny-goldin]: https://github.com/evgeny-goldin
   [@jsuereth]: https://github.com/jsuereth
   [@benjyw]: https://github.com/benjyw
   [@xuwei-k]: https://github.com/xuwei-k
@@ -79,6 +81,7 @@
 - Allows default auto plugins to be disabled. [#1451][1451] by [@jsuereth][@jsuereth]
 - Allows keys defined inside `build.sbt` to be used from sbt shell. [#1059][1059]/[#1456][1456]
 - Updates internal Ivy instance to cache the results of dependency exclusion rules. [#1476][1476] by [@eed3si9n][@eed3si9n]
+- Adds `Resolver.jcenterRepo` and `Resolver.bintrayRepo(owner, repo)` to add Bintray easier. [#1405][1405] by [@evgeny-goldin][@evgeny-goldin]
 
 ### Bug fixes
 


### PR DESCRIPTION
This is a belated amendment to #1405.

This is more consistent with other hardcoded repos like Sonatype.
Also I'm hardcoding everything to https. Especially for convenience methods like these, we should be encouraging people to use https out of the box.

build.sbt:

``` scala
resolvers += Resolver.bintrayRepo("foo", "bar")
```

/review @jsuereth, @evgeny-goldin
