### PR TITLE
Remove DefDef and check rhs

### DIFF
--- a/main/src/main/scala/sbt/internals/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtParser.scala
@@ -95,10 +95,9 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
     // Check No val (a,b) = foo *or* val a,b = foo as these are problematic to range positions and the WHOLE architecture.
     def isBadValDef(t: Tree): Boolean =
       t match {
-        case (x @ (toolbox.u.ValDef(_, _, _, _) | toolbox.u.DefDef(_, _, _, _, _, _))) =>
+        case x @ toolbox.u.ValDef(_, _, _, rhs) if rhs != toolbox.u.EmptyTree =>
           val content = modifiedContent.substring(x.pos.start, x.pos.end)
-          val prettyPrint = x.toString
-          (!(content contains "=") && (prettyPrint contains "="))
+          !(content contains "=")
         case _ => false
       }
     parsedTrees.filter(isBadValDef).foreach { badTree =>


### PR DESCRIPTION
#1662
- lhs pattern matching occurs only for vals.
- def also breaks due to proc notation.
- instead of pretty printing, we can just check rhs.
