### PR TITLE
ignore hidden build files from the build.

### DIFF
--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -723,8 +723,8 @@ object Load {
     // Finds all the build files associated with this project
     import AddSettings.{ User, SbtFiles, DefaultSbtFiles, Plugins, AutoPlugins, Sequence, BuildScalaFiles }
     def associatedFiles(auto: AddSettings): Seq[File] = auto match {
-      case sf: SbtFiles        => sf.files.map(f => IO.resolve(projectBase, f))
-      case sf: DefaultSbtFiles => defaultSbtFiles.filter(sf.include)
+      case sf: SbtFiles        => sf.files.map(f => IO.resolve(projectBase, f)).filterNot(_.isHidden)
+      case sf: DefaultSbtFiles => defaultSbtFiles.filter(sf.include).filterNot(_.isHidden)
       case q: Sequence         => (Seq.empty[File] /: q.sequence) { (b, add) => b ++ associatedFiles(add) }
       case _                   => Seq.empty
     }

--- a/notes/0.13.8.markdown
+++ b/notes/0.13.8.markdown
@@ -1,10 +1,12 @@
 [@jsuereth]: https://github.com/jsuereth
 [@kretes]: https://github.com/kretes
+[@j-keck]: https://github.com/j-keck
 [1180]: https://github.com/sbt/sbt/issues/1180
 [1180]: https://github.com/sbt/sbt/pull/1702
 [875]: https://github.com/sbt/sbt/issues/875
 [1542]: https://github.com/sbt/sbt/issues/1542
 [1702]: https://github.com/sbt/sbt/pull/1702
+[1746]: https://github.com/sbt/sbt/pull/1746
 
 ### Improvements
 
@@ -15,3 +17,4 @@
 
 - Javac warnings now always treated as warnings.  [#1702][1702]/[#875][875] by [@jsuereth][jsuereth]
 - compilerReporter now fed to javac during incremental compilation. [#1542][1542] by [@jsuereth][jsuereth]
+- ignore hidden build files from the build. [#1746][1746] by [@j-keck][@j-keck]

--- a/sbt/src/sbt-test/project/ignore-hidden-build-files/changes/invalid-build.sbt
+++ b/sbt/src/sbt-test/project/ignore-hidden-build-files/changes/invalid-build.sbt
@@ -1,0 +1,1 @@
+invalid build file content

--- a/sbt/src/sbt-test/project/ignore-hidden-build-files/test
+++ b/sbt/src/sbt-test/project/ignore-hidden-build-files/test
@@ -1,0 +1,6 @@
+# create a invalid .build.sbt file 
+#   - note the dot - it's a hidden file
+$ copy-file changes/invalid-build.sbt .build.sbt
+
+# trigger a reload - sbt should ignore the hidden build file
+> reload


### PR DESCRIPTION
sbt processes also hidden build files, which can be problematic:

https://groups.google.com/forum/#!topic/sbt-dev/MpaSiCcAHO4

---

this patch filters hidden build files when the project are loaded (in Load.discoverProjects)
