### PR TITLE
Fix url to sbt-dev group

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   [CONTRIBUTING]: CONTRIBUTING.md
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [FAQ]: http://www.scala-sbt.org/release/docs/faq
-  [sbt-dev]: https://groups.google.com/d/forum/sbt-dev‎
+  [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
   [StackOverflow]: http://stackoverflow.com/tags/sbt
   [LICENSE]: LICENSE
 


### PR DESCRIPTION
There is a unicode char at the end of that line.
