### PR TITLE
Add escape hatch to old parser in case we run into problems.

### DIFF
--- a/notes/0.13.7.markdown
+++ b/notes/0.13.7.markdown
@@ -66,6 +66,8 @@
 
 Starting sbt 0.13.7, build.sbt will be parsed using a customized Scala parser. This eliminates the requirement to use blank line as the delimiter between each settings, and also allows blank lines to be inserted at arbitrary position within a block.
 
+This feature can be disabled, if necessary, via the -Dsbt.parser.simple=true flag.
+
 This feature was contributed by [Andrzej Jozwik (@ajozwik)](https://github.com/ajozwik), [Rafał Krzewski (@rkrzewski)][@rkrzewski] and others at [@WarsawScala][@WarsawScala] inspired by Typesafe's [@gkossakowski][@gkossakowski] organizing multiple [meetups](http://blog.japila.pl/2014/07/gkossakowski-on-warszawscala-about-how-to-patch-scalasbt/) and [hackathons](http://blog.japila.pl/2014/07/hacking-scalasbt-with-gkossakowski-on-warszawscala-meetup-in-javeo_eu/) on how to patch sbt with the focus on this blank line issue. Dziękujemy! [#1606][1606]
 
 ### Custom Maven local repository location


### PR DESCRIPTION
Just make sure users have the means to still build in case there's any
issues we missed.  This code should be removed in sbt 1.0.

Missed this in the earlier wip / Merge.

Review by @eed3si9n  cc @gkossakowski 
