### PR TITLE
Fixes #1201. Display instruction to overrideScalaVersion

### DIFF
--- a/ivy/src/main/scala/sbt/EvictionWarning.scala
+++ b/ivy/src/main/scala/sbt/EvictionWarning.scala
@@ -2,6 +2,7 @@ package sbt
 
 import collection.mutable
 import Configurations.Compile
+import ScalaArtifacts.{ LibraryID, CompilerID }
 
 final class EvictionWarningOptions private[sbt] (
     val configurations: Seq[Configuration],
@@ -130,7 +131,7 @@ object EvictionWarning {
     module.moduleSettings.ivyScala match {
       case Some(s) =>
         organization == s.scalaOrganization &&
-          (name == "scala-library") || (name == "scala-compiler")
+          (name == LibraryID) || (name == CompilerID)
       case _ => false
     }
 
@@ -182,6 +183,8 @@ object EvictionWarning {
     if (!a.scalaEvictions.isEmpty) {
       out += "Scala version was updated by one of library dependencies:"
       out ++= (a.scalaEvictions flatMap { _.lines })
+      out += "To force scalaVersion, add the following:"
+      out += "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }"
     }
 
     if (!a.directEvictions.isEmpty || !a.transitiveEvictions.isEmpty) {

--- a/ivy/src/test/scala/EvictionWarningSpec.scala
+++ b/ivy/src/test/scala/EvictionWarningSpec.scala
@@ -86,6 +86,8 @@ class EvictionWarningSpec extends BaseIvySpecification {
     EvictionWarning(m, defaultOptions, report, log).lines must_==
       List("Scala version was updated by one of library dependencies:",
         "\t* org.scala-lang:scala-library:2.10.2 -> 2.10.3",
+        "To force scalaVersion, add the following:",
+        "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }",
         "Run 'evicted' to see detailed eviction warnings")
   }
 
@@ -94,7 +96,9 @@ class EvictionWarningSpec extends BaseIvySpecification {
     val report = ivyUpdate(m)
     EvictionWarning(m, defaultOptions.withShowCallers(true), report, log).lines must_==
       List("Scala version was updated by one of library dependencies:",
-        "\t* org.scala-lang:scala-library:2.10.2 -> 2.10.3 (caller: com.typesafe.akka:akka-actor_2.10:2.3.0, com.example:foo:0.1.0)")
+        "\t* org.scala-lang:scala-library:2.10.2 -> 2.10.3 (caller: com.typesafe.akka:akka-actor_2.10:2.3.0, com.example:foo:0.1.0)",
+        "To force scalaVersion, add the following:",
+        "\tivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }")
   }
 
   def javaLibDirectDeps = Seq(commonsIo14, commonsIo24)


### PR DESCRIPTION
Fixes #1201

scala-library is currently treated as just one of the library modules. This means that it’s at the mercy of eviction if some other library uses newer version of scala-library.

This PR displays the instruction on how to force `scalaVersion` if `warnScalaVersionEviction` flag is true on `EvictionWarningOptions`.

/review @havocp 
