### PR TITLE
Add warning to MakePom for intransitive dependencies.

### DIFF
--- a/ivy/src/main/scala/sbt/MakePom.scala
+++ b/ivy/src/main/scala/sbt/MakePom.scala
@@ -236,21 +236,30 @@ class MakePom(val log: Logger) {
   def makeDependency(dependency: DependencyDescriptor, includeTypes: Set[String]): NodeSeq =
     makeDependency(dependency, includeTypes, Nil)
 
-  def makeDependency(dependency: DependencyDescriptor, includeTypes: Set[String], excludes: Seq[ExcludeRule]): NodeSeq =
-    {
-      val artifacts = dependency.getAllDependencyArtifacts
-      val includeArtifacts = artifacts.filter(d => includeTypes(d.getType))
-      if (artifacts.isEmpty) {
-        val configs = dependency.getModuleConfigurations
-        if (configs.filterNot(Set("sources", "docs")).nonEmpty) {
-          val (scope, optional) = getScopeAndOptional(dependency.getModuleConfigurations)
-          makeDependencyElem(dependency, scope, optional, None, None, excludes)
-        } else NodeSeq.Empty
-      } else if (includeArtifacts.isEmpty)
-        NodeSeq.Empty
-      else
-        NodeSeq.fromSeq(artifacts.flatMap(a => makeDependencyElem(dependency, a, excludes)))
+  def makeDependency(dependency: DependencyDescriptor, includeTypes: Set[String], excludes: Seq[ExcludeRule]): NodeSeq = {
+    def warnIntransitve(): Unit =
+      if (!dependency.isTransitive)
+        log.warn(
+          s"""Translating intransitive dependency (${dependency.getDependencyId}) into pom.xml, but maven does not support intransitive dependencies.
+             |  Please use exclusions instead so transitive dependencies will be correctly excluded in dependent projects.
+           """.stripMargin)
+      else ()
+    val artifacts = dependency.getAllDependencyArtifacts
+    val includeArtifacts = artifacts.filter(d => includeTypes(d.getType))
+    if (artifacts.isEmpty) {
+      val configs = dependency.getModuleConfigurations
+      if (configs.filterNot(Set("sources", "docs")).nonEmpty) {
+        warnIntransitve()
+        val (scope, optional) = getScopeAndOptional(dependency.getModuleConfigurations)
+        makeDependencyElem(dependency, scope, optional, None, None, excludes)
+      } else NodeSeq.Empty
+    } else if (includeArtifacts.isEmpty) {
+      NodeSeq.Empty
+    } else {
+      warnIntransitve()
+      NodeSeq.fromSeq(artifacts.flatMap(a => makeDependencyElem(dependency, a, excludes)))
     }
+  }
 
   @deprecated("Use `makeDependencyElem` variant which takes excludes", "0.13.9")
   def makeDependencyElem(dependency: DependencyDescriptor, artifact: DependencyArtifactDescriptor): Option[Elem] =

--- a/notes/0.13.10/warn-on-intransitive-pom.markdown
+++ b/notes/0.13.10/warn-on-intransitive-pom.markdown
@@ -1,9 +1,10 @@
 [@jsuereth]: http://github.com/jsuereth
+[2127]: https://github.com/sbt/sbt/pull/2127
 
 ### Fixes with compatibility implications
 
 ### Improvements
 
-- makePom now warns when it sees intransitive dependencies, which do not translate to Maven. by [@jsuereth][@jsuereth]
+- makePom now warns when it sees intransitive dependencies, which do not translate to Maven. by [#2127][2127][@jsuereth][@jsuereth]
 
 ### Bug fixes

--- a/notes/0.13.10/warn-on-intransitive-pom.markdown
+++ b/notes/0.13.10/warn-on-intransitive-pom.markdown
@@ -1,0 +1,9 @@
+[@jsuereth]: http://github.com/jsuereth
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- makePom now warns when it sees intransitive dependencies, which do not translate to Maven. by [@jsuereth][@jsuereth]
+
+### Bug fixes

--- a/sbt/src/sbt-test/dependency-management/pom-type/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-type/build.sbt
@@ -13,7 +13,6 @@ checkPom := {
 		sys.error("Expected no <type> sections, got: " + tpe + " in \n\n" + pom)
 	}
 	val dir = (streams in makePom).value.cacheDirectory / "out"
-	System.out.println(dir.getAbsolutePath)
 	val lines = IO.readLines(dir)
 	val hasError = lines exists { line => line contains "Translating intransitive dependency "}
 	assert(hasError, s"Failed to detect intransitive dependencies, got: ${lines.mkString("\n")}")

--- a/sbt/src/sbt-test/dependency-management/pom-type/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-type/build.sbt
@@ -1,6 +1,7 @@
 scalaVersion := "2.10.2"
 
 libraryDependencies += "org.scala-sbt" %% "sbinary" % "0.4.1" withSources() withJavadoc()
+libraryDependencies += "org.scala-sbt" % "io" % "0.13.8" intransitive()
 
 lazy val checkPom = taskKey[Unit]("check pom to ensure no <type> sections are generated")
 
@@ -8,6 +9,12 @@ checkPom := {
 	val pomFile = makePom.value
 	val pom = xml.XML.loadFile(pomFile)
 	val tpe = pom \\ "type"
-	if(tpe.nonEmpty)
-		error("Expected no <type> sections, got: " + tpe + " in \n\n" + pom)
+	if(tpe.nonEmpty) {
+		sys.error("Expected no <type> sections, got: " + tpe + " in \n\n" + pom)
+	}
+	val dir = (streams in makePom).value.cacheDirectory / "out"
+	System.out.println(dir.getAbsolutePath)
+	val lines = IO.readLines(dir)
+	val hasError = lines exists { line => line contains "Translating intransitive dependency "}
+	assert(hasError, s"Failed to detect intransitive dependencies, got: ${lines.mkString("\n")}")
 }


### PR DESCRIPTION
Intransitive does not work in Maven, and does not translate to pom.xml.

Review by @eed3si9n or @dwijnand 
