### PR TITLE
Local ivy repository defined in sbt launcher configuration doesn't respect useOrigin

### DIFF
--- a/launch/src/test/scala/UpdateTest.scala
+++ b/launch/src/test/scala/UpdateTest.scala
@@ -1,0 +1,53 @@
+package xsbt.boot
+
+import xsbti._
+import org.specs2._
+import mutable.Specification
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.resolver.{ FileSystemResolver, URLResolver, AbstractPatternsBasedResolver }
+
+object UpdateTests extends Specification {
+  val configuration = new UpdateConfiguration(new java.io.File("/tmp"), None, "org.scala", None, List.empty[Repository], List.empty[String])
+  val update = new Update(configuration)
+  val ivySettings = new IvySettings()
+
+  val fileResolver = {
+    val resolver = new FileSystemResolver
+    resolver.setName("foo")
+    resolver.addIvyPattern("/tmp/cache/[orgPath]/[module]/[revision]/[module]-[revision].ivy")
+    resolver.addArtifactPattern("/tmp/cache/[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]")
+    resolver
+  }
+
+  val urlResolver = {
+    val resolver = new URLResolver
+    resolver.setName("foo")
+    resolver.addIvyPattern("http://artifactory:8081/release/[orgPath]/[module]/[revision]/[module]-[revision].ivy")
+    resolver.addArtifactPattern("http://artifactory:8081/release/[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]")
+    resolver
+  }
+
+  "Update.toIvyRepository" should {
+    "convert IvyRepository" in {
+      "local file path to FileSystemResolver" in {
+        converstionEquals("file:///tmp/cache", fileResolver)
+        converstionEquals("file:///tmp/cache/", fileResolver)
+      }
+
+      "others to UrlResolver" in {
+        converstionEquals("http://artifactory:8081/release", urlResolver)
+        converstionEquals("http://artifactory:8081/release/", urlResolver)
+      }
+    }
+  }
+
+  def converstionEquals(base: String, expected: AbstractPatternsBasedResolver) = {
+    val repo = Repository.Ivy("foo", new java.net.URL(base), "[orgPath]/[module]/[revision]/[module]-[revision].ivy", "[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]", false)
+    val resolver = update.toIvyRepository(ivySettings, repo)
+
+    resolver.getClass mustEqual expected.getClass
+    resolver.getIvyPatterns mustEqual expected.getIvyPatterns
+    resolver.getArtifactPatterns mustEqual expected.getArtifactPatterns
+  }
+
+}


### PR DESCRIPTION
Sbt sets useOrigin=true for the default ivy cache, however, that does not work for any ivy repository defined in sbt launcher configuration files. This is because ivy's useOrigin only applies to FileSystemResolver, but not URLResolver. 

A patch was proposed, but doesn't seem be taken: http://ant.1045680.n5.nabble.com/PATCH-Ivy-useOrigin-true-support-for-URLResolver-with-file-URLs-td5714566.html

This pull request will create FileSystemResolver if the ivy repository defined in the sbt launcher configuration file is a local file system one.

Also a unit test is added to this. The risk should be minimal.
