### PR TITLE
Addional form of  to allow better syntax for bundled plugins.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -948,7 +948,7 @@ object Defaults extends BuildCommon {
   @deprecated("Settings now split into AutoPlugins.", "0.13.2")
   lazy val projectBaseSettings: Seq[Setting[_]] = projectCore ++ runnerSettings ++ paths ++ baseClasspaths ++ baseTasks ++ compileBase ++ disableAggregation
 
-  // These are project level settings that MUST be on every project.  
+  // These are project level settings that MUST be on every project.
   lazy val coreDefaultSettings: Seq[Setting[_]] =
     projectCore ++ disableAggregation ++ Seq(
       // Missing but core settings
@@ -1111,8 +1111,8 @@ object Classpaths {
     projectResolver <<= projectResolverTask,
     projectDependencies <<= projectDependenciesTask,
     // TODO - Is this the appropriate split?  Ivy defines this simply as
-    //        just project + library, while the JVM plugin will define it as 
-    //        having the additional sbtPlugin + autoScala magikz. 
+    //        just project + library, while the JVM plugin will define it as
+    //        having the additional sbtPlugin + autoScala magikz.
     allDependencies := {
       projectDependencies.value ++ libraryDependencies.value
     },
@@ -1798,6 +1798,14 @@ trait BuildExtra extends BuildCommon {
    */
   def addSbtPlugin(dependency: ModuleID): Setting[Seq[ModuleID]] =
     libraryDependencies <+= (sbtBinaryVersion in update, scalaBinaryVersion in update) { (sbtV, scalaV) => sbtPluginExtra(dependency, sbtV, scalaV) }
+
+  /**
+   * Adds `dependency` as an sbt plugin for the sbt and Scala versions configured by
+   * `sbtBinaryVersion` and `scalaBinaryVersion` respectively scoped to `update`.
+   * The plugin version is same as the `sbtBinaryVersion` and does not need to be specified explicitly.
+   */
+  def addSbtPlugin(dependency: impl.GroupArtifactID): Setting[Seq[ModuleID]] =
+    libraryDependencies <+= (sbtBinaryVersion in update, scalaBinaryVersion in update) { (sbtV, scalaV) => sbtPluginExtra(dependency % sbtV, sbtV, scalaV) }
 
   /** Transforms `dependency` to be in the auto-compiler plugin configuration. */
   def compilerPlugin(dependency: ModuleID): ModuleID =

--- a/notes/0.13.8/aether-resolvers.markdown
+++ b/notes/0.13.8/aether-resolvers.markdown
@@ -11,14 +11,13 @@
 
 ### Maven resolver plugin
 
-sbt 0.13.8 adds an extention point in the dependency resolution to customize Maven resolvers.
+sbt 0.13.8 adds an extension point in the dependency resolution to customize Maven resolvers.
 This allows us to write sbt-maven-resolver auto plugin, which internally uses Eclipse Aether
 to resolve Maven dependencies instead of Apache Ivy.
 
 To enable this plugin, add the following to `project/maven.sbt` (or `project/plugin.sbt` the file name doesn't matter):
 
-    libraryDependencies += Defaults.sbtPluginExtra("org.scala-sbt" % "sbt-maven-resolver" % sbtVersion.value,
-      sbtBinaryVersion.value, scalaBinaryVersion.value)
+    addSbtPlugin("org.scala-sbt" % "sbt-maven-resolver")
 
 This will create a new `~/.ivy2/maven-cache` directory, which contains the Aether cache of files.
 You may notice some file will be re-downloaded for the new cache layout.


### PR DESCRIPTION
Again, one of those random ideas to open conversation :)

Since this hurts: 

``` scala
libraryDependencies += Defaults.sbtPluginExtra("org.scala-sbt" % "sbt-maven-resolver" % sbtVersion.value, sbtBinaryVersion.value, scalaBinaryVersion.value)
```

and this isn't allowed:

``` scala
addSbtPlugin("org.scala-sbt" % "sbt-maven-resolver" % sbtVersion.value)
```
