### PR TITLE
Allow the "-bin" Scala version suffix to specify a bincompat version

### DIFF
--- a/util/cross/src/main/input_sources/CrossVersionUtil.scala
+++ b/util/cross/src/main/input_sources/CrossVersionUtil.scala
@@ -39,9 +39,11 @@ object CrossVersionUtil
 	private[${{cross.package0}}] def scalaApiVersion(v: String): Option[(Int, Int)] =
 	{
 		val ReleaseV = """(\d+)\.(\d+)\.(\d+)(-\d+)?""".r
+		val BinCompatV = """(\d+)\.(\d+)\.(\d+)-bin(-.*)?""".r
 		val NonReleaseV = """(\d+)\.(\d+)\.(\d+)(-\w+)""".r
 		v match {
 			case ReleaseV(x, y, z, ht)    => Some((x.toInt, y.toInt))
+			case BinCompatV(x, y, z, ht)    => Some((x.toInt, y.toInt))
 			case NonReleaseV(x, y, z, ht) if z.toInt > 0 => Some((x.toInt, y.toInt))
 			case _ => None
 		}


### PR DESCRIPTION
There is sometimes the need to use a test version of Scala that is
intended to be binary compatible with a standard release version.

At this time, due to the particular logic implemented within sbt,
a non-numeric suffix will never have the same binaryScalaVersion
of a release version ending in ".0", like for instance "2.11.0".

This commit allows developers to use as suffix any string that
begins with "-bin", for instance "2.11.0-bin-compat-test-1".
Such a suffix will have a binaryScalaVersion of "2.11", being
therefore considered binary compatible with release versions.
