### PR TITLE
Adjust 'projectMacroImpl' to work for camelCased project names.

### DIFF
--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -567,7 +567,10 @@ object Project extends ProjectExtra {
       import c.universe._
       val enclosingValName = std.KeyMacro.definingValName(c, methodName => s"""$methodName must be directly assigned to a val, such as `val x = $methodName`.""")
       val name = c.Expr[String](Literal(Constant(enclosingValName)))
-      reify { Project(name.splice, new File(name.splice)) }
+      reify {
+        val hyphenated = Util.camelToHypen(name.splice)
+        Project(hyphenated, new File(hyphenated))
+      }
     }
 }
 


### PR DESCRIPTION
Currently `project` macro allows us to do this:

``` scala
lazy val util = project // Project('util', file('util'))
```

This patch allows `project` macro to expands in backward compatible way allowing camelCased project names to be hyphenated like so without resorting to `backtick-workaround`:

``` scala
lazy val projUtil = project // Project('proj-util', file('proj-util'))
```
