### PR TITLE
Fixes #2105/#1763. Cached resolution: removes duplicate callers during merge

### DIFF
--- a/ivy/src/test/scala/BaseIvySpecification.scala
+++ b/ivy/src/test/scala/BaseIvySpecification.scala
@@ -59,6 +59,11 @@ trait BaseIvySpecification extends Specification {
     IvyActions.updateEither(module, config, UnresolvedWarningConfiguration(), LogicalClock.unknown, Some(currentDependency), log)
   }
 
+  def cleanIvyCache: Unit =
+    {
+      IO.delete(currentTarget / "cache")
+    }
+
   def cleanCachedResolutionCache(module: IvySbt#Module): Unit =
     {
       IvyActions.cleanCachedResolutionCache(module, log)

--- a/ivy/src/test/scala/CachedResolutionSpec.scala
+++ b/ivy/src/test/scala/CachedResolutionSpec.scala
@@ -28,6 +28,7 @@ class CachedResolutionSpec extends BaseIvySpecification {
   import ShowLines._
 
   def e1 = {
+    cleanIvyCache
     val m = module(ModuleID("com.example", "foo", "0.1.0", Some("compile")),
       Seq(commonsIo13), Some("2.10.2"), UpdateOptions().withCachedResolution(true))
     val report = ivyUpdate(m)
@@ -65,7 +66,8 @@ class CachedResolutionSpec extends BaseIvySpecification {
   // avro:1.4.0 will be evicted by avro:1.7.7.
   // #2046 says that netty:3.2.0.Final is incorrectly evicted by netty:3.2.1.Final
   def e3 = {
-    log.setLevel(Level.Debug)
+    // log.setLevel(Level.Debug)
+    cleanIvyCache
     val m = module(ModuleID("com.example", "foo", "0.3.0", Some("compile")),
       Seq(avro177, dataAvro1940, netty320),
       Some("2.10.2"), UpdateOptions().withCachedResolution(true))

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -119,7 +119,7 @@ On a larger dependency graph, the JSON file growing to be 100MB+
 with 97% of taken up by *caller* information.
 To make the matter worse, these large JSON files were never cleaned up.
 
-sbt 0.13.9 filters out artificial callers,
+sbt 0.13.9 filters out artificial or duplicate callers,
 which fixes `OutOfMemoryException` seen on some builds.
 This generally shrinks the size of JSON, so it should make the IO operations faster.
 Dynamic graphs will be rotated with directories named after `yyyy-mm-dd`,


### PR DESCRIPTION
Fixes #2105/#1763

In #2097 which became 0.13.9-RC2 I ended up regressing on OOM (#1763), which I thought I tested locally, but apparently I tested on an older SNAPSHOT.
I've gotten to the root cause of the bloating caller info this time, I think. It's my merge code that was `flatMap`ing all callers across the subprojects. So the more subproject you add the more it was duplicating the callers.

/review @jsuereth, @dwijnand 
