### PR TITLE
Extract Def.settings from Project#settings.

### DIFF
--- a/main/settings/src/main/scala/sbt/Def.scala
+++ b/main/settings/src/main/scala/sbt/Def.scala
@@ -10,6 +10,8 @@ import KeyRanks.{ DTask, Invisible }
 object Def extends Init[Scope] with TaskMacroExtra {
   type Classpath = Seq[Attributed[File]]
 
+  def settings(ss: SettingsDefinition*): Seq[Setting[_]] = ss.flatMap(_.settings)
+
   val triggeredBy = AttributeKey[Seq[Task[_]]]("triggered-by")
   val runBefore = AttributeKey[Seq[Task[_]]]("run-before")
   val resolvedScoped = SettingKey[ScopedKey[_]]("resolved-scoped", "The ScopedKey for the referencing setting or task.", KeyRanks.DSetting)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -141,7 +141,7 @@ sealed trait Project extends ProjectDefinition[ProjectReference] {
   def aggregate(refs: ProjectReference*): Project = copy(aggregate = (aggregate: Seq[ProjectReference]) ++ refs)
 
   /** Appends settings to the current settings sequence for this project. */
-  def settings(ss: Def.SettingsDefinition*): Project = copy(settings = (settings: Seq[Def.Setting[_]]) ++ ss.flatMap(_.settings))
+  def settings(ss: Def.SettingsDefinition*): Project = copy(settings = (settings: Seq[Def.Setting[_]]) ++ Def.settings(ss: _*))
 
   @deprecated("Use settingSets method.", "0.13.5")
   def autoSettings(select: AddSettings*): Project = settingSets(select.toSeq: _*)

--- a/notes/0.13.10/def-settings.markdown
+++ b/notes/0.13.10/def-settings.markdown
@@ -1,0 +1,22 @@
+
+  [@dwijnand]: http://github.com/dwijnand
+  [2151]: https://github.com/sbt/sbt/pull/2151
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Adds `Def.settings`, which facilitates mixing settings with seq of settings. See below.
+
+### Bug fixes
+
+### `Def.settings`
+
+Using `Def.settings` it is now possible to nicely define settings as such:
+
+    val modelSettings = Def.settings(
+      sharedSettings,
+      libraryDependencies += foo
+    )
+
+[#2151][2151] by [@dwijnand][@dwijnand].


### PR DESCRIPTION
This allows for the same functionality that using `SettingsDefinition` in
`Project#settings` allows (specifying either bare `Setting[_]` or a `Seq[Setting[_]]`)
to be available outside of the settings for a project, for instance when
defining a val.

In short, it allows:

``` scala
val modelSettings = Def.settings(
  sharedSettings,
  libraryDependencies += foo
)
```
