### PR TITLE
Prevent history command(s) from going into an infinite loop

### DIFF
--- a/notes/0.13.9/history-infinite-loop.markdown
+++ b/notes/0.13.9/history-infinite-loop.markdown
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Prevent history command(s) from going into an infinite loop [#1562][1562] by [@PanAeon][@PanAeon]

--- a/util/complete/src/main/scala/sbt/complete/HistoryCommands.scala
+++ b/util/complete/src/main/scala/sbt/complete/HistoryCommands.scala
@@ -61,7 +61,7 @@ object HistoryCommands {
 
   def execute(f: History => Option[String]): History => Option[List[String]] = (h: History) =>
     {
-      val command = f(h)
+      val command = f(h).filterNot(_.startsWith(Start))
       val lines = h.lines.toArray
       command.foreach(lines(lines.length - 1) = _)
       h.path foreach { h => IO.writeLines(h, lines) }


### PR DESCRIPTION
Preventing execution of history commands as result of another history command, thus fixing infinite loops. Ticket  [#1562][1562]
