### PR TITLE
Fix logger not overwriting the previous line in alternate shells

### DIFF
--- a/util/log/src/main/scala/sbt/ConsoleOut.scala
+++ b/util/log/src/main/scala/sbt/ConsoleOut.scala
@@ -16,7 +16,7 @@ object ConsoleOut {
     cur.contains(s) && prev.contains(s)
 
   /** Move to beginning of previous line and clear the line. */
-  private[this] final val OverwriteLine = "\r\u001BM\u001B[2K"
+  private[this] final val OverwriteLine = "\u001B[A\r\u001B[2K"
 
   /**
    * ConsoleOut instance that is backed by System.out.  It overwrites the previously printed line


### PR DESCRIPTION
When running the 'update' task in bash, the output is all collapsed onto one line.
On Windows, even using an ANSI capable shell, running 'update' spams the console.

Tested with dash in Ubuntu; ANSICON, Console2 and ConsoleZ in Windows.
