### PR TITLE
Cut valid text corrected

### DIFF
--- a/main/src/main/scala/sbt/SessionSettingsNoBlankies.scala
+++ b/main/src/main/scala/sbt/SessionSettingsNoBlankies.scala
@@ -1,13 +1,12 @@
 package sbt
 
-import java.io.File
-
 import scala.collection.immutable.SortedMap
 import scala.reflect.runtime.universe._
 
 object SessionSettingsNoBlankies {
 
-  private val FAKE_FILE = new File("fake")
+  import SplitExpressionsNoBlankies.FAKE_FILE
+
   val REVERSE_ORDERING_INT = Ordering[Int].reverse
 
   def oldLinesToNew(content: List[String], lineMap: SortedMap[Int, List[(Int, List[String])]]): List[String] =

--- a/main/src/main/scala/sbt/SplitExpressionsNoBlankies.scala
+++ b/main/src/main/scala/sbt/SplitExpressionsNoBlankies.scala
@@ -9,6 +9,7 @@ import scala.reflect.runtime.universe._
 object SplitExpressionsNoBlankies {
   val END_OF_LINE_CHAR = '\n'
   val END_OF_LINE = String.valueOf(END_OF_LINE_CHAR)
+  private[sbt] val FAKE_FILE = new File("fake")
 }
 
 case class SplitExpressionsNoBlankies(file: File, lines: Seq[String]) {
@@ -102,16 +103,22 @@ private[sbt] object BugInParser {
    * @param positionEnd - from index
    * @param positionLine - number of start position line
    * @param fileName - file name
-   * @param th - original exception
+   * @param originalException - original exception
    * @return
    */
-  private[sbt] def findMissingText(content: String, positionEnd: Int, positionLine: Int, fileName: String, th: Throwable): String = {
-    //    val scanner = new syntaxAnalyzer.UnitScanner(new CompilationUnit(source))
+  private[sbt] def findMissingText(content: String, positionEnd: Int, positionLine: Int, fileName: String, originalException: Throwable): String = {
     findClosingBracketIndex(content, positionEnd) match {
       case Some(index) =>
-        content.substring(positionEnd, index + 1)
+        val text = content.substring(positionEnd, index + 1)
+        val textWithoutBracket = text.substring(0, text.length - 1)
+        util.Try(SplitExpressionsNoBlankies(FAKE_FILE, textWithoutBracket.lines.toSeq)) match {
+          case util.Success(_) =>
+            text
+          case util.Failure(th) =>
+            findMissingText(content, index + 1, positionLine, fileName, originalException)
+        }
       case _ =>
-        throw new MessageOnlyException(s"""[$fileName]:$positionLine: ${th.getMessage}""".stripMargin)
+        throw new MessageOnlyException(s"""[$fileName]:$positionLine: ${originalException.getMessage}""".stripMargin)
     }
   }
 
@@ -126,20 +133,7 @@ private[sbt] object BugInParser {
     if (index == -1) {
       None
     } else {
-      val c = content.charAt(index)
-      if (c == '/' && content.size > index + 1) {
-        val nextChar = content.charAt(index + 1)
-        if (nextChar == '/') {
-          val endOfLine = content.indexOf('\n', index)
-          findClosingBracketIndex(content, endOfLine)
-        } else {
-          //if (nextChar == '*')
-          val endOfCommented = content.indexOf("*/", index + 1)
-          findClosingBracketIndex(content, endOfCommented + 2)
-        }
-      } else {
-        Some(index)
-      }
+      Some(index)
     }
   }
 }

--- a/main/src/test/scala/sbt/CommentedXmlSpec.scala
+++ b/main/src/test/scala/sbt/CommentedXmlSpec.scala
@@ -7,8 +7,8 @@ class CommentedXmlSpec extends CheckIfParsedSpec {
       s"""|
          |val pom = "</scm>"
          |
-         |val aaa= <scm><url>git@github.com:mohiva/play.git</url>
-         |    <cc>ewrer</cc>
+         |val aaa= <scm><url>git@a.com:a/a.git</url>
+         |    <cc>e</cc>
          |  </scm>
          |
          |val tra = "</scm>"

--- a/main/src/test/scala/sbt/ErrorSpec.scala
+++ b/main/src/test/scala/sbt/ErrorSpec.scala
@@ -38,7 +38,7 @@ class ErrorSpec extends AbstractSpec with ScalaCheck {
           | } /* */ //
           |}
         """.stripMargin
-      BugInParser.tryWithNextStatement(buildSbt, buildSbt.length, 2, "fake.txt", new MessageOnlyException("fake")) must throwA[MessageOnlyException]
+      BugInParser.findMissingText(buildSbt, buildSbt.length, 2, "fake.txt", new MessageOnlyException("fake")) must throwA[MessageOnlyException]
     }
   }
 

--- a/main/src/test/scala/sbt/SessionSettingsCutExpressionSpec.scala
+++ b/main/src/test/scala/sbt/SessionSettingsCutExpressionSpec.scala
@@ -1,0 +1,21 @@
+package sbt
+
+class SessionSettingsCutExpressionSpec extends AbstractSpec {
+
+  "Cut expression " should {
+
+    "Cut only statement which we are interesting " in {
+      val name = "scalaVersion"
+      val expression = s"""$name := "2.9.2""""
+      val line = s"""name := "newName";$expression; organization := "jozwikr""""
+      SessionSettingsNoBlankies.cutExpression(List(line), name) must_== List(expression)
+    }
+
+    "Do not cut not valid expression " in {
+      val name = "k4"
+      val line = s"$name := { val x = $name.value; () }"
+      SessionSettingsNoBlankies.cutExpression(List(line), name) must_== List(line)
+
+    }
+  }
+}


### PR DESCRIPTION
Solution for https://github.com/sbt/sbt/commit/30b9cfc843077267fd3f0e0fa38d7c234c2d791d#sbt-src-sbt-test-project-session-save-test-P13. Problem was in `cutExpression` function. Now scala parser is used to split first line in sbt expression.
