### PR TITLE
HTTPS: Various HTTPS related changes

### DIFF
--- a/ivy/src/main/scala/sbt/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/ConvertResolver.scala
@@ -112,6 +112,8 @@ private object ConvertResolver {
             resolver.setPatterns() // has to be done after initializeMavenStyle, which calls methods that overwrite the patterns
             resolver
           }
+        // TODO: HTTP repository is no longer recommended. #1541
+        // Remove `JavaNet1Repository` when we bump up the API.
         case r: JavaNet1Repository =>
           {
             // Thanks to Matthias Pfau for posting how to use the Maven 1 repository on java.net with Ivy:

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -148,7 +148,7 @@ sealed trait JavaNet1Repository extends Resolver {
 object Resolver {
   private[sbt] def useSecureResolvers = sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
 
-  val TypesafeRepositoryRoot = "http://repo.typesafe.com/typesafe"
+  val TypesafeRepositoryRoot = typesafeRepositoryRoot(useSecureResolvers)
   val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
@@ -162,6 +162,8 @@ object Resolver {
   private[sbt] def javanet2RepositoryRoot(secure: Boolean) =
     if (secure) "https://maven.java.net/content/repositories/public/"
     else "http://download.java.net/maven/2"
+  // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
+  private[sbt] def typesafeRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo.typesafe.com/typesafe"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -152,11 +152,16 @@ object Resolver {
   val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
-  val JavaNet2RepositoryRoot = "http://download.java.net/maven/2"
+  val JavaNet2RepositoryRoot = javanet2RepositoryRoot(useSecureResolvers)
   val JCenterRepositoryName = "jcenter"
   val JCenterRepositoryRoot = "https://jcenter.bintray.com/"
   val DefaultMavenRepositoryRoot = "https://repo1.maven.org/maven2/"
+  // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
   private[sbt] def centralRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo1.maven.org/maven2/"
+  // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
+  private[sbt] def javanet2RepositoryRoot(secure: Boolean) =
+    if (secure) "https://maven.java.net/content/repositories/public/"
+    else "http://download.java.net/maven/2"
 
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -138,7 +138,9 @@ import Resolver._
 object DefaultMavenRepository extends MavenRepository("public", centralRepositoryRoot(useSecureResolvers))
 object JavaNet2Repository extends MavenRepository(JavaNet2RepositoryName, JavaNet2RepositoryRoot)
 object JCenterRepository extends MavenRepository(JCenterRepositoryName, JCenterRepositoryRoot)
+@deprecated("HTTP repository is no longer recommended.", "0.13.6")
 object JavaNet1Repository extends JavaNet1Repository
+@deprecated("HTTP repository is no longer recommended.", "0.13.6")
 sealed trait JavaNet1Repository extends Resolver {
   def name = "java.net Maven1 Repository"
 }

--- a/launch/src/main/scala/xsbt/boot/Update.scala
+++ b/launch/src/main/scala/xsbt/boot/Update.scala
@@ -344,20 +344,20 @@ final class Update(config: UpdateConfiguration) {
   /** Creates a maven-style resolver.*/
   private def mavenResolver(name: String, root: String) =
     {
-      val resolver = defaultMavenResolver(name)
+      val resolver = new IBiblioResolver
+      resolver.setName(name)
+      resolver.setM2compatible(true)
       resolver.setRoot(root)
       resolver
     }
+  private def useSecureResolvers = sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
+  private def centralRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo1.maven.org/maven2/"
+
   /** Creates a resolver for Maven Central.*/
   private def mavenMainResolver = defaultMavenResolver("Maven Central")
   /** Creates a maven-style resolver with the default root.*/
   private def defaultMavenResolver(name: String) =
-    {
-      val resolver = new IBiblioResolver
-      resolver.setName(name)
-      resolver.setM2compatible(true)
-      resolver
-    }
+    mavenResolver(name, centralRepositoryRoot(useSecureResolvers))
   private def localResolver(ivyUserDirectory: String) =
     {
       val localIvyRoot = ivyUserDirectory + "/local"

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -51,6 +51,7 @@
   [1524]: https://github.com/sbt/sbt/issues/1524
   [1530]: https://github.com/sbt/sbt/issues/1530
   [1536]: https://github.com/sbt/sbt/pull/1536
+  [1541]: https://github.com/sbt/sbt/issues/1541
   [1546]: https://github.com/sbt/sbt/pull/1546
 
   [@benmccann]: https://github.com/benmccann
@@ -77,7 +78,7 @@
 
 ### Fixes with compatibility implications
 
-- Maven Central Repository now defaults to HTTPS. [#1494][1494] by [@rtyley][@rtyley] (See below)
+- Maven Central Repository, Java.net Maven 2 Repository, and Typesafe Repository now defaults to HTTPS. (See below)
 - `ThisProject` used to resolve to the root project in a build even when it's place in `subproj/build.sbt`. sbt 0.13.6 fixes it to resolve to the sub project. [#1194][1194]/[#1358][1358] by [@dansanduleac][@dansanduleac]
 - Global plugins classpath used to be injected into every build. This will no longer be the case. [#1347][1347]/[#1352][1352] by [@dansanduleac][@dansanduleac]
 - Fixes `newer` command in scripted. [#1419][1419] by [@jroper][@jroper]
@@ -126,11 +127,9 @@ Thanks to Sonatype, HTTPS access to Maven Central Repository is available to pub
 
     -Dsbt.repository.secure=false
 
-[#1494][1494] by [@rtyley][@rtyley]
+Java.net Maven 2 repository and Typesafe repository also defaults to HTTPS.
 
-Launcher also defaults to HTTPS address of the Typesafe repository.
-
-[#1536][1536] by [@benmccann][@benmccann].
+[#1494][1494] by [@rtyley][@rtyley], [#1536][1536] by [@benmccann][@benmccann], and [#1541][1541] by [@eed3si9n][@eed3si9n].
 
 ### enablePlugins/disablePlugins
 


### PR DESCRIPTION
Fixes various issues related to HTTPS. I am using #1541 as the epic issue.
## what this changes
- Launcher to use HTTPS Maven Central by default
- Deprecate Java.net Maven 1 repository
- Java.net Maven 2 repository to use HTTPS by default
- Typesafe repository to use HTTPS by default

/review @havocp 
