### PR TITLE
Added Extracted.runInputTask

### DIFF
--- a/notes/0.13.9/run-input-task.markdown
+++ b/notes/0.13.9/run-input-task.markdown
@@ -1,0 +1,11 @@
+
+  [@jroper]: http://github.com/jroper
+  [2006]: https://github.com/sbt/sbt/pull/2006
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Add an Extracted.runInputTask helper to assist with imperatively executing input tasks. [#2006][2006] by [@jroper][@jroper]
+
+### Bug fixes

--- a/sbt/src/sbt-test/api/extracted/build.sbt
+++ b/sbt/src/sbt-test/api/extracted/build.sbt
@@ -1,0 +1,54 @@
+import java.util.Locale
+
+lazy val myTask = taskKey[String]("My task")
+lazy val myInputTask = inputKey[String]("My input task")
+
+lazy val root = project in file(".")
+lazy val sub = project in file("sub")
+
+def testTask[T](name: String, expected: String, task: TaskKey[T]) = TaskKey[Unit](name) := {
+  val s = state.value
+  val e = Project.extract(s)
+  val (_, result) = e.runTask(task, s)
+  if (expected != result) {
+    throw sys.error(s"Error in test $name: Expected $expected but got $result")
+  }
+}
+
+myTask := "root"
+testTask("testRunTaskRoot", "root", myTask)
+
+myTask in Compile := "root compile"
+testTask("testRunTaskRootCompile", "root compile", myTask in Compile)
+
+myTask in sub := "sub"
+testTask("testRunTaskSub", "sub", myTask in sub)
+
+myTask in (sub, Compile) := "sub compile"
+testTask("testRunTaskSubCompile", "sub compile", myTask in (sub, Compile))
+
+def argFunction(f: String => String) = Def.inputTask {
+  import sbt.complete.Parsers._
+  f((OptSpace ~> StringBasic).parsed)
+}
+
+def testInputTask[T](name: String, expected: String, task: InputKey[T], arg: String) = TaskKey[Unit](name) := {
+  val s = state.value
+  val e = Project.extract(s)
+  val (_, result) = e.runInputTask(task, arg, s)
+  if (expected != result) {
+    throw sys.error(s"Error in test $name: Expected $expected but got $result")
+  }
+}
+
+myInputTask <<= argFunction(_.toUpperCase(Locale.ENGLISH))
+testInputTask("testRunInputTaskRoot", "FOO", myInputTask, "foo")
+
+myInputTask in Compile <<= argFunction(_.toLowerCase(Locale.ENGLISH))
+testInputTask("testRunInputTaskRootCompile", "foo", myInputTask in Compile, "FOO")
+
+myInputTask in sub <<= argFunction(_.head.toString)
+testInputTask("testRunInputTaskSub", "f", myInputTask in sub, "foo")
+
+myInputTask in (sub, Compile) <<= argFunction(_.tail)
+testInputTask("testRunInputTaskSubCompile", "oo", myInputTask in (sub, Compile), "foo")

--- a/sbt/src/sbt-test/api/extracted/test
+++ b/sbt/src/sbt-test/api/extracted/test
@@ -1,0 +1,9 @@
+> testRunTaskRoot
+> testRunTaskRootCompile
+> testRunTaskSub
+> testRunTaskSubCompile
+
+> testRunInputTaskRoot
+> testRunInputTaskRootCompile
+> testRunInputTaskSub
+> testRunInputTaskSubCompile


### PR DESCRIPTION
This provides a convenience function for running an input task from the extracted state. This is particularly useful for commands, release steps etc that may want to run input tasks, like scripted.

I haven't added tests, because I'm not sure where the right place to test this is - I don't think any of the specs are applicable here unless there's any easy way to fire up a fake sbt project, so maybe a scripted test? But should it be an existing scripted test? If there is a right place, let me know, and I'll add a test there.
