### PR TITLE
cached resolution: transitive dependency survives even after its caller is evicted

### DIFF
--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -350,7 +350,7 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
       new ConfigurationReport(rootModuleConf, modules, details, evicted)
     }
   /**
-   * Returns a touple of (merged org + name combo, newly evicted modules)
+   * Returns a tuple of (merged org + name combo, newly evicted modules)
    */
   def mergeOrganizationArtifactReports(rootModuleConf: String, reports0: Vector[OrganizationArtifactReport], os: Vector[IvyOverride], log: Logger): Vector[OrganizationArtifactReport] =
     {

--- a/notes/0.13.8/cached-resolution-fixes.markdown
+++ b/notes/0.13.8/cached-resolution-fixes.markdown
@@ -4,6 +4,7 @@
   [@jsuereth]: https://github.com/jsuereth
   [1711]: https://github.com/sbt/sbt/issues/1711
   [1752]: https://github.com/sbt/sbt/pull/1752
+  [1760]: https://github.com/sbt/sbt/pull/1760
 
 ### Fixes with compatibility implications
 
@@ -13,3 +14,4 @@
 
 - Fixes cached resolution handling of internal depdendencies. [#1711][1711] by [@eed3si9n][@eed3si9n]
 - Fixes cached resolution being too verbose. [#1752][1752] by [@eed3si9n][@eed3si9n]
+- Fixes cached resolution not evicting modules transitively. [#1760][#1760] by [@eed3si9n][@eed3si9n]

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/multi.sbt
@@ -1,4 +1,5 @@
 // https://github.com/sbt/sbt/issues/1710
+// https://github.com/sbt/sbt/issues/1760
 lazy val check = taskKey[Unit]("Runs the check")
 
 def commonSettings: Seq[Def.Setting[_]] =
@@ -17,7 +18,7 @@ def cachedResolutionSettings: Seq[Def.Setting[_]] =
   )
 
 lazy val X1 = project.
-  settings(commonSettings: _*).
+  settings(cachedResolutionSettings: _*).
   settings(
     libraryDependencies ++= Seq(
       "com.example" %% "y1" % "0.1.0" % "compile->compile;runtime->runtime",
@@ -25,7 +26,7 @@ lazy val X1 = project.
   )
 
 lazy val Y1 = project.
-  settings(commonSettings: _*).
+  settings(cachedResolutionSettings: _*).
   settings(
     name := "y1",
     libraryDependencies ++= Seq(
@@ -33,19 +34,23 @@ lazy val Y1 = project.
       "com.ning" % "async-http-client" % "1.8.14",
       // this includes slf4j 1.6.6
       "com.twitter" % "summingbird-core_2.10" % "0.5.0",
-      "org.slf4j" % "slf4j-api" % "1.6.6" force()
+      "org.slf4j" % "slf4j-api" % "1.6.6" force(),
+      // this includes servlet-api 2.3
+      "commons-logging" % "commons-logging" % "1.1"
     )
   )
 
 lazy val Y2 = project.
-  settings(commonSettings: _*).
+  settings(cachedResolutionSettings: _*).
   settings(
     name := "y2",
     libraryDependencies ++= Seq(
       // this includes slf4j 1.6.6
       "com.twitter" % "summingbird-core_2.10" % "0.5.0",
       // this includes slf4j 1.7.5
-      "com.ning" % "async-http-client" % "1.8.14")
+      "com.ning" % "async-http-client" % "1.8.14",
+      "commons-logging" % "commons-logging" % "1.1.3"
+    )
   )
 
 lazy val root = (project in file(".")).
@@ -53,10 +58,15 @@ lazy val root = (project in file(".")).
     organization in ThisBuild := "org.example",
     version in ThisBuild := "1.0",
     check := {
-      val x1cp = (externalDependencyClasspath in Compile in X1).value.sortBy {_.data.getName}
+      val x1cp = (externalDependencyClasspath in Compile in X1).value.map {_.data.getName}.sorted
       // sys.error("slf4j-api is not found on X1" + x1cp)
-      if (!(x1cp exists {_.data.getName contains "slf4j-api"})) {
-        sys.error("slf4j-api is not found on X1" + x1cp)
+      if (!(x1cp contains "slf4j-api-1.6.6.jar")) {
+        sys.error("slf4j-api-1.6.6.jar is not found on X1" + x1cp)
       }
+
+      //sys.error(x1cp.toString)
+      if (x1cp contains "servlet-api-2.3.jar") {
+        sys.error("servlet-api-2.3.jar is found when it should be evicted:" + x1cp)
+      } 
     }
   )


### PR DESCRIPTION
## steps
- Have one graph resolve `"commons-logging" % "commons-logging" % "1.1"`
- Have another graph resolve `"commons-logging" % "commons-logging" % "1.1.3"`

``` scala
lazy val check = taskKey[Unit]("Runs the check")

def commonSettings: Seq[Def.Setting[_]] =
  Seq(
    organization := "com.example",
    version := "0.1.0",
    ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),
    dependencyCacheDirectory := (baseDirectory in LocalRootProject).value / "dependency",
    scalaVersion := "2.10.4",
    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project")
  )

def cachedResolutionSettings: Seq[Def.Setting[_]] =
  commonSettings ++ Seq(
    updateOptions := updateOptions.value.withCachedResolution(true)
  )

lazy val X1 = project.
  settings(cachedResolutionSettings: _*).
  settings(
    libraryDependencies ++= Seq(
      "com.example" %% "y1" % "0.1.0" % "compile->compile;runtime->runtime",
      "com.example" %% "y2" % "0.1.0" % "compile->compile;runtime->runtime")
  )

lazy val Y1 = project.
  settings(cachedResolutionSettings: _*).
  settings(
    name := "y1",
    libraryDependencies ++= Seq(
      // this includes servlet-api 2.3
      "commons-logging" % "commons-logging" % "1.1"
    )
  )

lazy val Y2 = project.
  settings(cachedResolutionSettings: _*).
  settings(
    name := "y2",
    libraryDependencies ++= Seq(
      "commons-logging" % "commons-logging" % "1.1.3"
    )
  )

lazy val root = (project in file(".")).
  settings(
    organization in ThisBuild := "org.example",
    version in ThisBuild := "1.0",
    check := {
      val x1cp = (externalDependencyClasspath in Compile in X1).value.map {_.data.getName}.sorted
      if (x1cp contains "servlet-api-2.3.jar") {
        sys.error("servlet-api-2.3.jar is found when it should be evicted:" + x1cp)
      } 
    }
  )
```
## problem

When two graphs merge, transitive dependency from "commons-logging" % "1.1" sticks around. Namely servlet-api-2.3.jar among others.
## expectation

Transitive dependencies of evicted modules are transitively evicted.
## original report

After enabling cached resolution in updateOptions, missing servlet-api dependency causes runtime error when running tests of Apache Velocity module. (sbt version: 0.13.7)

Change: https://github.com/skinny-framework/skinny-framework/commit/b8bc7c161f400e590cfd96abbfc802df2d91a00e

```
[info] Exception encountered when attempting to run a suite with class name: skinny.controller.feature.VelocityTemplateEngineFeatureSpec *** ABORTED ***
[info]   java.lang.NoSuchMethodError: javax.servlet.ServletContext.getContextPath()Ljava/lang/String;
[info]   at org.scalatra.servlet.RichServletContext.contextPath(RichServletContext.scala:210)
[info]   at org.scalatra.ScalatraBase$class.contextPath(ScalatraBase.scala:726)
[info]   at skinny.controller.SkinnyController.contextPath(SkinnyController.scala:6)
[info]   at org.scalatra.ScalatraBase$class.initialize(ScalatraBase.scala:598)
[info]   at skinny.controller.SkinnyController.org$scalatra$scalate$ScalateSupport$$super$initialize(SkinnyController.scala:6)
[info]   at org.scalatra.scalate.ScalateSupport$class.initialize(ScalateSupport.scala:52)
[info]   at skinny.controller.SkinnyController.initialize(SkinnyController.scala:6)
[info]   at org.scalatra.ScalatraFilter$class.init(ScalatraFilter.scala:79)
[info]   at skinny.controller.SkinnyController.init(SkinnyController.scala:6)
[info]   at org.eclipse.jetty.servlet.FilterHolder.initialize(FilterHolder.java:137)
[info]   ...
```
