### PR TITLE
Fixes #2046. Cached resolution: Fixes double eviction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,7 +250,7 @@ lazy val ivyProj = (project in file("ivy")).
   settings(
     baseSettings,
     name := "Ivy",
-    libraryDependencies ++= Seq(ivy, jsch, sbtSerialization, launcherInterface),
+    libraryDependencies ++= Seq(ivy, jsch, sbtSerialization, scalaReflect.value, launcherInterface),
     testExclusive)
 
 // Runner for uniform test interface
@@ -293,7 +293,7 @@ lazy val cacheProj = (project in cachePath).
   settings(
     baseSettings,
     name := "Cache",
-    libraryDependencies ++= Seq(sbinary, sbtSerialization) ++ scalaXml.value
+    libraryDependencies ++= Seq(sbinary, sbtSerialization, scalaReflect.value) ++ scalaXml.value
   )
 
 // Builds on cache to provide caching for filesystem-related operations

--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -27,7 +27,7 @@ private[sbt] object CachedResolutionResolveCache {
   def createID(organization: String, name: String, revision: String) =
     ModuleRevisionId.newInstance(organization, name, revision)
   def sbtOrgTemp = "org.scala-sbt.temp"
-  def graphVersion = "0.13.9"
+  def graphVersion = "0.13.9B"
   val buildStartup: Long = System.currentTimeMillis
   lazy val todayStr: String = toYyyymmdd(buildStartup)
   lazy val tomorrowStr: String = toYyyymmdd(buildStartup + (1 day).toMillis)
@@ -367,6 +367,7 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
       val cachedReports = reports filter { !_.stats.cached }
       val stats = new UpdateStats(resolveTime, (cachedReports map { _.stats.downloadTime }).sum, (cachedReports map { _.stats.downloadSize }).sum, false)
       val configReports = rootModuleConfigs map { conf =>
+        log.debug("::: -----------")
         val crs = reports flatMap { _.configurations filter { _.configuration == conf.getName } }
         mergeConfigurationReports(conf.getName, crs, os, log)
       }
@@ -392,70 +393,86 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
   /**
    * Returns a tuple of (merged org + name combo, newly evicted modules)
    */
-  def mergeOrganizationArtifactReports(rootModuleConf: String, reports0: Seq[OrganizationArtifactReport], os: Vector[IvyOverride], log: Logger): Vector[OrganizationArtifactReport] =
+  def mergeOrganizationArtifactReports(rootModuleConf: String, reports0: Vector[OrganizationArtifactReport], os: Vector[IvyOverride], log: Logger): Vector[OrganizationArtifactReport] =
     {
-      val evicteds: mutable.ListBuffer[ModuleReport] = mutable.ListBuffer()
-      val results: mutable.ListBuffer[OrganizationArtifactReport] = mutable.ListBuffer()
       // group by takes up too much memory. trading space with time.
       val orgNamePairs = (reports0 map { oar => (oar.organization, oar.name) }).distinct
-      orgNamePairs foreach {
-        case (organization, name) =>
-          // hand rolling groupBy to avoid memory allocation
-          val xs = reports0 filter { oar => oar.organization == organization && oar.name == name }
-          if (xs.size == 0) () // do nothing
-          else if (xs.size == 1) results += xs.head
-          else
-            results += (mergeModuleReports(rootModuleConf, xs flatMap { _.modules }, os, log) match {
-              case (survivor, newlyEvicted) =>
-                evicteds ++= newlyEvicted
-                new OrganizationArtifactReport(organization, name, survivor ++ newlyEvicted)
-            })
-      }
-      transitivelyEvict(rootModuleConf, results.toList.toVector, evicteds.toList, log)
-    }
-  /**
-   * This transitively evicts any non-evicted modules whose only callers are newly evicted.
-   */
-  @tailrec
-  private final def transitivelyEvict(rootModuleConf: String, reports0: Vector[OrganizationArtifactReport],
-    evicted0: List[ModuleReport], log: Logger): Vector[OrganizationArtifactReport] =
-    {
-      val em = evicted0 map { _.module }
-      def isTransitivelyEvicted(mr: ModuleReport): Boolean =
-        mr.callers forall { c => em contains { c.caller } }
-      val evicteds: mutable.ListBuffer[ModuleReport] = mutable.ListBuffer()
-      // Ordering of the OrganizationArtifactReport matters
-      val reports: Vector[OrganizationArtifactReport] = reports0 map { oar =>
-        val organization = oar.organization
-        val name = oar.name
-        val (affected, unaffected) = oar.modules partition { mr =>
-          val x = !mr.evicted && mr.problem.isEmpty && isTransitivelyEvicted(mr)
-          if (x) {
-            log.debug(s""":::: transitively evicted $rootModuleConf: $organization:$name""")
+      // this might take up some memory, but it's limited to a single
+      val reports1 = reports0 map { recoverCallers }
+      val allModules: ListMap[(String, String), Vector[OrganizationArtifactReport]] =
+        ListMap(orgNamePairs map {
+          case (organization, name) =>
+            val xs = reports1 filter { oar => oar.organization == organization && oar.name == name }
+            ((organization, name), xs)
+        }: _*)
+      val stackGuard = reports0.size * reports0.size * 2
+      // sort the all modules such that less called modules comes earlier
+      def sortModules(cs: ListMap[(String, String), Vector[OrganizationArtifactReport]],
+        n: Int): ListMap[(String, String), Vector[OrganizationArtifactReport]] =
+        {
+          val keys = cs.keySet
+          val (called, notCalled) = cs partition {
+            case (k, oas) =>
+              oas exists {
+                _.modules.exists {
+                  _.callers exists { caller =>
+                    val m = caller.caller
+                    keys((m.organization, m.name))
+                  }
+                }
+              }
           }
-          x
+          notCalled ++
+            (if (called.isEmpty || n > stackGuard) called
+            else sortModules(called, n + 1))
         }
-        val newlyEvicted = affected map { _.copy(evicted = true, evictedReason = Some("transitive-evict")) }
-        if (affected.isEmpty) oar
-        else {
-          evicteds ++= newlyEvicted
-          new OrganizationArtifactReport(organization, name, unaffected ++ newlyEvicted)
+      def resolveConflicts(cs: List[((String, String), Vector[OrganizationArtifactReport])]): List[OrganizationArtifactReport] =
+        cs match {
+          case Nil => Nil
+          case (k, Vector()) :: rest => resolveConflicts(rest)
+          case (k, Vector(oa)) :: rest if (oa.modules.size == 0) => resolveConflicts(rest)
+          case (k, Vector(oa)) :: rest if (oa.modules.size == 1 && !oa.modules.head.evicted) =>
+            log.debug(s":: no conflict $rootModuleConf: ${oa.organization}:${oa.name}")
+            oa :: resolveConflicts(rest)
+          case ((organization, name), oas) :: rest =>
+            (mergeModuleReports(rootModuleConf, oas flatMap { _.modules }, os, log) match {
+              case (survivor, newlyEvicted) =>
+                val evicted = (survivor ++ newlyEvicted) filter { m => m.evicted }
+                val notEvicted = (survivor ++ newlyEvicted) filter { m => !m.evicted }
+                log.debug("::: adds " + (notEvicted map { _.module }).mkString(", "))
+                log.debug("::: evicted " + (evicted map { _.module }).mkString(", "))
+                val x = new OrganizationArtifactReport(organization, name, survivor ++ newlyEvicted)
+                val next = transitivelyEvict(rootModuleConf, rest, evicted, log)
+                x :: resolveConflicts(next)
+            })
         }
-      }
-      if (evicteds.isEmpty) reports
-      else transitivelyEvict(rootModuleConf, reports, evicteds.toList, log)
+      val sorted = sortModules(allModules, 0)
+      val result = resolveConflicts(sorted.toList) map { summarizeCallers }
+      result.toVector
     }
+  def recoverCallers(report0: OrganizationArtifactReport): OrganizationArtifactReport =
+    OrganizationArtifactReport(
+      report0.organization,
+      report0.name,
+      report0.modules map { mr => mr.copy(callers = JsonUtil.unsummarizeCallers(mr.callers)) })
+  def summarizeCallers(report0: OrganizationArtifactReport): OrganizationArtifactReport =
+    OrganizationArtifactReport(
+      report0.organization,
+      report0.name,
+      report0.modules map { mr => mr.copy(callers = JsonUtil.summarizeCallers(mr.callers)) })
   /**
    * Merges ModuleReports, which represents orgnization, name, and version.
    * Returns a touple of (surviving modules ++ non-conflicting modules, newly evicted modules).
    */
   def mergeModuleReports(rootModuleConf: String, modules: Seq[ModuleReport], os: Vector[IvyOverride], log: Logger): (Vector[ModuleReport], Vector[ModuleReport]) =
     {
+      if (modules.nonEmpty) {
+        log.debug(s":: merging module reports for $rootModuleConf: ${modules.head.module.organization}:${modules.head.module.name}")
+      }
       def mergeModuleReports(org: String, name: String, version: String, xs: Seq[ModuleReport]): ModuleReport = {
         val completelyEvicted = xs forall { _.evicted }
         val allCallers = xs flatMap { _.callers }
         val allArtifacts = (xs flatMap { _.artifacts }).distinct
-        log.debug(s":: merging module report for $org:$name:$version - $allArtifacts")
         xs.head.copy(artifacts = allArtifacts, evicted = completelyEvicted, callers = allCallers)
       }
       val merged = (modules groupBy { m => (m.module.organization, m.module.name, m.module.revision) }).toSeq.toVector flatMap {
@@ -469,6 +486,33 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
         case (survivor, evicted) =>
           (survivor ++ (merged filter { m => m.evicted || m.problem.isDefined }), evicted)
       }
+    }
+  /**
+   * This transitively evicts any non-evicted modules whose only callers are newly evicted.
+   */
+  def transitivelyEvict(rootModuleConf: String, reports0: List[((String, String), Vector[OrganizationArtifactReport])],
+    evicted0: Vector[ModuleReport], log: Logger): List[((String, String), Vector[OrganizationArtifactReport])] =
+    {
+      val em = (evicted0 map { _.module }).toSet
+      def isTransitivelyEvicted(mr: ModuleReport): Boolean =
+        mr.callers forall { c => em(c.caller) }
+      val reports: List[((String, String), Vector[OrganizationArtifactReport])] = reports0 map {
+        case ((organization, name), oars0) =>
+          val oars = oars0 map { oar =>
+            val (affected, unaffected) = oar.modules partition { mr =>
+              val x = !mr.evicted && mr.problem.isEmpty && isTransitivelyEvicted(mr)
+              if (x) {
+                log.debug(s""":::: transitively evicted $rootModuleConf: ${mr.module}""")
+              }
+              x
+            }
+            val newlyEvicted = affected map { _.copy(evicted = true, evictedReason = Some("transitive-evict")) }
+            if (affected.isEmpty) oar
+            else new OrganizationArtifactReport(organization, name, unaffected ++ newlyEvicted)
+          }
+          ((organization, name), oars)
+      }
+      reports
     }
   /**
    * resolves dependency resolution conflicts in which multiple candidates are found for organization+name combos.
@@ -487,7 +531,7 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
       val head = conflicts.head
       val organization = head.module.organization
       val name = head.module.name
-      log.debug(s"- conflict in $rootModuleConf:$organization:$name " + (conflicts map { _.module }).mkString("(", ", ", ")"))
+      log.debug(s"::: resolving conflict in $rootModuleConf:$organization:$name " + (conflicts map { _.module }).mkString("(", ", ", ")"))
       def useLatest(lcm: LatestConflictManager): (Vector[ModuleReport], Vector[ModuleReport], String) =
         (conflicts find { m =>
           m.callers.exists { _.isDirectlyForceDependency }
@@ -536,7 +580,8 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
       if (conflicts.size == 2 && os.isEmpty) {
         val (cf0, cf1) = (conflicts(0).module, conflicts(1).module)
         val cache = cachedResolutionResolveCache
-        cache.getOrElseUpdateConflict(cf0, cf1, conflicts) { doResolveConflict }
+        val (surviving, evicted) = cache.getOrElseUpdateConflict(cf0, cf1, conflicts) { doResolveConflict }
+        (surviving, evicted)
       } else {
         val (surviving, evicted, mgr) = doResolveConflict
         (surviving, evicted)

--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -454,7 +454,14 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
     OrganizationArtifactReport(
       report0.organization,
       report0.name,
-      report0.modules map { mr => mr.copy(callers = JsonUtil.unsummarizeCallers(mr.callers)) })
+      report0.modules map { mr =>
+        val original = JsonUtil.unsummarizeCallers(mr.callers)
+        // https://github.com/sbt/sbt/issues/1763
+        mr.copy(callers = original filter { c =>
+          (c.caller.organization != sbtOrgTemp) &&
+            (c.caller.organization != JsonUtil.fakeCallerOrganization)
+        })
+      })
   def summarizeCallers(report0: OrganizationArtifactReport): OrganizationArtifactReport =
     OrganizationArtifactReport(
       report0.organization,

--- a/ivy/src/test/scala/BaseIvySpecification.scala
+++ b/ivy/src/test/scala/BaseIvySpecification.scala
@@ -59,6 +59,11 @@ trait BaseIvySpecification extends Specification {
     IvyActions.updateEither(module, config, UnresolvedWarningConfiguration(), LogicalClock.unknown, Some(currentDependency), log)
   }
 
+  def cleanCachedResolutionCache(module: IvySbt#Module): Unit =
+    {
+      IvyActions.cleanCachedResolutionCache(module, log)
+    }
+
   def ivyUpdate(module: IvySbt#Module) =
     ivyUpdateEither(module) match {
       case Right(r) => r

--- a/ivy/src/test/scala/CachedResolutionSpec.scala
+++ b/ivy/src/test/scala/CachedResolutionSpec.scala
@@ -12,27 +12,38 @@ class CachedResolutionSpec extends BaseIvySpecification {
 
   Resolving the unsolvable module should
     not work                                                    $e2
+
+  Resolving a module with a pseudo-conflict should
+    work                                                        $e3
                                                                 """
 
   def commonsIo13 = ModuleID("commons-io", "commons-io", "1.3", Some("compile"))
   def mavenCayennePlugin302 = ModuleID("org.apache.cayenne.plugins", "maven-cayenne-plugin", "3.0.2", Some("compile"))
+  def avro177 = ModuleID("org.apache.avro", "avro", "1.7.7", Some("compile"))
+  def dataAvro1940 = ModuleID("com.linkedin.pegasus", "data-avro", "1.9.40", Some("compile"))
+  def netty320 = ModuleID("org.jboss.netty", "netty", "3.2.0.Final", Some("compile"))
 
   def defaultOptions = EvictionWarningOptions.default
 
   import ShowLines._
 
   def e1 = {
-    val m = module(ModuleID("com.example", "foo", "0.1.0", Some("compile")), Seq(commonsIo13), Some("2.10.2"), UpdateOptions().withCachedResolution(true))
+    val m = module(ModuleID("com.example", "foo", "0.1.0", Some("compile")),
+      Seq(commonsIo13), Some("2.10.2"), UpdateOptions().withCachedResolution(true))
     val report = ivyUpdate(m)
+    cleanCachedResolutionCache(m)
     val report2 = ivyUpdate(m)
+    // first resolution creates the minigraph
     println(report)
+    // second resolution reads from the minigraph
     println(report.configurations.head.modules.head.artifacts)
     report.configurations.size must_== 3
   }
 
   def e2 = {
-    log.setLevel(Level.Debug)
-    val m = module(ModuleID("com.example", "foo", "0.2.0", Some("compile")), Seq(mavenCayennePlugin302), Some("2.10.2"), UpdateOptions().withCachedResolution(true))
+    // log.setLevel(Level.Debug)
+    val m = module(ModuleID("com.example", "foo", "0.2.0", Some("compile")),
+      Seq(mavenCayennePlugin302), Some("2.10.2"), UpdateOptions().withCachedResolution(true))
     ivyUpdateEither(m) match {
       case Right(_) => sys.error("this should've failed")
       case Left(uw) =>
@@ -47,5 +58,23 @@ class CachedResolutionSpec extends BaseIvySpecification {
           "\t\t  +- org.apache.cayenne.plugins:maven-cayenne-plugin:3.0.2",
           "\t\t  +- com.example:foo:0.2.0"))
     }
+  }
+
+  // https://github.com/sbt/sbt/issues/2046
+  // data-avro:1.9.40 depends on avro:1.4.0, which depends on netty:3.2.1.Final.
+  // avro:1.4.0 will be evicted by avro:1.7.7.
+  // #2046 says that netty:3.2.0.Final is incorrectly evicted by netty:3.2.1.Final
+  def e3 = {
+    log.setLevel(Level.Debug)
+    val m = module(ModuleID("com.example", "foo", "0.3.0", Some("compile")),
+      Seq(avro177, dataAvro1940, netty320),
+      Some("2.10.2"), UpdateOptions().withCachedResolution(true))
+    // first resolution creates the minigraph
+    val report0 = ivyUpdate(m)
+    cleanCachedResolutionCache(m)
+    // second resolution reads from the minigraph
+    val report = ivyUpdate(m)
+    val modules = report.configurations.head.modules
+    modules must containMatch("""org\.jboss\.netty:netty:3\.2\.0.Final""")
   }
 }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1411,13 +1411,13 @@ object Classpaths {
 
       val outCacheFile = cacheFile / "output"
       def skipWork: In => UpdateReport =
-        Tracked.lastOutput[In, UpdateReport](outCacheFile) {
+        Tracked.lastOutputWithJson[In, UpdateReport](outCacheFile) {
           case (_, Some(out)) => out
           case _              => sys.error("Skipping update requested, but update has not previously run successfully.")
         }
       def doWork: In => UpdateReport =
         Tracked.inputChanged(cacheFile / "inputs") { (inChanged: Boolean, in: In) =>
-          val outCache = Tracked.lastOutput[In, UpdateReport](outCacheFile) {
+          val outCache = Tracked.lastOutputWithJson[In, UpdateReport](outCacheFile) {
             case (_, Some(out)) if uptodate(inChanged, out) => out
             case _ => work(in)
           }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1411,13 +1411,13 @@ object Classpaths {
 
       val outCacheFile = cacheFile / "output"
       def skipWork: In => UpdateReport =
-        Tracked.lastOutputWithJson[In, UpdateReport](outCacheFile) {
+        Tracked.lastOutput[In, UpdateReport](outCacheFile) {
           case (_, Some(out)) => out
           case _              => sys.error("Skipping update requested, but update has not previously run successfully.")
         }
       def doWork: In => UpdateReport =
         Tracked.inputChanged(cacheFile / "inputs") { (inChanged: Boolean, in: In) =>
-          val outCache = Tracked.lastOutputWithJson[In, UpdateReport](outCacheFile) {
+          val outCache = Tracked.lastOutput[In, UpdateReport](outCacheFile) {
             case (_, Some(out)) if uptodate(inChanged, out) => out
             case _ => work(in)
           }

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -48,6 +48,8 @@
   [2006]: https://github.com/sbt/sbt/pull/2006
   [2008]: https://github.com/sbt/sbt/issues/2008
   [2009]: https://github.com/sbt/sbt/pull/2009
+  [2046]: https://github.com/sbt/sbt/issues/2046
+  [2097]: https://github.com/sbt/sbt/pull/2097
 
 ### Fixes with compatibility implications
 
@@ -74,7 +76,7 @@
 
 ### Bug fixes
 
-- Fixes memory/performance issue with cached resolution. See below.
+- Fixes memory/performance/correctness issue with cached resolution. See below.
 - Correct incremental compile debug message for invalidated products [#1961][1961] by [@jroper][@jroper]
 - Enables forced GC by default. See below.
 - Fixes Maven compatibility to read `maven-metadata.xml`. See below.
@@ -115,16 +117,20 @@ It also adds `configurationsToRetrieve` key, that takes values of `Option[Set[Co
 
 On a larger dependency graph, the JSON file growing to be 100MB+
 with 97% of taken up by *caller* information.
-The caller information is not useful once the graph is successfully resolved.
 To make the matter worse, these large JSON files were never cleaned up.
 
-sbt 0.13.9 creates a single caller to represent all callers,
+sbt 0.13.9 filters out artificial callers,
 which fixes `OutOfMemoryException` seen on some builds.
 This generally shrinks the size of JSON, so it should make the IO operations faster.
 Dynamic graphs will be rotated with directories named after `yyyy-mm-dd`,
 and stale JSON files will be cleaned up after few days.
 
-[#2030][2030]/[#1721][1721]/[#2014][2014] by [@eed3si9n][@eed3si9n]
+sbt 0.13.9 also fixes a correctness issue that was found in the earlier releases.
+Under some circumstances, libraries that shouldn't have been evicted was being evicted.
+This occured when library `A1` depended on `B2`, but a newer `A2` dropped the dependency,
+and `A2` and `B1` are also is in the graph. This is fixed by sorting the graph prior to eviction.
+
+[#2030][2030]/[#1721][1721]/[#2014][2014]/[#2046][2046]/[#2097][2097] by [@eed3si9n][@eed3si9n]
 
 ### Force GC
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"
   lazy val sbtSerialization = "org.scala-sbt" %% "serialization" % "0.1.1"
   lazy val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
+  lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
   lazy val testInterface = "org.scala-sbt" % "test-interface" % "1.0"
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.4"
   lazy val specs2 = "org.specs2" %% "specs2" % "2.3.11"


### PR DESCRIPTION
Fixes #2046

This PR is against 0.13.9 branch, intending to fix cached resolution correctness issue.
The issue is fixed by sorting the stitched graph prior to resolving any conflicts.
To sort the stitched graph, we need the caller info.

Simply bringing back the entire caller list resulted in #1763 regression. I was able to work around this by removing all but one artificial callers.

/review @jsuereth, @dwijnand 
