### PR TITLE
Bump to a version of ivy that will not swap in httpclient URL handler.

### DIFF
--- a/notes/0.13.7/ivy-no-httpclient.md
+++ b/notes/0.13.7/ivy-no-httpclient.md
@@ -1,0 +1,7 @@
+  [1602]: https://github.com/sbt/sbt/pull/1602
+  [@jsuereth]: https://github.com/jsuereth
+  
+
+### Fixes
+
+* Ivy no longer silently flops to HttpClient resolver when httpclient is on the classpath.  [#1602][1602] by [@jsuereth][@jsuereth]

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -174,7 +174,7 @@ object Common {
   def lib(m: ModuleID) = libraryDependencies += m
   lazy val jlineDep = "jline" % "jline" % "2.11"
   lazy val jline = lib(jlineDep)
-  lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-14d4d23e25f354cd296c73bfff405544434d5f80")
+  lazy val ivy = lib("org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-ba72610c018ef6b640551964f61d79a480b4c4e4")
   lazy val httpclient = lib("commons-httpclient" % "commons-httpclient" % "3.1")
   lazy val jsch = lib("com.jcraft" % "jsch" % "0.1.46" intransitive ())
   lazy val sbinary = libraryDependencies += "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"


### PR DESCRIPTION
When ivy finds the httpclient on the classpath, it will silently change
its url handler, and the httpclient in ivy 2.3.x has a few known
issues.

Review by @eed3si9n 
