### PR TITLE
Don't show the stack trace on compilation error in build definition

### DIFF
--- a/notes/0.13.10/hide-stacktrace.markdown
+++ b/notes/0.13.10/hide-stacktrace.markdown
@@ -1,0 +1,12 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [2071]: https://github.com/sbt/sbt/issues/2071
+  [2091]: https://github.com/sbt/sbt/pull/2091
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Hide the stack trace on compilation error in build definition [#2071][2071]/[#2091][2091] by [@Duhemm][@Duhemm]
+
+### Bug fixes


### PR DESCRIPTION
This pull request hides the stack trace on compilation error in the build definition, as suggested in https://github.com/sbt/sbt/issues/2071.
