### PR TITLE
HTTPS: Use HTTPS when downloading JARs from Typesafe repo and repo.scala-sbt.org

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -146,11 +146,11 @@ sealed trait JavaNet1Repository extends Resolver {
 object Resolver {
   private[sbt] def useSecureResolvers = sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
 
-  val TypesafeRepositoryRoot = "http://repo.typesafe.com/typesafe"
-  val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
+  val TypesafeRepositoryRoot = "https://repo.typesafe.com/typesafe"
+  val SbtPluginRepositoryRoot = "https://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
-  val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
+  // val JavaNet2RepositoryRoot = "http://download.java.net/maven/2" // DANGER: unavailable via https.
   val JCenterRepositoryName = "jcenter"
   val JCenterRepositoryRoot = "https://jcenter.bintray.com/"
   val DefaultMavenRepositoryRoot = "https://repo1.maven.org/maven2/"


### PR DESCRIPTION
By using secure URLs, people on your network are not (trivially) able to inject executable code into your dependencies to run on your computer or your build server.

Unfortunately `JavaNet2RepositoryRoot` has no `https` mirror. Is there an alternative mirror or a Scala annotation to warn users (and transitive users) that anyone could execute arbitrary code on their computers?
