### PR TITLE
Don't hardcode existing relations in TextAnalysisFormat

### DIFF
--- a/compile/inc/src/test/scala/sbt/inc/AnalysisTest.scala
+++ b/compile/inc/src/test/scala/sbt/inc/AnalysisTest.scala
@@ -65,7 +65,9 @@ object AnalysisTest extends Properties("Analysis") {
   // Merge and split large, generated examples.
   // Mustn't shrink, as the default Shrink[Int] doesn't respect the lower bound of choose(), which will cause
   // a divide-by-zero error masking the original error.
-  property("Complex Merge and Split") = forAllNoShrink(genAnalysis, choose(1, 10)) { (analysis: Analysis, numSplits: Int) =>
+  // Note that the generated Analyses have nameHashing = false (Grouping of Analyses with name hashing enabled
+  // is not supported right now)
+  property("Complex Merge and Split") = forAllNoShrink(genAnalysis(nameHashing = false), choose(1, 10)) { (analysis: Analysis, numSplits: Int) =>
     val grouped: Map[Int, Analysis] = analysis.groupBy({ f: File => abs(f.hashCode()) % numSplits })
     def getGroup(i: Int): Analysis = grouped.getOrElse(i, Analysis.empty(false))
     val splits = (Range(0, numSplits) map getGroup).toList

--- a/compile/persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
+++ b/compile/persist/src/test/scala/sbt/inc/TextAnalysisFormatSpecification.scala
@@ -1,0 +1,112 @@
+package sbt
+package inc
+
+import java.io.{ BufferedReader, File, StringReader, StringWriter }
+import scala.math.abs
+import org.scalacheck._
+import Gen._
+import Prop._
+
+object TextAnalysisFormatTest extends Properties("TextAnalysisFormat") {
+
+  val nameHashing = true
+  val dummyOutput = new xsbti.compile.SingleOutput { def outputDirectory: java.io.File = new java.io.File("dummy") }
+  val commonSetup = new CompileSetup(dummyOutput, new CompileOptions(Nil, Nil), "2.10.4", xsbti.compile.CompileOrder.Mixed, nameHashing)
+  val commonHeader = """format version: 5
+                    |output mode:
+                    |1 items
+                    |0 -> single
+                    |output directories:
+                    |1 items
+                    |output dir -> dummy
+                    |compile options:
+                    |0 items
+                    |javac options:
+                    |0 items
+                    |compiler version:
+                    |1 items
+                    |0 -> 2.10.4
+                    |compile order:
+                    |1 items
+                    |0 -> Mixed
+                    |name hashing:
+                    |1 items
+                    |0 -> true""".stripMargin
+
+  property("Write and read empty Analysis") = {
+
+    val writer = new StringWriter
+    val analysis = Analysis.empty(nameHashing)
+    TextAnalysisFormat.write(writer, analysis, commonSetup)
+
+    val result = writer.toString
+
+    result.startsWith(commonHeader)
+    val reader = new BufferedReader(new StringReader(result))
+
+    val (readAnalysis, readSetup) = TextAnalysisFormat.read(reader)
+
+    analysis == readAnalysis
+
+  }
+
+  property("Write and read simple Analysis") = {
+
+    import TestCaseGenerators._
+
+    def f(s: String) = new File(s)
+    val aScala = f("A.scala")
+    val bScala = f("B.scala")
+    val aSource = genSource("A" :: "A$" :: Nil).sample.get
+    val bSource = genSource("B" :: "B$" :: Nil).sample.get
+    val cSource = genSource("C" :: Nil).sample.get
+    val exists = new Exists(true)
+    val sourceInfos = SourceInfos.makeInfo(Nil, Nil)
+
+    var analysis = Analysis.empty(nameHashing)
+    analysis = analysis.addProduct(aScala, f("A.class"), exists, "A")
+    analysis = analysis.addProduct(aScala, f("A$.class"), exists, "A$")
+    analysis = analysis.addSource(aScala, aSource, exists, Nil, Nil, sourceInfos)
+    analysis = analysis.addBinaryDep(aScala, f("x.jar"), "x", exists)
+    analysis = analysis.addExternalDep(aScala, "C", cSource, inherited = false)
+
+    val writer = new StringWriter
+
+    TextAnalysisFormat.write(writer, analysis, commonSetup)
+
+    val result = writer.toString
+
+    result.startsWith(commonHeader)
+    val reader = new BufferedReader(new StringReader(result))
+
+    val (readAnalysis, readSetup) = TextAnalysisFormat.read(reader)
+
+    compare(analysis, readAnalysis)
+
+  }
+
+  property("Write and read complex Analysis") = forAllNoShrink(TestCaseGenerators.genAnalysis(nameHashing)) { analysis: Analysis =>
+    val writer = new StringWriter
+
+    TextAnalysisFormat.write(writer, analysis, commonSetup)
+
+    val result = writer.toString
+
+    result.startsWith(commonHeader)
+    val reader = new BufferedReader(new StringReader(result))
+
+    val (readAnalysis, readSetup) = TextAnalysisFormat.read(reader)
+
+    compare(analysis, readAnalysis)
+  }
+
+  // Compare two analyses with useful labelling when they aren't equal.
+  private[this] def compare(left: Analysis, right: Analysis): Prop =
+    s" LEFT: $left" |:
+      s"RIGHT: $right" |:
+      s"STAMPS EQUAL: ${left.stamps == right.stamps}" |:
+      s"APIS EQUAL: ${left.apis == right.apis}" |:
+      s"RELATIONS EQUAL: ${left.relations == right.relations}" |:
+      "UNEQUAL" |:
+      (left == right)
+}

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -153,7 +153,7 @@ object Sbt extends Build {
   //   Defines the data structures for representing file fingerprints and relationships and the overall source analysis
   lazy val compileIncrementalSub = testedBaseProject(compilePath / "inc", "Incremental Compiler") dependsOn (apiSub, ioSub, logSub, classpathSub, relationSub)
   // Persists the incremental data structures using SBinary
-  lazy val compilePersistSub = baseProject(compilePath / "persist", "Persist") dependsOn (compileIncrementalSub, apiSub) settings (sbinary)
+  lazy val compilePersistSub = testedBaseProject(compilePath / "persist", "Persist") dependsOn (compileIncrementalSub, apiSub, compileIncrementalSub % "test->test") settings (sbinary)
   // sbt-side interface to compiler.  Calls compiler-side interface reflectively
   lazy val compilerSub = testedBaseProject(compilePath, "Compile") dependsOn (launchInterfaceSub, interfaceSub % "compile;test->test", logSub, ioSub, classpathSub,
     logSub % "test->test", launchSub % "test->test", apiSub % "test") settings (compilerSettings: _*)


### PR DESCRIPTION
This follows my work on making it easier to add new dependency kinds in sbt.

> The previous implementation of TextAnalysisFormat contained the list
> of all the existing relations that sbt knew of, and used this
> information to write to and read from the disk the persisted analyses.
> 
> In this knew implementation, TextAnalysisFormat gets from the
> Relations object what are the existing relations, and then persists
> them to disk.
> 
> The previous situation was not optimal since it meant that, in order
> to add a new dependency kind, one had to modify both the Relations
> and TextAnalysisFormat.
> 
> Using this new implementation, no change to TextAnalysisFormat is
> required whenever a new dependency kind is added.

Thanks @gkossakowski for the help !

/cc @xeno-by
