### PR TITLE
[0.13.9-RC3] cached resolution: stack overflow when circular dependency is found

### DIFF
--- a/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/CachedResolutionResolveEngine.scala
@@ -396,59 +396,68 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
   def mergeOrganizationArtifactReports(rootModuleConf: String, reports0: Vector[OrganizationArtifactReport], os: Vector[IvyOverride], log: Logger): Vector[OrganizationArtifactReport] =
     {
       // group by takes up too much memory. trading space with time.
-      val orgNamePairs = (reports0 map { oar => (oar.organization, oar.name) }).distinct
+      val orgNamePairs: Vector[(String, String)] = (reports0 map { oar => (oar.organization, oar.name) }).distinct
       // this might take up some memory, but it's limited to a single
       val reports1 = reports0 map { filterOutCallers }
-      val allModules: ListMap[(String, String), Vector[OrganizationArtifactReport]] =
-        ListMap(orgNamePairs map {
+      val allModules0: Map[(String, String), Vector[OrganizationArtifactReport]] =
+        Map(orgNamePairs map {
           case (organization, name) =>
             val xs = reports1 filter { oar => oar.organization == organization && oar.name == name }
             ((organization, name), xs)
         }: _*)
-      val stackGuard = reports0.size * reports0.size * 2
       // sort the all modules such that less called modules comes earlier
-      @tailrec def sortModules(cs: ListMap[(String, String), Vector[OrganizationArtifactReport]],
-        acc: ListMap[(String, String), Vector[OrganizationArtifactReport]],
-        n: Int): ListMap[(String, String), Vector[OrganizationArtifactReport]] =
+      @tailrec def sortModules(cs: Vector[(String, String)],
+        acc: Vector[(String, String)],
+        n: Int, guard: Int): Vector[(String, String)] =
         {
-          println(s"sortModules: $n / $stackGuard")
-          val keys = cs.keySet
-          val (called, notCalled) = cs partition {
-            case (k, oas) =>
-              oas exists {
-                _.modules.exists {
-                  _.callers exists { caller =>
-                    val m = caller.caller
-                    keys((m.organization, m.name))
-                  }
+          // println(s"sortModules: $n / $guard")
+          val keys = cs.toSet
+          val (called, notCalled) = cs partition { k =>
+            val reports = allModules0(k)
+            reports exists {
+              _.modules.exists {
+                _.callers exists { caller =>
+                  val m = caller.caller
+                  keys((m.organization, m.name))
                 }
               }
+            }
           }
-          (if (called.isEmpty || n > stackGuard) acc ++ notCalled ++ called
-          else sortModules(called, acc ++ notCalled, n + 1))
+          lazy val result0 = acc ++ notCalled ++ called
+          (if (n > guard) {
+            log.warn(s"""cached resolution detected circular dependencies: ${cs.mkString(",")}""")
+            result0
+          } else if (called.isEmpty || notCalled.isEmpty) result0
+          else sortModules(called, acc ++ notCalled, 0, called.size * called.size + 1))
         }
-      def resolveConflicts(cs: List[((String, String), Vector[OrganizationArtifactReport])]): List[OrganizationArtifactReport] =
+      def resolveConflicts(cs: List[(String, String)],
+        allModules: Map[(String, String), Vector[OrganizationArtifactReport]]): List[OrganizationArtifactReport] =
         cs match {
           case Nil => Nil
-          case (k, Vector()) :: rest => resolveConflicts(rest)
-          case (k, Vector(oa)) :: rest if (oa.modules.size == 0) => resolveConflicts(rest)
-          case (k, Vector(oa)) :: rest if (oa.modules.size == 1 && !oa.modules.head.evicted) =>
-            log.debug(s":: no conflict $rootModuleConf: ${oa.organization}:${oa.name}")
-            oa :: resolveConflicts(rest)
-          case ((organization, name), oas) :: rest =>
-            (mergeModuleReports(rootModuleConf, oas flatMap { _.modules }, os, log) match {
-              case (survivor, newlyEvicted) =>
-                val evicted = (survivor ++ newlyEvicted) filter { m => m.evicted }
-                val notEvicted = (survivor ++ newlyEvicted) filter { m => !m.evicted }
-                log.debug("::: adds " + (notEvicted map { _.module }).mkString(", "))
-                log.debug("::: evicted " + (evicted map { _.module }).mkString(", "))
-                val x = new OrganizationArtifactReport(organization, name, survivor ++ newlyEvicted)
-                val next = transitivelyEvict(rootModuleConf, rest, evicted, log)
-                x :: resolveConflicts(next)
-            })
+          case (organization, name) :: rest =>
+            val reports = allModules((organization, name))
+            reports match {
+              case Vector()                             => resolveConflicts(rest, allModules)
+              case Vector(oa) if (oa.modules.size == 0) => resolveConflicts(rest, allModules)
+              case Vector(oa) if (oa.modules.size == 1 && !oa.modules.head.evicted) =>
+                log.debug(s":: no conflict $rootModuleConf: ${oa.organization}:${oa.name}")
+                oa :: resolveConflicts(rest, allModules)
+              case oas =>
+                (mergeModuleReports(rootModuleConf, oas flatMap { _.modules }, os, log) match {
+                  case (survivor, newlyEvicted) =>
+                    val evicted = (survivor ++ newlyEvicted) filter { m => m.evicted }
+                    val notEvicted = (survivor ++ newlyEvicted) filter { m => !m.evicted }
+                    log.debug("::: adds " + (notEvicted map { _.module }).mkString(", "))
+                    log.debug("::: evicted " + (evicted map { _.module }).mkString(", "))
+                    val x = new OrganizationArtifactReport(organization, name, survivor ++ newlyEvicted)
+                    val nextModules = transitivelyEvict(rootModuleConf, rest, allModules, evicted, log)
+                    x :: resolveConflicts(rest, nextModules)
+                })
+            }
         }
-      val sorted = sortModules(allModules, ListMap(), 0)
-      val result = resolveConflicts(sorted.toList)
+      val guard0 = (orgNamePairs.size * orgNamePairs.size) + 1
+      val sorted: Vector[(String, String)] = sortModules(orgNamePairs, Vector(), 0, guard0)
+      val result = resolveConflicts(sorted.toList, allModules0)
       result.toVector
     }
   def filterOutCallers(report0: OrganizationArtifactReport): OrganizationArtifactReport =
@@ -491,13 +500,15 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
   /**
    * This transitively evicts any non-evicted modules whose only callers are newly evicted.
    */
-  def transitivelyEvict(rootModuleConf: String, reports0: List[((String, String), Vector[OrganizationArtifactReport])],
-    evicted0: Vector[ModuleReport], log: Logger): List[((String, String), Vector[OrganizationArtifactReport])] =
+  def transitivelyEvict(rootModuleConf: String, pairs: List[(String, String)],
+    reports0: Map[(String, String), Vector[OrganizationArtifactReport]],
+    evicted0: Vector[ModuleReport], log: Logger): Map[(String, String), Vector[OrganizationArtifactReport]] =
     {
       val em = (evicted0 map { _.module }).toSet
       def isTransitivelyEvicted(mr: ModuleReport): Boolean =
         mr.callers forall { c => em(c.caller) }
-      val reports: List[((String, String), Vector[OrganizationArtifactReport])] = reports0 map {
+      val reports: Seq[((String, String), Vector[OrganizationArtifactReport])] = reports0.toSeq flatMap {
+        case (k, v) if !(pairs contains k) => Seq()
         case ((organization, name), oars0) =>
           val oars = oars0 map { oar =>
             val (affected, unaffected) = oar.modules partition { mr =>
@@ -511,9 +522,9 @@ private[sbt] trait CachedResolutionResolveEngine extends ResolveEngine {
             if (affected.isEmpty) oar
             else new OrganizationArtifactReport(organization, name, unaffected ++ newlyEvicted)
           }
-          ((organization, name), oars)
+          Seq(((organization, name), oars))
       }
-      reports
+      Map(reports: _*)
     }
   /**
    * resolves dependency resolution conflicts in which multiple candidates are found for organization+name combos.

--- a/ivy/src/test/scala/CachedResolutionSpec.scala
+++ b/ivy/src/test/scala/CachedResolutionSpec.scala
@@ -77,6 +77,7 @@ class CachedResolutionSpec extends BaseIvySpecification {
     // second resolution reads from the minigraph
     val report = ivyUpdate(m)
     val modules = report.configurations.head.modules
-    modules must containMatch("""org\.jboss\.netty:netty:3\.2\.0.Final""")
+    (modules must containMatch("""org\.jboss\.netty:netty:3\.2\.0.Final""")) and
+      (modules must not containMatch ("""org\.jboss\.netty:netty:3\.2\.1.Final"""))
   }
 }

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
@@ -21,7 +21,10 @@ lazy val a = project.
     libraryDependencies := Seq(
       organization.value %% "c" % version.value,
       "commons-io" % "commons-io" % "1.3",
-      "org.apache.spark" %% "spark-core" % "0.9.0-incubating"
+      "org.apache.spark" %% "spark-core" % "0.9.0-incubating",
+      "org.apache.avro" % "avro" % "1.7.7",
+      "com.linkedin.pegasus" % "data-avro" % "1.9.40",
+      "org.jboss.netty" % "netty" % "3.2.0.Final"
     )
   )
 
@@ -44,5 +47,11 @@ lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
     organization in ThisBuild := "org.example",
-    version in ThisBuild := "1.0-SNAPSHOT"
+    version in ThisBuild := "1.0-SNAPSHOT",
+    check := {
+      val acp = (externalDependencyClasspath in Compile in a).value.map {_.data.getName}.sorted
+      if (!(acp contains "netty-3.2.0.Final.jar")) {
+        sys.error("netty-3.2.0.Final not found when it should be included: " + acp.toString)
+      }
+    }
   )

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
@@ -1,10 +1,17 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+val sprayV = "1.1.1"
+val playVersion = "2.2.0"
+val summingbirdVersion = "0.4.0"
+val luceneVersion = "4.0.0"
+val akkaVersion = "2.3.1"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),
     scalaVersion := "2.10.4",
-    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project")
+    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
+    updateOptions := updateOptions.value.withCachedResolution(true)
   )
 
 lazy val a = project.
@@ -12,14 +19,18 @@ lazy val a = project.
   settings(
     name := "a",
     libraryDependencies := Seq(
-      "commons-io" % "commons-io" % "1.3"
+      organization.value %% "c" % version.value,
+      "commons-io" % "commons-io" % "1.3",
+      "org.apache.spark" %% "spark-core" % "0.9.0-incubating"
     )
   )
 
 lazy val b = project.
   settings(commonSettings: _*).
   settings(
-    name := "b"
+    name := "b",
+    // this adds circular dependency
+    libraryDependencies := Seq(organization.value %% "c" % version.value)
   )
 
 lazy val c = project.

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
@@ -20,7 +20,10 @@ lazy val a = project.
     name := "a",
     libraryDependencies := Seq(
       "commons-io" % "commons-io" % "1.3",
-      "org.apache.spark" %% "spark-core" % "0.9.0-incubating"
+      "org.apache.spark" %% "spark-core" % "0.9.0-incubating",
+      "org.apache.avro" % "avro" % "1.7.7",
+      "com.linkedin.pegasus" % "data-avro" % "1.9.40",
+      "org.jboss.netty" % "netty" % "3.2.0.Final"
     )
   )
 

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
@@ -1,10 +1,17 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+val sprayV = "1.1.1"
+val playVersion = "2.2.0"
+val summingbirdVersion = "0.4.0"
+val luceneVersion = "4.0.0"
+val akkaVersion = "2.3.1"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),
     scalaVersion := "2.10.4",
-    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project")
+    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
+    updateOptions := updateOptions.value.withCachedResolution(true)
   )
 
 lazy val a = project.
@@ -12,7 +19,8 @@ lazy val a = project.
   settings(
     name := "a",
     libraryDependencies := Seq(
-      "commons-io" % "commons-io" % "1.3"
+      "commons-io" % "commons-io" % "1.3",
+      "org.apache.spark" %% "spark-core" % "0.9.0-incubating"
     )
   )
 

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/test
@@ -10,4 +10,4 @@ $ copy-file changes/multi.sbt multi.sbt
 
 > b/publishLocal
 
-> a/update
+> check

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/test
@@ -1,0 +1,13 @@
+> a/publishLocal
+
+> b/publishLocal
+
+> c/publishLocal
+
+$ copy-file changes/multi.sbt multi.sbt
+
+> reload
+
+> b/publishLocal
+
+> a/update

--- a/sbt/src/sbt-test/dependency-management/circular-dependency/changes/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/circular-dependency/changes/multi.sbt
@@ -4,6 +4,7 @@ def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),
     scalaVersion := "2.10.4",
+    fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
     updateOptions := updateOptions.value.withCircularDependencyLevel(CircularDependencyLevel.Error)
   )
 


### PR DESCRIPTION
## steps
1. use cached resolution
2. have sizable graph (for instance by using spark)
3. have a circular dependency
## problem

```
java.lang.StackOverflowError
    at scala.collection.MapLike$DefaultKeySet.contains(MapLike.scala:169)
    at scala.collection.GenSetLike$class.apply(GenSetLike.scala:43)
    at scala.collection.AbstractSet.apply(Set.scala:47)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15$$anonfun$apply$16$$anonfun$apply$17.apply(CachedResolutionResolveEngine.scala:420)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15$$anonfun$apply$16$$anonfun$apply$17.apply(CachedResolutionResolveEngine.scala:418)
    at scala.collection.LinearSeqOptimized$class.exists(LinearSeqOptimized.scala:80)
    at scala.collection.immutable.List.exists(List.scala:84)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15$$anonfun$apply$16.apply(CachedResolutionResolveEngine.scala:418)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15$$anonfun$apply$16.apply(CachedResolutionResolveEngine.scala:418)
    at scala.collection.Iterator$class.exists(Iterator.scala:753)
    at scala.collection.AbstractIterator.exists(Iterator.scala:1157)
    at scala.collection.IterableLike$class.exists(IterableLike.scala:77)
    at scala.collection.AbstractIterable.exists(Iterable.scala:54)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15.apply(CachedResolutionResolveEngine.scala:417)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32$$anonfun$apply$15.apply(CachedResolutionResolveEngine.scala:417)
    at scala.collection.Iterator$class.exists(Iterator.scala:753)
    at scala.collection.AbstractIterator.exists(Iterator.scala:1157)
    at scala.collection.IterableLike$class.exists(IterableLike.scala:77)
    at scala.collection.AbstractIterable.exists(Iterable.scala:54)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32.apply(CachedResolutionResolveEngine.scala:416)
    at sbt.ivyint.CachedResolutionResolveEngine$$anonfun$32.apply(CachedResolutionResolveEngine.scala:414)
    at scala.collection.TraversableLike$$anonfun$partition$1.apply(TraversableLike.scala:321)
    at scala.collection.TraversableLike$$anonfun$partition$1.apply(TraversableLike.scala:321)
    at scala.collection.Iterator$class.foreach(Iterator.scala:727)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
    at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
    at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
    at scala.collection.TraversableLike$class.partition(TraversableLike.scala:321)
    at scala.collection.AbstractTraversable.partition(Traversable.scala:105)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:414)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:427)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:427)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:427)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:427)
    at sbt.ivyint.CachedResolutionResolveEngine$class.sortModules$1(CachedResolutionResolveEngine.scala:427)
```
## what this PR changes
1. First `sortModules` is now tail recursive so blowing up the stack should not occur.
2. Second, it short circuits when the algorithm stops making progress (`notCalled.isEmpty`), so the total number of iteration should be much fewer.

/review @jsuereth, @dwijnand 
