### PR TITLE
Fixes #1181/#1501. Fixes ArrayIndexOutOfBoundsException: -1

### DIFF
--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -2,6 +2,7 @@
   [856]: https://github.com/sbt/sbt/issues/856
   [1036]: https://github.com/sbt/sbt/pull/1036
   [1059]: https://github.com/sbt/sbt/issues/1059
+  [1181]: https://github.com/sbt/sbt/issues/1181
   [1194]: https://github.com/sbt/sbt/issues/1194
   [1200]: https://github.com/sbt/sbt/issues/1200
   [1213]: https://github.com/sbt/sbt/issues/1213
@@ -93,6 +94,7 @@
 - sbt no longer crashes when run in root directory [#1488][1488] by [@jsuereth][@jsuereth]
 - set no longer removes any `++` scala version setting.  [#856][856]/[#1489][1489] by [@jsuereth][@jsuereth]
 - Fixes `Scope.parseScopedKey`. [#1384][1384] by [@eed3si9n][@eed3si9n]
+- Fixes `build.sbt` errors causing `ArrayIndexOutOfBoundsException` due to invalid source in position. [#1181][1181] by [@eed3si9n][@eed3si9n]
 
 ### enablePlugins/disablePlugins
 


### PR DESCRIPTION
Fixes #1181/#1501

When the compiler reports back the error to CompilationUnit created by Eval#mkUnit, it sometimes returns OffsetPosition whose `source` is set to `NoSourceFile`.

This causes ArrayIndexOutOfBoundsException. The current workaround is to pattern match on the passed in pos and create a new one when the incoming source looks suspicious.
I have not figured out whether this is caused by our macro code or compiler.
There are various build.sbt errors that would cause this behavior:

``` scala
libraryDependencies ++= Seq(
  depA
  depB // missing comma
)

lazy val bob = scala.Console println

test ++

run+
```
