### PR TITLE
Make Initialize[T] covariant

### DIFF
--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -410,7 +410,7 @@ trait Init[Scope] {
       allDefs flatMap { case d: DerivedSetting[_] => (derivedToStruct get d map (_.outputs)).toStream.flatten; case s => Stream(s) }
     }
 
-  sealed trait Initialize[T] {
+  sealed trait Initialize[+T] {
     def dependencies: Seq[ScopedKey[_]]
     def apply[S](g: T => S): Initialize[S]
 
@@ -589,7 +589,7 @@ trait Init[Scope] {
       case Some(i) => Right(new Optional(i.validateKeyReferenced(g).right.toOption, f))
     }
     def mapConstant(g: MapConstant): Initialize[T] = new Optional(a map mapConstantT(g).fn, f)
-    def evaluate(ss: Settings[Scope]): T = f(a.flatMap(i => trapBadRef(evaluateT(ss)(i))))
+    def evaluate(ss: Settings[Scope]): T = f(a.flatMap(i => trapBadRef(evaluateT(ss)(i))): Option[Id[S]])
     // proper solution is for evaluate to be deprecated or for external use only and a new internal method returning Either be used
     private[this] def trapBadRef[A](run: => A): Option[A] = try Some(run) catch { case e: InvalidReference => None }
     private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S = a match {


### PR DESCRIPTION
Allows for build definitions like this:

```
import sbt._

class Foo

class Bar extends Foo

object AppBuild extends Build {
    private val fooKey = SettingKey[Foo]("foo")

    private val fooSetting = Def.setting(new Bar)

    lazy val root = (project in file(".")).settings(
        fooKey <<= fooSetting
    )
}
```

which currently does not compile.
