### PR TITLE
Replace @WarszawScala by @WarsawScala

### DIFF
--- a/notes/0.13.7.markdown
+++ b/notes/0.13.7.markdown
@@ -10,6 +10,7 @@
   [@rkrzewski]: https://github.com/rkrzewski
   [@tmandke]: https://github.com/tmandke
   [@topping]: https://github.com/topping
+  [@WarsawScala]: https://github.com/WarsawScala
   [1237]: https://github.com/sbt/sbt/issues/1237
   [1430]: https://github.com/sbt/sbt/issues/1430
   [1544]: https://github.com/sbt/sbt/issues/1544
@@ -38,7 +39,7 @@
 
 ### Improvements
 
-- Natural whitespace handling. See below. [#1606][1606] by [@rkrzewski][@rkrzewski], [@ajozwik][@ajozwik], and others at @WarszawScala
+- Natural whitespace handling. See below. [#1606][1606] by [@rkrzewski][@rkrzewski], [@ajozwik][@ajozwik], and others at [@WarsawScala][@WarsawScala]
 - Adds support for publishing to a custom Maven local repository. See below. [#1589][1589]/[#1600][1600] by [@topping][@topping]
 - Adds circular dependency check. See below. [#1601][1601] by [@eed3si9n][@eed3si9n]
 - Adds cached resolution (minigraph caching). See below. [#1631][1631] by [@eed3si9n][@eed3si9n]
@@ -65,7 +66,7 @@
 
 Starting sbt 0.13.7, build.sbt will be parsed using a customized Scala parser. This eliminates the requirement to use blank line as the delimiter between each settings, and also allows blank lines to be inserted at arbitrary position within a block.
 
-This feature was contributed by [Andrzej Jozwik (@ajozwik)](https://github.com/ajozwik), [Rafał Krzewski (@rkrzewski)][@rkrzewski] and others at @WarszawScala inspired by Typesafe's [@gkossakowski][@gkossakowski] organizing multiple [meetups](http://blog.japila.pl/2014/07/gkossakowski-on-warszawscala-about-how-to-patch-scalasbt/) and [hackathons](http://blog.japila.pl/2014/07/hacking-scalasbt-with-gkossakowski-on-warszawscala-meetup-in-javeo_eu/) on how to patch sbt with the focus on this blank line issue. Dziękujemy! [#1606][1606]
+This feature was contributed by [Andrzej Jozwik (@ajozwik)](https://github.com/ajozwik), [Rafał Krzewski (@rkrzewski)][@rkrzewski] and others at [@WarsawScala][@WarsawScala] inspired by Typesafe's [@gkossakowski][@gkossakowski] organizing multiple [meetups](http://blog.japila.pl/2014/07/gkossakowski-on-warszawscala-about-how-to-patch-scalasbt/) and [hackathons](http://blog.japila.pl/2014/07/hacking-scalasbt-with-gkossakowski-on-warszawscala-meetup-in-javeo_eu/) on how to patch sbt with the focus on this blank line issue. Dziękujemy! [#1606][1606]
 
 ### Custom Maven local repository location
 


### PR DESCRIPTION
Organization name changed to more readable. Old name does not match any organization.
