### PR TITLE
Fixes #1834, `<developers>` section is not rendered correctly in the pom.xml 

### DIFF
--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -109,13 +109,15 @@ class MakePom(val log: Logger) {
     {
       if (moduleInfo.developers.nonEmpty) {
         <developers>
-          moduleInfo.developers.map{ developer: Developer =>
-            <developer>
-              <id>{ developer.id }</id>
-              <name>{ developer.name }</name>
-              <email>{ developer.email }</email>
-              <url>{ developer.url }</url>
-            </developer>
+          {
+            moduleInfo.developers.map { developer: Developer =>
+              <developer>
+                <id>{ developer.id }</id>
+                <name>{ developer.name }</name>
+                <email>{ developer.email }</email>
+                <url>{ developer.url }</url>
+              </developer>
+            }
           }
         </developers>
       } else NodeSeq.Empty


### PR DESCRIPTION
Fixes #1834
Inserted missing brackets so developer xml renders correctly
