### PR TITLE
Add Ivy `branch` support to ModuleID

### DIFF
--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -496,7 +496,8 @@ private[sbt] object IvySbt {
     }
   private[this] def defaultInfo(module: ModuleID): scala.xml.Elem = {
     import module._
-    <info organisation={ organization } module={ name } revision={ revision }/>
+    val base = <info organisation={ organization } module={ name } revision={ revision }/>
+    branch.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
   }
   private[this] def addExtraAttributes(elem: scala.xml.Elem, extra: Map[String, String]): scala.xml.Elem =
     (elem /: extra) { case (e, (key, value)) => e % new scala.xml.UnprefixedAttribute(key, value, scala.xml.Null) }

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -427,7 +427,7 @@ private[sbt] object IvySbt {
   def toID(m: ModuleID) =
     {
       import m._
-      ModuleRevisionId.newInstance(organization, name, revision, javaMap(extraAttributes))
+      ModuleRevisionId.newInstance(organization, name, branch.orNull, revision, javaMap(extraAttributes))
     }
 
   private def substituteCross(m: ModuleSettings): ModuleSettings =

--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -427,7 +427,7 @@ private[sbt] object IvySbt {
   def toID(m: ModuleID) =
     {
       import m._
-      ModuleRevisionId.newInstance(organization, name, branch.orNull, revision, javaMap(extraAttributes))
+      ModuleRevisionId.newInstance(organization, name, branchName.orNull, revision, javaMap(extraAttributes))
     }
 
   private def substituteCross(m: ModuleSettings): ModuleSettings =
@@ -497,7 +497,7 @@ private[sbt] object IvySbt {
   private[this] def defaultInfo(module: ModuleID): scala.xml.Elem = {
     import module._
     val base = <info organisation={ organization } module={ name } revision={ revision }/>
-    branch.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
+    branchName.fold(base) { br => base % new scala.xml.UnprefixedAttribute("branch", br, scala.xml.Null) }
   }
   private[this] def addExtraAttributes(elem: scala.xml.Elem, extra: Map[String, String]): scala.xml.Elem =
     (elem /: extra) { case (e, (key, value)) => e % new scala.xml.UnprefixedAttribute(key, value, scala.xml.Null) }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -313,7 +313,7 @@ object IvyActions {
     {
       val mextra = IvySbt.javaMap(mid.extraAttributes, true)
       val aextra = IvySbt.extra(art, true)
-      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branch.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
+      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branchName.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
     }
 
   import UpdateLogging.{ Quiet, Full, DownloadOnly, Default }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -313,7 +313,7 @@ object IvyActions {
     {
       val mextra = IvySbt.javaMap(mid.extraAttributes, true)
       val aextra = IvySbt.extra(art, true)
-      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.revision, art.name, art.`type`, art.extension, conf, mextra, aextra)
+      IvyPatternHelper.substitute(pattern, mid.organization, mid.name, mid.branch.orNull, mid.revision, art.name, art.`type`, art.extension, conf, null, mextra, aextra)
     }
 
   import UpdateLogging.{ Quiet, Full, DownloadOnly, Default }

--- a/ivy/src/main/scala/sbt/IvyActions.scala
+++ b/ivy/src/main/scala/sbt/IvyActions.scala
@@ -269,6 +269,8 @@ object IvyActions {
 
   private[this] def restrictedCopy(m: ModuleID, confs: Boolean) =
     ModuleID(m.organization, m.name, m.revision, crossVersion = m.crossVersion, extraAttributes = m.extraAttributes, configurations = if (confs) m.configurations else None)
+      .branch(m.branchName)
+
   private[this] def resolve(logging: UpdateLogging.Value)(ivy: Ivy, module: DefaultModuleDescriptor, defaultConf: String): (ResolveReport, Option[ResolveException]) =
     {
       val resolveOptions = new ResolveOptions

--- a/ivy/src/main/scala/sbt/IvyRetrieve.scala
+++ b/ivy/src/main/scala/sbt/IvyRetrieve.scala
@@ -150,6 +150,7 @@ object IvyRetrieve {
 
   def toModuleID(revID: ModuleRevisionId): ModuleID =
     ModuleID(revID.getOrganisation, revID.getName, revID.getRevision, extraAttributes = IvySbt.getExtraAttributes(revID))
+      .branch(nonEmptyString(revID.getBranch))
 
   def toArtifact(art: IvyArtifact): Artifact =
     {

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -146,4 +146,17 @@ private[sbt] trait ModuleIDSetBranch { self: ModuleID =>
 }
 
 /** This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility. */
-final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch
+final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
+  override def copy(organization: String,
+    name: String,
+    revision: String,
+    configurations: Option[String],
+    isChanging: Boolean,
+    isTransitive: Boolean,
+    isForce: Boolean,
+    explicitArtifacts: Seq[Artifact],
+    exclusions: Seq[ExclusionRule],
+    extraAttributes: Map[String, String],
+    crossVersion: CrossVersion) =
+    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).onBranch(branch)
+}

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -119,7 +119,7 @@ sealed case class ModuleID(organization: String, name: String, revision: String,
    */
   def jar() = artifacts(Artifact(name))
 
-  override val branch: Option[String] = None
+  override val branchName: Option[String] = None
 }
 
 object ModuleID {
@@ -135,18 +135,18 @@ object ModuleID {
  * This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility.
  */
 private[sbt] trait ModuleIDSetBranch { self: ModuleID =>
-  val branch: Option[String]
+  val branchName: Option[String]
 
   /**
    * Sets the Ivy branch of this module.
    */
-  def onBranch(branch: String) = new ModuleIDWithBranch(self, Some(branch))
+  def branch(branchName: String) = new ModuleIDWithBranch(self, Some(branchName))
 
-  def onBranch(branch: Option[String]) = new ModuleIDWithBranch(self, branch)
+  def branch(branchName: Option[String]) = new ModuleIDWithBranch(self, branchName)
 }
 
 /** This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility. */
-final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
+final class ModuleIDWithBranch(m: ModuleID, override val branchName: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch {
   override def copy(organization: String,
     name: String,
     revision: String,
@@ -158,5 +158,5 @@ final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String])
     exclusions: Seq[ExclusionRule],
     extraAttributes: Map[String, String],
     crossVersion: CrossVersion) =
-    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).onBranch(branch)
+    m.copy(organization, name, revision, configurations, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).branch(branchName)
 }

--- a/ivy/src/main/scala/sbt/ModuleID.scala
+++ b/ivy/src/main/scala/sbt/ModuleID.scala
@@ -8,7 +8,7 @@ import java.net.URL
 import sbt.mavenint.SbtPomExtraProperties
 import sbt.serialization._
 
-final case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, isForce: Boolean = false, explicitArtifacts: Seq[Artifact] = Nil, exclusions: Seq[ExclusionRule] = Nil, extraAttributes: Map[String, String] = Map.empty, crossVersion: CrossVersion = CrossVersion.Disabled) {
+sealed case class ModuleID(organization: String, name: String, revision: String, configurations: Option[String] = None, isChanging: Boolean = false, isTransitive: Boolean = true, isForce: Boolean = false, explicitArtifacts: Seq[Artifact] = Nil, exclusions: Seq[ExclusionRule] = Nil, extraAttributes: Map[String, String] = Map.empty, crossVersion: CrossVersion = CrossVersion.Disabled) extends ModuleIDSetBranch {
   override def toString: String =
     organization + ":" + name + ":" + revision +
       (configurations match { case Some(s) => ":" + s; case None => "" }) +
@@ -118,7 +118,10 @@ final case class ModuleID(organization: String, name: String, revision: String, 
    * as when adding a dependency on an artifact with a classifier.
    */
   def jar() = artifacts(Artifact(name))
+
+  override val branch: Option[String] = None
 }
+
 object ModuleID {
   implicit val pickler: Pickler[ModuleID] with Unpickler[ModuleID] = PicklerUnpickler.generate[ModuleID]
 
@@ -126,3 +129,21 @@ object ModuleID {
   def checkE(attributes: Seq[(String, String)]) =
     for ((key, value) <- attributes) yield if (key.startsWith("e:")) (key, value) else ("e:" + key, value)
 }
+
+/**
+ * Trait to mix in which allows querying and changing the branch of a ModuleID.
+ * This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility.
+ */
+private[sbt] trait ModuleIDSetBranch { self: ModuleID =>
+  val branch: Option[String]
+
+  /**
+   * Sets the Ivy branch of this module.
+   */
+  def onBranch(branch: String) = new ModuleIDWithBranch(self, Some(branch))
+
+  def onBranch(branch: Option[String]) = new ModuleIDWithBranch(self, branch)
+}
+
+/** This will be removed in 1.0 when the `branch` parameter can be added directly to ModuleID, breaking binary compatibility. */
+final class ModuleIDWithBranch(m: ModuleID, override val branch: Option[String]) extends ModuleID(m.organization, m.name, m.revision, m.configurations, m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion) with ModuleIDSetBranch

--- a/ivy/src/main/scala/sbt/ResolutionCache.scala
+++ b/ivy/src/main/scala/sbt/ResolutionCache.scala
@@ -86,5 +86,5 @@ private[sbt] object ResolutionCache {
   private val Name = "sbt-resolution-cache"
 
   // use sbt-specific extra attributes so that resolved xml files do not get overwritten when using different Scala/sbt versions
-  private val ResolvedPattern = "[organisation]/[module]/" + Resolver.PluginPattern + "[revision]/[artifact].[ext]"
+  private val ResolvedPattern = "[organisation]/[module]/" + Resolver.PluginPattern + "([branch]/)[revision]/[artifact].[ext]"
 }

--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -326,7 +326,7 @@ object Resolver {
 
   def defaultPatterns = mavenStylePatterns
   def mavenStyleBasePattern = "[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]"
-  def localBasePattern = "[organisation]/[module]/" + PluginPattern + "[revision]/[type]s/[artifact](-[classifier]).[ext]"
+  def localBasePattern = "[organisation]/[module]/" + PluginPattern + "(/[branch])/[revision]/[type]s/[artifact](-[classifier]).[ext]"
   def defaultRetrievePattern = "[type]s/[organisation]/[module]/" + PluginPattern + "[artifact](-[revision])(-[classifier]).[ext]"
   final val PluginPattern = "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)"
   private[this] def mavenLocalDir: File = {

--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -108,9 +108,9 @@ object CacheIvy {
   private[this] val crossToInt = (c: CrossVersion) => c match { case Disabled => 0; case b: Binary => BinaryValue; case f: Full => FullValue }
 
   implicit def moduleIDFormat(implicit sf: Format[String], bf: Format[Boolean]): Format[ModuleID] =
-    wrap[ModuleID, ((String, String, String, Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Map[String, String], CrossVersion))](
-      m => ((m.organization, m.name, m.revision, m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion)),
-      { case ((o, n, r, cs), (ch, t, f, as, excl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, x, cv) }
+    wrap[ModuleID, ((String, String, String, Option[String], Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Map[String, String], CrossVersion))](
+      m => ((m.organization, m.name, m.revision, m.configurations, m.branchName), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion)),
+      { case ((o, n, r, cs, br), (ch, t, f, as, excl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, x, cv).branch(br) }
     )
   // For some reason sbinary seems to detect unserialized instance Set[ModuleID] to be not equal. #1620
   implicit def moduleSetIC: InputCache[Set[ModuleID]] =

--- a/main/actions/src/test/scala/sbt/CacheIvyTest.scala
+++ b/main/actions/src/test/scala/sbt/CacheIvyTest.scala
@@ -1,0 +1,75 @@
+package sbt
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import Prop._
+
+class CacheIvyTest extends Properties("CacheIvy") {
+  import CacheIvy._
+  import sbinary.Operations._
+  import sbinary._
+  import sbinary.DefaultProtocol._
+
+  private def cachePreservesEquality[T: Format](m: T, eq: (T, T) => Prop, str: T => String): Prop = {
+    val out = fromByteArray[T](toByteArray(m))
+    eq(out, m) :| s"Expected: ${str(m)}" :| s"Got: ${str(out)}"
+  }
+
+  implicit val arbExclusionRule: Arbitrary[ExclusionRule] = Arbitrary(
+    for {
+      o <- Gen.alphaStr
+      n <- Gen.alphaStr
+      a <- Gen.alphaStr
+      cs <- arbitrary[List[String]]
+    } yield ExclusionRule(o, n, a, cs)
+  )
+
+  implicit val arbCrossVersion: Arbitrary[CrossVersion] = Arbitrary {
+    // Actual functions don't matter, just Disabled vs Binary vs Full
+    import CrossVersion._
+    Gen.oneOf(Disabled, new Binary(identity), new Full(identity))
+  }
+
+  implicit val arbArtifact: Arbitrary[Artifact] = Arbitrary {
+    for {
+      (n, t, e, cls) <- arbitrary[(String, String, String, String)]
+    } yield Artifact(n, t, e, cls) // keep it simple
+  }
+
+  implicit val arbModuleID: Arbitrary[ModuleID] = Arbitrary {
+    for {
+      o <- Gen.identifier
+      n <- Gen.identifier
+      r <- for { n <- Gen.numChar; ns <- Gen.numStr } yield n + ns
+      cs <- arbitrary[Option[String]]
+      branch <- arbitrary[Option[String]]
+      isChanging <- arbitrary[Boolean]
+      isTransitive <- arbitrary[Boolean]
+      isForce <- arbitrary[Boolean]
+      explicitArtifacts <- Gen.listOf(arbitrary[Artifact])
+      exclusions <- Gen.listOf(arbitrary[ExclusionRule])
+      extraAttributes <- Gen.mapOf(arbitrary[(String, String)])
+      crossVersion <- arbitrary[CrossVersion]
+    } yield ModuleID(o, n, r, cs, isChanging, isTransitive, isForce, explicitArtifacts, exclusions, extraAttributes, crossVersion).branch(branch)
+  }
+
+  property("moduleIDFormat") = forAll { (m: ModuleID) =>
+    def str(m: ModuleID) = {
+      import m._
+      s"ModuleID($organization, ${m.name}, $revision, $configurations, $isChanging, $isTransitive, $isForce, $explicitArtifacts, $exclusions, " +
+        s"$extraAttributes, $crossVersion) branch $branchName"
+    }
+    def eq(a: ModuleID, b: ModuleID): Prop = {
+      import CrossVersion._
+      def rest = a.copy(crossVersion = b.crossVersion) == b
+      (a.crossVersion, b.crossVersion) match {
+        case (Disabled, Disabled)   => rest
+        case (_: Binary, _: Binary) => rest
+        case (_: Full, _: Full)     => rest
+        case (a, b)                 => Prop(false) :| s"CrossVersions don't match: $a vs $b"
+      }
+
+    }
+    cachePreservesEquality(m, eq _, str)
+  }
+}


### PR DESCRIPTION
Allow an Ivy branch to be set on the project's module (such that Ivy is aware of it) , as well as on its dependencies.
This change:
- adds the `branchName: Option[String]` to `ModuleID` while preserving backwards-compatibility.
- changes the resolution cache's artifact pattern to include the `([branch]/)` after the module name
- changes `defaultIvyPatterns` as well as the local ivy repository pattern to include the `([branch]/)` after the module name
- changes `ModuleReport` generation to set the branch onto the `ModuleID` (on top of saving it inside the `ModuleReport`)
- includes `branchName` in `Format[ModuleID]` and adds a `CacheIvyTest` that ensures a cached-then-read `ModuleID` remains equal to the original (save for `CrossVersion`, which is not being cached perfectly)

Usage: 

``` scala
libraryDependencies += "org.something" % "module" % "version" branch "myBranch"
```

or

``` scala
libraryDependencies += "org.something" % "module" % "version" branch "myBranch"
```
