### PR TITLE
Events reported by forked tests should be sequence of (String, SuiteResult)

### DIFF
--- a/main/actions/src/main/scala/sbt/ForkTests.scala
+++ b/main/actions/src/main/scala/sbt/ForkTests.scala
@@ -20,7 +20,7 @@ private[sbt] object ForkTests {
 
     val main =
       if (opts.tests.isEmpty)
-        constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
+        constant(TestOutput(TestResult.Passed, mutable.ListBuffer.empty[(String, SuiteResult)], Iterable.empty))
       else
         mainTestTask(runners, opts, classpath, fork, log, config.parallel).tagw(config.tags: _*)
     main.dependsOn(all(opts.setup): _*) flatMap { results =>
@@ -37,8 +37,8 @@ private[sbt] object ForkTests {
       }
 
       object Acceptor extends Runnable {
-        val resultsAcc = mutable.Map.empty[String, SuiteResult]
-        lazy val result = TestOutput(overall(resultsAcc.values.map(_.result)), resultsAcc.toMap, Iterable.empty)
+        val resultsAcc = mutable.ListBuffer.empty[(String, SuiteResult)]
+        lazy val result = TestOutput(overall(resultsAcc.map(_._2.result)), resultsAcc, Iterable.empty)
 
         def run() {
           val socket =
@@ -88,7 +88,7 @@ private[sbt] object ForkTests {
         val ec = Fork.java(fork, options)
         val result =
           if (ec != 0)
-            TestOutput(TestResult.Error, Map("Running java with options " + options.mkString(" ") + " failed with exit code " + ec -> SuiteResult.Error), Iterable.empty)
+            TestOutput(TestResult.Error, mutable.ListBuffer("Running java with options " + options.mkString(" ") + " failed with exit code " + ec -> SuiteResult.Error), Iterable.empty)
           else {
             // Need to wait acceptor thread to finish its business
             acceptorThread.join()
@@ -109,7 +109,7 @@ private[sbt] object ForkTests {
       case _                       => sys.error("Unknown fingerprint type: " + f.getClass)
     }
 }
-private final class React(is: ObjectInputStream, os: ObjectOutputStream, log: Logger, listeners: Seq[TestReportListener], results: mutable.Map[String, SuiteResult]) {
+private final class React(is: ObjectInputStream, os: ObjectOutputStream, log: Logger, listeners: Seq[TestReportListener], results: mutable.Buffer[(String, SuiteResult)]) {
   import ForkTags._
   @annotation.tailrec def react(): Unit = is.readObject match {
     case `Done` =>

--- a/main/actions/src/main/scala/sbt/Tests.scala
+++ b/main/actions/src/main/scala/sbt/Tests.scala
@@ -25,7 +25,7 @@ object Tests {
    * @param events The result of each test group (suite) executed during this test run.
    * @param summaries Explicit summaries directly provided by test frameworks.  This may be empty, in which case a default summary will be generated.
    */
-  final case class Output(overall: TestResult.Value, events: Map[String, SuiteResult], summaries: Iterable[Summary])
+  final case class Output(overall: TestResult.Value, events: Seq[(String, SuiteResult)], summaries: Iterable[Summary])
 
   /**
    * Summarizes a test run.
@@ -246,10 +246,10 @@ object Tests {
     }
 
   def processResults(results: Iterable[(String, SuiteResult)]): Output =
-    Output(overall(results.map(_._2.result)), results.toMap, Iterable.empty)
+    Output(overall(results.map(_._2.result)), results.toSeq, Iterable.empty)
   def foldTasks(results: Seq[Task[Output]], parallel: Boolean): Task[Output] =
     if (results.isEmpty)
-      task { Output(TestResult.Passed, Map.empty, Nil) }
+      task { Output(TestResult.Passed, collection.mutable.ListBuffer.empty, Nil) }
     else if (parallel)
       reduced(results.toIndexedSeq, {
         case (Output(v1, m1, _), Output(v2, m2, _)) => Output(if (v1.id < v2.id) v2 else v1, m1 ++ m2, Iterable.empty)


### PR DESCRIPTION
Currently events reported by forked tests are a `Map[String, SuiteResult]`. With some configurations (in particular, nested suites in ScalaTest), the suite name is the same for all nested suites. Using a Map causes loss of reporting information for all but one tests with the same name.

Changing this to a Seq allows all results to be reported.

This is related to https://github.com/scalatest/scalatest/issues/167
Also related to https://github.com/sbt/sbt/pull/1364
But this fixes the issue when `fork in Test := true`.

Example failure at https://gist.github.com/fiadliel/4071e61b3fd9331a81d4
