### PR TITLE
Rename root project to sbtRoot.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ def baseSettings: Seq[Setting[_]] =
 def testedBaseSettings: Seq[Setting[_]] =
   baseSettings ++ testDependencies
 
-lazy val root: Project = (project in file(".")).
+lazy val sbtRoot: Project = (project in file(".")).
   configs(Sxr.sxrConf).
   aggregate(nonRoots: _*).
   settings(buildLevelSettings: _*).
@@ -490,7 +490,7 @@ def otherRootSettings = Seq(
   }
 ))
 lazy val docProjects: ScopeFilter = ScopeFilter(
-  inAnyProject -- inProjects(root, sbtProj, scriptedBaseProj, scriptedSbtProj, scriptedPluginProj, precompiled282, precompiled292, precompiled293, mavenResolverPluginProj),
+  inAnyProject -- inProjects(sbtRoot, sbtProj, scriptedBaseProj, scriptedSbtProj, scriptedPluginProj, precompiled282, precompiled292, precompiled293, mavenResolverPluginProj),
   inConfigurations(Compile)
 )
 def fullDocSettings = Util.baseScalacOptions ++ Docs.settings ++ Sxr.settings ++ Seq(


### PR DESCRIPTION
This is mostly for IntelliJ IDEA.

Currently IntelliJ IDEA's Scala (and SBT) plugin defines:
- the project name (as seen in the window title and in the "open recent
  project" list) from `name`
- the root module (as seen in the project view and in project structure)
  from `id`
- doesn't use `moduleName` at all

After this change the sbt project is no longer identified as "root".

I was undecided between `sbtRoot` and `sbtRootProj`, and went with the
shorter option. I'm happy to revise this decision.
