### PR TITLE
Fix nightly publishing location by demoting publish-status to ThisBuild

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ def commonSettings: Seq[Setting[_]] = Seq(
 )
 
 def minimalSettings: Seq[Setting[_]] =
-  commonSettings ++ customCommands ++ Status.settings ++
+  commonSettings ++ customCommands ++
   publishPomSettings ++ Release.javaVersionCheckSettings
 
 def baseSettings: Seq[Setting[_]] =

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -1,6 +1,6 @@
 import sbt._
 import Keys._
-import Status.publishStatus
+import StatusPlugin.autoImport._
 import com.typesafe.sbt.{ SbtGhPages, SbtGit, SbtSite, site => sbtsite }
 import SbtSite.{ site, SiteKeys }
 import SbtGhPages.{ ghpages, GhPagesKeys => ghkeys }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,6 +1,6 @@
 import sbt._
 import Keys._
-import Status.publishStatus
+import StatusPlugin.autoImport._
 import org.apache.ivy.util.url.CredentialsStore
 import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
 

--- a/project/StatusPlugin.scala
+++ b/project/StatusPlugin.scala
@@ -2,10 +2,17 @@ import sbt._
 import Keys._
 import java.util.regex.Pattern
 
-object Status {
-  lazy val publishStatus = SettingKey[String]("publish-status")
+object StatusPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
 
-  def settings: Seq[Setting[_]] = Seq(
+  object autoImport {
+    lazy val publishStatus = SettingKey[String]("publish-status")
+  }
+
+  import autoImport._
+
+  override def buildSettings: Seq[Setting[_]] = Seq(
     isSnapshot <<= version(v => v.contains("-") && snapshotQualifier(v)),
     publishStatus <<= isSnapshot { snap => if (snap) "snapshots" else "releases" },
     commands += stampVersion


### PR DESCRIPTION
`stamp-version` is a command used to substitute `-SNAPSHOT` with the current timestamp. This is called by Jenkins job for the nightlies.
## steps
1. run `stamp-version` from sbt shell
2. run `publishStatus` from sbt shell
## problem

`publishStatus` currently returns "releases", causing nightly releases to get published on the wrong repository by the Jenkins job.
## expectations

`publishStatus` returns "snapshots".
## analysis

Nightlies broke in general when I migrated the build in #1784 so we didn't notice this for a while.
Another thing I broke there was promoting `publishStatus` setting from build level to project level in
https://github.com/sbt/sbt/pull/1784/files#diff-fdc3abdfd754eeb24090dbd90aeec2ceR27.
This overrides `(publishStatus in ThisBuild := status)`, which is part of the `stamp-version` command.
A few days ago #1842 was merged, making the nightlies to build again, and now this bug is surfaced.

The fix is to demote `publishStatus` back as a build-level setting by making it an auto plugin.

/review @jsuereth, @havocp 
