### PR TITLE
Fix pom-export of Maven Central repository

### DIFF
--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -307,7 +307,7 @@ class MakePom(val log: Logger) {
       val repositories = if (includeAll) allResolvers(settings) else resolvers(settings.getDefaultResolver)
       val mavenRepositories =
         repositories.flatMap {
-          case m: IBiblioResolver if m.isM2compatible && m.getRoot != IBiblioResolver.DEFAULT_M2_ROOT =>
+          case m: IBiblioResolver if m.isM2compatible && m.getRoot != DefaultMavenRepository.root =>
             MavenRepository(m.getName, m.getRoot) :: Nil
           case _ => Nil
         }


### PR DESCRIPTION
Commit a1e26ca6 (in PR #1507) broke the `make-pom` & `pom-advanced` dependency-management tests by replacing one reference to `IBiblioResolver.DEFAULT_M2_ROOT` in `Resolver`, but not the other reference in `MakePom`:

https://travis-ci.org/sbt/sbt/jobs/31939788#L2517-L2519

...the secure url was no longer recognised as the default Maven Repository root, so was erroneously exported.

Apologies for not running the full test suite sooner...

cc @eed3si9n 
