### PR TITLE
(don't merge) Limit the Travis tests to scripted dependency-management/publish-local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,26 +15,8 @@ jdk:
 
 env:
   matrix:
-    - SCRIPTED_TEST="scripted actions/*"
-    - SCRIPTED_TEST="scripted api/*"
-    - SCRIPTED_TEST="scripted compiler-project/*""
-    - SCRIPTED_TEST="scripted dependency-management/*1of2"
-    - SCRIPTED_TEST="scripted dependency-management/*2of2"
-    - SCRIPTED_TEST="mavenResolverPluginTest:scripted dependency-management/*1of2 project/transitive-plugins"
-    - SCRIPTED_TEST="mavenResolverPluginTest:scripted dependency-management/*2of2"
-    - SCRIPTED_TEST="scripted java/*"
-    - SCRIPTED_TEST="scripted package/*"
-    - SCRIPTED_TEST="scripted project/*1of2"
-    - SCRIPTED_TEST="scripted project/*2of2"
-    - SCRIPTED_TEST="scripted reporter/*"
-    - SCRIPTED_TEST="scripted run/*"
-    - SCRIPTED_TEST="scripted source-dependencies/*1of3"
-    - SCRIPTED_TEST="scripted source-dependencies/*2of3"
-    - SCRIPTED_TEST="scripted source-dependencies/*3of3"
-    - SCRIPTED_TEST="scripted tests/*"
-    - SCRIPTED_TEST="scripted project-load/*"
-    - SCRIPTED_TEST="safeUnitTests"
-    - SCRIPTED_TEST="checkBuildScala211"
+    - SCRIPTED_TEST="scripted dependency-management/publish-local"
+    - SCRIPTED_TEST="mavenResolverPluginTest:scripted dependency-management/publish-local"
 
 notifications:
   email:


### PR DESCRIPTION
This is a PR for debugging Travis failures on `scripted dependency-management/publish-local`
