### PR TITLE
Do not use `ListBuffer#readOnly`

### DIFF
--- a/util/log/src/main/scala/sbt/BufferedLogger.scala
+++ b/util/log/src/main/scala/sbt/BufferedLogger.scala
@@ -39,7 +39,7 @@ class BufferedLogger(delegate: AbstractLogger) extends BasicLogger {
    * Flushes the buffer to the delegate logger.  This method calls logAll on the delegate
    * so that the messages are written consecutively. The buffer is cleared in the process.
    */
-  def play(): Unit = synchronized { delegate.logAll(buffer.readOnly); buffer.clear() }
+  def play(): Unit = synchronized { delegate.logAll(buffer.toList); buffer.clear() }
   /** Clears buffered events and disables buffering. */
   def clear(): Unit = synchronized { buffer.clear(); recording = false }
   /** Plays buffered events and disables buffering. */


### PR DESCRIPTION
It's dangerous, deprecated, and was removed in 2.12.0-M1.
See https://github.com/scala/scala/pull/4140.

`ListBuffer#toList` has equivalent performance,
except it actually returns an immutable copy(-on-write).

This turned up while trying to get the community build to [pass for 2.12.0-M2](https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/33/console)
