### PR TITLE
Fix for #1430

### DIFF
--- a/main/src/main/scala/sbt/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/SettingCompletions.scala
@@ -27,7 +27,7 @@ private[sbt] object SettingCompletions {
     {
       import extracted._
       val r = relation(extracted.structure, true)
-      val allDefs = r._1s.toSeq
+      val allDefs = Def.flattenLocals(Def.compiled(extracted.structure.settings, true)(structure.delegates, structure.scopeLocal, implicitly[Show[ScopedKey[_]]])).map(_._1)
       val projectScope = Load.projectScope(currentRef)
       def resolve(s: Setting[_]): Seq[Setting[_]] = Load.transformSettings(projectScope, currentRef.build, rootProject, s :: Nil)
       def rescope[T](setting: Setting[T]): Seq[Setting[_]] =

--- a/sbt/src/sbt-test/tests/set-every/build.sbt
+++ b/sbt/src/sbt-test/tests/set-every/build.sbt
@@ -1,0 +1,16 @@
+val a = project.settings(version := "2.8.1")
+
+val trySetEvery = taskKey[Unit]("Tests \"set every\"")
+
+trySetEvery := {
+        val s = state.value
+        val extracted = Project.extract(s)
+        import extracted._
+        val allProjs = structure.allProjectRefs
+        val Some(aProj) = allProjs.find(_.project == "a")
+        val aVer = (version in aProj get structure.data).get
+        if (aVer != "1.0") {
+          println("Version of project a: " + aVer + ", expected: 1.0")
+          error("\"set every\" did not change the version of all projects.")
+        }
+}

--- a/sbt/src/sbt-test/tests/set-every/test
+++ b/sbt/src/sbt-test/tests/set-every/test
@@ -1,0 +1,3 @@
+> set every version := '"1.0"'
+> trySetEvery
+

--- a/util/relation/src/main/scala/sbt/Relation.scala
+++ b/util/relation/src/main/scala/sbt/Relation.scala
@@ -129,7 +129,7 @@ private final class MRelation[A, B](fwd: Map[A, Set[B]], rev: Map[B, Set[A]]) ex
 
   def +(pair: (A, B)) = this + (pair._1, Set(pair._2))
   def +(from: A, to: B) = this + (from, to :: Nil)
-  def +(from: A, to: Traversable[B]) =
+  def +(from: A, to: Traversable[B]) = if (to.isEmpty) this else
     new MRelation(add(fwd, from, to), (rev /: to) { (map, t) => add(map, t, from :: Nil) })
 
   def ++(rs: Traversable[(A, B)]) = ((this: Relation[A, B]) /: rs) { _ + _ }

--- a/util/relation/src/main/scala/sbt/Relation.scala
+++ b/util/relation/src/main/scala/sbt/Relation.scala
@@ -129,7 +129,7 @@ private final class MRelation[A, B](fwd: Map[A, Set[B]], rev: Map[B, Set[A]]) ex
 
   def +(pair: (A, B)) = this + (pair._1, Set(pair._2))
   def +(from: A, to: B) = this + (from, to :: Nil)
-  def +(from: A, to: Traversable[B]) = if (to.isEmpty) this else
+  def +(from: A, to: Traversable[B]) =
     new MRelation(add(fwd, from, to), (rev /: to) { (map, t) => add(map, t, from :: Nil) })
 
   def ++(rs: Traversable[(A, B)]) = ((this: Relation[A, B]) /: rs) { _ + _ }


### PR DESCRIPTION
In Relation, `_1s` is defined as "Returns the set of all `_1`s such that `(_1, _2)` is in this relation.". Which is false: it is implemented as fwd.keySet, but it should be fwd.filterNot(_._2.isEmpty).keySet. Except setAll() depends on the incorrect semantics, and the apparently innocuous optimization in 322f6de broke it as a result. This pull request reverts the change, pending an implementation of setAll which does not depend on `_1s` (after which `_1s` can probably be fixed). See #1430.
