### PR TITLE
Update ForkError.getMessage() to include exception's original name.

### DIFF
--- a/notes/0.13.8.markdown
+++ b/notes/0.13.8.markdown
@@ -8,6 +8,7 @@
   [@dwickern]: https://github.com/dwickern
   [@dwijnand]: http://github.com/dwijnand
   [@Duhemm]: https://github.com/Duhemm
+  [@kamilkloch]: https://github.com/kamilkloch
   [@kretes]: https://github.com/kretes
   [@indrajitr]: https://github.com/indrajitr
   [@j-keck]: https://github.com/j-keck
@@ -53,6 +54,7 @@
   [1899]: https://github.com/sbt/sbt/pull/1899
   [1902]: https://github.com/sbt/sbt/pull/1902
   [1921]: https://github.com/sbt/sbt/issues/1921
+  [2028]: https://github.com/sbt/sbt/issues/2028
 
 ### Changes with compatibility implications
 
@@ -71,6 +73,7 @@
 - Better abstration to track new kinds of dependencies for incremental compiler. [#1340][1340] by [@Duhemm][@Duhemm]
 - Source dependency uses `--depth 1` for git clone. [#1787][1787] by [@xuwei-k][@xuwei-k]
 - Facilitate nicer ways of declaring project settings. See below. [#1902][1902] by [@dwijnand][@dwijnand]
+- Update ForkError.getMessage() to include exception's original name. [#2028][2028] by [@kamilkloch][@kamilkloch]
 
 ### Fixes
 

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -95,13 +95,15 @@ public class ForkMain {
 
 	static class ForkError extends Exception {
 		private String originalMessage;
+		private String originalName;
 		private ForkError cause;
 		ForkError(Throwable t) {
 			originalMessage = t.getMessage();
+			originalName = t.getClass().getName();
 			setStackTrace(t.getStackTrace());
 			if (t.getCause() != null) cause = new ForkError(t.getCause());
 		}
-		public String getMessage() { return originalMessage; }
+		public String getMessage() { return originalName + ": " + originalMessage; }
 		public Exception getCause() { return cause; }
 	}
 


### PR DESCRIPTION
See #2028
