### PR TITLE
Fixes #1711, #1730. Cached resolution: fixes internal project

### DIFF
--- a/notes/0.13.8/cached-resolution-fixes.markdown
+++ b/notes/0.13.8/cached-resolution-fixes.markdown
@@ -1,0 +1,15 @@
+  [@cunei]: https://github.com/cunei
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@gkossakowski]: https://github.com/gkossakowski
+  [@jsuereth]: https://github.com/jsuereth
+  [1711]: https://github.com/sbt/sbt/issues/1711
+  [1752]: https://github.com/sbt/sbt/pull/1752
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes cached resolution handling of internal depdendencies. [#1711][1711] by [@eed3si9n][@eed3si9n]
+- Fixes cached resolution being too verbose. [#1752][1752] by [@eed3si9n][@eed3si9n]

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/multi.sbt
@@ -63,30 +63,30 @@ lazy val root = (project in file(".")).
     organization in ThisBuild := "org.example",
     version in ThisBuild := "1.0",
     check := {
-      val acp = (externalDependencyClasspath in Compile in a).value.sortBy {_.data.getName}
-      val bcp = (externalDependencyClasspath in Compile in b).value.sortBy {_.data.getName}
-      val ccp = (externalDependencyClasspath in Compile in c).value.sortBy {_.data.getName} filterNot { _.data.getName == "demo_2.10.jar"}
-      if (!(acp exists { _.data.getName contains "commons-io-1.4-sources.jar" })) {
+      val acp = (externalDependencyClasspath in Compile in a).value.map {_.data.getName}.sorted
+      val bcp = (externalDependencyClasspath in Compile in b).value.map {_.data.getName}.sorted
+      val ccp = (externalDependencyClasspath in Compile in c).value.map {_.data.getName}.sorted filterNot { _ == "demo_2.10.jar"}
+      if (!(acp contains "commons-io-1.4-sources.jar")) {
         sys.error("commons-io-1.4-sources not found when it should be included: " + acp.toString)
       }
-      if (!(acp exists { _.data.getName contains "commons-io-1.4.jar" })) {
+      if (!(acp contains "commons-io-1.4.jar")) {
         sys.error("commons-io-1.4 not found when it should be included: " + acp.toString)
       }
       
       // stock Ivy implementation doesn't contain regular (non-source) jar, which probably is a bug
-      val acpWithoutSource = acp filterNot { _.data.getName contains "commons-io-1.4"}
-      val bcpWithoutSource = bcp filterNot { _.data.getName contains "commons-io-1.4"}
-      val ccpWithoutSource = ccp filterNot { _.data.getName contains "commons-io-1.4"}
+      val acpWithoutSource = acp filterNot { _ == "commons-io-1.4.jar"}
+      val bcpWithoutSource = bcp filterNot { _ == "commons-io-1.4.jar"}
+      val ccpWithoutSource = ccp filterNot { _ == "commons-io-1.4.jar"}
       if (acpWithoutSource == bcpWithoutSource && acpWithoutSource == ccpWithoutSource) ()
       else sys.error("Different classpaths are found:" +
         "\n - a (cached)        " + acpWithoutSource.toString +
         "\n - b (plain)         " + bcpWithoutSource.toString +
         "\n - c (inter-project) " + ccpWithoutSource.toString)
       
-      val atestcp = (externalDependencyClasspath in Test in a).value.sortBy {_.data.getName} filterNot { _.data.getName contains "commons-io-1.4"}
-      val btestcp = (externalDependencyClasspath in Test in b).value.sortBy {_.data.getName} filterNot { _.data.getName contains "commons-io-1.4"}
-      val ctestcp = (externalDependencyClasspath in Test in c).value.sortBy {_.data.getName} filterNot { _.data.getName == "demo_2.10.jar"} filterNot { _.data.getName contains "commons-io-1.4"}
-      if (ctestcp exists { _.data.getName contains "junit-4.11.jar" }) {
+      val atestcp = (externalDependencyClasspath in Test in a).value.map {_.data.getName}.sorted filterNot { _ == "commons-io-1.4.jar"}
+      val btestcp = (externalDependencyClasspath in Test in b).value.map {_.data.getName}.sorted filterNot { _ == "commons-io-1.4.jar"}
+      val ctestcp = (externalDependencyClasspath in Test in c).value.map {_.data.getName}.sorted filterNot { _ == "demo_2.10.jar"} filterNot { _ == "commons-io-1.4.jar"}
+      if (ctestcp contains "junit-4.11.jar") {
         sys.error("junit found when it should be excluded: " + ctestcp.toString)
       }
 
@@ -96,3 +96,4 @@ lazy val root = (project in file(".")).
         "\n - b test (plain)  " + btestcp.toString)
     }
   )
+

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/test
@@ -1,3 +1,5 @@
+> debug
+
 > a/update
 
 > a/updateClassifiers

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
@@ -1,0 +1,56 @@
+// https://github.com/sbt/sbt/issues/1730
+lazy val check = taskKey[Unit]("Runs the check")
+
+def commonSettings: Seq[Def.Setting[_]] =
+  Seq(
+    ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),
+    dependencyCacheDirectory := (baseDirectory in LocalRootProject).value / "dependency",
+    scalaVersion := "2.11.4",
+    resolvers += Resolver.sonatypeRepo("snapshots")
+  )
+
+def cachedResolutionSettings: Seq[Def.Setting[_]] =
+  commonSettings ++ Seq(
+   updateOptions := updateOptions.value.withCachedResolution(true)
+  )
+
+lazy val transitiveTest = project.
+  settings(cachedResolutionSettings: _*).
+  settings(
+    libraryDependencies += "junit" % "junit" % "4.11" % Test
+  )
+
+lazy val transitiveTestDefault = project.
+  settings(cachedResolutionSettings: _*).
+  settings(
+    libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1"
+  )
+
+lazy val a = project.
+dependsOn(transitiveTestDefault % Test, transitiveTest % "test->test").
+  settings(cachedResolutionSettings: _*)
+
+lazy val root = (project in file(".")).
+  aggregate(a).
+  settings(
+    organization in ThisBuild := "org.example",
+    version in ThisBuild := "1.0",
+    check := {
+      val ur = (update in a).value
+      val acp = (externalDependencyClasspath in Compile in a).value.map {_.data.getName}
+      val atestcp0 = (fullClasspath in Test in a).value
+      val atestcp = (externalDependencyClasspath in Test in a).value.map {_.data.getName}
+      // This is checking to make sure interproject dependency works
+      if (acp exists { _ contains "scalatest" }) {
+        sys.error("scalatest found when it should NOT be included: " + acp.toString)
+      }
+      // This is checking to make sure interproject dependency works
+      if (!(atestcp exists { _ contains "scalatest" })) {
+        sys.error("scalatest NOT found when it should be included: " + atestcp.toString)
+      }
+      // This is checking to make sure interproject dependency works
+      if (!(atestcp exists { _ contains "junit" })) {
+        sys.error("junit NOT found when it should be included: " + atestcp.toString)
+      }
+    }
+  )

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/test
@@ -1,0 +1,4 @@
+> debug
+
+> check
+


### PR DESCRIPTION
Fixes #1711, #1730

Re-fixes cached resolution's internal dependency issue by recursively calling customResolve instead of including the transitive dependencies from internal dependencies into your own graph.

Transformation of configuration still happens, but at the level of resolved graph (UpdateReport), which is much less granular, and hopefully less error-prone.

This should also fix #1776. Needs testing.

See #1811 for the list of cached resolution issues.
