### PR TITLE
Fix sbinary cache limit when caching doc inputs

### DIFF
--- a/main/actions/src/main/scala/sbt/RawCompileLike.scala
+++ b/main/actions/src/main/scala/sbt/RawCompileLike.scala
@@ -38,8 +38,8 @@ object RawCompileLike {
   def cached(cache: File, doCompile: Gen): Gen = cached(cache, Seq(), doCompile)
   def cached(cache: File, fileInputOpts: Seq[String], doCompile: Gen): Gen = (sources, classpath, outputDirectory, options, maxErrors, log) =>
     {
-      type Inputs = FilesInfo[HashFileInfo] :+: FilesInfo[ModifiedFileInfo] :+: String :+: File :+: Seq[String] :+: Int :+: HNil
-      val inputs: Inputs = hash(sources.toSet ++ optionFiles(options, fileInputOpts)) :+: lastModified(classpath.toSet) :+: classpath.absString :+: outputDirectory :+: options :+: maxErrors :+: HNil
+      type Inputs = FilesInfo[HashFileInfo] :+: FilesInfo[ModifiedFileInfo] :+: Seq[File] :+: File :+: Seq[String] :+: Int :+: HNil
+      val inputs: Inputs = hash(sources.toSet ++ optionFiles(options, fileInputOpts)) :+: lastModified(classpath.toSet) :+: classpath :+: outputDirectory :+: options :+: maxErrors :+: HNil
       implicit val stringEquiv: Equiv[String] = defaultEquiv
       implicit val fileEquiv: Equiv[File] = defaultEquiv
       implicit val intEquiv: Equiv[Int] = defaultEquiv


### PR DESCRIPTION
Cache the classpath as Seq[File] rather than String in RawCompileLike. Fixes #1614.

I've based this PR on 0.13.7 branch. Let me know if it should be targeted at a different branch.

Have tried it with the Play aggregated docs and it looks good there.
