### PR TITLE
Updated ForkError.getMessage() to include exception's original name.

### DIFF
--- a/notes/0.13.9/fork-error-get-message.markdown
+++ b/notes/0.13.9/fork-error-get-message.markdown
@@ -1,0 +1,10 @@
+  [@kamilkloch]: https://github.com/kamilkloch
+  [2028]: https://github.com/sbt/sbt/issues/2028
+
+### Changes with compatibility implications
+
+### Improvements
+
+- Update ForkError.getMessage() to include exception's original name. [#2028][2028] by [@kamilkloch][@kamilkloch]
+
+### Fixes

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -95,13 +95,15 @@ public class ForkMain {
 
 	static class ForkError extends Exception {
 		private String originalMessage;
+		private String originalName;
 		private ForkError cause;
 		ForkError(Throwable t) {
 			originalMessage = t.getMessage();
+			originalName = t.getClass().getName();
 			setStackTrace(t.getStackTrace());
 			if (t.getCause() != null) cause = new ForkError(t.getCause());
 		}
-		public String getMessage() { return originalMessage; }
+		public String getMessage() { return originalName + ": " + originalMessage; }
 		public Exception getCause() { return cause; }
 	}
 


### PR DESCRIPTION
See #2028.
