### PR TITLE
Remove javac options from doc tool.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -729,7 +729,7 @@ object Defaults extends BuildCommon {
       val srcs = sources.value
       val out = target.value
       val sOpts = scalacOptions.value
-      val jOpts = javacOptions.value
+      val jOpts = javaDocOptions.value
       val xapis = apiMappings.value
       val hasScala = srcs.exists(_.name.endsWith(".scala"))
       val hasJava = srcs.exists(_.name.endsWith(".java"))

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -118,6 +118,7 @@ object Keys {
   val maxErrors = SettingKey[Int]("max-errors", "The maximum number of errors, such as compile errors, to list.", ASetting)
   val scalacOptions = TaskKey[Seq[String]]("scalac-options", "Options for the Scala compiler.", BPlusTask)
   val javacOptions = TaskKey[Seq[String]]("javac-options", "Options for the Java compiler.", BPlusTask)
+  val javaDocOptions = TaskKey[Seq[String]]("javadoc-options", "Options for the Java Doc tool", BPlusTask)
   val incOptions = TaskKey[sbt.inc.IncOptions]("inc-options", "Options for the incremental compiler.", BTask)
   val compileOrder = SettingKey[CompileOrder]("compile-order", "Configures the order in which Java and sources within a single compilation are compiled.  Valid values are: JavaThenScala, ScalaThenJava, or Mixed.", BPlusSetting)
   val initialCommands = SettingKey[String]("initial-commands", "Initial commands to execute when starting up the Scala interpreter.", AMinusSetting)


### PR DESCRIPTION
The java documentation tool does not take all the options that the javac tool accepts so I believe it makes sense to have two separate keys for them in sbt
