### PR TITLE
Set version to 0.13.10-SNAPSHOT.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Build from source
 
 	If using the 0.13 development branch, the launcher is at:
 
-		<sbt>/target/sbt-launch-0.13.9-SNAPSHOT.jar
+		<sbt>/target/sbt-launch-0.13.10-SNAPSHOT.jar
 		
 	Directory `target` is removed by clean command. Second solution is using artifact stored in local ivy repository.
 		
@@ -141,7 +141,7 @@ Build from source
                 
 	 for v0.13.8 tag, or in:
                 
-              $HOME/.ivy2/local/org.scala-sbt/sbt-launch/0.13.9-SNAPSHOT/jars/sbt-launch.jar
+              $HOME/.ivy2/local/org.scala-sbt/sbt-launch/0.13.10-SNAPSHOT/jars/sbt-launch.jar
                 
 	 for development branch.
 
@@ -153,7 +153,7 @@ Build from source
 
 3. After each `publishLocal`, clean the `~/.sbt/boot/` directory.  Alternatively, if sbt is running and the launcher hasn't changed, run `reboot full` to have sbt do this for you.
 
-4. If a project has `project/build.properties` defined, either delete the file or change `sbt.version` to `0.13.9-SNAPSHOT`.
+4. If a project has `project/build.properties` defined, either delete the file or change `sbt.version` to `0.13.10-SNAPSHOT`.
 
 Building Documentation
 ----------------------

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import Sxr.sxr
 // but can be shared across the multi projects.
 def buildLevelSettings: Seq[Setting[_]] = Seq(
   organization in ThisBuild := "org.scala-sbt",
-  version in ThisBuild := "0.13.9-SNAPSHOT",
+  version in ThisBuild := "0.13.10-SNAPSHOT",
   // bintrayOrganization in ThisBuild := None,
   // bintrayRepository in ThisBuild := "test-test-test",
   bintrayOrganization in ThisBuild :=  {


### PR DESCRIPTION
Given that work for the 0.13.9 is now on the 0.13.9 branch, 0.13 should be set to 0.13.10-SNAPSHOT.
