### PR TITLE
Fixes #1550/#1546. Name hashing change to fix the build

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncOptions.scala
@@ -217,7 +217,7 @@ final class IncOptions(
 
 object IncOptions extends Serializable {
   private val recompileOnMacroDefDefault: Boolean = true
-  private val nameHashingDefault: Boolean = true
+  private[sbt] val nameHashingDefault: Boolean = true
   private val antStyleDefault: Boolean = false
   val Default = IncOptions(
     //    1. recompile changed sources

--- a/compile/inc/src/main/scala/sbt/inc/Relations.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Relations.scala
@@ -227,7 +227,7 @@ object Relations {
 
   def emptySource: Source = es
   private[inc] lazy val emptySourceDependencies: SourceDependencies = new SourceDependencies(e, estr)
-  def empty: Relations = empty(nameHashing = false)
+  def empty: Relations = empty(nameHashing = IncOptions.nameHashingDefault)
   private[inc] def empty(nameHashing: Boolean): Relations =
     if (nameHashing)
       new MRelationsNameHashing(e, e, emptySourceDependencies, emptySourceDependencies, estr, estr)

--- a/compile/inc/src/test/scala/sbt/inc/AnalysisTest.scala
+++ b/compile/inc/src/test/scala/sbt/inc/AnalysisTest.scala
@@ -21,7 +21,7 @@ object AnalysisTest extends Properties("Analysis") {
     val sourceInfos = SourceInfos.makeInfo(Nil, Nil)
 
     // a
-    var a = Analysis.Empty
+    var a = Analysis.empty(false)
     a = a.addProduct(aScala, f("A.class"), exists, "A")
     a = a.addProduct(aScala, f("A$.class"), exists, "A$")
     a = a.addSource(aScala, aSource, exists, Nil, Nil, sourceInfos)
@@ -29,7 +29,7 @@ object AnalysisTest extends Properties("Analysis") {
     a = a.addExternalDep(aScala, "C", cSource, inherited = false)
 
     // b
-    var b = Analysis.Empty
+    var b = Analysis.empty(false)
     b = b.addProduct(bScala, f("B.class"), exists, "B")
     b = b.addProduct(bScala, f("B$.class"), exists, "B$")
     b = b.addSource(bScala, bSource, exists, Nil, Nil, sourceInfos)
@@ -38,7 +38,7 @@ object AnalysisTest extends Properties("Analysis") {
     b = b.addExternalDep(bScala, "A", aSource, inherited = true)
 
     // ab
-    var ab = Analysis.Empty
+    var ab = Analysis.empty(false)
     ab = ab.addProduct(aScala, f("A.class"), exists, "A")
     ab = ab.addProduct(aScala, f("A$.class"), exists, "A$")
     ab = ab.addProduct(bScala, f("B.class"), exists, "B")
@@ -52,8 +52,8 @@ object AnalysisTest extends Properties("Analysis") {
 
     val split: Map[String, Analysis] = ab.groupBy({ f: File => f.getName.substring(0, 1) })
 
-    val aSplit = split.getOrElse("A", Analysis.Empty)
-    val bSplit = split.getOrElse("B", Analysis.Empty)
+    val aSplit = split.getOrElse("A", Analysis.empty(false))
+    val bSplit = split.getOrElse("B", Analysis.empty(false))
 
     val merged = Analysis.merge(a :: b :: Nil)
 
@@ -67,7 +67,7 @@ object AnalysisTest extends Properties("Analysis") {
   // a divide-by-zero error masking the original error.
   property("Complex Merge and Split") = forAllNoShrink(genAnalysis, choose(1, 10)) { (analysis: Analysis, numSplits: Int) =>
     val grouped: Map[Int, Analysis] = analysis.groupBy({ f: File => abs(f.hashCode()) % numSplits })
-    def getGroup(i: Int): Analysis = grouped.getOrElse(i, Analysis.Empty)
+    def getGroup(i: Int): Analysis = grouped.getOrElse(i, Analysis.empty(false))
     val splits = (Range(0, numSplits) map getGroup).toList
 
     val merged: Analysis = Analysis.merge(splits)

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -81,6 +81,7 @@
 - `ThisProject` used to resolve to the root project in a build even when it's place in `subproj/build.sbt`. sbt 0.13.6 fixes it to resolve to the sub project. [#1194][1194]/[#1358][1358] by [@dansanduleac][@dansanduleac]
 - Global plugins classpath used to be injected into every build. This will no longer be the case. [#1347][1347]/[#1352][1352] by [@dansanduleac][@dansanduleac]
 - Fixes `newer` command in scripted. [#1419][1419] by [@jroper][@jroper]
+- Name hashing is enabled by default. `inc.Analysis.empty` also defaults to the one compatible with name hashing. [#1546][1546] by [@gkossakowski][@gkossakowski]
 
 ### Improvements
 
@@ -98,7 +99,6 @@
 - Updates internal Ivy instance to cache the results of dependency exclusion rules. [#1476][1476] by [@eed3si9n][@eed3si9n]
 - Adds `Resolver.jcenterRepo` and `Resolver.bintrayRepo(owner, repo)` to add Bintray easier. [#1405][1405] by [@evgeny-goldin][@evgeny-goldin]
 - AutoPlugins with no requirements enabled by allRequirements can now be disable dby the user. [#1516][1516] by [@jsuereth][@jsuereth]
-- Name hashing is enabled by default. [#1546][1546] by [@gkossakowski][@gkossakowski]
 
 ### Bug fixes
 

--- a/sbt/src/sbt-test/compiler-project/inc-ant-style/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/inc-ant-style/build.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Debug
 
-incOptions := incOptions.value.withAntStyle(true)
+incOptions := incOptions.value.withNameHashing(false).withAntStyle(true)
 
 /* Performs checks related to compilations:
  *  a) checks in which compilation given set of files was recompiled


### PR DESCRIPTION
Fixes #1550.

Some tests are failing after merging #1546. See https://travis-ci.org/sbt/sbt/builds/33265884
- actions / join
- compiler-project / inc-ant-style
## what this changes

`inc.Relations.empty` now takes a default parameter `IncOptions.nameHashingDefault` instead of `false`. This changes the semantics of `inc.Analysis.empty` to match the default `IncOptions`.

/review @gkossakowski 
