### PR TITLE
Macrotracker support

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/IncrementalNameHashing.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncrementalNameHashing.scala
@@ -45,6 +45,12 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     val transitiveInheritance = byExternalInheritance flatMap { file =>
       invalidateByInheritance(relations, file)
     }
+    val externalMacroExpansionR = relations.macroExpansion.external
+    val byExternalMacroExpansion = externalMacroExpansionR.reverse(modified)
+    log.debug(s"Files invalidated by macro expansion from (external) $modified: $byExternalMacroExpansion; now invalidating by macro expansion (internally).")
+    val transitiveMacroExpansion = byExternalMacroExpansion flatMap { file =>
+      invalidateByMacroExpansion(relations, file)
+    }
     val memberRefInvalidationInternal = memberRefInvalidator.get(relations.memberRef.internal,
       relations.names, externalAPIChange)
     val memberRefInvalidationExternal = memberRefInvalidator.get(relations.memberRef.external,
@@ -57,7 +63,7 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     // This includes non-inheritance dependencies and is not transitive.
     log.debug(s"Getting sources that directly depend on (external) $modified.")
     val memberRefB = memberRefInvalidationExternal(modified)
-    transitiveInheritance ++ memberRefA ++ memberRefB
+    transitiveInheritance ++ transitiveMacroExpansion ++ memberRefA ++ memberRefB
   }
 
   private def invalidateByInheritance(relations: Relations, modified: File): Set[File] = {
@@ -68,19 +74,28 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     transitiveInheritance
   }
 
+  private def invalidateByMacroExpansion(relations: Relations, modified: File): Set[File] = {
+    val macroExpansionDeps = relations.macroExpansion.internal.reverse _
+    log.debug(s"Invalidating (transitively) by macro expansion from $modified...")
+    val transitiveByMacroExpansion = transitiveDeps(Set(modified))(macroExpansionDeps)
+    log.debug("Invalidated by transitive macro expansion dependency: " + transitiveByMacroExpansion)
+    transitiveByMacroExpansion
+  }
+
   override protected def invalidateSource(relations: Relations, change: APIChange[File]): Set[File] = {
     log.debug(s"Invalidating ${change.modified}...")
     val transitiveInheritance = invalidateByInheritance(relations, change.modified)
+    val transitiveByMacroExpansion = invalidateByMacroExpansion(relations, change.modified)
     val reasonForInvalidation = memberRefInvalidator.invalidationReason(change)
     log.debug(s"$reasonForInvalidation\nAll member reference dependencies will be considered within this context.")
     val memberRefInvalidation = memberRefInvalidator.get(relations.memberRef.internal,
       relations.names, change)
     val memberRef = transitiveInheritance flatMap memberRefInvalidation
-    val all = transitiveInheritance ++ memberRef
+    val all = transitiveInheritance ++ transitiveByMacroExpansion ++ memberRef
     all
   }
 
   override protected def allDeps(relations: Relations): File => Set[File] =
-    f => relations.memberRef.internal.reverse(f)
+    f => relations.memberRef.internal.reverse(f) ++ relations.macroExpansion.internal.reverse(f)
 
 }

--- a/compile/inc/src/main/scala/sbt/inc/IncrementalNameHashing.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncrementalNameHashing.scala
@@ -47,10 +47,7 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     }
     val externalMacroExpansionR = relations.macroExpansion.external
     val byExternalMacroExpansion = externalMacroExpansionR.reverse(modified)
-    log.debug(s"Files invalidated by macro expansion from (external) $modified: $byExternalMacroExpansion; now invalidating by macro expansion (internally).")
-    val transitiveMacroExpansion = byExternalMacroExpansion flatMap { file =>
-      invalidateByMacroExpansion(relations, file)
-    }
+    log.debug(s"Files invalidated by macro expansion from (external) $modified: $byExternalMacroExpansion.")
     val memberRefInvalidationInternal = memberRefInvalidator.get(relations.memberRef.internal,
       relations.names, externalAPIChange)
     val memberRefInvalidationExternal = memberRefInvalidator.get(relations.memberRef.external,
@@ -63,7 +60,7 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     // This includes non-inheritance dependencies and is not transitive.
     log.debug(s"Getting sources that directly depend on (external) $modified.")
     val memberRefB = memberRefInvalidationExternal(modified)
-    transitiveInheritance ++ transitiveMacroExpansion ++ memberRefA ++ memberRefB
+    transitiveInheritance ++ byExternalMacroExpansion ++ memberRefA ++ memberRefB
   }
 
   private def invalidateByInheritance(relations: Relations, modified: File): Set[File] = {
@@ -74,24 +71,16 @@ private final class IncrementalNameHashing(log: Logger, options: IncOptions) ext
     transitiveInheritance
   }
 
-  private def invalidateByMacroExpansion(relations: Relations, modified: File): Set[File] = {
-    val macroExpansionDeps = relations.macroExpansion.internal.reverse _
-    log.debug(s"Invalidating (transitively) by macro expansion from $modified...")
-    val transitiveByMacroExpansion = transitiveDeps(Set(modified))(macroExpansionDeps)
-    log.debug("Invalidated by transitive macro expansion dependency: " + transitiveByMacroExpansion)
-    transitiveByMacroExpansion
-  }
-
   override protected def invalidateSource(relations: Relations, change: APIChange[File]): Set[File] = {
     log.debug(s"Invalidating ${change.modified}...")
     val transitiveInheritance = invalidateByInheritance(relations, change.modified)
-    val transitiveByMacroExpansion = invalidateByMacroExpansion(relations, change.modified)
+    val byMacroExpansion = relations.macroExpansion.internal.reverse(change.modified)
     val reasonForInvalidation = memberRefInvalidator.invalidationReason(change)
     log.debug(s"$reasonForInvalidation\nAll member reference dependencies will be considered within this context.")
     val memberRefInvalidation = memberRefInvalidator.get(relations.memberRef.internal,
       relations.names, change)
     val memberRef = transitiveInheritance flatMap memberRefInvalidation
-    val all = transitiveInheritance ++ transitiveByMacroExpansion ++ memberRef
+    val all = transitiveInheritance ++ byMacroExpansion ++ memberRef
     all
   }
 

--- a/compile/inc/src/main/scala/sbt/inc/Relations.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Relations.scala
@@ -189,6 +189,15 @@ trait Relations {
    */
   private[inc] def inheritance: SourceDependencies
 
+  /**
+   * The source dependency relation between source files introduced by a macro expansion.
+   * This dependency is introduced when a macro implementation uses the reflection API to collect
+   * information about another object.
+   *
+   * The client of this macro should be recompiled if the inspected object is modified.
+   */
+  private[inc] def macroExpansion: SourceDependencies
+
   /** The dependency relations between sources.  These include both direct and inherited dependencies.*/
   def direct: Source
 
@@ -247,6 +256,8 @@ object Relations {
       ("member reference external dependencies", identity[String] _),
       ("inheritance internal dependencies", string2File),
       ("inheritance external dependencies", identity[String] _),
+      ("macro expansion internal dependencies", string2File),
+      ("macro expansion external dependencies", identity[String] _),
       ("class names", identity[String] _),
       ("used names", identity[String] _))
   }
@@ -256,13 +267,14 @@ object Relations {
    */
   def construct(nameHashing: Boolean, relations: List[Relation[_, _]]) =
     relations match {
-      case p :: bin :: di :: de :: pii :: pie :: mri :: mre :: ii :: ie :: cn :: un :: Nil =>
+      case p :: bin :: di :: de :: pii :: pie :: mri :: mre :: ii :: ie :: mei :: mee :: cn :: un :: Nil =>
         val srcProd = p.asInstanceOf[Relation[File, File]]
         val binaryDep = bin.asInstanceOf[Relation[File, File]]
         val directSrcDeps = makeSource(di.asInstanceOf[Relation[File, File]], de.asInstanceOf[Relation[File, String]])
         val publicInheritedSrcDeps = makeSource(pii.asInstanceOf[Relation[File, File]], pie.asInstanceOf[Relation[File, String]])
         val memberRefSrcDeps = makeSourceDependencies(mri.asInstanceOf[Relation[File, File]], mre.asInstanceOf[Relation[File, String]])
         val inheritanceSrcDeps = makeSourceDependencies(ii.asInstanceOf[Relation[File, File]], ie.asInstanceOf[Relation[File, String]])
+        val macroExpSrcDeps = makeSourceDependencies(mei.asInstanceOf[Relation[File, File]], mee.asInstanceOf[Relation[File, String]])
         val classes = cn.asInstanceOf[Relation[File, String]]
         val names = un.asInstanceOf[Relation[File, String]]
 
@@ -272,8 +284,8 @@ object Relations {
         assert(!nameHashing || (directSrcDeps == emptySource), "When name hashing is enabled the `direct` relation should be empty.")
 
         if (nameHashing) {
-          val internal = InternalDependencies(Map(DependencyByMemberRef -> mri.asInstanceOf[Relation[File, File]], DependencyByInheritance -> ii.asInstanceOf[Relation[File, File]]))
-          val external = ExternalDependencies(Map(DependencyByMemberRef -> mre.asInstanceOf[Relation[File, String]], DependencyByInheritance -> ie.asInstanceOf[Relation[File, String]]))
+          val internal = InternalDependencies(Map(DependencyByMemberRef -> mri.asInstanceOf[Relation[File, File]], DependencyByInheritance -> ii.asInstanceOf[Relation[File, File]], DependencyByMacroExpansion -> mei.asInstanceOf[Relation[File, File]]))
+          val external = ExternalDependencies(Map(DependencyByMemberRef -> mre.asInstanceOf[Relation[File, String]], DependencyByInheritance -> ie.asInstanceOf[Relation[File, String]], DependencyByMacroExpansion -> mee.asInstanceOf[Relation[File, String]]))
           Relations.make(srcProd, binaryDep, internal, external, classes, names)
         } else {
           assert(names.all.isEmpty, s"When `nameHashing` is disabled `names` relation should be empty: $names")
@@ -496,6 +508,9 @@ private class MRelationsDefaultImpl(srcProd: Relation[File, File], binaryDep: Re
   def inheritance: SourceDependencies =
     throw new UnsupportedOperationException("The `memberRef` source dependencies relation is not supported " +
       "when `nameHashing` flag is disabled.")
+  def macroExpansion: SourceDependencies =
+    throw new UnsupportedOperationException("The `macroExpansion` source dependencies relations is not supported" +
+      "when `nameHashing` flag is disabled.")
 
   def addProduct(src: File, prod: File, name: String): Relations =
     new MRelationsDefaultImpl(srcProd + (src, prod), binaryDep, direct = direct,
@@ -609,6 +624,8 @@ private class MRelationsDefaultImpl(srcProd: Relation[File, File], binaryDep: Re
       Relations.emptySourceDependencies.external, // Default implementation doesn't provide memberRef source deps
       Relations.emptySourceDependencies.internal, // Default implementation doesn't provide inheritance source deps
       Relations.emptySourceDependencies.external, // Default implementation doesn't provide inheritance source deps
+      Relations.emptySourceDependencies.internal, // Default implementation doesn't provide macro expansion source deps
+      Relations.emptySourceDependencies.external, // Default implementation doesn't provide macro expansion source deps
       classes,
       Relation.empty[File, String]) // Default implementation doesn't provide used names relation
     Relations.existingRelations map (_._1) zip rels
@@ -692,6 +709,8 @@ private class MRelationsNameHashing(srcProd: Relation[File, File], binaryDep: Re
     new SourceDependencies(internalDependencies.dependencies.getOrElse(DependencyByInheritance, Relation.empty), externalDependencies.dependencies.getOrElse(DependencyByInheritance, Relation.empty))
   override def memberRef: SourceDependencies =
     new SourceDependencies(internalDependencies.dependencies.getOrElse(DependencyByMemberRef, Relation.empty), externalDependencies.dependencies.getOrElse(DependencyByMemberRef, Relation.empty))
+  override def macroExpansion: SourceDependencies =
+    new SourceDependencies(internalDependencies.dependencies.getOrElse(DependencyByMacroExpansion, Relation.empty), externalDependencies.dependencies.getOrElse(DependencyByMacroExpansion, Relation.empty))
 
   def ++(o: Relations): Relations = {
     if (!o.nameHashing)
@@ -730,12 +749,14 @@ private class MRelationsNameHashing(srcProd: Relation[File, File], binaryDep: Re
       memberRef.external,
       inheritance.internal,
       inheritance.external,
+      macroExpansion.internal,
+      macroExpansion.external,
       classes,
       names)
     Relations.existingRelations map (_._1) zip rels
   }
 
-  override def hashCode = (srcProd :: binaryDep :: memberRef :: inheritance :: classes :: Nil).hashCode
+  override def hashCode = (srcProd :: binaryDep :: memberRef :: inheritance :: macroExpansion :: classes :: Nil).hashCode
 
   override def toString = (
     """

--- a/compile/interface/src/main/scala/xsbt/Dependency.scala
+++ b/compile/interface/src/main/scala/xsbt/Dependency.scala
@@ -48,6 +48,11 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile {
           val dependenciesByInheritance = extractDependenciesByInheritance(unit)
           for (on <- dependenciesByInheritance)
             processDependency(on, context = DependencyByInheritance)
+
+          val dependenciesByMacroExpansion = extractDependenciesByMacroExpansion(unit)
+          for (on <- dependenciesByMacroExpansion)
+            processDependency(on, context = DependencyByMacroExpansion)
+
         } else {
           for (on <- unit.depends) processDependency(on, context = DependencyByMemberRef)
           for (on <- inheritedDependencies.getOrElse(sourceFile, Nil: Iterable[Symbol])) processDependency(on, context = DependencyByInheritance)
@@ -184,6 +189,21 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile {
 
   private def extractDependenciesByInheritance(unit: CompilationUnit): collection.immutable.Set[Symbol] = {
     val traverser = new ExtractDependenciesByInheritanceTraverser
+    traverser.traverse(unit.body)
+    val dependencies = traverser.dependencies
+    dependencies.map(enclosingTopLevelClass)
+  }
+
+  private class ExtractDependenciesByMacroExpansion extends ExtractDependenciesTraverser {
+
+    override def traverse(tree: Tree): Unit = {
+      extractTouchedSymbols(tree) foreach addDependency
+      super.traverse(tree)
+    }
+  }
+
+  private def extractDependenciesByMacroExpansion(unit: CompilationUnit): collection.immutable.Set[Symbol] = {
+    val traverser = new ExtractDependenciesByMacroExpansion
     traverser.traverse(unit.body)
     val dependencies = traverser.dependencies
     dependencies.map(enclosingTopLevelClass)

--- a/compile/interface/src/main/scala/xsbt/ExtractUsedNames.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractUsedNames.scala
@@ -94,6 +94,8 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType) ext
         case _ => ()
       }
 
+      extractTouchedSymbols(node) foreach addSymbol
+
       node match {
         case MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
           handleClassicTreeNode(node)

--- a/interface/src/main/java/xsbti/DependencyContext.java
+++ b/interface/src/main/java/xsbti/DependencyContext.java
@@ -18,5 +18,10 @@ public enum DependencyContext {
 	 * class A
 	 * class B extends A
 	 */
-	DependencyByInheritance
+	DependencyByInheritance,
+
+	/**
+	 * Dependencies coming from the expansion of a macro
+	 */
+	DependencyByMacroExpansion
 }

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-1.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-1.scala
@@ -1,0 +1,7 @@
+package macros
+
+class Foo {
+  def bar = 10
+  def baz = 10
+  def fizz(x: Int) = 10
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-2.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-2.scala
@@ -1,0 +1,7 @@
+package macros
+
+class Foo {
+  def bar = 10
+  def baz = 10
+  def fizz(x: Int) = 10
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-3.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/changes/Foo-3.scala
@@ -1,0 +1,7 @@
+package macros
+
+class Foo {
+  def bar = 10
+  def baz = 10
+  def fizz(y: Int) = 10
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/build.sbt
@@ -1,0 +1,9 @@
+// Check that a file has been recompiled during last compilation
+InputKey[Unit]("check-recompiled") <<= inputTask { (argTask: TaskKey[Seq[String]]) =>
+    (argTask, compile in Compile) map { (args: Seq[String], a: sbt.inc.Analysis) =>
+        assert(args.size == 1)
+        val fileCompilation = a.apis.internal.collect { case (file, src) if file.name.endsWith(args(0)) => src.compilation }.head
+        val lastCompilation = a.compilations.allCompilations.last
+        assert(fileCompilation.startTime == lastCompilation.startTime, "File has not been recompiled during last compilation.")
+    }
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/src/main/scala/Bar.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/src/main/scala/Bar.scala
@@ -1,0 +1,8 @@
+package macros
+
+// If we don't add this class and something breaks (that is, if Client.scala is not
+// recompiled after changes are made to Foo.scala), then there won't be any
+// recompilation in this subproject, therefore Client.scala will have been part of the
+// last compilation. This class is always recompiled if changes are made to Foo.scala,
+// so we will be able to know for sure if Client.scala was part of the last recompilation.
+class Bar extends Foo

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/src/main/scala/Client.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-client/src/main/scala/Client.scala
@@ -1,0 +1,5 @@
+package macros
+
+object Client extends App {
+  println(Provider.getMembers)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-provider/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-provider/src/main/scala/Foo.scala
@@ -1,0 +1,6 @@
+package macros
+
+class Foo {
+  def bar = 10
+  def fizz(x: Int) = 10
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-provider/src/main/scala/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/macro-provider/src/main/scala/Provider.scala
@@ -1,0 +1,12 @@
+package macros
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+  def getMembers: String = macro getMembersImpl
+  def getMembersImpl(c: Context): c.Tree = {
+    import c.universe._
+    val members = weakTypeOf[Foo].members.sorted
+    q"${members.toString}"
+  }
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/project/build.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/project/build.scala
@@ -1,0 +1,32 @@
+import sbt._
+import Keys._
+
+object build extends Build {
+	val defaultSettings = Seq(
+		libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ ),
+		incOptions := incOptions.value.withNameHashing(true),
+		scalaVersion := "2.11.0",
+		resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+		addCompilerPlugin("org.scalamacros" %% "macrotracker" % "0.1.0-SNAPSHOT" cross CrossVersion.full)
+	)
+
+	lazy val root = Project(
+	   base = file("."),
+	   id = "macro",
+	   aggregate = Seq(macroProvider, macroClient),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroProvider = Project(
+	   base = file("macro-provider"),
+	   id = "macro-provider",
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+
+	lazy val macroClient = Project(
+	   base = file("macro-client"),
+	   id = "macro-client",
+	   dependencies = Seq(macroProvider),
+	   settings = Defaults.defaultSettings ++ defaultSettings
+	)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-macrotracker/test
+++ b/sbt/src/sbt-test/source-dependencies/macro-macrotracker/test
@@ -1,0 +1,25 @@
+> compile
+
+# Add a new method to Foo, we should therefore recompile
+# Client.scala which lists members of Foo.
+$ copy-file changes/Foo-1.scala macro-provider/src/main/scala/Foo.scala
+
+> compile
+
+> macro-client/check-recompiled Client.scala
+
+# Remove a method from Foo, we should therefore recompile
+# Client.scala which lists members of Foo.
+$ copy-file changes/Foo-2.scala macro-provider/src/main/scala/Foo.scala
+
+> compile
+
+> macro-client/check-recompiled Client.scala
+
+# Rename the argument of Foo.fizz. We should therefore recompile
+# Client.scala because it inspected this method.
+$ copy-file changes/Foo-3.scala macro-provider/src/main/scala/Foo.scala
+
+> compile
+
+> macro-client/check-recompiled Client.scala


### PR DESCRIPTION
Hi !

> MacroTracker is a compiler plugin for scalac 2.11.0. Its job is to register all the symbols that are touched during the expansion of a macro, and attach them to the expanded macro. Using this information, we can deduct the dependencies between the expanded macro and everything that has been involved in its expansion. 

(From [this thread in sbt-dev](https://groups.google.com/forum/#!topic/sbt-dev/clIbzCp9VX8))

MacroTracker helps to track the dependencies that are introduced using the reflection API. Whenever a symbol is accessed using the reflection API, MacroTracker registers it and finally attaches all the touched symbols to the expanded macro.

It can help greatly in cases such as the ones that are exposed in the [accompanied scripted test](https://github.com/Duhemm/sbt/tree/macrotracker-support/sbt/src/sbt-test/source-dependencies/macro-macrotracker).

MacroTracker can be found here : [scalamacros/macrotracker](https://github.com/scalamacros/macrotracker).
