### PR TITLE
A library is missing from dependencyClasspath if it's added to libraryDependencies twice in ascending order

### DIFF
--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -166,6 +166,8 @@ object IvyActions {
       case (ivy, md, default) if module.owner.configuration.updateOptions.cachedResolution && depDir.isDefined =>
         ivy.getResolveEngine match {
           case x: CachedResolutionResolveEngine =>
+            val iw = IvySbt.inconsistentDuplicateWarning(md)
+            iw foreach { log.warn(_) }
             val resolveOptions = new ResolveOptions
             val resolveId = ResolveOptions.getDefaultResolveId(md)
             resolveOptions.setResolveId(resolveId)
@@ -181,6 +183,8 @@ object IvyActions {
             }
         }
       case (ivy, md, default) =>
+        val iw = IvySbt.inconsistentDuplicateWarning(md)
+        iw foreach { log.warn(_) }
         val (report, err) = resolve(configuration.logging)(ivy, md, default)
         err match {
           case Some(x) if !configuration.missingOk =>

--- a/ivy/src/test/scala/InconsistentDuplicateSpec.scala
+++ b/ivy/src/test/scala/InconsistentDuplicateSpec.scala
@@ -1,0 +1,28 @@
+package sbt
+
+import org.specs2._
+
+class InconsistentDuplicateSpec extends Specification {
+  def is = s2"""
+
+  This is a specification to check the inconsistent duplicate warnings
+
+  Duplicate with different version should
+    be warned                                                   $warn1
+
+  Duplicate with same version should
+    not be warned                                               $nodupe1
+                                                                """
+
+  def akkaActor214 = ModuleID("com.typesafe.akka", "akka-actor", "2.1.4", Some("compile")) cross CrossVersion.binary
+  def akkaActor230 = ModuleID("com.typesafe.akka", "akka-actor", "2.3.0", Some("compile")) cross CrossVersion.binary
+  def akkaActor230Test = ModuleID("com.typesafe.akka", "akka-actor", "2.3.0", Some("test")) cross CrossVersion.binary
+
+  def warn1 =
+    IvySbt.inconsistentDuplicateWarning(Seq(akkaActor214, akkaActor230)) must_==
+      List("Multiple dependencies with the same organization/name but different versions. To avoid conflict, pick one version:",
+        " * com.typesafe.akka:akka-actor:(2.1.4, 2.3.0)")
+
+  def nodupe1 =
+    IvySbt.inconsistentDuplicateWarning(Seq(akkaActor230Test, akkaActor230)) must_== Nil
+}

--- a/notes/0.13.8/inconsistent-duplicates.markdown
+++ b/notes/0.13.8/inconsistent-duplicates.markdown
@@ -1,0 +1,13 @@
+  [@cunei]: https://github.com/cunei
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@gkossakowski]: https://github.com/gkossakowski
+  [@jsuereth]: https://github.com/jsuereth
+  [1634]: https://github.com/sbt/sbt/pull/1634
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Issues warning if multiple dependencies to a same library is found with different version. [#1634][1634] by [@eed3si9n][@eed3si9n]


### PR DESCRIPTION
For example, if different versions of scalatest are added in ascending order, then it's not included in dependencyClasspath.

```
libraryDependencies ++= Seq(
  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
  "org.scalatest" %% "scalatest" % "2.2.2" % "test"
)
```

```
> show test:dependencyClasspath
[info] Updating {file:/Users/kawachi/tmp/xxxxx/}xxxxx...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] List(Attributed(/Users/kawachi/tmp/xxxxx/target/scala-2.10/classes), Attributed(/Users/kawachi/.sbt/boot/scala-2.10.4/lib/scala-library.jar), Attributed(/Users/kawachi/.sbt/boot/scala-2.10.4/lib/scala-reflect.jar))
```

When it is added in descending order, the newer is in dependencyClasspath.

Ref. https://groups.google.com/d/msg/sbt-dev/K7ji0gLOvV8/mr8a2Z3jszAJ
