### PR TITLE
HTTPS: Fetch typesafe artifacts using https

### DIFF
--- a/launch/src/main/resources/sbt.boot.properties0.10.0
+++ b/launch/src/main/resources/sbt.boot.properties0.10.0
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/launch/src/main/resources/sbt.boot.properties0.10.1
+++ b/launch/src/main/resources/sbt.boot.properties0.10.1
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/launch/src/main/resources/sbt.boot.properties0.11.0
+++ b/launch/src/main/resources/sbt.boot.properties0.11.0
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/launch/src/main/resources/sbt.boot.properties0.11.1
+++ b/launch/src/main/resources/sbt.boot.properties0.11.1
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/launch/src/main/resources/sbt.boot.properties0.11.2
+++ b/launch/src/main/resources/sbt.boot.properties0.11.2
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/launch/src/main/resources/sbt.boot.properties0.11.3
+++ b/launch/src/main/resources/sbt.boot.properties0.11.3
@@ -11,7 +11,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -92,5 +92,5 @@ object Transform {
   lazy val Releases = typesafeRepository("releases")
   lazy val Snapshots = typesafeRepository("snapshots")
   def typesafeRepository(status: String) =
-    """  typesafe-ivy-%s: http://repo.typesafe.com/typesafe/ivy-%<s/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly""" format status
+    """  typesafe-ivy-%s: https://repo.typesafe.com/typesafe/ivy-%<s/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly""" format status
 }

--- a/sbt/src/sbt-test/dependency-management/module-confs/Test.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-confs/Test.sbt
@@ -1,5 +1,5 @@
 {
-	def snapshotPattern = "http://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
+	def snapshotPattern = "https://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
 	def scalaSnapshots = Resolver.url("Scala Tools Snapshots (Typesafe)") ivys(snapshotPattern) artifacts(snapshotPattern) mavenStyle()
 	moduleConfigurations += ModuleConfiguration("org.scala-lang", "*", "2.10.0-.*", scalaSnapshots)
 }

--- a/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongOrg.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongOrg.sbt
@@ -1,5 +1,5 @@
 {
-	def snapshotPattern = "http://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
+	def snapshotPattern = "https://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
 	def scalaSnapshots = Resolver.url("Scala Tools Snapshots") artifacts(snapshotPattern) ivys(snapshotPattern) mavenStyle()
 	moduleConfigurations += ModuleConfiguration("org.not-scala-lang", "*", "2.10.0-.*", scalaSnapshots)
 }

--- a/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongPattern.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongPattern.sbt
@@ -1,5 +1,5 @@
 {
-	def snapshotPattern = "http://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.a-SNAPSHOT/[artifact]-[revision].[ext]"
+	def snapshotPattern = "https://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.a-SNAPSHOT/[artifact]-[revision].[ext]"
 	def scalaSnapshots = Resolver.url("Scala Tools Snapshots") artifacts(snapshotPattern) ivys(snapshotPattern) mavenStyle()
 	moduleConfigurations += ModuleConfiguration("org.scala-lang", "*", "2.10.0-.*", scalaSnapshots)
 }

--- a/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongVersion.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-confs/changes/WrongVersion.sbt
@@ -1,5 +1,5 @@
 {
-	def snapshotPattern = "http://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
+	def snapshotPattern = "https://repo.typesafe.com/typesafe/scala-tools-snapshots/[organization]/[module]/2.10.0-SNAPSHOT/[artifact]-[revision].[ext]"
 	def scalaSnapshots = Resolver.url("Scala Tools Snapshots") artifacts(snapshotPattern) ivys(snapshotPattern) mavenStyle()
 	moduleConfigurations += ModuleConfiguration("org.scala-lang", "*", "2.10.0-.*", scalaSnapshots)
 }

--- a/src/main/conscript/sbt/launchconfig
+++ b/src/main/conscript/sbt/launchconfig
@@ -12,7 +12,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]

--- a/src/main/conscript/scalas/launchconfig
+++ b/src/main/conscript/scalas/launchconfig
@@ -12,7 +12,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]

--- a/src/main/conscript/screpl/launchconfig
+++ b/src/main/conscript/screpl/launchconfig
@@ -12,7 +12,7 @@
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
 
 [boot]


### PR DESCRIPTION
See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/

Seems some people are having problems with typesafe's ssl cert, so may want to fix that before comitting this. Sounds like [the solution](http://stackoverflow.com/questions/18746565/godaddy-ssl-cert-not-working-with-java/21117993#21117993) for Java not supporting GoDaddy G2 certs is for typesafe to rekey it's SSL cert using SHA-1
http://support.godaddy.com/help/article/4976/re-keying-an-ssl-certificate

Hopefully that's not too much trouble. If it ends up being tricky, could also just buy an SSL cert from someplace else. They start at $4.99/yr from ssls.com
