### PR TITLE
Fixing precompiled and nightly build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -604,11 +604,12 @@ def customCommands: Seq[Setting[_]] = Seq(
     test.all(safeProjects).value
   },
   commands += Command.command("release-sbt-local") { state =>
-    "so clean" ::
+    "clean" ::
     "allPrecompiled/clean" ::
     "allPrecompiled/compile" ::
-    "so compile" ::
     "allPrecompiled/publishLocal" ::
+    "so clean" ::
+    "so compile" ::
     "so publishLocal" ::
     "reload" ::
     state
@@ -631,27 +632,27 @@ def customCommands: Seq[Setting[_]] = Seq(
    */
   commands += Command.command("release-sbt") { state =>
     // TODO - Any sort of validation
-    "so clean" ::
-      "allPrecompiled/clean" ::
-      "checkCredentials" ::
-      "conscript-configs" ::
+    "checkCredentials" ::
+    "clean" ::
+    "allPrecompiled/clean" ::
       "allPrecompiled/compile" ::
+      "allPrecompiled/publishSigned" ::
+      "so clean" ::
+      "conscript-configs" ::
       "so compile" ::
       "so publishSigned" ::
-      "allPrecompiled/publishSigned" ::
       "publishLauncher" ::
       state
   },
+  // stamp-version doesn't work with ++ or "so".
   commands += Command.command("release-nightly") { state =>
     "stamp-version" ::
-      "so clean" ::
+      "clean" ::
       "allPrecompiled/clean" ::
       "allPrecompiled/compile" ::
-      "so compile" ::
-      "so publish" ::
       "allPrecompiled/publish" ::
-      "publishLauncher" ::
+      "compile" ::
+      "publish" ::
       state
   }
 )
-


### PR DESCRIPTION
We noticed that -SNAPSHOT is being published as our nightly.
This is because "wow" command (or ++) does not replay version injected by stamp-version.

Another thing is that precompiled and `++` have bad interaction, so I'm pushing everything precompiled up front.

```
java.text.ParseException: inconsistent module descriptor file found in 'https://repo.typesafe.com/typesafe/ivy-snapshots/org.scala-sbt/precompiled-2_8_2/0.13.8-SNAPSHOT/ivys/ivy.xml': bad module name: expected='precompiled-2_8_2' found='precompiled-2_9_3';
```
