### PR TITLE
Update incremental compile debug message

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/IncrementalCommon.scala
+++ b/compile/inc/src/main/scala/sbt/inc/IncrementalCommon.scala
@@ -196,7 +196,7 @@ private[inc] abstract class IncrementalCommon(log: Logger, options: IncOptions) 
       checkAbsolute(srcChanges.added.toList)
       log.debug(
         "\nInitial source changes: \n\tremoved:" + srcChanges.removed + "\n\tadded: " + srcChanges.added + "\n\tmodified: " + srcChanges.changed +
-          "\nRemoved products: " + changes.removedProducts +
+          "\nInvalidated products: " + changes.removedProducts +
           "\nExternal API changes: " + changes.external +
           "\nModified binary dependencies: " + changes.binaryDeps +
           "\nInitial directly invalidated sources: " + srcDirect +

--- a/notes/0.13.9/debug-removed-products.markdown
+++ b/notes/0.13.9/debug-removed-products.markdown
@@ -1,0 +1,10 @@
+  [@jroper]: https://github.com/jroper
+  [1961]: https://github.com/sbt/sbt/issues/1961
+
+### Changes with compatibility implications
+
+### Improvements
+
+### Fixes
+
+- Correct incermental compile debug message for invalidated products [#1961][1961] by [@jroper][@jroper]


### PR DESCRIPTION
sbt 0.13.1 was changed so that products were invalidated not just when they were deleted, but also when they were modified, however the debug message was not updated to reflect this, causing people to think invalidated class files were being deleted, rather than modified, for example:

https://groups.google.com/forum/#!topic/play-framework/-lJ2qTKxhz8
