### PR TITLE
enable -deprecation for Scala 2.10

### DIFF
--- a/ivy/src/main/scala/sbt/Credentials.scala
+++ b/ivy/src/main/scala/sbt/Credentials.scala
@@ -27,7 +27,7 @@ object Credentials {
   def toDirect(c: Credentials): DirectCredentials = c match {
     case dc: DirectCredentials => dc
     case fc: FileCredentials => loadCredentials(fc.path) match {
-      case Left(err) => error(err)
+      case Left(err) => sys.error(err)
       case Right(dc) => dc
     }
   }

--- a/ivy/src/main/scala/sbt/EvictionWarning.scala
+++ b/ivy/src/main/scala/sbt/EvictionWarning.scala
@@ -155,7 +155,7 @@ object EvictionWarning {
     val transitiveEvictions: mutable.ListBuffer[EvictionPair] = mutable.ListBuffer()
     def guessCompatible(p: EvictionPair): Boolean =
       p.evicteds forall { r =>
-        options.guessCompatible(r.module, p.winner map { _.module }, module.moduleSettings.ivyScala)
+        options.guessCompatible((r.module, p.winner map { _.module }, module.moduleSettings.ivyScala))
       }
     pairs foreach {
       case p if isScalaArtifact(module, p.organization, p.name) =>

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -313,7 +313,7 @@ object IvyActions {
   private[this] def checkFilesPresent(artifacts: Seq[(IArtifact, File)]) {
     val missing = artifacts filter { case (a, file) => !file.exists }
     if (missing.nonEmpty)
-      error("Missing files for publishing:\n\t" + missing.map(_._2.getAbsolutePath).mkString("\n\t"))
+      sys.error("Missing files for publishing:\n\t" + missing.map(_._2.getAbsolutePath).mkString("\n\t"))
   }
 }
 final class ResolveException(

--- a/ivy/src/main/scala/sbt/UpdateReport.scala
+++ b/ivy/src/main/scala/sbt/UpdateReport.scala
@@ -220,7 +220,7 @@ object UpdateReport {
 
     private[this] def select0(f: DependencyFilter): Seq[File] =
       for (cReport <- report.configurations; mReport <- cReport.modules; (artifact, file) <- mReport.artifacts if f(cReport.configuration, mReport.module, artifact)) yield {
-        if (file == null) error("Null file: conf=" + cReport.configuration + ", module=" + mReport.module + ", art: " + artifact)
+        if (file == null) sys.error("Null file: conf=" + cReport.configuration + ", module=" + mReport.module + ", art: " + artifact)
         file
       }
 

--- a/launch/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launch/src/main/scala/xsbt/boot/Configuration.scala
@@ -70,7 +70,7 @@ object Configuration {
       if (!resolving.hasNext) multiPartError("Could not find configuration file '" + path + "'.  Searched:", against)
       resolving.next()
     }
-  def multiPartError[T](firstLine: String, lines: List[T]) = error((firstLine :: lines).mkString("\n\t"))
+  def multiPartError[T](firstLine: String, lines: List[T]) = sys.error((firstLine :: lines).mkString("\n\t"))
 
   def UnspecifiedVersionPart = "Unspecified"
   def DefaultVersionPart = "Default"
@@ -131,7 +131,7 @@ object Configuration {
   def classLocation(cl: Class[_]): URL =
     {
       val codeSource = cl.getProtectionDomain.getCodeSource
-      if (codeSource == null) error("No class location for " + cl)
+      if (codeSource == null) sys.error("No class location for " + cl)
       else codeSource.getLocation
     }
   // single-arg constructor doesn't properly escape

--- a/launch/src/main/scala/xsbt/boot/Configuration.scala
+++ b/launch/src/main/scala/xsbt/boot/Configuration.scala
@@ -70,7 +70,7 @@ object Configuration {
       if (!resolving.hasNext) multiPartError("Could not find configuration file '" + path + "'.  Searched:", against)
       resolving.next()
     }
-  def multiPartError[T](firstLine: String, lines: List[T]) = sys.error((firstLine :: lines).mkString("\n\t"))
+  def multiPartError[T](firstLine: String, lines: List[T]) = Pre.error((firstLine :: lines).mkString("\n\t"))
 
   def UnspecifiedVersionPart = "Unspecified"
   def DefaultVersionPart = "Default"
@@ -131,7 +131,7 @@ object Configuration {
   def classLocation(cl: Class[_]): URL =
     {
       val codeSource = cl.getProtectionDomain.getCodeSource
-      if (codeSource == null) sys.error("No class location for " + cl)
+      if (codeSource == null) Pre.error("No class location for " + cl)
       else codeSource.getLocation
     }
   // single-arg constructor doesn't properly escape

--- a/launch/src/main/scala/xsbt/boot/ConfigurationParser.scala
+++ b/launch/src/main/scala/xsbt/boot/ConfigurationParser.scala
@@ -101,14 +101,14 @@ class ConfigurationParser {
   def readValue[T](label: String)(implicit read: String => T): String => Value[T] = value0 =>
     {
       val value = substituteVariables(value0)
-      if (isEmpty(value)) error(label + " cannot be empty (omit declaration to use the default)")
+      if (isEmpty(value)) sys.error(label + " cannot be empty (omit declaration to use the default)")
       try { parsePropertyValue(label, value)(Value.readImplied[T]) }
       catch { case e: BootException => new Explicit(read(value)) }
     }
   def processSection[T](sections: SectionMap, name: String, f: LabelMap => T) =
     process[String, LabelMap, T](sections, name, m => f(m default (x => None)))
   def process[K, V, T](sections: ListMap[K, V], name: K, f: V => T): (T, ListMap[K, V]) = (f(sections(name)), sections - name)
-  def check(map: ListMap[String, _], label: String): Unit = if (map.isEmpty) () else error(map.keys.mkString("Invalid " + label + "(s): ", ",", ""))
+  def check(map: ListMap[String, _], label: String): Unit = if (map.isEmpty) () else sys.error(map.keys.mkString("Invalid " + label + "(s): ", ",", ""))
   def check[T](label: String, pair: (T, ListMap[String, _])): T = { check(pair._2, label); pair._1 }
   def id(map: LabelMap, name: String, default: String): (String, LabelMap) =
     (substituteVariables(orElse(getOrNone(map, name), default)), map - name)
@@ -198,7 +198,7 @@ class ConfigurationParser {
         case (key, Some(BootOnly)) => Predefined(key, true)
         case (key, Some(value)) =>
           val r = trim(substituteVariables(value).split(",", 7))
-          val url = try { new URL(r(0)) } catch { case e: MalformedURLException => error("Invalid URL specified for '" + key + "': " + e.getMessage) }
+          val url = try { new URL(r(0)) } catch { case e: MalformedURLException => sys.error("Invalid URL specified for '" + key + "': " + e.getMessage) }
           val (optionPart, patterns) = r.tail.partition(OptSet.contains(_))
           val options = (optionPart.contains(BootOnly), optionPart.contains(MvnComp), optionPart.contains(DescriptorOptional), optionPart.contains(DontCheckConsistency))
           (patterns, options) match {
@@ -206,7 +206,7 @@ class ConfigurationParser {
             case (ivy :: art :: Nil, (bo, mc, dso, cc)) => Ivy(key, url, ivy, art, mavenCompatible = mc, bootOnly = bo, descriptorOptional = dso, skipConsistencyCheck = cc)
             case (Nil, (true, false, false, cc))        => Maven(key, url, bootOnly = true)
             case (Nil, (false, false, false, false))    => Maven(key, url)
-            case _                                      => error("Could not parse %s: %s".format(key, value))
+            case _                                      => sys.error("Could not parse %s: %s".format(key, value))
           }
       }
     }
@@ -217,19 +217,19 @@ class ConfigurationParser {
     }
   def parsePropertyDefinition(name: String)(value: String) = value.split("=", 2) match {
     case Array(mode, value) => (mode, parsePropertyValue(name, value)(defineProperty(name)))
-    case x                  => error("Invalid property definition '" + x + "' for property '" + name + "'")
+    case x                  => sys.error("Invalid property definition '" + x + "' for property '" + name + "'")
   }
   def defineProperty(name: String)(action: String, requiredArg: String, optionalArg: Option[String]) =
     action match {
       case "prompt" => new PromptProperty(requiredArg, optionalArg)
       case "set"    => new SetProperty(requiredArg)
-      case _        => error("Unknown action '" + action + "' for property '" + name + "'")
+      case _        => sys.error("Unknown action '" + action + "' for property '" + name + "'")
     }
   private[this] lazy val propertyPattern = Pattern.compile("""(.+)\((.*)\)(?:\[(.*)\])?""") // examples: prompt(Version)[1.0] or set(1.0)
   def parsePropertyValue[T](name: String, definition: String)(f: (String, String, Option[String]) => T): T =
     {
       val m = propertyPattern.matcher(definition)
-      if (!m.matches()) error("Invalid property definition '" + definition + "' for property '" + name + "'")
+      if (!m.matches()) sys.error("Invalid property definition '" + definition + "' for property '" + name + "'")
       val optionalArg = m.group(3)
       f(m.group(1), m.group(2), if (optionalArg eq null) None else Some(optionalArg))
     }
@@ -244,10 +244,10 @@ class ConfigurationParser {
         (((ListMap.empty.default(x => ListMap.empty[String, Option[String]]), None): State) /: lines) {
           case (x, Comment)            => x
           case ((map, _), s: Section)  => (map, Some(s.name))
-          case ((_, None), l: Labeled) => error("Label " + l.label + " is not in a section")
+          case ((_, None), l: Labeled) => sys.error("Label " + l.label + " is not in a section")
           case ((map, s @ Some(section)), l: Labeled) =>
             val sMap = map(section)
-            if (sMap.contains(l.label)) error("Duplicate label '" + l.label + "' in section '" + section + "'")
+            if (sMap.contains(l.label)) sys.error("Duplicate label '" + l.label + "' in section '" + section + "'")
             else (map(section) = (sMap(l.label) = l.value), s)
         }
       s._1

--- a/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -57,7 +57,7 @@ final class Implicit[T](val name: String, val default: Option[T]) extends Value[
 object Value {
   def get[T](v: Value[T]): T = v match { case e: Explicit[T] => e.value; case _ => throw new BootException("Unresolved version: " + v) }
   def readImplied[T](s: String, name: String, default: Option[String])(implicit read: String => T): Value[T] =
-    if (s == "read") new Implicit(name, default map read) else error("Expected 'read', got '" + s + "'")
+    if (s == "read") new Implicit(name, default map read) else sys.error("Expected 'read', got '" + s + "'")
 }
 
 final case class Classifiers(forScala: Value[List[String]], app: Value[List[String]])
@@ -71,7 +71,7 @@ object LaunchCrossVersion {
       case x if CrossVersionUtil.isFull(s)     => xsbti.CrossValue.Full
       case x if CrossVersionUtil.isBinary(s)   => xsbti.CrossValue.Binary
       case x if CrossVersionUtil.isDisabled(s) => xsbti.CrossValue.Disabled
-      case x                                   => error("Unknown value '" + x + "' for property 'cross-versioned'")
+      case x                                   => sys.error("Unknown value '" + x + "' for property 'cross-versioned'")
     }
 }
 

--- a/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
+++ b/launch/src/main/scala/xsbt/boot/LaunchConfiguration.scala
@@ -57,7 +57,7 @@ final class Implicit[T](val name: String, val default: Option[T]) extends Value[
 object Value {
   def get[T](v: Value[T]): T = v match { case e: Explicit[T] => e.value; case _ => throw new BootException("Unresolved version: " + v) }
   def readImplied[T](s: String, name: String, default: Option[String])(implicit read: String => T): Value[T] =
-    if (s == "read") new Implicit(name, default map read) else sys.error("Expected 'read', got '" + s + "'")
+    if (s == "read") new Implicit(name, default map read) else Pre.error("Expected 'read', got '" + s + "'")
 }
 
 final case class Classifiers(forScala: Value[List[String]], app: Value[List[String]])
@@ -71,7 +71,7 @@ object LaunchCrossVersion {
       case x if CrossVersionUtil.isFull(s)     => xsbti.CrossValue.Full
       case x if CrossVersionUtil.isBinary(s)   => xsbti.CrossValue.Binary
       case x if CrossVersionUtil.isDisabled(s) => xsbti.CrossValue.Disabled
-      case x                                   => sys.error("Unknown value '" + x + "' for property 'cross-versioned'")
+      case x                                   => Pre.error("Unknown value '" + x + "' for property 'cross-versioned'")
     }
 }
 

--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -106,7 +106,7 @@ private[sbt] object ForkTests {
     f match {
       case s: SubclassFingerprint  => new ForkMain.SubclassFingerscan(s)
       case a: AnnotatedFingerprint => new ForkMain.AnnotatedFingerscan(a)
-      case _                       => error("Unknown fingerprint type: " + f.getClass)
+      case _                       => sys.error("Unknown fingerprint type: " + f.getClass)
     }
 }
 private final class React(is: ObjectInputStream, os: ObjectOutputStream, log: Logger, listeners: Seq[TestReportListener], results: mutable.Map[String, SuiteResult]) {

--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -41,7 +41,7 @@ object InputWrapper {
   @compileTimeOnly("`previous` can only be called on a task within a task or input task definition macro, such as :=, +=, ++=, Def.task, or Def.inputTask.")
   def wrapPrevious_\u2603\u2603[T](in: Any): T = implDetailError
 
-  private[this] def implDetailError = error("This method is an implementation detail and should not be referenced.")
+  private[this] def implDetailError = sys.error("This method is an implementation detail and should not be referenced.")
 
   private[std] def wrapTask[T: c.WeakTypeTag](c: Context)(ts: c.Expr[Any], pos: c.Position): c.Expr[T] =
     wrapImpl[T, InputWrapper.type](c, InputWrapper, WrapTaskName)(ts, pos)
@@ -166,10 +166,10 @@ object ParserInput {
   private[std] val WrapInitName = "initParser_\u2603\u2603"
 
   @compileTimeOnly("`parsed` can only be used within an input task macro, such as := or Def.inputTask.")
-  def parser_\u2603\u2603[T](i: Any): T = error("This method is an implementation detail and should not be referenced.")
+  def parser_\u2603\u2603[T](i: Any): T = sys.error("This method is an implementation detail and should not be referenced.")
 
   @compileTimeOnly("`parsed` can only be used within an input task macro, such as := or Def.inputTask.")
-  def initParser_\u2603\u2603[T](i: Any): T = error("This method is an implementation detail and should not be referenced.")
+  def initParser_\u2603\u2603[T](i: Any): T = sys.error("This method is an implementation detail and should not be referenced.")
 
   private[std] def wrap[T: c.WeakTypeTag](c: Context)(ts: c.Expr[Any], pos: c.Position): c.Expr[T] =
     InputWrapper.wrapImpl[T, ParserInput.type](c, ParserInput, WrapName)(ts, pos)

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -60,7 +60,7 @@ object Cross {
           )
           (settings, excludeKeys(Set(scalaVersion.key, scalaHome.key, scalaInstance.key)))
         } else if (!resolveVersion.isEmpty) {
-          error("Scala home directory did not exist: " + home)
+          sys.error("Scala home directory did not exist: " + home)
         } else {
           state.log.info("Setting version to " + arg)
           val settings = Seq(

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -320,7 +320,7 @@ object Defaults extends BuildCommon {
       override def watchPaths(s: State) = EvaluateTask.evaluateTask(Project structure s, key, s, base) match {
         case Some(Value(ps)) => ps
         case Some(Inc(i))    => throw i
-        case None            => error("key not found: " + Def.displayFull(key))
+        case None            => sys.error("key not found: " + Def.displayFull(key))
       }
     }
   }
@@ -360,13 +360,13 @@ object Defaults extends BuildCommon {
 
   def scalaInstanceFromUpdate: Initialize[Task[ScalaInstance]] = Def.task {
     val toolReport = update.value.configuration(Configurations.ScalaTool.name) getOrElse
-      error(noToolConfiguration(managedScalaInstance.value))
+      sys.error(noToolConfiguration(managedScalaInstance.value))
     def files(id: String) =
       for {
         m <- toolReport.modules if m.module.name == id;
         (art, file) <- m.artifacts if art.`type` == Artifact.DefaultType
       } yield file
-    def file(id: String) = files(id).headOption getOrElse error(s"Missing ${id}.jar")
+    def file(id: String) = files(id).headOption getOrElse sys.error(s"Missing ${id}.jar")
     val allFiles = toolReport.modules.flatMap(_.artifacts.map(_._2))
     val libraryJar = file(ScalaArtifacts.LibraryID)
     val compilerJar = file(ScalaArtifacts.CompilerID)
@@ -691,7 +691,7 @@ object Defaults extends BuildCommon {
       import Def.parserToInput
       val parser = Def.spaceDelimited()
       Def.inputTask {
-        val mainClass = mainClassTask.value getOrElse error("No main class detected.")
+        val mainClass = mainClassTask.value getOrElse sys.error("No main class detected.")
         toError(scalaRun.value.run(mainClass, data(classpath.value), parser.parsed, streams.value.log))
       }
     }
@@ -751,7 +751,7 @@ object Defaults extends BuildCommon {
         val fullcp = (cpFiles ++ si.jars).distinct
         val loader = sbt.classpath.ClasspathUtilities.makeLoader(fullcp, si, IO.createUniqueDirectory(temp))
         val compiler = cs.scalac.onArgs(exported(s, "scala"))
-        (new Console(compiler))(cpFiles, options, loader, initCommands, cleanup)()(s.log).foreach(msg => error(msg))
+        (new Console(compiler))(cpFiles, options, loader, initCommands, cleanup)()(s.log).foreach(msg => sys.error(msg))
         println()
     }
 
@@ -964,7 +964,7 @@ object Classpaths {
     {
       val defined = report.allConfigurations.toSet
       val search = map(thisConfig) +: (delegated.toList ++ Seq(Compile, Configurations.Default))
-      def notFound = error("Configuration to use for managed classpath must be explicitly defined when default configurations are not present.")
+      def notFound = sys.error("Configuration to use for managed classpath must be explicitly defined when default configurations are not present.")
       search find { defined contains _.name } getOrElse notFound
     }
 
@@ -1310,7 +1310,7 @@ object Classpaths {
       def skipWork: In => UpdateReport =
         Tracked.lastOutput[In, UpdateReport](outCacheFile) {
           case (_, Some(out)) => out
-          case _              => error("Skipping update requested, but update has not previously run successfully.")
+          case _              => sys.error("Skipping update requested, but update has not previously run successfully.")
         }
       def doWork: In => UpdateReport =
         Tracked.inputChanged(cacheFile / "inputs") { (inChanged: Boolean, in: In) =>
@@ -1382,7 +1382,7 @@ object Classpaths {
 	}*/
 
   def defaultRepositoryFilter = (repo: MavenRepository) => !repo.root.startsWith("file:")
-  def getPublishTo(repo: Option[Resolver]): Resolver = repo getOrElse error("Repository for publishing is not specified.")
+  def getPublishTo(repo: Option[Resolver]): Resolver = repo getOrElse sys.error("Repository for publishing is not specified.")
 
   def deliverConfig(outputDirectory: File, status: String = "release", logging: UpdateLogging.Value = UpdateLogging.DownloadOnly) =
     new DeliverConfiguration(deliverPattern(outputDirectory), status, None, logging)
@@ -1506,7 +1506,7 @@ object Classpaths {
           case x :: Nil => for (a <- parseList(x, masterConfs)) yield (a, default(a))
           case x :: y :: Nil =>
             val target = parseList(y, depConfs); for (a <- parseList(x, masterConfs)) yield (a, target)
-          case _ => error("Invalid configuration '" + confString + "'") // shouldn't get here
+          case _ => sys.error("Invalid configuration '" + confString + "'") // shouldn't get here
         }
       val m = ms.toMap
       s => m.getOrElse(s, Nil)
@@ -1521,7 +1521,7 @@ object Classpaths {
 
   private def trim(a: Array[String]): List[String] = a.toList.map(_.trim)
   def missingConfiguration(in: String, conf: String) =
-    error("Configuration '" + conf + "' not defined in '" + in + "'")
+    sys.error("Configuration '" + conf + "' not defined in '" + in + "'")
   def allConfigs(conf: Configuration): Seq[Configuration] =
     Dag.topologicalSort(conf)(_.extendsConfigs)
 
@@ -1682,7 +1682,7 @@ object Classpaths {
           case Predefined.ScalaToolsSnapshots  => Resolver.ScalaToolsSnapshots
           case Predefined.SonatypeOSSReleases  => Resolver.sonatypeRepo("releases")
           case Predefined.SonatypeOSSSnapshots => Resolver.sonatypeRepo("snapshots")
-          case unknown                         => error("Unknown predefined resolver '" + unknown + "'.  This resolver may only be supported in newer sbt versions.")
+          case unknown                         => sys.error("Unknown predefined resolver '" + unknown + "'.  This resolver may only be supported in newer sbt versions.")
         }
       }
     }

--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -477,7 +477,7 @@ object Load {
     {
       def normalizeID(f: File) = Project.normalizeProjectID(f.getName) match {
         case Right(id) => id
-        case Left(msg) => error(autoIDError(f, msg))
+        case Left(msg) => sys.error(autoIDError(f, msg))
       }
       def nthParentName(f: File, i: Int): String =
         if (f eq null) Build.defaultID(localBase) else if (i <= 0) normalizeID(f) else nthParentName(f.getParentFile, i - 1)

--- a/main/src/test/resources/session-settings-quick/4.sbt.txt
+++ b/main/src/test/resources/session-settings-quick/4.sbt.txt
@@ -11,7 +11,7 @@ k3 := {
 
 k4 := { }; k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 
 k4 := { val x = k4.value; () }
 

--- a/main/src/test/resources/session-settings-quick/4.sbt.txt_1/1.set.result
+++ b/main/src/test/resources/session-settings-quick/4.sbt.txt_1/1.set.result
@@ -11,5 +11,5 @@ k3 := {
 
 k4 := (); k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 

--- a/main/src/test/resources/session-settings/4.sbt.txt
+++ b/main/src/test/resources/session-settings/4.sbt.txt
@@ -11,7 +11,7 @@ k3 := {
 
 k4 := { }; k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 
 k4 := { val x = k4.value; () }
 

--- a/main/src/test/resources/session-settings/4.sbt.txt_1/1.set.result
+++ b/main/src/test/resources/session-settings/4.sbt.txt_1/1.set.result
@@ -11,5 +11,5 @@ k3 := {
 
 k4 := (); k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 

--- a/main/src/test/scala/TestBuild.scala
+++ b/main/src/test/scala/TestBuild.scala
@@ -246,7 +246,7 @@ object TestBuild {
         genAcyclic(maxDeps, xs, next :: acc)
     }
   def sequence[T](gs: Seq[Gen[T]]): Gen[Seq[T]] = Gen.parameterized { prms =>
-    wrap(gs map { g => g(prms) getOrElse error("failed generator") })
+    wrap(gs map { g => g(prms) getOrElse sys.error("failed generator") })
   }
   type Inputs[A, T] = (T, Seq[T], Seq[A] => A)
 }

--- a/project/Proguard.scala
+++ b/project/Proguard.scala
@@ -124,7 +124,7 @@ object LaunchProguard {
     IO.delete(outputJar)
     val fileString = mkpath(configFile.getAbsolutePath, '\'')
     val exitValue = Process("java", List("-Xmx256M", "-cp", Path.makeString(cp), "proguard.ProGuard", "-include " + fileString)) ! log
-    if (exitValue != 0) error("Proguard failed with nonzero exit code (" + exitValue + ")")
+    if (exitValue != 0) sys.error("Proguard failed with nonzero exit code (" + exitValue + ")")
   }
 
   def mapInJars(inJars: Seq[File], log: Logger): Seq[String] =

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -55,7 +55,7 @@ object Release extends Build {
     {
       Credentials.forHost(cs, PublishRepoHost) match {
         case Some(creds) => (creds.userName, creds.passwd)
-        case None        => error("No credentials defined for " + PublishRepoHost)
+        case None        => sys.error("No credentials defined for " + PublishRepoHost)
       }
     }
 

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -18,7 +18,7 @@ object Transform {
 
   def conscriptSettings(launch: Reference) = Seq(
     conscriptConfigs <<= (managedResources in launch in Compile, sourceDirectory in Compile).map { (res, src) =>
-      val source = res.filter(_.getName == "sbt.boot.properties").headOption getOrElse error("No managed boot.properties file.")
+      val source = res.filter(_.getName == "sbt.boot.properties").headOption getOrElse sys.error("No managed boot.properties file.")
       copyConscriptProperties(source, src / "conscript")
       ()
     }
@@ -79,7 +79,7 @@ object Transform {
 
   def transform(in: File, out: File, map: Map[String, String]): File =
     {
-      def get(key: String): String = map.getOrElse(key, error("No value defined for key '" + key + "'"))
+      def get(key: String): String = map.getOrElse(key, sys.error("No value defined for key '" + key + "'"))
       val newString = Property.replaceAllIn(IO.read(in), mtch => get(mtch.group(1)))
       if (Some(newString) != read(out))
         IO.write(out, newString)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -52,6 +52,10 @@ object Util {
     scalacOptions <++= scalaVersion map CrossVersion.partialVersion map {
       case Some((2, 9)) => Nil // support 2.9 for some subprojects for the Scala Eclipse IDE
       case _            => Seq("-feature", "-language:implicitConversions", "-language:postfixOps", "-language:higherKinds", "-language:existentials")
+    },
+    scalacOptions <++= scalaVersion map CrossVersion.partialVersion map {
+      case Some((2, 10)) => Seq("-deprecation", "-Xlint")
+      case _             => Seq()
     }
   )
 
@@ -196,7 +200,7 @@ object Licensed {
   lazy val extractLicenses = TaskKey[Seq[File]]("extract-licenses")
 
   lazy val seeRegex = """\(see (.*?)\)""".r
-  def licensePath(base: File, str: String): File = { val path = base / str; if (path.exists) path else error("Referenced license '" + str + "' not found at " + path) }
+  def licensePath(base: File, str: String): File = { val path = base / str; if (path.exists) path else sys.error("Referenced license '" + str + "' not found at " + path) }
   def seePaths(base: File, noticeString: String): Seq[File] = seeRegex.findAllIn(noticeString).matchData.map(d => licensePath(base, d.group(1))).toList
 
   def settings: Seq[Setting[_]] = Seq(

--- a/sbt/src/sbt-test/actions/add-alias/A.scala
+++ b/sbt/src/sbt-test/actions/add-alias/A.scala
@@ -1,3 +1,3 @@
 object A extends App {
-  if(args(0).toBoolean) () else error("Fail")
+  if(args(0).toBoolean) () else sys.error("Fail")
 }

--- a/sbt/src/sbt-test/actions/compile-time-only/build.sbt
+++ b/sbt/src/sbt-test/actions/compile-time-only/build.sbt
@@ -7,6 +7,6 @@ expectErrorNotCrash := {
 	val fail = (compile in Compile).failure.value
 	fail.directCause match {
 		case Some(x: xsbti.CompileFailed) => ()
-		case _ => error("Compiler crashed instead of providing a compile-time-only exception.")
+		case _ => sys.error("Compiler crashed instead of providing a compile-time-only exception.")
 	}
 }

--- a/sbt/src/sbt-test/actions/depends-on/project/B.scala
+++ b/sbt/src/sbt-test/actions/depends-on/project/B.scala
@@ -5,7 +5,7 @@ import Keys._
 object B extends Build
 {
 	lazy val root = Project("root", file(".")) settings(
-		a <<= baseDirectory map (b =>  if( (b / "succeed").exists) () else error("fail")),
+		a <<= baseDirectory map (b =>  if( (b / "succeed").exists) () else sys.error("fail")),
 		b <<= a.task(at => nop dependsOn(at) ),
 		c <<= a map { _ => () },
 		d <<= a flatMap { _ => task { () } }
@@ -16,8 +16,8 @@ object B extends Build
 	lazy val d = TaskKey[Unit]("d")
 
 	lazy val input = Project("input", file("input")) settings(
-		f <<= inputTask { _ map { args => if(args(0) == "succeed") () else error("fail") } },
-		j := error("j"),
+		f <<= inputTask { _ map { args => if(args(0) == "succeed") () else sys.error("fail") } },
+		j := sys.error("j"),
 		g <<= f dependsOn(j),
 		h <<= f map { _ => IO.touch(file("h")) }
 	)

--- a/sbt/src/sbt-test/actions/reload/project/TestProject.scala
+++ b/sbt/src/sbt-test/actions/reload/project/TestProject.scala
@@ -3,7 +3,7 @@ import sbt._
 object TestBuild extends Build
 {
 	lazy val root = Project("root", file("."), aggregate = Seq(sub)) settings(
-		TaskKey[Unit]("f") := error("f")
+		TaskKey[Unit]("f") := sys.error("f")
 	)
 	lazy val sub = Project("sub", file("sub")) settings(
 		TaskKey[Unit]("f") := {}

--- a/sbt/src/sbt-test/actions/update-state-fail/project/Build.scala
+++ b/sbt/src/sbt-test/actions/update-state-fail/project/Build.scala
@@ -10,7 +10,7 @@ object TestBuild extends Build
     check := checkState(checkParser.parsed, state.value)
   )
 
-  lazy val a = Project("a", file("a")).settings(t := error("Failing"))
+  lazy val a = Project("a", file("a")).settings(t := sys.error("Failing"))
 
   lazy val b = Project("b", file("b")).settings(t <<= Def.task("").updateState(updater))
 

--- a/sbt/src/sbt-test/compiler-project/src-dep-plugin/changes/DemoPlugin.scala
+++ b/sbt/src/sbt-test/compiler-project/src-dep-plugin/changes/DemoPlugin.scala
@@ -6,5 +6,5 @@ class DemoPlugin(val global: Global) extends plugins.Plugin
 {
 	val name = "demo-plugin"
 	val description = "Throws an error"
-	val components = error("The plugin was successfully registered.")
+	val components = sys.error("The plugin was successfully registered.")
 }

--- a/sbt/src/sbt-test/dependency-management/artifact/project/ArtifactTest.scala
+++ b/sbt/src/sbt-test/dependency-management/artifact/project/ArtifactTest.scala
@@ -39,6 +39,6 @@ object ArtifactTest extends Build
 	def checkTask(classpath: TaskKey[Classpath]) = (classpath in Compile, scalaInstance) map { (cp, si) =>
 		val loader = sbt.classpath.ClasspathUtilities.toLoader(cp.files, si.loader)
 		try { Class.forName("test.Test", false, loader); () }
-		catch { case _: ClassNotFoundException | _: NoClassDefFoundError => error("Dependency not retrieved properly") }
+		catch { case _: ClassNotFoundException | _: NoClassDefFoundError => sys.error("Dependency not retrieved properly") }
 	}
 }

--- a/sbt/src/sbt-test/dependency-management/info/project/InfoTest.scala
+++ b/sbt/src/sbt-test/dependency-management/info/project/InfoTest.scala
@@ -29,14 +29,14 @@ object InfoTest extends Build
 		else
 			<dependency org="org.scala-tools.testing" name="scalacheck_2.9.1" rev="1.9"/>
 
-	def checkDownload = (dependencyClasspath in Compile) map { cp => if(cp.isEmpty) error("Dependency not downloaded"); () }
+	def checkDownload = (dependencyClasspath in Compile) map { cp => if(cp.isEmpty) sys.error("Dependency not downloaded"); () }
 	def checkInfo = (customInfo, delivered) map { (addInfo, d) =>
 		if((d \ "info").isEmpty)
-			error("No info tag generated")
+			sys.error("No info tag generated")
 		else if(addInfo) {
-			if( !deliveredWithCustom(d) ) error("Expected 'license' and 'description' tags in info tag, got: \n" + (d \ "info")) else ()
+			if( !deliveredWithCustom(d) ) sys.error("Expected 'license' and 'description' tags in info tag, got: \n" + (d \ "info")) else ()
 		} else
-			if( deliveredWithCustom(d) ) error("Expected empty 'info' tag, got: \n" + (d \ "info")) else ()
+			if( deliveredWithCustom(d) ) sys.error("Expected empty 'info' tag, got: \n" + (d \ "info")) else ()
 	}
 	def deliveredWithCustom(d: NodeSeq) = !(d \ "info" \ "license").isEmpty && !(d \ "info" \ "description").isEmpty
 }

--- a/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
+++ b/sbt/src/sbt-test/dependency-management/make-pom/project/MakePomTest.scala
@@ -21,18 +21,18 @@ object MakePomTest extends Build
 	val fakeRepo = fakeName at fakeURL
 	def extraTagName = "extra-tag"
 
-	def checkProject(pom: Elem) = if(pom.label != "project") error("Top level element was not 'project': " + pom.label)
+	def checkProject(pom: Elem) = if(pom.label != "project") sys.error("Top level element was not 'project': " + pom.label)
 	
 	def withRepositories[T](pomXML: Elem)(f: NodeSeq => T) =
 	{
 		val repositoriesElement = pomXML \ "repositories"
-		if(repositoriesElement.size == 1) f(repositoriesElement) else error("'repositories' element not found in generated pom")
+		if(repositoriesElement.size == 1) f(repositoriesElement) else sys.error("'repositories' element not found in generated pom")
 	}
 	
 	lazy val checkExtra = readPom map { pomXML =>
 		checkProject(pomXML)
 		val extra =  pomXML \ extraTagName
-		if(extra.isEmpty) error("'" + extraTagName + "' not found in generated pom.xml.") else ()
+		if(extra.isEmpty) sys.error("'" + extraTagName + "' not found in generated pom.xml.") else ()
 	}
 	
 	lazy val checkVersionPlusMapping = (readPom) map { (pomXml) =>
@@ -56,7 +56,7 @@ object MakePomTest extends Build
 			lazy val explain = (("Written:" +: writtenRepositories) ++ ("Declared:" +: mavenStyleRepositories)).mkString("\n\t")
 			
 			if( writtenRepositories != mavenStyleRepositories )
-				error("Written repositories did not match declared repositories.\n\t" + explain)
+				sys.error("Written repositories did not match declared repositories.\n\t" + explain)
 			else
 				()
 		}

--- a/sbt/src/sbt-test/dependency-management/pom-packaging/project/PomTest.scala
+++ b/sbt/src/sbt-test/dependency-management/pom-packaging/project/PomTest.scala
@@ -18,7 +18,7 @@ object PomTest extends Build
 	def checkPackaging(pom: File, expected: String) =
 	{
 		val packaging = (xml.XML.loadFile(pom) \\ "packaging").text
-		if(packaging != expected) error("Incorrect packaging for '" + pom + "'.  Expected '" + expected + "', but got '" + packaging + "'")
+		if(packaging != expected) sys.error("Incorrect packaging for '" + pom + "'.  Expected '" + expected + "', but got '" + packaging + "'")
 	}
 	def warArtifact = artifact in (Compile, packageBin) ~= { _.copy(`type` = "war", extension = "war") }
 }

--- a/sbt/src/sbt-test/dependency-management/pom-scope/project/PomTest.scala
+++ b/sbt/src/sbt-test/dependency-management/pom-scope/project/PomTest.scala
@@ -34,7 +34,7 @@ object PomTest extends Build
 		val loaded = xml.XML.loadFile(pom)
 		val deps = loaded \\ "dependency"
 		expected foreach { case (id, scope, opt, classifier) =>
-			val dep = deps.find(d => (d \ "artifactId").text == id).getOrElse( error("Dependency '" + id + "' not written to pom:\n" + loaded))
+			val dep = deps.find(d => (d \ "artifactId").text == id).getOrElse( sys.error("Dependency '" + id + "' not written to pom:\n" + loaded))
 			val actualOpt = java.lang.Boolean.parseBoolean( (dep \\ "optional").text )
 			assert(opt == actualOpt, "Invalid 'optional' section '" + (dep \\ "optional") + "' for " + id + ", expected optional=" + opt)
 

--- a/sbt/src/sbt-test/dependency-management/provided/project/TestProject.scala
+++ b/sbt/src/sbt-test/dependency-management/provided/project/TestProject.scala
@@ -14,7 +14,7 @@ object TestProject extends Build
 		managedClasspath in Provided <<= (classpathTypes, update) map { (cpts, report) => Classpaths.managedJars(Provided, cpts, report) },
 		check <<= InputTask(_ => Space ~> token(Compile.name.id | Runtime.name | Provided.name | Test.name) ~ token(Space ~> Bool)) { result =>
 			(result, managedClasspath in Provided, fullClasspath in Runtime, fullClasspath in Compile, fullClasspath in Test) map { case ((conf, expected), p, r, c, t) =>
-				val cp = if(conf == Compile.name) c else if(conf == Runtime.name) r else if(conf == Provided.name) p else if(conf == Test.name) t else error("Invalid config: " + conf)
+				val cp = if(conf == Compile.name) c else if(conf == Runtime.name) r else if(conf == Provided.name) p else if(conf == Test.name) t else sys.error("Invalid config: " + conf)
 				checkServletAPI(cp.files, expected, conf)
 			}
 		}
@@ -26,9 +26,9 @@ object TestProject extends Build
 		if(shouldBeIncluded)
 		{
 			if(servletAPI.isEmpty)
-				error("Servlet API should have been included in " + label + ".")
+				sys.error("Servlet API should have been included in " + label + ".")
 		}
 		else
-			servletAPI.foreach(s => error(s + " incorrectly included in " + label + "."))
+			servletAPI.foreach(s => sys.error(s + " incorrectly included in " + label + "."))
 	}
 }

--- a/sbt/src/sbt-test/dependency-management/sources/project/Test.scala
+++ b/sbt/src/sbt-test/dependency-management/sources/project/Test.scala
@@ -17,15 +17,15 @@ object Test extends Build
 	{
 		val srcs = getSources(report)
 		if(srcs.isEmpty)
-			error("No sources retrieved")
+			sys.error("No sources retrieved")
 		else if(srcs.size != 2)
-			error("Incorrect sources retrieved:\n\t" + srcs.mkString("\n\t"))
+			sys.error("Incorrect sources retrieved:\n\t" + srcs.mkString("\n\t"))
 		else
 			()
 	}
 	def checkBinaries(report: UpdateReport): Unit =
 	{
 		val srcs = getSources(report)
-		if(!srcs.isEmpty) error("Sources retrieved:\n\t" + srcs.mkString("\n\t")) else ()
+		if(!srcs.isEmpty) sys.error("Sources retrieved:\n\t" + srcs.mkString("\n\t")) else ()
 	}
 }

--- a/sbt/src/sbt-test/dependency-management/url/project/TestProject.scala
+++ b/sbt/src/sbt-test/dependency-management/url/project/TestProject.scala
@@ -21,7 +21,7 @@ object TestProject extends Build
 			}
 			catch
 			{
-				case _: ClassNotFoundException => error("Dependency not downloaded.")
+				case _: ClassNotFoundException => sys.error("Dependency not downloaded.")
 			}
 		}
 }

--- a/sbt/src/sbt-test/project/delegates/project/Build.scala
+++ b/sbt/src/sbt-test/project/delegates/project/Build.scala
@@ -11,7 +11,7 @@ object B extends Build
 
 	lazy val checkTask = InputTask(_ => Space ~> NatBasic) { result =>
 		(result, maxErrors) map { (i, max)  =>
-			if(i != max) error("Expected max-errors to be " + i + ", but it was " + max)
+			if(i != max) sys.error("Expected max-errors to be " + i + ", but it was " + max)
 		}
 	}
 }

--- a/sbt/src/sbt-test/project/provided/project/P.scala
+++ b/sbt/src/sbt-test/project/provided/project/P.scala
@@ -25,7 +25,7 @@ object P extends Build
 		(err, shouldSucceed) match
 		{
 			case (None, true) | (Some(_), false) => ()
-			case (None, false) => error("Expected failure")
+			case (None, false) => sys.error("Expected failure")
 			case (Some(x), true) => throw x
 		}
 	}

--- a/sbt/src/sbt-test/project/session-save/build.check.3
+++ b/sbt/src/sbt-test/project/session-save/build.check.3
@@ -11,5 +11,5 @@ k3 := {
 
 k4 := { }; k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 

--- a/sbt/src/sbt-test/project/session-save/build.check.4
+++ b/sbt/src/sbt-test/project/session-save/build.check.4
@@ -11,7 +11,7 @@ k3 := {
 
 k4 := { }; k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 
 k4 := { val x = k4.value; () }
 

--- a/sbt/src/sbt-test/project/session-save/build.check.5
+++ b/sbt/src/sbt-test/project/session-save/build.check.5
@@ -11,5 +11,5 @@ k3 := {
 
 k4 := (); k5 := ()
 
-k1 <<= k1 map {_ => error("k1")}
+k1 <<= k1 map {_ => sys.error("k1")}
 

--- a/sbt/src/sbt-test/project/session-save/test
+++ b/sbt/src/sbt-test/project/session-save/test
@@ -16,7 +16,7 @@ $ must-mirror build.sbt build.check.1
 > k2
 $ must-mirror build.sbt build.check.2
 
-> set k1 <<= k1 map {_ => error("k1")}
+> set k1 <<= k1 map {_ => sys.error("k1")}
 > set k2 := {}
 > session save
 > reload

--- a/sbt/src/sbt-test/project/transitive-plugins/project/Build.scala
+++ b/sbt/src/sbt-test/project/transitive-plugins/project/Build.scala
@@ -10,7 +10,7 @@ object Build extends Build
 	def project(s: String) = Project(s, file(s)) settings(
 		ivyPaths <<= (baseDirectory in root, target in root)( (dir, t) => new IvyPaths(dir, Some(t / "ivy-cache"))),
 		resolvers <+= appConfiguration { app => // need this to resolve sbt
-			val ivyHome = Classpaths.bootIvyHome(app) getOrElse error("Launcher did not provide the Ivy home directory.")
+			val ivyHome = Classpaths.bootIvyHome(app) getOrElse sys.error("Launcher did not provide the Ivy home directory.")
 			Resolver.file("real-local",  ivyHome / "local")(Resolver.ivyStylePatterns)
 		},
 		resolvers += Resolver.typesafeIvyRepo("releases") // not sure why this isn't included by default

--- a/sbt/src/sbt-test/run/concurrent/build.sbt
+++ b/sbt/src/sbt-test/run/concurrent/build.sbt
@@ -5,9 +5,9 @@ def runTestTask(pre: Def.Initialize[Task[Unit]]) =
 		val _ = pre.value
 		val r = (runner in (Compile, run)).value
 		val cp = (fullClasspath in Compile).value
-		val main = (mainClass in Compile).value getOrElse error("No main class found")
+		val main = (mainClass in Compile).value getOrElse sys.error("No main class found")
 		val args = baseDirectory.value.getAbsolutePath :: Nil
-		r.run(main, cp.files, args, streams.value.log) foreach error
+		r.run(main, cp.files, args, streams.value.log) foreach sys.error
 	}
 
 lazy val b = project.settings(

--- a/sbt/src/sbt-test/run/error/changes/ThreadRunError.scala
+++ b/sbt/src/sbt-test/run/error/changes/ThreadRunError.scala
@@ -6,6 +6,6 @@ object Spawn
 	}
 	class ThreadA extends Thread
 	{
-		override def run(): Unit = error("Test error thread")
+		override def run(): Unit = sys.error("Test error thread")
 	}
 }

--- a/sbt/src/sbt-test/source-dependencies/compactify/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/compactify/build.sbt
@@ -1,6 +1,6 @@
 TaskKey[Unit]("output-empty") <<= classDirectory in Configurations.Compile map { outputDirectory =>
 	def classes = (outputDirectory ** "*.class").get
-	if(!classes.isEmpty) error("Classes existed:\n\t" + classes.mkString("\n\t")) else ()
+	if(!classes.isEmpty) sys.error("Classes existed:\n\t" + classes.mkString("\n\t")) else ()
 }
 
 // apparently Travis CI stopped allowing long file names

--- a/sbt/src/sbt-test/source-dependencies/struct-usage/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-usage/A.scala
@@ -1,3 +1,3 @@
 object A {
-	def x: { def q: Int } = error("not important")
+	def x: { def q: Int } = sys.error("not important")
 }

--- a/sbt/src/sbt-test/source-dependencies/struct-usage/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/struct-usage/changes/A.scala
@@ -1,3 +1,3 @@
 object A {
-	def x: { def q: String } = error("not important")
+	def x: { def q: String } = sys.error("not important")
 }

--- a/sbt/src/sbt-test/source-dependencies/typeref-return/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/typeref-return/A.scala
@@ -1,4 +1,4 @@
 object A {
 	type I = Int
-	def x: I = error("not important")
+	def x: I = sys.error("not important")
 }

--- a/sbt/src/sbt-test/source-dependencies/typeref-return/changes/A.scala
+++ b/sbt/src/sbt-test/source-dependencies/typeref-return/changes/A.scala
@@ -1,4 +1,4 @@
 object A {
 	type I = String
-	def x: I = error("Not important")
+	def x: I = sys.error("Not important")
 }

--- a/sbt/src/sbt-test/tests/arguments-new/src/test/scala/ArgumentTest.scala
+++ b/sbt/src/sbt-test/tests/arguments-new/src/test/scala/ArgumentTest.scala
@@ -7,8 +7,8 @@ class ArgumentTest extends FunSuite{
   override def withFixture(test: OneArgTest) = {
     test(test.configMap)
   }
-  test("1", Tag("test1")){ conf => error("error #1") }
+  test("1", Tag("test1")){ conf => sys.error("error #1") }
   test("2", Tag("test2")){ conf => () }
   test("3", Tag("test3")){ conf => () }
-  test("4", Tag("test4")){ conf => error("error #4") }
+  test("4", Tag("test4")){ conf => sys.error("error #4") }
 }

--- a/sbt/src/sbt-test/tests/arguments/src/test/scala/ArgumentTest.scala
+++ b/sbt/src/sbt-test/tests/arguments/src/test/scala/ArgumentTest.scala
@@ -7,8 +7,8 @@ class ArgumentTest extends FixtureFunSuite{
   override def withFixture(test: OneArgTest) {
     test(test.configMap)
   }
-  test("1", Tag("test1")){ conf => error("error #1") }
+  test("1", Tag("test1")){ conf => sys.error("error #1") }
   test("2", Tag("test2")){ conf => () }
   test("3", Tag("test3")){ conf => () }
-  test("4", Tag("test4")){ conf => error("error #4") }
+  test("4", Tag("test4")){ conf => sys.error("error #4") }
 }

--- a/sbt/src/sbt-test/tests/junit/changes/Failure.scala
+++ b/sbt/src/sbt-test/tests/junit/changes/Failure.scala
@@ -4,5 +4,5 @@ import org.junit._
 
 class Failure
 {
-	@Test def fail() { error("Fail!") }
+	@Test def fail() { sys.error("Fail!") }
 }

--- a/sbt/src/sbt-test/tests/set-every/build.sbt
+++ b/sbt/src/sbt-test/tests/set-every/build.sbt
@@ -11,6 +11,6 @@ trySetEvery := {
         val aVer = (version in aProj get structure.data).get
         if (aVer != "1.0") {
           println("Version of project a: " + aVer + ", expected: 1.0")
-          error("\"set every\" did not change the version of all projects.")
+          sys.error("\"set every\" did not change the version of all projects.")
         }
 }

--- a/sbt/src/sbt-test/tests/t543/project/Ticket543Test.scala
+++ b/sbt/src/sbt-test/tests/t543/project/Ticket543Test.scala
@@ -30,7 +30,7 @@ object Ticket543Test extends Build {
 		check := {
 			val exists = marker.exists
 			marker.delete()
-			if (!exists) error("Null or invalid error had been returned previously")
+			if (!exists) sys.error("Null or invalid error had been returned previously")
 		}
 	))
 }

--- a/tasks/standard/src/main/scala/sbt/std/Streams.scala
+++ b/tasks/standard/src/main/scala/sbt/std/Streams.scala
@@ -143,7 +143,7 @@ object Streams {
         }
       }
       def checkOpen(): Unit = synchronized {
-        if (closed) error("Streams for '" + name(a) + "' have been closed.")
+        if (closed) sys.error("Streams for '" + name(a) + "' have been closed.")
       }
     }
   }

--- a/tasks/standard/src/main/scala/sbt/std/TaskExtra.scala
+++ b/tasks/standard/src/main/scala/sbt/std/TaskExtra.scala
@@ -188,7 +188,7 @@ object TaskExtra extends TaskExtra {
     }
   def reduced[S](i: IndexedSeq[Task[S]], f: (S, S) => S): Task[S] =
     i match {
-      case Seq()     => error("Cannot reduce empty sequence")
+      case Seq()     => sys.error("Cannot reduce empty sequence")
       case Seq(x)    => x
       case Seq(x, y) => reducePair(x, y, f)
       case z =>

--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -92,7 +92,7 @@ trait Init[Scope] {
    * Only the static dependencies are tracked, however.  Dependencies on previous values do not introduce a derived setting either.
    */
   final def derive[T](s: Setting[T], allowDynamic: Boolean = false, filter: Scope => Boolean = const(true), trigger: AttributeKey[_] => Boolean = const(true), default: Boolean = false): Setting[T] = {
-    deriveAllowed(s, allowDynamic) foreach error
+    deriveAllowed(s, allowDynamic) foreach sys.error
     val d = new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger)
     if (default) d.default() else d
   }
@@ -248,7 +248,7 @@ trait Init[Scope] {
     new Undefined(fakeUndefinedSetting(definingKey, derived), referencedKey)
   private[this] def fakeUndefinedSetting[T](definingKey: ScopedKey[T], d: Boolean): Setting[T] =
     {
-      val init: Initialize[T] = pure(() => error("Dummy setting for compatibility only."))
+      val init: Initialize[T] = pure(() => sys.error("Dummy setting for compatibility only."))
       new Setting(definingKey, init, NoPosition) { override def isDerived = d }
     }
 

--- a/util/complete/src/main/scala/sbt/complete/History.scala
+++ b/util/complete/src/main/scala/sbt/complete/History.scala
@@ -13,7 +13,7 @@ final class History private (val lines: IndexedSeq[String], val path: Option[Fil
   def all: Seq[String] = lines
   def size = lines.length
   def !! : Option[String] = !-(1)
-  def apply(i: Int): Option[String] = if (0 <= i && i < size) Some(lines(i)) else { error("Invalid history index: " + i); None }
+  def apply(i: Int): Option[String] = if (0 <= i && i < size) Some(lines(i)) else { sys.error("Invalid history index: " + i); None }
   def !(i: Int): Option[String] = apply(i)
 
   def !(s: String): Option[String] =
@@ -27,7 +27,7 @@ final class History private (val lines: IndexedSeq[String], val path: Option[Fil
 
   private def nonEmpty[T](s: String)(act: => Option[T]): Option[T] =
     if (s.isEmpty) {
-      error("No action specified to history command")
+      sys.error("No action specified to history command")
       None
     } else
       act
@@ -37,7 +37,7 @@ final class History private (val lines: IndexedSeq[String], val path: Option[Fil
 }
 
 object History {
-  def apply(lines: Seq[String], path: Option[File], error: String => Unit): History = new History(lines.toIndexedSeq, path, error)
+  def apply(lines: Seq[String], path: Option[File], error: String => Unit): History = new History(lines.toIndexedSeq, path, sys.error)
 
   def number(s: String): Option[Int] =
     try { Some(s.toInt) }

--- a/util/logic/src/main/scala/sbt/logic/Logic.scala
+++ b/util/logic/src/main/scala/sbt/logic/Logic.scala
@@ -225,7 +225,7 @@ object Logic {
         if (newlyFalse.nonEmpty)
           newlyFalse
         else // should never happen due to the acyclic negation rule
-          error(s"No progress:\n\tclauses: $clauses\n\tpossibly true: $possiblyTrue")
+          sys.error(s"No progress:\n\tclauses: $clauses\n\tpossibly true: $possiblyTrue")
       }
     }
 

--- a/util/logic/src/test/scala/sbt/logic/Test.scala
+++ b/util/logic/src/test/scala/sbt/logic/Test.scala
@@ -19,7 +19,7 @@ object LogicTest extends Properties("Logic") {
     Logic.reduceAll(badClauses, Set()) match {
       case Right(res)                      => false
       case Left(err: Logic.CyclicNegation) => true
-      case Left(err)                       => error(s"Expected cyclic error, got: $err")
+      case Left(err)                       => sys.error(s"Expected cyclic error, got: $err")
     }
   )
 
@@ -27,7 +27,7 @@ object LogicTest extends Properties("Logic") {
     case Left(err) => false
     case Right(res) =>
       val actual = res.provenSet
-      (actual == expected) || error(s"Expected to prove $expected, but actually proved $actual")
+      (actual == expected) || sys.error(s"Expected to prove $expected, but actually proved $actual")
   }
 }
 

--- a/util/process/src/main/scala/sbt/ProcessImpl.scala
+++ b/util/process/src/main/scala/sbt/ProcessImpl.scala
@@ -131,7 +131,7 @@ private abstract class AbstractProcessBuilder extends ProcessBuilder with SinkPa
     {
       val buffer = new StringBuffer
       val code = this ! BasicIO(buffer, log, withIn)
-      if (code == 0) buffer.toString else error("Nonzero exit value: " + code)
+      if (code == 0) buffer.toString else sys.error("Nonzero exit value: " + code)
     }
   def !! = getString(None, false)
   def !!(log: ProcessLogger) = getString(Some(log), false)
@@ -190,7 +190,7 @@ private abstract class BasicProcess extends Process {
 
 private abstract class CompoundProcess extends BasicProcess {
   def destroy() { destroyer() }
-  def exitValue() = getExitValue().getOrElse(error("No exit code: process destroyed."))
+  def exitValue() = getExitValue().getOrElse(sys.error("No exit code: process destroyed."))
 
   def start() = getExitValue
 
@@ -426,7 +426,7 @@ private object Streamed {
       def next(): Stream[T] =
         q.take match {
           case Left(0)    => Stream.empty
-          case Left(code) => if (nonzeroException) error("Nonzero exit code: " + code) else Stream.empty
+          case Left(code) => if (nonzeroException) sys.error("Nonzero exit code: " + code) else Stream.empty
           case Right(s)   => Stream.cons(s, next)
         }
       new Streamed((s: T) => q.put(Right(s)), code => q.put(Left(code)), () => next())


### PR DESCRIPTION
Enable `-deprecation` flag to catch old code being use when we migrate things.
In this commit I moved error to sys.error.
