### PR TITLE
0.13.6 eviction notices too noisy

### DIFF
--- a/ivy/src/main/scala/sbt/EvictionWarning.scala
+++ b/ivy/src/main/scala/sbt/EvictionWarning.scala
@@ -41,6 +41,8 @@ final class EvictionWarningOptions private[sbt] (
 }
 
 object EvictionWarningOptions {
+  def empty: EvictionWarningOptions =
+    new EvictionWarningOptions(Vector(), false, false, false, false, defaultGuess)
   def default: EvictionWarningOptions =
     new EvictionWarningOptions(Vector(Compile), true, true, false, false, defaultGuess)
   def full: EvictionWarningOptions =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1337,7 +1337,7 @@ object Classpaths {
       case Some(x) if uc0.logging == Default => uc0.copy(logging = DownloadOnly)
       case _ => uc0
     }
-    cachedUpdate(s.cacheDirectory / updateCacheName.value, show, ivyModule.value, uc0, transform,
+    cachedUpdate(s.cacheDirectory / updateCacheName.value, show, ivyModule.value, uc, transform,
       skip = (skip in update).value, force = isRoot, depsUpdated = depsUpdated,
       uwConfig = uwConfig, logicalClock = logicalClock, depDir = Some(depDir), log = s.log)
   }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1163,6 +1163,7 @@ object Classpaths {
       val log = streams.value.log
       val ew = EvictionWarning(ivyModule.value, (evictionWarningOptions in evicted).value, report, log)
       ew.lines foreach { log.warn(_) }
+      ew.infoAllTheThings foreach { log.info(_) }
       ew
     },
     classifiersModule in updateClassifiers := {
@@ -1367,6 +1368,7 @@ object Classpaths {
           val result = transform(r)
           val ew = EvictionWarning(module, ewo, result, log)
           ew.lines foreach { log.warn(_) }
+          ew.infoAllTheThings foreach { log.info(_) }
           result
       }
       def uptodate(inChanged: Boolean, out: UpdateReport): Boolean =

--- a/notes/0.13.8/eviction-warning-fix.markdown
+++ b/notes/0.13.8/eviction-warning-fix.markdown
@@ -1,0 +1,13 @@
+  [@cunei]: https://github.com/cunei
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@gkossakowski]: https://github.com/gkossakowski
+  [@jsuereth]: https://github.com/jsuereth
+  [1615]: https://github.com/sbt/sbt/issues/1615
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes eviction warning being too noisy. [#1615][1615] by [@eed3si9n][@eed3si9n]

--- a/notes/0.13.8/eviction-warning-fix.markdown
+++ b/notes/0.13.8/eviction-warning-fix.markdown
@@ -8,6 +8,8 @@
 
 ### Improvements
 
+- `evicted` will display all evictions (including the ones not suspected of binary incompatibility). [#1615][1615] by [@eed3si9n][@eed3si9n]
+
 ### Bug fixes
 
 - Fixes eviction warning being too noisy. [#1615][1615] by [@eed3si9n][@eed3si9n]


### PR DESCRIPTION
It's pretty cool that SBT now lets me know of evictions. The problem with it is that it warns so often; I think we need a way to say _I'm aware of eviction X, please don't bug me about it_.

Example, this is what `~compile` looks like now for me.

```
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:18:43 PM
1. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:01 PM
2. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:04 PM
3. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:06 PM
4. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:08 PM
5. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:10 PM
6. Waiting for source changes... (press enter to interrupt)
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.github.japgolly.fork.scalaz:scalaz-effect_sjs0.5_2.11:7.1.0-2 -> 7.1.0-3
[warn] Run 'evicted' to see detailed eviction warnings
[success] Total time: 0 s, completed 24/09/2014 5:19:13 PM
7. Waiting for source changes... (press enter to interrupt)
```
