### PR TITLE
Fix #1368 - getResources should never return null

### DIFF
--- a/util/classpath/src/main/scala/sbt/classpath/DualLoader.scala
+++ b/util/classpath/src/main/scala/sbt/classpath/DualLoader.scala
@@ -6,12 +6,13 @@ package classpath
 
 import java.net.URL
 import java.util.Enumeration
+import java.util.Collections
 
 /** A class loader that always fails to load classes and resources. */
 final class NullLoader extends ClassLoader {
   override final def loadClass(className: String, resolve: Boolean): Class[_] = throw new ClassNotFoundException("No classes can be loaded from the null loader")
   override def getResource(name: String): URL = null
-  override def getResources(name: String): Enumeration[URL] = null
+  override def getResources(name: String): Enumeration[URL] = Collections.enumeration(Collections.emptyList())
   override def toString = "NullLoader"
 }
 
@@ -77,9 +78,9 @@ class DualLoader(parentA: ClassLoader, aOnlyClasses: String => Boolean, aOnlyRes
       else {
         val urlsA = parentA.getResources(name)
         val urlsB = parentB.getResources(name)
-        if (urlsA eq null)
+        if (!urlsA.hasMoreElements)
           urlsB
-        else if (urlsB eq null)
+        else if (!urlsB.hasMoreElements)
           urlsA
         else
           new DualEnumeration(urlsA, urlsB)


### PR DESCRIPTION
This has been tested manually and confirmed to fix the original issue in which the return null broke builds that used hazelcast.

I've checked for any code within the sbt repo relying on a null return from getResources, but could find none apart from the updated lines and ClassLoaders.scala.

I've left the null check and subsequent null return in place on line 89 of ClassLoaders.scala as it does no harm and might conceivably be relied on by third party code with it's own non compliant classloader.
