### PR TITLE
Fix the run logic so the mainClass setting is actually used when set.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -264,7 +264,7 @@ object Defaults extends BuildCommon {
     definedSbtPlugins <<= discoverPlugins,
     discoveredSbtPlugins <<= discoverSbtPluginNames,
     inTask(run)(runnerTask :: Nil).head,
-    selectMainClass := pickMainClass(discoveredMainClasses.value) orElse askForMainClass(discoveredMainClasses.value),
+    selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
     mainClass in run := (selectMainClass in run).value,
     mainClass := pickMainClassOrWarn(discoveredMainClasses.value, streams.value.log),
     run <<= runTask(fullClasspath, mainClass in run, runner in run),

--- a/sbt/src/sbt-test/run/non-local-main/build.sbt
+++ b/sbt/src/sbt-test/run/non-local-main/build.sbt
@@ -1,0 +1,22 @@
+
+
+lazy val main = project.settings(
+  organization := "org.scala-sbt.testsuite.example",
+  name := "has-main",
+  version := "1.0-SNAPSHOT"
+)
+
+lazy val user = project.settings(
+  fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
+  libraryDependencies += (projectID in main).value,
+  mainClass in Compile := Some("Test")
+)
+
+// NOTE - This will NOT work, as mainClass must be scoped by Compile (and optionally task) to function correctly).
+lazy val user2 = project.settings(
+  fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
+  libraryDependencies += (projectID in main).value,
+  mainClass := Some("Test")
+)
+
+

--- a/sbt/src/sbt-test/run/non-local-main/main/src/main/scala/Test.scala
+++ b/sbt/src/sbt-test/run/non-local-main/main/src/main/scala/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    println("SUCCESS")
+  }
+}

--- a/sbt/src/sbt-test/run/non-local-main/test
+++ b/sbt/src/sbt-test/run/non-local-main/test
@@ -1,0 +1,3 @@
+> main/publishLocal
+> user/run
+-> user2/run


### PR DESCRIPTION
This is one of those super hard to test scenarios where the "main class" being run is a from a different JAR (i.e. we'll never discover one).    More importantly, the run task wasn't using the configured main class due to, what appears to be, a refactoring mixup we didn't catch during code review of the new select-main-class warning.

Review by @eed3si9n cc @fommil
