### PR TITLE
call bintrayRelease on nightly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ def buildLevelSettings: Seq[Setting[_]] = Seq(
   // bintrayRepository in ThisBuild := "test-test-test",
   bintrayOrganization in ThisBuild := Some("sbt"),
   bintrayRepository in ThisBuild := s"ivy-${(publishStatus in ThisBuild).value}",
-  bintrayPackage in ThisBuild := "sbt"
+  bintrayPackage in ThisBuild := "sbt",
+  bintrayReleaseOnPublish in ThisBuild := false
 )
 
 def commonSettings: Seq[Setting[_]] = Seq(
@@ -638,6 +639,7 @@ def customCommands: Seq[Setting[_]] = Seq(
       "allPrecompiled/publish" ::
       "compile" ::
       "publish" ::
+      "bintrayRelease" ::
       state
   }
 )


### PR DESCRIPTION
This is a continuation from #1983. The nightly process almost worked at least when I ran it manually from Jenkins, except it staged everything and didn't release it (by design).
I manually hit the publish, and it looks ok:
https://bintray.com/sbt/ivy-snapshots/sbt/0.13.9-20150422-040039/

This PR does the publishing bit.

/review @jsuereth 
