### PR TITLE
#1541. Use HTTPS for sbt plugin repository

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -149,7 +149,7 @@ object Resolver {
   private[sbt] def useSecureResolvers = sys.props.get("sbt.repository.secure") map { _.toLowerCase == "true" } getOrElse true
 
   val TypesafeRepositoryRoot = typesafeRepositoryRoot(useSecureResolvers)
-  val SbtPluginRepositoryRoot = "http://repo.scala-sbt.org/scalasbt"
+  val SbtPluginRepositoryRoot = sbtPluginRepositoryRoot(useSecureResolvers)
   val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
   val JavaNet2RepositoryName = "java.net Maven2 Repository"
   val JavaNet2RepositoryRoot = javanet2RepositoryRoot(useSecureResolvers)
@@ -164,7 +164,9 @@ object Resolver {
     else "http://download.java.net/maven/2"
   // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
   private[sbt] def typesafeRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo.typesafe.com/typesafe"
-
+  // TODO: This switch is only kept for backward compatibility. Hardcode to HTTPS in the future.
+  private[sbt] def sbtPluginRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo.scala-sbt.org/scalasbt"
+  
   // obsolete: kept only for launcher compatibility
   private[sbt] val ScalaToolsReleasesName = "Sonatype OSS Releases"
   private[sbt] val ScalaToolsSnapshotsName = "Sonatype OSS Snapshots"

--- a/notes/0.13.6.md
+++ b/notes/0.13.6.md
@@ -79,7 +79,7 @@
 
 ### Fixes with compatibility implications
 
-- Maven Central Repository, Java.net Maven 2 Repository, and Typesafe Repository now defaults to HTTPS. (See below)
+- Maven Central Repository, Java.net Maven 2 Repository, Typesafe Repository, and sbt Plugin repository now defaults to HTTPS. (See below)
 - `ThisProject` used to resolve to the root project in a build even when it's place in `subproj/build.sbt`. sbt 0.13.6 fixes it to resolve to the sub project. [#1194][1194]/[#1358][1358] by [@dansanduleac][@dansanduleac]
 - Global plugins classpath used to be injected into every build. This will no longer be the case. [#1347][1347]/[#1352][1352] by [@dansanduleac][@dansanduleac]
 - Fixes `newer` command in scripted. [#1419][1419] by [@jroper][@jroper]
@@ -128,7 +128,7 @@ Thanks to Sonatype, HTTPS access to Maven Central Repository is available to pub
 
     -Dsbt.repository.secure=false
 
-Java.net Maven 2 repository and Typesafe repository also defaults to HTTPS.
+Java.net Maven 2 repository, Typesafe repository, and sbt Plugin repository also defaults to HTTPS.
 
 [#1494][1494] by [@rtyley][@rtyley], [#1536][1536] by [@benmccann][@benmccann], and [#1541][1541] by [@eed3si9n][@eed3si9n].
 


### PR DESCRIPTION
#1541. This is the last of builtin repo that's HTTP. (Except for Java.net Maven 1 repo that we just deprecated).

```
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.eed3si9n/sbt-assembly/scala_2.10/sbt_0.13/0.11.1/jars/sbt-assembly.jar ...
[info]  [SUCCESSFUL ] com.eed3si9n#sbt-assembly;0.11.1!sbt-assembly.jar (1544ms)
```
