### PR TITLE
Fixes #1711 and #1704. Cached resolution fixes

### DIFF
--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -87,8 +87,10 @@ private[sbt] class CachedResolutionResolveCache() {
           case rules    => Some(conf + "->(" + (rules map includeRuleString).mkString(",") + ")")
         }
       })
+      val mes = parent.getAllExcludeRules.toVector
+      val mesStr = (mes map excludeRuleString).mkString(",")
       val os = extractOverrides(parent)
-      val moduleLevel = s"""dependencyOverrides=${os.mkString(",")}"""
+      val moduleLevel = s"""dependencyOverrides=${os.mkString(",")};moduleExclusions=$mesStr"""
       val depsString = s"""$mrid;${confMap.mkString(",")};isForce=${dd.isForce};isChanging=${dd.isChanging};isTransitive=${dd.isTransitive};""" +
         s"""exclusions=${exclusions.mkString(",")};inclusions=${inclusions.mkString(",")};$moduleLevel;"""
       val sha1 = Hash.toHex(Hash(depsString))
@@ -101,6 +103,9 @@ private[sbt] class CachedResolutionResolveCache() {
       md1.addDependency(dd)
       os foreach { ovr =>
         md1.addDependencyDescriptorMediator(ovr.moduleId, ovr.pm, ovr.ddm)
+      }
+      mes foreach { exclude =>
+        md1.addExcludeRule(exclude)
       }
       (md1, IvySbt.isChanging(dd))
     }

--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -11,7 +11,7 @@ import org.apache.ivy.core
 import core.resolve._
 import core.module.id.{ ModuleRevisionId, ModuleId => IvyModuleId }
 import core.report.{ ResolveReport, ConfigurationResolveReport, DownloadReport }
-import core.module.descriptor.{ DefaultModuleDescriptor, ModuleDescriptor, DependencyDescriptor, Configuration => IvyConfiguration, ExcludeRule, IncludeRule }
+import core.module.descriptor.{ DefaultModuleDescriptor, ModuleDescriptor, DefaultDependencyDescriptor, DependencyDescriptor, Configuration => IvyConfiguration, ExcludeRule, IncludeRule }
 import core.module.descriptor.OverrideDependencyDescriptorMediator
 import core.{ IvyPatternHelper, LogOptions }
 import org.apache.ivy.util.Message
@@ -29,42 +29,85 @@ private[sbt] class CachedResolutionResolveCache() {
   val updateReportCache: concurrent.Map[ModuleRevisionId, Either[ResolveException, UpdateReport]] = concurrent.TrieMap()
   val resolveReportCache: concurrent.Map[ModuleRevisionId, ResolveReport] = concurrent.TrieMap()
   val resolvePropertiesCache: concurrent.Map[ModuleRevisionId, String] = concurrent.TrieMap()
-  val directDependencyCache: concurrent.Map[ModuleRevisionId, Vector[DependencyDescriptor]] = concurrent.TrieMap()
   val conflictCache: concurrent.Map[(ModuleID, ModuleID), (Vector[ModuleID], Vector[ModuleID], String)] = concurrent.TrieMap()
   val maxConflictCacheSize: Int = 10000
 
   def clean(md0: ModuleDescriptor, prOpt: Option[ProjectResolver]): Unit = {
-    val mrid0 = md0.getModuleRevisionId
-    val mds =
-      if (mrid0.getOrganisation == sbtOrgTemp) Vector(md0)
-      else buildArtificialModuleDescriptors(md0, prOpt) map { _._1 }
-
-    updateReportCache.remove(md0.getModuleRevisionId)
-    directDependencyCache.remove(md0.getModuleRevisionId)
-    mds foreach { md =>
-      updateReportCache.remove(md.getModuleRevisionId)
-      directDependencyCache.remove(md.getModuleRevisionId)
-    }
+    updateReportCache.clear
   }
   def directDependencies(md0: ModuleDescriptor): Vector[DependencyDescriptor] =
-    directDependencyCache.getOrElseUpdate(md0.getModuleRevisionId, md0.getDependencies.toVector)
-
-  def buildArtificialModuleDescriptors(md0: ModuleDescriptor, prOpt: Option[ProjectResolver]): Vector[(DefaultModuleDescriptor, Boolean)] =
+    md0.getDependencies.toVector
+  def buildArtificialModuleDescriptors(md0: ModuleDescriptor, data: ResolveData, prOpt: Option[ProjectResolver]): Vector[(DefaultModuleDescriptor, Boolean)] =
     {
-      def expandInternalDeps(dep: DependencyDescriptor): Vector[DependencyDescriptor] =
-        prOpt map {
-          _.getModuleDescriptor(dep.getDependencyRevisionId) match {
-            case Some(internal) => directDependencies(internal) filter { dd =>
-              !dd.getDependencyConfigurations("compile").isEmpty
-            } flatMap expandInternalDeps
-            case _ => Vector(dep)
-          }
-        } getOrElse Vector(dep)
-      val expanded = directDependencies(md0) flatMap expandInternalDeps
-      val rootModuleConfigs = md0.getConfigurations.toVector
+      val rootModuleConfigs = md0.getConfigurations.toArray.toVector
+      val expanded = expandInternalDependencies(md0, data, prOpt)
       expanded map { buildArtificialModuleDescriptor(_, rootModuleConfigs, md0, prOpt) }
     }
-
+  // This expands out all internal dependencies and merge them into a single graph that consists
+  // only of external dependencies.
+  // The tricky part is the merger of configurations, even though in most cases we will only see compile->compile when it comes to internal deps.
+  // Theoretically, there could be a potential for test->test->runtime kind of situation. nextConfMap and remapConfigurations track
+  // the configuration chains transitively.
+  def expandInternalDependencies(md0: ModuleDescriptor, data: ResolveData, prOpt: Option[ProjectResolver]): Vector[DependencyDescriptor] =
+    {
+      val rootModuleConfigs = md0.getConfigurations.toArray.toVector
+      val rootNode = new IvyNode(data, md0)
+      def expandInternalDeps(dep: DependencyDescriptor, confMap: Map[String, Array[String]]): Vector[DependencyDescriptor] =
+        internalDependency(dep) match {
+          case Some(internal) =>
+            val allConfigurations: Vector[String] =
+              (if (confMap.isEmpty) nextConfMap(dep, confMap)
+              else confMap).values.flatten.toList.distinct.toVector
+            directDependencies(internal) filter { dd =>
+              allConfigurations exists { conf => !dd.getDependencyConfigurations(conf).isEmpty }
+            } flatMap { dd => expandInternalDeps(dd, nextConfMap(dd, confMap)) }
+          case _ =>
+            if (confMap.isEmpty) Vector(dep)
+            else Vector(remapConfigurations(dep, confMap))
+        }
+      def internalDependency(dep: DependencyDescriptor): Option[ModuleDescriptor] =
+        prOpt match {
+          case Some(pr) => pr.getModuleDescriptor(dep.getDependencyRevisionId)
+          case _        => None
+        }
+      // This creates confMap. The key of the map is rootModuleConf for md0, the value is the dependency configs for dd.
+      def nextConfMap(dd: DependencyDescriptor, previous: Map[String, Array[String]]): Map[String, Array[String]] =
+        if (previous.isEmpty) {
+          ListMap(dd.getModuleConfigurations.toList map { conf =>
+            conf -> (dd.getDependencyConfigurations(conf) flatMap { confName =>
+              if (confName == "*") Array(confName)
+              else rootNode.getRealConfs(confName)
+            })
+          }: _*)
+        } else previous map {
+          case (rootModuleConf, vs) =>
+            rootModuleConf -> (vs flatMap { conf =>
+              dd.getDependencyConfigurations(conf) flatMap { confName =>
+                if (confName == "*") Array(confName)
+                else rootNode.getRealConfs(confName)
+              }
+            })
+        }
+      def remapConfigurations(dd0: DependencyDescriptor, confMap: Map[String, Array[String]]): DependencyDescriptor =
+        {
+          val dd = new DefaultDependencyDescriptor(md0, dd0.getDependencyRevisionId, dd0.getDynamicConstraintDependencyRevisionId,
+            dd0.isForce, dd0.isChanging, dd0.isTransitive)
+          for {
+            moduleConf <- dd0.getModuleConfigurations
+            (rootModuleConf, vs) <- confMap
+          } if (vs contains moduleConf) {
+            // moduleConf in dd0 maps to rootModuleConf in dd
+            dd0.getDependencyConfigurations(moduleConf) foreach { conf =>
+              dd.addDependencyConfiguration(rootModuleConf, conf)
+            }
+            dd0.getExcludeRules(moduleConf) foreach { rule =>
+              dd.addExcludeRule(rootModuleConf, rule)
+            }
+          }
+          dd
+        }
+      directDependencies(md0) flatMap { dep => expandInternalDeps(dep, Map()) }
+    }
   def buildArtificialModuleDescriptor(dd: DependencyDescriptor, rootModuleConfigs: Vector[IvyConfiguration], parent: ModuleDescriptor, prOpt: Option[ProjectResolver]): (DefaultModuleDescriptor, Boolean) =
     {
       def excludeRuleString(rule: ExcludeRule): String =
@@ -235,9 +278,10 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
     val miniGraphPath = depDir / "module"
     val cachedDescriptor = getSettings.getResolutionCacheManager.getResolvedIvyFileInCache(md0.getModuleRevisionId)
     val cache = cachedResolutionResolveCache
-    cache.directDependencyCache.remove(md0.getModuleRevisionId)
     val os = cache.extractOverrides(md0)
-    val mds = cache.buildArtificialModuleDescriptors(md0, projectResolver)
+    val options1 = new ResolveOptions(options0)
+    val data = new ResolveData(this, options1)
+    val mds = cache.buildArtificialModuleDescriptors(md0, data, projectResolver)
     def doWork(md: ModuleDescriptor): Either[ResolveException, UpdateReport] =
       {
         val options1 = new ResolveOptions(options0)

--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -54,8 +54,10 @@ private[sbt] class CachedResolutionResolveCache() {
       def expandInternalDeps(dep: DependencyDescriptor): Vector[DependencyDescriptor] =
         prOpt map {
           _.getModuleDescriptor(dep.getDependencyRevisionId) match {
-            case Some(internal) => directDependencies(internal) flatMap expandInternalDeps
-            case _              => Vector(dep)
+            case Some(internal) => directDependencies(internal) filter { dd =>
+              !dd.getDependencyConfigurations("compile").isEmpty
+            } flatMap expandInternalDeps
+            case _ => Vector(dep)
           }
         } getOrElse Vector(dep)
       val expanded = directDependencies(md0) flatMap expandInternalDeps

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-exclude/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-exclude/multi.sbt
@@ -17,7 +17,11 @@ def cachedResolutionSettings: Seq[Def.Setting[_]] =
 lazy val a = project.
   settings(cachedResolutionSettings: _*).
   settings(
-    libraryDependencies += "net.databinder" %% "unfiltered-uploads" % "0.8.0" exclude("commons-io", "commons-io")
+    libraryDependencies += "net.databinder" %% "unfiltered-uploads" % "0.8.0" exclude("commons-io", "commons-io"),
+    ivyXML :=
+      <dependencies>
+        <exclude module="commons-codec"/>
+      </dependencies>
   )
 
 lazy val b = project.
@@ -32,12 +36,15 @@ lazy val root = (project in file(".")).
     organization in ThisBuild := "org.example",
     version in ThisBuild := "1.0",
     check := {
-      // sys.error(dependencyCacheDirectory.value.toString)
       val acp = (externalDependencyClasspath in Compile in a).value.sortBy {_.data.getName}
       val bcp = (externalDependencyClasspath in Compile in b).value.sortBy {_.data.getName}
       if (acp exists { _.data.getName contains "commons-io" }) {
         sys.error("commons-io found when it should be excluded")
       }
+      if (acp exists { _.data.getName contains "commons-codec" }) {
+        sys.error("commons-codec found when it should be excluded")
+      }
+      // This is checking to make sure excluded graph is not getting picked up
       if (!(bcp exists { _.data.getName contains "commons-io" })) {
         sys.error("commons-io NOT found when it should NOT be excluded")
       }

--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -85,7 +85,6 @@ trait Init[Scope] {
    */
   private[sbt] final def validated[T](key: ScopedKey[T], selfRefOk: Boolean): ValidationCapture[T] = new ValidationCapture(key, selfRefOk)
 
-
   @deprecated("0.13.7", "Use the version with default arguments and default paramter.")
   final def derive[T](s: Setting[T], allowDynamic: Boolean, filter: Scope => Boolean, trigger: AttributeKey[_] => Boolean): Setting[T] =
     derive(s, allowDynamic, filter, trigger, false)


### PR DESCRIPTION
## fix for #1711

Cached resolution flattens external dependencies coming from subproject dependencies.
That process needs to ignore non-compile configurations, otherwise I'd end up with test dependencies from subprojects.
## fix for #1704

Exclude rules at the project level (using `ivyXML`) are now ported over to artificial graph so it's respected.
