### PR TITLE
Do not emit in the pom dependencies that are only sources or docs

### DIFF
--- a/notes/0.13.9/source-pom.markdown
+++ b/notes/0.13.9/source-pom.markdown
@@ -1,0 +1,21 @@
+
+  [@cunei]: http://github.com/cunei
+  [2001]: https://github.com/sbt/sbt/issues/2001
+  [2027]: https://github.com/sbt/sbt/pull/2027
+
+### Fixes with compatibility implications
+
+- Starting with 0.13.9, the generated POM files no longer include dependencies on source or javadoc jars
+  obtained via withSources() or withJavadoc()
+
+### Improvements
+
+### Bug fixes
+
+### POM files no longer include certain source and javadoc jars
+
+When declaring library dependencies using the withSources() or withJavadoc() options, sbt was also including
+in the pom file, as dependencies, the source or javadoc jars using the default Maven scope. Such dependencies
+might be erroneously processed as they were regular jars by automated tools
+
+[#2001][2001]/[#2027][2027] by [@cunei][@cunei]


### PR DESCRIPTION
The pom generation code tries its best to map Ivy's configurations
to Maven scopes; however, sources and javadoc artifacts cannot be
properly mapped and they currently are emitted as dependencies in
the default scope (compile). That may lead to the source/doc jars
being erroneously processed like regular jars by automated tools. 

Arguably, the source/docs jars should not be included in the pom
file as dependencies at all. This commit filters out the
dependencies that only appear in the sources and/or javadoc Ivy
configurations, thereby preventing them from appearing in the
final pom file.

This pull request should fix #2001. Review by @eed3si9n and @jsuereth.
