### PR TITLE
Use Option.apply instead of Some.apply in ClassToAPI

### DIFF
--- a/compile/api/src/main/scala/sbt/ClassToAPI.scala
+++ b/compile/api/src/main/scala/sbt/ClassToAPI.scala
@@ -138,7 +138,7 @@ object ClassToAPI {
     }
 
   def methodToDef(enclPkg: Option[String])(m: Method): api.Def =
-    defLike(m.getName, m.getModifiers, m.getDeclaredAnnotations, typeParameterTypes(m), m.getParameterAnnotations, parameterTypes(m), Some(returnType(m)), exceptionTypes(m), m.isVarArgs, enclPkg)
+    defLike(m.getName, m.getModifiers, m.getDeclaredAnnotations, typeParameterTypes(m), m.getParameterAnnotations, parameterTypes(m), Option(returnType(m)), exceptionTypes(m), m.isVarArgs, enclPkg)
 
   def constructorToDef(enclPkg: Option[String])(c: Constructor[_]): api.Def =
     defLike("<init>", c.getModifiers, c.getDeclaredAnnotations, typeParameterTypes(c), c.getParameterAnnotations, parameterTypes(c), None, exceptionTypes(c), c.isVarArgs, enclPkg)


### PR DESCRIPTION
When dealing with Java APIs (Java reflection in case of ClassToAPI), one
should always go through Option.apply that performs null check.

This is supposed to fix NPE reported in #1617. We don't have a reproduction
so this is just an educated guess.
