### PR TITLE
Disable pattern matching in val syntax in sbt 0.13.7.

### DIFF
--- a/main/src/main/scala/sbt/internals/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtParser.scala
@@ -95,6 +95,21 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
         Seq(t)
     }
 
+    // Check No val (a,b) = foo *or* val a,b = foo as these are problematic to range positions and the WHOLE architecture.
+    def isBadValDef(t: Tree): Boolean =
+      t match {
+        case (x @ (toolbox.u.ValDef(_, _, _, _) | toolbox.u.DefDef(_, _, _, _, _, _))) =>
+          val content = modifiedContent.substring(x.pos.start, x.pos.end)
+          val prettyPrint = x.toString
+          (!(content contains "=") && (prettyPrint contains "="))
+        case _ => false
+      }
+    parsedTrees.filter(isBadValDef).foreach { badTree =>
+      // Issue errors
+      val positionLine = badTree.pos.line
+      throw new MessageOnlyException(s"""[$fileName]:$positionLine: Pattern matching in val statements is not supported""".stripMargin)
+    }
+
     val (imports, statements) = parsedTrees partition {
       case _: Import => true
       case _         => false

--- a/main/src/main/scala/sbt/internals/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtParser.scala
@@ -98,10 +98,9 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
     // Check No val (a,b) = foo *or* val a,b = foo as these are problematic to range positions and the WHOLE architecture.
     def isBadValDef(t: Tree): Boolean =
       t match {
-        case (x @ (toolbox.u.ValDef(_, _, _, _) | toolbox.u.DefDef(_, _, _, _, _, _))) =>
+        case x @ toolbox.u.ValDef(_, _, _, rhs) if rhs != toolbox.u.EmptyTree =>
           val content = modifiedContent.substring(x.pos.start, x.pos.end)
-          val prettyPrint = x.toString
-          (!(content contains "=") && (prettyPrint contains "="))
+          !(content contains "=")
         case _ => false
       }
     parsedTrees.filter(isBadValDef).foreach { badTree =>

--- a/main/src/test/resources/error-format/4.sbt.txt
+++ b/main/src/test/resources/error-format/4.sbt.txt
@@ -1,0 +1,1 @@
+val a,b = project

--- a/main/src/test/resources/old-format/21.sbt.txt
+++ b/main/src/test/resources/old-format/21.sbt.txt
@@ -70,3 +70,4 @@ pomPostProcess := { xi: scala.xml.Node =>
   }
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+

--- a/main/src/test/resources/old-format/22.sbt.txt
+++ b/main/src/test/resources/old-format/22.sbt.txt
@@ -1,0 +1,6 @@
+val x = bar
+
+{
+  val a,b = project
+}
+

--- a/main/src/test/scala/sbt/internals/parser/SplitExpressionsFilesTest.scala
+++ b/main/src/test/scala/sbt/internals/parser/SplitExpressionsFilesTest.scala
@@ -136,6 +136,7 @@ abstract class AbstractSplitExpressionsFilesTest(pathName: String) extends Speci
           println(s"In file: $fileName, old splitter failed. ${ex.toString}")
         case SplitterComparison(_, util.Failure(ex)) =>
           println(s"In file: $fileName, new splitter failed. ${ex.toString}")
+          ex.printStackTrace()
         case SplitterComparison(util.Success(resultOld), util.Success(resultNew)) =>
           if (resultOld == resultNew) {
             println(s"In file: $fileName, same results (imports, settings): $resultOld")

--- a/sbt/src/sbt-test/project/defs/build.sbt
+++ b/sbt/src/sbt-test/project/defs/build.sbt
@@ -1,3 +1,5 @@
+lazy val a,b = project
+
 def now = System.currentTimeMillis
 
 lazy val v = "1.0-" +
@@ -10,3 +12,5 @@ val descr = "Description"
 name := n
 
 version := v
+
+


### PR DESCRIPTION
Fixes #1661 or at least works around it for now.

Review by @eed3si9n cc> @jaceklaskowski 
