### PR TITLE
Line content from diagnostic classes if available

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -573,7 +573,7 @@ lazy val safeUnitTests = taskKey[Unit]("Known working tests (for both 2.10 and 2
 lazy val safeProjects: ScopeFilter = ScopeFilter(
   inProjects(mainSettingsProj, mainProj, ivyProj, completeProj,
     actionsProj, classpathProj, collectionProj, compileIncrementalProj,
-    logProj, runProj, stdTaskProj),
+    logProj, runProj, stdTaskProj, compilerProj),
   inConfigurations(Test)
 )
 lazy val otherUnitTests = taskKey[Unit]("Unit test other projects")

--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -69,18 +69,37 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
         def startPosition: Option[Long] = checkNoPos(d.getStartPosition)
         def endPosition: Option[Long] = checkNoPos(d.getEndPosition)
         override val offset: Maybe[Integer] = Logger.o2m(checkNoPos(d.getPosition) map { x => new Integer(x.toInt) })
-        // TODO - Is this pulling contents of the line correctly?
-        // Would be ok to just return null if this version of the JDK doesn't support grabbing
-        // source lines?
-        override def lineContent: String =
-          Option(d.getSource) match {
-            case Some(source: JavaFileObject) =>
-              (Option(source.getCharContent(true)), startPosition, endPosition) match {
-                case (Some(cc), Some(start), Some(end)) => cc.subSequence(start.toInt, end.toInt).toString
-                case _                                  => ""
+        override def lineContent: String = {
+          def getDiagnosticLine: Option[String] =
+            try {
+              // See com.sun.tools.javac.api.ClientCodeWrapper.DiagnosticSourceUnwrapper
+              val diagnostic = d.getClass.getField("d").get(d)
+              // See com.sun.tools.javac.util.JCDiagnostic#getDiagnosticSource
+              val getDiagnosticSourceMethod = diagnostic.getClass.getDeclaredMethod("getDiagnosticSource")
+              Option(getDiagnosticSourceMethod.invoke(diagnostic)) match {
+                case Some(diagnosticSource) =>
+                  // See com.sun.tools.javac.util.DiagnosticSource
+                  val getLineMethod = diagnosticSource.getClass.getMethod("getLine", Integer.TYPE)
+                  Option(getLineMethod.invoke(diagnosticSource, line.get())).map(_.toString)
+                case _ => None
               }
-            case _ => ""
-          }
+            } catch {
+              case ignored: NoSuchMethodException => None
+              case ignored: NoSuchFieldException  => None
+            }
+
+          def getExpression: String =
+            Option(d.getSource) match {
+              case Some(source: JavaFileObject) =>
+                (Option(source.getCharContent(true)), startPosition, endPosition) match {
+                  case (Some(cc), Some(start), Some(end)) => cc.subSequence(start.toInt, end.toInt).toString
+                  case _                                  => ""
+                }
+              case _ => ""
+            }
+
+          getDiagnosticLine.getOrElse(getExpression)
+        }
         private val sourceUri = fixSource(d.getSource)
         override val sourcePath = Logger.o2m(sourceUri)
         override val sourceFile = Logger.o2m(sourceUri.map(new File(_)))

--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -84,6 +84,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
                 case _ => None
               }
             } catch {
+              // TODO - catch ReflectiveOperationException once sbt is migrated to JDK7
               case ignored: Throwable => None
             }
 

--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -84,8 +84,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
                 case _ => None
               }
             } catch {
-              case ignored: NoSuchMethodException => None
-              case ignored: NoSuchFieldException  => None
+              case ignored: ReflectiveOperationException => None
             }
 
           def getExpression: String =

--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -84,7 +84,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
                 case _ => None
               }
             } catch {
-              case ignored: ReflectiveOperationException => None
+              case ignored: Throwable => None
             }
 
           def getExpression: String =

--- a/compile/src/test/scala/sbt/compiler/javac/JavaCompilerSpec.scala
+++ b/compile/src/test/scala/sbt/compiler/javac/JavaCompilerSpec.scala
@@ -114,7 +114,7 @@ object JavaCompilerSpec extends Specification {
         case Some(content) => content.equalsIgnoreCase(p.position.lineContent())
         case _             => true
       }
-    def lineNumberCheck = p.position.line.exists(_ == lineno)
+    def lineNumberCheck = p.position.line.isDefined && (p.position.line.get == lineno)
     lineNumberCheck && lineContentCheck
   }
 

--- a/compile/src/test/scala/sbt/compiler/javac/JavaCompilerSpec.scala
+++ b/compile/src/test/scala/sbt/compiler/javac/JavaCompilerSpec.scala
@@ -114,7 +114,7 @@ object JavaCompilerSpec extends Specification {
         case Some(content) => content.equalsIgnoreCase(p.position.lineContent())
         case _             => true
       }
-    def lineNumberCheck = p.position.line.isDefined && (p.position.line.get == lineno)
+    def lineNumberCheck = p.position.line.exists(_ == lineno)
     lineNumberCheck && lineContentCheck
   }
 

--- a/notes/0.13.10/proper-line-content-from-local-javac.markdown
+++ b/notes/0.13.10/proper-line-content-from-local-javac.markdown
@@ -1,5 +1,6 @@
 
   [@fkorotkov]: http://github.com/fkorotkov
+  [#2108]: https://github.com/sbt/sbt/pull/2108
 
 ### Fixes with compatibility implications
 

--- a/notes/0.13.9/proper-line-content-from-local-javac.markdown
+++ b/notes/0.13.9/proper-line-content-from-local-javac.markdown
@@ -1,0 +1,10 @@
+
+  [@fkorotkov]: http://github.com/fkorotkov
+
+### Fixes with compatibility implications
+
+### Improvements
+
+Use diagnostic classes to get lines contents in local java compiler.
+
+### Bug fixes


### PR DESCRIPTION
### Problem

While using local java compiler line content in errors is wrong. Only an expression is shown and not a whole line of code.
### Expectation

Get a proper line content.
### Solution

When you run javac from command line com.sun.tools.javac.util.AbstractDiagnosticFormatter#formatSourceLine is used to format an output. There diagnostic classes are used to get line content. Made a change to try to use diagnostic classes if they are available.
