### PR TITLE
Cached resolution is too verbose

### DIFF
--- a/notes/0.13.8/cached-resolution-fixes.markdown
+++ b/notes/0.13.8/cached-resolution-fixes.markdown
@@ -1,0 +1,13 @@
+  [@cunei]: https://github.com/cunei
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@gkossakowski]: https://github.com/gkossakowski
+  [@jsuereth]: https://github.com/jsuereth
+  [1752]: https://github.com/sbt/sbt/pull/1752
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes cached resolution being too verbose. [#1752][1752]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
The cached resolution is really great, but it's way too verbose. I'm not including the output here, I can do that if needed.

It would be great, if by default the output would be comparable to the non-cached resolution (in terms of logged lines).

Is there a workaround, can I set the logLevel for the resolution to Warn? I already tried "logLevel in update := Level.Warn", but this didn't do the trick (while "logLevel := Level.Warn" worked, which is not what I want).
