### PR TITLE
propagate pattern descriptorOptional and skipConsistencyCheck

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -285,7 +285,7 @@ object Resolver {
   private def resolvePatterns(base: String, basePatterns: Patterns): Patterns =
     {
       def resolveAll(patterns: Seq[String]) = patterns.map(p => resolvePattern(base, p))
-      Patterns(resolveAll(basePatterns.ivyPatterns), resolveAll(basePatterns.artifactPatterns), basePatterns.isMavenCompatible)
+      Patterns(resolveAll(basePatterns.ivyPatterns), resolveAll(basePatterns.artifactPatterns), basePatterns.isMavenCompatible, basePatterns.descriptorOptional, basePatterns.skipConsistencyCheck)
     }
   private[sbt] def resolvePattern(base: String, pattern: String): String =
     {

--- a/ivy/src/test/scala/ResolverTest.scala
+++ b/ivy/src/test/scala/ResolverTest.scala
@@ -1,0 +1,24 @@
+import java.net.URL
+
+import org.specs2.mutable.Specification
+import sbt._
+
+object ResolverTest extends Specification {
+
+  "Resolver" should {
+    "url" should {
+      "propagate pattern descriptorOptional and skipConsistencyCheck." in {
+        val pats = Seq("[orgPath]")
+        val patsExpected = Seq("http://foo.com/test/[orgPath]")
+        val patterns = Resolver.url("test", new URL("http://foo.com/test"))(Patterns(pats, pats, isMavenCompatible = false, descriptorOptional = true, skipConsistencyCheck = true)).patterns
+
+        patterns.ivyPatterns must equalTo(patsExpected)
+        patterns.artifactPatterns must equalTo(patsExpected)
+        patterns.isMavenCompatible must beFalse
+        patterns.skipConsistencyCheck must beTrue
+        patterns.descriptorOptional must beTrue
+      }
+    }
+  }
+
+}

--- a/notes/0.13.7/propagate-pattern-descriptorOptional-and-skipConsistencyCheck.md
+++ b/notes/0.13.7/propagate-pattern-descriptorOptional-and-skipConsistencyCheck.md
@@ -1,0 +1,6 @@
+  [@tmandke]: https://github.com/tmandke
+
+
+### Fixes
+
+* propagate pattern descriptorOptional and skipConsistencyCheck when Resolver.url(name, url)(patterns) is called.


### PR DESCRIPTION
propagate pattern descriptorOptional and skipConsistencyCheck when `Resolver.url(name, url)(patterns)` is called.
