### PR TITLE
Bumping up Scala version to 2.10.5/2.11.6. Fixes #1666, Ref #1980

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ def buildLevelSettings: Seq[Setting[_]] = Seq(
 )
 
 def commonSettings: Seq[Setting[_]] = Seq(
-  scalaVersion := "2.10.4",
+  scalaVersion := scala210,
   publishArtifact in packageDoc := false,
   publishMavenStyle := false,
   componentID := None,
@@ -387,7 +387,7 @@ lazy val scriptedBaseProj = (project in scriptedPath / "base").
   )
 
 lazy val scriptedSbtProj = (project in scriptedPath / "sbt").
-  dependsOn (ioProj, logProj, processProj, scriptedBaseProj).
+  dependsOn (ioProj, logProj, processProj, scriptedBaseProj, interfaceProj).
   settings(
     baseSettings,
     name := "Scripted sbt",

--- a/main/src/test/resources/old-format/15.sbt.txt
+++ b/main/src/test/resources/old-format/15.sbt.txt
@@ -3,7 +3,7 @@ name := "play-html-compressor"
 
 scalaVersion := "2.11.1"
 
-val pom = <xml:group><scm>
+val pom = <scm>
     <url>git@github.com:mohiva/play-html-compressor.git</url>
     <connection>scm:git:git@github.com:mohiva/play-html-compressor.git</connection>
   </scm>
@@ -13,9 +13,6 @@ val pom = <xml:group><scm>
       <name>Christian Kaps</name>
       <url>http://mohiva.com</url>
     </developer>
-  </developers></xml:group>
+  </developers>
 
 publishMavenStyle := true
-
-
-

--- a/main/src/test/resources/old-format/22.sbt.txt
+++ b/main/src/test/resources/old-format/22.sbt.txt
@@ -22,7 +22,6 @@ parallelExecution in Test := false
 // publishing
 
 pomExtra :=
-  <xml:group>
   <url>http://nbronson.github.com/scala-stm/</url>
   <licenses>
     <license>
@@ -42,7 +41,6 @@ pomExtra :=
       <email>ngbronson@gmail.com</email>
     </developer>
   </developers>
-  </xml:group>
 
 publishMavenStyle := true
 

--- a/main/src/test/resources/session-settings-quick/3.sbt.txt
+++ b/main/src/test/resources/session-settings-quick/3.sbt.txt
@@ -2,7 +2,7 @@ import sbt._
 
 val scmpom = taskKey[xml.NodeBuffer]("Node buffer")
 
-scmpom := <xml:group><scm>
+scmpom := <scm>
     <url>git@github.com:mohiva/play-html-compressor.git</url>
     <connection>scm:git:git@github.com:mohiva/play-html-compressor.git</connection>
   </scm>
@@ -13,4 +13,4 @@ scmpom := <xml:group><scm>
       <url>http://mohiva.com</url>
     </developer>
   </developers>
-  <a></a></xml:group>
+  <a></a>

--- a/main/src/test/resources/session-settings-quick/3.sbt.txt_1/1.set
+++ b/main/src/test/resources/session-settings-quick/3.sbt.txt_1/1.set
@@ -1,1 +1,1 @@
-scmpom := <xml:group><a/><b a="rt">OK</b></xml:group>
+scmpom := <a/><b a="rt">OK</b>

--- a/main/src/test/resources/session-settings-quick/3.sbt.txt_1/1.set.result
+++ b/main/src/test/resources/session-settings-quick/3.sbt.txt_1/1.set.result
@@ -2,4 +2,4 @@ import sbt._
 
 val scmpom = taskKey[xml.NodeBuffer]("Node buffer")
 
-scmpom := <xml:group><a/><b a="rt">OK</b></xml:group>
+scmpom := <a/><b a="rt">OK</b>

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -11,7 +11,7 @@
   [@PanAeon]: https://github.com/PanAeon
   [@asflierl]: http://github.com/asflierl
   [@matthewfarwell]: http://github.com/matthewfarwell
-
+  [SI9027]: https://issues.scala-lang.org/browse/SI-9027
   [1950]: https://github.com/sbt/sbt/pull/1950
   [1987]: https://github.com/sbt/sbt/pull/1987
   [1970]: https://github.com/sbt/sbt/pull/1970
@@ -40,11 +40,14 @@
   [2035]: https://github.com/sbt/sbt/pull/2035
   [2001]: https://github.com/sbt/sbt/issues/2001
   [2027]: https://github.com/sbt/sbt/pull/2027
+  [1666]: https://github.com/sbt/sbt/issues/1666
+  [2068]: https://github.com/sbt/sbt/pull/2068
 
 ### Fixes with compatibility implications
 
 - Starting 0.13.9, `crossScalaVersions` default value is fixed back to the older 0.12.x behavior. See below for details.
 - Starting 0.13.9, the generated POM files no longer include dependencies on source or javadoc jars obtained via `withSources()` or `withJavadoc()`. See below for details.
+- Scala version is bumped to 2.10.5. This brings in the fix for [SI-9027][SI9027]: XML node sequence literal bug. [#1666][1666]/[#2068][2068] by [@eed3si9n][@eed3si9n]
 
 ### Improvements
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ object Dependencies {
   lazy val scala282 = "2.8.2"
   lazy val scala292 = "2.9.2"
   lazy val scala293 = "2.9.3"
-  lazy val scala210 = "2.10.4"
-  lazy val scala211 = "2.11.1"
+  lazy val scala210 = "2.10.5"
+  lazy val scala211 = "2.11.6"
 
   lazy val jline = "jline" % "jline" % "2.11"
   lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-fccfbd44c9f64523b61398a0155784dcbaeae28f"

--- a/project/p.sbt
+++ b/project/p.sbt
@@ -1,3 +1,5 @@
+scalaVersion := "2.10.5"
+
 libraryDependencies ++= Seq(
   "net.databinder" %% "dispatch-http" % "0.8.9",
   "org.jsoup" % "jsoup" % "1.7.1"

--- a/scripted/sbt/src/main/scala/sbt/test/ScriptedTests.scala
+++ b/scripted/sbt/src/main/scala/sbt/test/ScriptedTests.scala
@@ -114,6 +114,7 @@ object ScriptedTests extends ScriptedRunner {
 class ScriptedRunner {
   import ScriptedTests._
 
+  @deprecated("No longer used", "0.13.9")
   def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], bootProperties: File,
     launchOpts: Array[String]): Unit =
     run(resourceBaseDirectory, bufferLog, tests, ConsoleLogger(), bootProperties, launchOpts, emptyCallback) //new FullLogger(Logger.xlog2Log(log)))
@@ -125,11 +126,17 @@ class ScriptedRunner {
     run(resourceBaseDirectory, bufferLog, tests, ConsoleLogger(), bootProperties, launchOpts,
       { f: File => prescripted.add(f); () }) //new FullLogger(Logger.xlog2Log(log)))
 
-  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], logger: xsbti.Logger, bootProperties: File,
+  @deprecated("No longer used", "0.13.9")
+  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], bootProperties: File,
+    launchOpts: Array[String], prescripted: File => Unit): Unit =
+    run(resourceBaseDirectory, bufferLog, tests, ConsoleLogger(), bootProperties, launchOpts, prescripted)
+
+  @deprecated("No longer used", "0.13.9")
+  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], logger: AbstractLogger, bootProperties: File,
     launchOpts: Array[String]): Unit =
     run(resourceBaseDirectory, bufferLog, tests, logger, bootProperties, launchOpts, emptyCallback)
 
-  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], logger: xsbti.Logger, bootProperties: File,
+  def run(resourceBaseDirectory: File, bufferLog: Boolean, tests: Array[String], logger: AbstractLogger, bootProperties: File,
     launchOpts: Array[String], prescripted: File => Unit) {
     val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, bootProperties, launchOpts)
     val allTests = get(tests, resourceBaseDirectory, logger) flatMap {


### PR DESCRIPTION
Fixes #1666, Subsumes #1980

To pass `File => Unit` callback across the classloader boundary
I am encoding it as a `java.util.List[File]` by overriding `add(x: File)` method.
This was needed since Java didn't allow me to cast from one classloader to the other.

/review @jsuereth, @dwijnand 
