### PR TITLE
Fixes #1439. Fixes metabuild downloading unused Scala 2.10.2

### DIFF
--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -16,6 +16,7 @@ object ScalaArtifacts {
   val Organization = ScalaOrganization
   val LibraryID = ScalaLibraryID
   val CompilerID = ScalaCompilerID
+  val ReflectID = "scala-reflect"
   def libraryDependency(version: String): ModuleID = ModuleID(Organization, LibraryID, version)
 
   private[sbt] def toolDependencies(org: String, version: String): Seq[ModuleID] = Seq(
@@ -47,6 +48,7 @@ private object IvyScala {
   def overrideScalaVersion(module: DefaultModuleDescriptor, version: String) {
     overrideVersion(module, Organization, LibraryID, version)
     overrideVersion(module, Organization, CompilerID, version)
+    overrideVersion(module, Organization, ReflectID, version)
   }
   def overrideVersion(module: DefaultModuleDescriptor, org: String, name: String, version: String) {
     val id = new ModuleId(org, name)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1070,8 +1070,8 @@ object Classpaths {
     allDependencies := {
       projectDependencies.value ++ libraryDependencies.value
     },
-    ivyScala <<= ivyScala or (scalaHome, scalaVersion in update, scalaBinaryVersion in update, scalaOrganization) { (sh, fv, bv, so) =>
-      Some(new IvyScala(fv, bv, Nil, filterImplicit = false, checkExplicit = true, overrideScalaVersion = false, scalaOrganization = so))
+    ivyScala <<= ivyScala or (scalaHome, scalaVersion in update, scalaBinaryVersion in update, scalaOrganization, sbtPlugin) { (sh, fv, bv, so, plugin) =>
+      Some(new IvyScala(fv, bv, Nil, filterImplicit = false, checkExplicit = true, overrideScalaVersion = plugin, scalaOrganization = so))
     },
     artifactPath in makePom <<= artifactPathSetting(artifact in makePom),
     publishArtifact in makePom := publishMavenStyle.value && publishArtifact.value,

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -31,6 +31,7 @@
   [1423]: https://github.com/sbt/sbt/pull/1423
   [1426]: https://github.com/sbt/sbt/pull/1426
   [1433]: https://github.com/sbt/sbt/pull/1433
+  [1439]: https://github.com/sbt/sbt/issues/1439
   [1447]: https://github.com/sbt/sbt/pull/1447
   [1450]: https://github.com/sbt/sbt/pull/1450
   [1451]: https://github.com/sbt/sbt/pull/1451
@@ -112,6 +113,7 @@
 - Fixes config-classes leak in loading build files. [#1524][1524] by [@jsuereth][@jsuereth]
 - Fixes name-conflicts in hashed settings class files. [#1465][1465] by [@jsuereth][@jsuereth]
 - Fixes `NullPointerError` in tab completion by `FileExamples`. [#1530][1530] by [@eed3si9n][@eed3si9n]
+- Fixes metabuild downloading unused Scala 2.10.2. [#1439][1439] by [@eed3si9n][@eed3si9n]
 
 ### Maven Central Repository defaults to HTTPS
 


### PR DESCRIPTION
Fixes #1439 

Scala instance is added to the Ivy graph via autoLibraryDependency. For metabuilds, scala-library is scoped under “provided” configuration, which does not seem to evict modules on “compiled” configuration.

This PR turns `overrideScalaVersion` flag to `true` for the metabuilds, so override rules are added for the following modules:
- scala-library
- scala-compiler
- scala-reflect

/review @havocp 
