### PR TITLE
Honor overwrite flag when publishing locally.

### DIFF
--- a/ivy/src/main/scala/sbt/ConvertResolver.scala
+++ b/ivy/src/main/scala/sbt/ConvertResolver.scala
@@ -253,7 +253,7 @@ private[sbt] object ConvertResolver {
           if (totalLength > 0) {
             progress.setTotalLength(totalLength);
           }
-          FileUtil.copy(source, new java.io.File(url.toURI), progress)
+          FileUtil.copy(source, new java.io.File(url.toURI), progress, overwrite)
         } catch {
           case ex: IOException =>
             fireTransferError(ex)

--- a/notes/0.13.9/overwrite.markdown
+++ b/notes/0.13.9/overwrite.markdown
@@ -1,0 +1,11 @@
+
+  [@asflierl]: http://github.com/asflierl
+  [1960]: https://github.com/sbt/sbt/pull/1960
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Honor overwrite flag when publishing locally. [#1960][1960] by [@asflierl][@asflierl]


### PR DESCRIPTION
It seems since SBT 0.13.8, publishM2 does not overwrite files in the local Maven repo anymore (even though isSnapshot and publishM2Configuration.overwrite are both actually 'true'). I've tracked it down to a 'put' method in ConvertResolver that does not pass along the 'overwrite' flag to the actual file copy method. 
I was unsure how to best proceed with the issue so I just created this pull request for simplicity's sake. The change seems rather uncontroversial but then again: who knows. :) 
