### PR TITLE
Removes println when removing unused *.class files.

### DIFF
--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -262,7 +262,6 @@ object Load {
       val existing = (baseTarget.***.get).filterNot(_.isDirectory)
       val toDelete = existing.filterNot(keepFile)
       if (!toDelete.isEmpty) {
-        System.err.println(s"Discovered unused files: ${toDelete.mkString("\n * ", "\n * ", "\n")}.  Note: Please reload all other running sbt instances in $base")
         IO.delete(toDelete)
       }
     }


### PR DESCRIPTION
#1525 removes unused *.class files created by the metabuid. The implementation currently prints out a long list of *.class files it’s about to remove. Unless something bad happens, this information is not very useful to the user, so I suggest we don’t display it.

/review @havocp 
