### PR TITLE
Fix metadataonly tests.

### DIFF
--- a/sbt/src/sbt-test/dependency-management/metadata-only-resolver/repo/com/sun/jmx/jmxri/1.2.1/jmxri-1.2.1.pom
+++ b/sbt/src/sbt-test/dependency-management/metadata-only-resolver/repo/com/sun/jmx/jmxri/1.2.1/jmxri-1.2.1.pom
@@ -1,0 +1,6 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.sun.jmx</groupId>
+  <artifactId>jmxri</artifactId>
+  <version>1.2.1</version>
+</project>

--- a/sbt/src/sbt-test/dependency-management/metadata-only-resolver/test
+++ b/sbt/src/sbt-test/dependency-management/metadata-only-resolver/test
@@ -2,5 +2,5 @@
 -> update
 
 # add a repository with the dependency, which should then succeed
-> 'set resolvers += "Nuxeo" at "http://maven.nuxeo.org/nexus/content/groups/public/"'
+> 'set resolvers += "Nuxeo" at s"${(baseDirectory.value / "repo").toURI.toURL}"'
 > update


### PR DESCRIPTION
Turns out the repository we were relying on existing disappeared.  Using a fake jar/pom does the same trick.

review by @eed3si9n 
