### PR TITLE
Fixes #2043. bintrayRelease is repeated 20x?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -499,7 +499,8 @@ def otherRootSettings = Seq(
   Scripted.scriptedSource <<= (sourceDirectory in sbtProj) / "sbt-test",
   publishAll := {
     val _ = (publishLocal).all(ScopeFilter(inAnyProject)).value
-  }
+  },
+  aggregate in bintrayRelease := false
 ) ++ inConfig(Scripted.MavenResolverPluginTest)(Seq(
   Scripted.scripted <<= scriptedTask,
   Scripted.scriptedUnpublished <<= scriptedUnpublishedTask,


### PR DESCRIPTION
Fixes #2043

Currently nightlies are published but the Jenkins job is failing.
This is likely because the release command is running at the root project, and then aggregated to all subprojects! I think it's relatively safe to merge this, and then see if it works on tonight's nightly build.

/review @dwijnand, @jsuereth 

https://ci.typesafe.com/job/sbt-nightly/label=sbt-Linux-JDK6/633/console (sorry this CI box is probably not public)

```
[warn] You must run bintrayRelease once all artifacts are staged.
[success] Total time: 149 s, completed Jun 21, 2015 6:37:11 AM
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
[info] sbt/sbt@0.13.9-20150621-062029 was released
java.lang.RuntimeException: failed to release sbt/sbt@0.13.9-20150621-062029: <html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>

    at scala.sys.package$.error(package.scala:27)
    at bintray.BintrayRepo.release(BintrayRepo.scala:74)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:117)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:114)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:701)
java.lang.RuntimeException: failed to release sbt/sbt@0.13.9-20150621-062029: <html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>

    at scala.sys.package$.error(package.scala:27)
    at bintray.BintrayRepo.release(BintrayRepo.scala:74)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:117)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:114)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:701)
java.lang.RuntimeException: failed to release sbt/sbt@0.13.9-20150621-062029: <html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>

    at scala.sys.package$.error(package.scala:27)
    at bintray.BintrayRepo.release(BintrayRepo.scala:74)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:117)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:114)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:701)
java.lang.RuntimeException: failed to release sbt/sbt@0.13.9-20150621-062029: <html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>

    at scala.sys.package$.error(package.scala:27)
    at bintray.BintrayRepo.release(BintrayRepo.scala:74)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:117)
    at bintray.BintrayPlugin$$anonfun$bintrayPublishSettings$16.apply(BintrayPlugin.scala:114)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:701)
[error] (mainSettingsProj/*:bintrayRelease) failed to release sbt/sbt@0.13.9-20150621-062029: <html>
[error] <head><title>405 Not Allowed</title></head>
[error] <body bgcolor="white">
[error] <center><h1>405 Not Allowed</h1></center>
[error] <hr><center>nginx</center>
[error] </body>
[error] </html>
[error] (actionsProj/*:bintrayRelease) failed to release sbt/sbt@0.13.9-20150621-062029: <html>
[error] <head><title>405 Not Allowed</title></head>
[error] <body bgcolor="white">
[error] <center><h1>405 Not Allowed</h1></center>
[error] <hr><center>nginx</center>
[error] </body>
[error] </html>
[error] (stdTaskProj/*:bintrayRelease) failed to release sbt/sbt@0.13.9-20150621-062029: <html>
[error] <head><title>405 Not Allowed</title></head>
[error] <body bgcolor="white">
[error] <center><h1>405 Not Allowed</h1></center>
[error] <hr><center>nginx</center>
[error] </body>
[error] </html>
[error] (relationProj/*:bintrayRelease) failed to release sbt/sbt@0.13.9-20150621-062029: <html>
[error] <head><title>405 Not Allowed</title></head>
[error] <body bgcolor="white">
[error] <center><h1>405 Not Allowed</h1></center>
[error] <hr><center>nginx</center>
[error] </body>
[error] </html>
[error] Total time: 24 s, completed Jun 21, 2015 6:37:35 AM
Build step 'Build using sbt' changed build result to FAILURE
Build step 'Build using sbt' marked build as failure
Notifying upstream projects of job completion
```
