### PR TITLE
Check for null type trees in dependency extraction

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Dependency.scala
+++ b/compile/interface/src/main/scala/xsbt/Dependency.scala
@@ -137,7 +137,9 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile {
          */
         case ident: Ident =>
           addDependency(ident.symbol)
-        case typeTree: TypeTree =>
+        // In some cases (eg. macro annotations), `typeTree.tpe` may be null.
+        // See sbt/sbt#1593 and sbt/sbt#1655.
+        case typeTree: TypeTree if typeTree.tpe != null =>
           val typeSymbolCollector = new CollectTypeTraverser({
             case tpe if !tpe.typeSymbol.isPackage => tpe.typeSymbol
           })

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/core/src/main/scala/Test.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/core/src/main/scala/Test.scala
@@ -1,0 +1,6 @@
+@hello
+case class Test(x: Int)
+
+object Main extends App {
+  Test(3).hello
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/macros/src/main/scala/Macros.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/macros/src/main/scala/Macros.scala
@@ -1,0 +1,26 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object HelloMacro {
+  def impl(c: Context)(annottees: c.Tree*): c.Tree = {
+    import c.universe._
+
+    annottees match {
+      case (classDecl: ClassDef) :: Nil =>
+        val q"$mods class $name[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$bases { $self => ..$body }" = classDecl
+        q"""
+        case class $name(...$paramss) extends ..$bases {
+          ..$body
+          def hello = "Hello"
+        }
+        """
+
+      case _ => c.abort(c.enclosingPosition, "Invalid annottee")
+    }
+  }
+}
+
+class hello extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro HelloMacro.impl
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/project/Build.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/project/Build.scala
@@ -1,0 +1,45 @@
+import sbt._
+import Keys._
+
+object BuildSettings {
+  val paradiseVersion = "2.0.1"
+  val buildSettings = Defaults.defaultSettings ++ Seq(
+    version := "1.0.0",
+    scalacOptions ++= Seq(""),
+    scalaVersion := "2.11.4",
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    resolvers += Resolver.sonatypeRepo("releases"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full),
+    incOptions := incOptions.value.withNameHashing(true)
+  )
+}
+
+object MyBuild extends Build {
+  import BuildSettings._
+
+  lazy val root: Project = Project(
+    "root",
+    file("."),
+    settings = buildSettings ++ Seq(
+      run <<= run in Compile in core
+    )
+  ) aggregate(macros, core)
+
+  lazy val macros: Project = Project(
+    "macros",
+    file("macros"),
+    settings = buildSettings ++ Seq(
+      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
+      libraryDependencies ++= (
+        if (scalaVersion.value.startsWith("2.10")) List("org.scalamacros" %% "quasiquotes" % paradiseVersion)
+        else Nil
+      )
+    )
+  )
+
+  lazy val core: Project = Project(
+    "core",
+    file("core"),
+    settings = buildSettings
+  ) dependsOn(macros)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/test
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/test
@@ -1,0 +1,4 @@
+# The goal of this test is just to make sure that sbt does
+# not crash when it encounters a macro annotation
+# See #1655 and #1593
+> compile


### PR DESCRIPTION
In some cases the dependency extraction may encounter a null `TypeTree`
(eg. arguments of macro annotations that are untyped). In such cases,
we simply ignore the node.

This solves all the crashes that I've been able to reproduce (https://github.com/sbt/sbt/issues/1655#issue-45323426, julianpeeters/avro-scala-macro-annotations#4, [Duhemm/macro-annotation](https://github.com/Duhemm/macro-annotation))

/cc @xeno-by @dragos

Fixes #1655 
