### PR TITLE
Only enable cross sources when multiple versions.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -181,7 +181,7 @@ object Defaults extends BuildCommon {
     sourceManaged <<= configSrcSub(sourceManaged),
     scalaSource := sourceDirectory.value / "scala",
     javaSource := sourceDirectory.value / "java",
-    unmanagedSourceDirectories := makeCrossSources(scalaSource.value, javaSource.value, scalaBinaryVersion.value, crossPaths.value),
+    unmanagedSourceDirectories := makeCrossSources(scalaSource.value, javaSource.value, scalaBinaryVersion.value, crossPaths.value, crossScalaVersions.value),
     unmanagedSources <<= collectFiles(unmanagedSourceDirectories, includeFilter in unmanagedSources, excludeFilter in unmanagedSources),
     watchSources in ConfigGlobal <++= unmanagedSources,
     managedSourceDirectories := Seq(sourceManaged.value),
@@ -242,8 +242,8 @@ object Defaults extends BuildCommon {
     derive(scalaBinaryVersion := binaryScalaVersion(scalaVersion.value))
   ))
 
-  def makeCrossSources(scalaSrcDir: File, javaSrcDir: File, sv: String, cross: Boolean): Seq[File] = {
-    if (cross)
+  def makeCrossSources(scalaSrcDir: File, javaSrcDir: File, sv: String, cross: Boolean, svs: Seq[String]): Seq[File] = {
+    if (cross && svs.length > 1)
       Seq(scalaSrcDir.getParentFile / s"${scalaSrcDir.name}-$sv", scalaSrcDir, javaSrcDir)
     else
       Seq(scalaSrcDir, javaSrcDir)

--- a/sbt/src/sbt-test/source-dependencies/cross-source/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/cross-source/build.sbt
@@ -1,0 +1,1 @@
+crossScalaVersions := Seq("2.11.4", "2.10.4", "2.9.3")


### PR DESCRIPTION
The intent of the original feature/improvement was for projects with
multiple scala versions (`crossScalaVersions`) to automatically support
cross-version source directories (via `scalaBinaryVersion`).

Unfortunately for all cross-built projects configured for only one version
(2.11-only for instance) there were some noticeable effects with this
change, such as an extra `app-2.11` directory being created in a Play app.

As of this commit, only projects with multiple Scala versions will
support cross-version source directories, maintaining the above intent
and resolving the above effect.

The scripted test from the original pull request never explicitly
declared its `crossScalaVersions` and instead switched versions from the
shell to pickup sources at the correct path. It's now explicit about
which Scala versions it supports.
## 

Fixes #1957

cc @indrajitr as he authored the original change (https://github.com/sbt/sbt/pull/1799)
