### PR TITLE
Log javaOptions/fork interactions

### DIFF
--- a/notes/0.13.10/log-java-options.markdown
+++ b/notes/0.13.10/log-java-options.markdown
@@ -1,0 +1,13 @@
+[@pdalpra]: http://github.com/pdalpra
+[2041]: https://github.com/sbt/sbt/issues/2041
+[2087]: https://github.com/sbt/sbt/issues/2087
+[2103]: https://github.com/sbt/sbt/pull/2103
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Log javaOptions used when forking [#2087][2087]/[#2103][2103] by [@pdalpra][@pdalpra]
+- Warn when javaOptions are defined but fork is set to false [#2041][2041]/[#2103][2103] by [@pdalpra][@pdalpra]
+
+### Bug fixes


### PR DESCRIPTION
This fixes both #2041 and #2087.
- When forking, log the javaOptions that are used
- When javaOptions are defined but fork := false, warn that javaOptions
  will be ignored
