### PR TITLE
Fix most SBT's build warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,8 +108,7 @@ lazy val interfaceProj = (project in file("interface")).
     watchSources <++= apiDefinitions,
     resourceGenerators in Compile <+= (version, resourceManaged, streams, compile in Compile) map generateVersionFile,
     apiDefinitions <<= baseDirectory map { base => (base / "definition") :: (base / "other") :: (base / "type") :: Nil },
-    sourceGenerators in Compile <+= (cacheDirectory,
-      apiDefinitions,
+    sourceGenerators in Compile <+= (apiDefinitions,
       fullClasspath in Compile in datatypeProj,
       sourceManaged in Compile,
       mainClass in datatypeProj in Compile,
@@ -459,14 +458,14 @@ lazy val mavenResolverPluginProj = (project in file("sbt-maven-resolver")).
     sbtPlugin := true
   )
 
-def scriptedTask: Initialize[InputTask[Unit]] = Def.inputTask {
+def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => scriptedParser(dir)).parsed
   publishAll.value
   doScripted((sbtLaunchJar in bundledLauncherProj).value, (fullClasspath in scriptedSbtProj in Test).value,
     (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value)
 }
 
-def scriptedUnpublishedTask: Initialize[InputTask[Unit]] = Def.inputTask {
+def scriptedUnpublishedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => scriptedParser(dir)).parsed
   doScripted((sbtLaunchJar in bundledLauncherProj).value, (fullClasspath in scriptedSbtProj in Test).value,
     (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value)
@@ -496,7 +495,7 @@ def otherRootSettings = Seq(
   Scripted.scriptedPrescripted := { _ => },
   Scripted.scripted <<= scriptedTask,
   Scripted.scriptedUnpublished <<= scriptedUnpublishedTask,
-  Scripted.scriptedSource <<= (sourceDirectory in sbtProj) / "sbt-test",
+  Scripted.scriptedSource := (sourceDirectory in sbtProj).value / "sbt-test",
   publishAll := {
     val _ = (publishLocal).all(ScopeFilter(inAnyProject)).value
   },

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -35,9 +35,8 @@ object Docs {
   }
 
   def siteIncludeSxr(prefix: String) = Seq(
-    mappings in sxr <<= sxr.map(dir => Path.allSubpaths(dir).toSeq),
-    site.addMappingsToSiteDir(mappings in sxr, prefix)
-  )
+    mappings in sxr <<= sxr.map(dir => Path.allSubpaths(dir).toSeq)
+  ) ++ site.addMappingsToSiteDir(mappings in sxr, prefix)
 
   def synchLocalImpl = (ghkeys.privateMappings, ghkeys.updatedRepository, version, streams) map {
     (mappings, repo, v, s) =>

--- a/project/SbtLauncherPlugin.scala
+++ b/project/SbtLauncherPlugin.scala
@@ -42,7 +42,7 @@ object SbtLauncherPlugin extends AutoPlugin {
       IO.unzip(jar, dir)
       IO.copy(overrides.map({ case (n, f) => (f, dir / n)}), overwrite = true)
       // TODO - is the ok for creating a jar?
-      IO.zip((dir.*** --- dir) x relativeTo(dir), target)
+      IO.zip((dir.*** --- dir) pair relativeTo(dir), target)
     }
     target
   }

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -2,6 +2,8 @@ import sbt._
 import Keys._
 import Def.Initialize
 
+import scala.language.reflectiveCalls
+
 object Scripted {
   def scriptedPath = file("scripted")
   lazy val scripted = InputKey[Unit]("scripted")

--- a/project/Sxr.scala
+++ b/project/Sxr.scala
@@ -3,7 +3,7 @@ import Keys._
 import Scope.ThisScope
 
 object Sxr {
-  val sxrConf = config("sxr") hide
+  val sxrConf = config("sxr").hide
   val sxr = TaskKey[File]("sxr")
   val sourceDirectories = TaskKey[Seq[File]]("sxr-source-directories")
 

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -42,11 +42,11 @@ object Transform {
     IO.writeLines(target, IO.readLines(source) map subMain)
   }
 
-  def crossGenSettings = transSourceSettings ++ seq(
+  def crossGenSettings = transSourceSettings ++ Seq(
     sourceProperties := Map("cross.package0" -> "sbt", "cross.package1" -> "cross")
   )
-  def transSourceSettings = seq(
-    inputSourceDirectory <<= sourceDirectory / "input_sources",
+  def transSourceSettings = Seq(
+    inputSourceDirectory := sourceDirectory.value / "input_sources",
     inputSourceDirectories <<= Seq(inputSourceDirectory).join,
     inputSources <<= inputSourceDirectories.map(dirs => (dirs ** (-DirectoryFilter)).get),
     fileMappings in transformSources <<= transformSourceMappings,
@@ -56,15 +56,15 @@ object Transform {
     sourceGenerators <+= transformSources
   )
   def transformSourceMappings = (inputSources, inputSourceDirectories, sourceManaged) map { (ss, sdirs, sm) =>
-    (ss --- sdirs) x (rebase(sdirs, sm) | flat(sm)) toSeq
+    ((ss --- sdirs) pair (rebase(sdirs, sm) | flat(sm))).toSeq
   }
-  def configSettings = transResourceSettings ++ seq(
+  def configSettings = transResourceSettings ++ Seq(
     resourceProperties <<= (organization, version, scalaVersion, isSnapshot) map { (org, v, sv, isSnapshot) =>
       Map("org" -> org, "sbt.version" -> v, "scala.version" -> sv, "repositories" -> repositories(isSnapshot).mkString(IO.Newline))
     }
   )
-  def transResourceSettings = seq(
-    inputResourceDirectory <<= sourceDirectory / "input_resources",
+  def transResourceSettings = Seq(
+    inputResourceDirectory := sourceDirectory.value / "input_resources",
     inputResourceDirectories <<= Seq(inputResourceDirectory).join,
     inputResources <<= inputResourceDirectories.map(dirs => (dirs ** (-DirectoryFilter)).get),
     fileMappings in transformResources <<= transformResourceMappings,
@@ -74,7 +74,7 @@ object Transform {
     resourceGenerators <+= transformResources
   )
   def transformResourceMappings = (inputResources, inputResourceDirectories, resourceManaged) map { (rs, rdirs, rm) =>
-    (rs --- rdirs) x (rebase(rdirs, rm) | flat(rm)) toSeq
+    ((rs --- rdirs) pair (rebase(rdirs, rm) | flat(rm))).toSeq
   }
 
   def transform(in: File, out: File, map: Map[String, String]): File =

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -37,10 +37,10 @@ object Util {
 
   lazy val apiDefinitions = TaskKey[Seq[File]]("api-definitions")
 
-  def generateAPICached(cache: File, defs: Seq[File], cp: Classpath, out: File, main: Option[String], run: ScalaRun, s: TaskStreams): Seq[File] =
+  def generateAPICached(defs: Seq[File], cp: Classpath, out: File, main: Option[String], run: ScalaRun, s: TaskStreams): Seq[File] =
     {
       def gen() = generateAPI(defs, cp, out, main, run, s)
-      val f = FileFunction.cached(cache / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
+      val f = FileFunction.cached(s.cacheDirectory / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
       f(defs.toSet).toSeq
     }
   def generateAPI(defs: Seq[File], cp: Classpath, out: File, main: Option[String], run: ScalaRun, s: TaskStreams): Seq[File] =
@@ -91,7 +91,8 @@ object Util {
         case Elem(prefix, "classifier", attributes, scope, children @ _*) =>
           NodeSeq.Empty
         case Elem(prefix, label, attributes, scope, children @ _*) =>
-          Elem(prefix, label, attributes, scope, cleanNodes(children): _*).theSeq
+          val cleanedNodes = cleanNodes(children)
+          Elem(prefix, label, attributes, scope, cleanedNodes.isEmpty, cleanedNodes: _*).theSeq
         case other => other
       }
       cleanNodes(pomNode.theSeq)(0)


### PR DESCRIPTION
This PR fixes most (2 remain) warnings in SBT's own build.

Here are those which remain : 

```
/Users/pierredalpra/Work/Forks/sbt/build.sbt:12: warning: postfix operator intransitive should be enabled
by making the implicit value scala.language.postfixOps visible.
This can be achieved by adding the import clause 'import scala.language.postfixOps'
or by setting the compiler option -language:postfixOps.
See the Scala docs for value scala.language.postfixOps for a discussion
why the feature should be explicitly enabled.
def buildLevelSettings: Seq[Setting[_]] = Seq(
                                         ^
```

```
/Users/pierredalpra/Work/Forks/sbt/build.sbt:555: warning: method normalize in object StringUtilities is deprecated: Different use cases require different normalization.  Use Project.normalizeModuleID or normalizeProjectID instead.
def precompiled(scalav: String): Project = Project(id = normalize("Precompiled " + scalav.replace('.', '_')), base = compilePath / "interface").
```

I'm having quite a hard time to understand where the first one comes from with my basic knowledge of SBT's internals...
