### PR TITLE
Provide more diagnostic info for undefined settings

### DIFF
--- a/util/collection/src/main/scala/sbt/Settings.scala
+++ b/util/collection/src/main/scala/sbt/Settings.scala
@@ -244,7 +244,12 @@ trait Init[Scope] {
     @deprecated("Use the non-deprecated Undefined factory method.", "0.13.1")
     def this(definingKey: ScopedKey[_], referencedKey: ScopedKey[_], derived: Boolean) = this(fakeUndefinedSetting(definingKey, derived), referencedKey)
   }
-  final class RuntimeUndefined(val undefined: Seq[Undefined]) extends RuntimeException("References to undefined settings at runtime.")
+  final class RuntimeUndefined(val undefined: Seq[Undefined]) extends RuntimeException("References to undefined settings at runtime.") {
+    override def getMessage =
+      super.getMessage + undefined.map { u =>
+        "\n" + u.defining + " referenced from " + u.referencedKey
+      }.mkString
+  }
 
   @deprecated("Use the other overload.", "0.13.1")
   def Undefined(definingKey: ScopedKey[_], referencedKey: ScopedKey[_], derived: Boolean): Undefined =


### PR DESCRIPTION
This solves this issue:
https://github.com/sbt/sbt/issues/2008

This is my previous error message:

```
sbt.Init$RuntimeUndefined: References to undefined settings at runtime.
```

which doesn't tell me what is happening.

Now, I get this additional information:

```
setting(ScopedKey(Scope(Select(ProjectRef(file:/home/d/rds/,rds)),Global,Global,Global),testApi)) at RangePosition(/home/d/rds/build.sbt,LineRange(233,234)) referenced from ScopedKey(Scope(Select(ProjectRef(file:/home/d/rds/,servision)),Select(ConfigKey(api)),Global,Global),start)

```

Now I know where the problem lies!  :-)
