### PR TITLE
Lots of "No main class detected" warnings since 0.13.7

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -676,7 +676,6 @@ object Defaults extends BuildCommon {
     sbt.SelectMainClass(None, classes)
   private def pickMainClassOrWarn(classes: Seq[String], logger: Logger): Option[String] = {
     classes match {
-      case Nil                           => logger.warn("No main class detected")
       case multiple if multiple.size > 1 => logger.warn("Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list")
       case _                             =>
     }

--- a/notes/0.13.8/no-mainclass.markdown
+++ b/notes/0.13.8/no-mainclass.markdown
@@ -1,0 +1,13 @@
+  [@cunei]: https://github.com/cunei
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@gkossakowski]: https://github.com/gkossakowski
+  [@jsuereth]: https://github.com/jsuereth
+  [1766]: https://github.com/sbt/sbt/pull/1766
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Removes "No main class detected" warning. [#1766][1766] by [@eed3si9n][@eed3si9n]


### PR DESCRIPTION
In 0.13.7 a new feature was added - a check that a project has a main class. However, not every project needs one: for example, our build consists of a few dozens of projects, only several of which are runnable. Consequently SBT prints

```
[warn] No main class detected
```

for _every_ project in the build which does not have a main class (and there is a majority of them).

Discussed [here](https://groups.google.com/forum/#!topic/sbt-dev/-5zD6fbHcHc)
