### PR TITLE
Publish compiler interface to an alternate local repository for Scripted tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,31 @@ def baseSettings: Seq[Setting[_]] =
 def testedBaseSettings: Seq[Setting[_]] =
   baseSettings ++ testDependencies
 
+
+val altLocalRepoName = "alternative-local"
+val altLocalRepoPath = sys.props("user.home" + "/.ivy2/sbt-alternative")
+lazy val altLocalResolver = Resolver.file(altLocalRepoName, file(sys.props("user.home") + "/.ivy2/sbt-alternative"))(Resolver.ivyStylePatterns)
+lazy val altLocalPublish = TaskKey[Unit]("alt-local-publish", "Publishes an artifact locally to an alternative location.")
+def altPublishSettings: Seq[Setting[_]] = Seq(
+  resolvers += altLocalResolver,
+  altLocalPublish := {
+    val config = (Keys.publishLocalConfiguration).value
+    val moduleSettings = (Keys.moduleSettings).value
+    val ivy = new IvySbt((ivyConfiguration.value))
+
+    val module =
+        new ivy.Module(moduleSettings)
+    val newConfig =
+       new PublishConfiguration(
+           config.ivyFile,
+           altLocalRepoName,
+           config.artifacts,
+           config.checksums,
+           config.logging)
+    streams.value.log.info("Publishing " + module + " to local repo: " + altLocalRepoName)
+    IvyActions.publish(module, newConfig, streams.value.log)
+  })
+
 lazy val sbtRoot: Project = (project in file(".")).
   configs(Sxr.sxrConf).
   aggregate(nonRoots: _*).
@@ -93,7 +118,8 @@ lazy val interfaceProj = (project in file("interface")).
       sourceManaged in Compile,
       mainClass in datatypeProj in Compile,
       runner,
-      streams) map generateAPICached
+      streams) map generateAPICached,
+    altPublishSettings
   )
 
 // defines operations on the API of a source, including determining whether it has changed and converting it to a string
@@ -307,7 +333,8 @@ lazy val compileInterfaceProj = (project in compilePath / "interface").
     // needed because we fork tests and tests are ran in parallel so we have multiple Scala
     // compiler instances that are memory hungry
     javaOptions in Test += "-Xmx1G",
-    publishArtifact in (Compile, packageSrc) := true
+    publishArtifact in (Compile, packageSrc) := true,
+    altPublishSettings
   )
 
 // Implements the core functionality of detecting and propagating changes incrementally.
@@ -437,6 +464,11 @@ lazy val mavenResolverPluginProj = (project in file("sbt-maven-resolver")).
 def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => scriptedParser(dir)).parsed
   publishAll.value
+  // These two projects need to be visible in a repo even if the default
+  // local repository is hidden, so we publish them to an alternate location and add
+  // that alternate repo to the running scripted test (in Scripted.scriptedpreScripted).
+  (altLocalPublish in interfaceProj).value
+  (altLocalPublish in compileInterfaceProj).value
   doScripted((sbtLaunchJar in bundledLauncherProj).value, (fullClasspath in scriptedSbtProj in Test).value,
     (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value)
 }
@@ -468,7 +500,7 @@ def rootSettings = fullDocSettings ++
   Util.publishPomSettings ++ otherRootSettings ++ Formatting.sbtFilesSettings ++
   Transform.conscriptSettings(bundledLauncherProj)
 def otherRootSettings = Seq(
-  Scripted.scriptedPrescripted := { _ => },
+  Scripted.scriptedPrescripted := { addSbtAlternateResolver _ },
   Scripted.scripted <<= scriptedTask,
   Scripted.scriptedUnpublished <<= scriptedUnpublishedTask,
   Scripted.scriptedSource := (sourceDirectory in sbtProj).value / "sbt-test",
@@ -485,8 +517,18 @@ def otherRootSettings = Seq(
       IO.write(inj, "addMavenResolverPlugin")
       // sLog.value.info(s"""Injected project/maven.sbt to $f""")
     }
+
+    addSbtAlternateResolver(f)
   }
 ))
+
+def addSbtAlternateResolver(scriptedRoot: File) = {
+  val resolver = scriptedRoot / "project" / "sbt-local-repo.sbt"
+  if (!resolver.exists) {
+    IO.write(resolver, s"""resolvers += Resolver.file("$altLocalRepoName", file("$altLocalRepoPath"))(Resolver.ivyStylePatterns)""")
+  }
+}
+
 lazy val docProjects: ScopeFilter = ScopeFilter(
   inAnyProject -- inProjects(sbtRoot, sbtProj, scriptedBaseProj, scriptedSbtProj, scriptedPluginProj, mavenResolverPluginProj),
   inConfigurations(Compile)

--- a/sbt/src/sbt-test/dependency-management/mvn-local/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/mvn-local/build.sbt
@@ -4,8 +4,7 @@ def commonSettings: Seq[Def.Setting[_]] =
     dependencyCacheDirectory := (baseDirectory in LocalRootProject).value / "dependency",
     scalaVersion := "2.10.4",
     organization in ThisBuild := "org.example",
-    version in ThisBuild := "1.0-SNAPSHOT",
-    resolvers += Resolver.file("old-local", file(sys.props("user.home") + "/.ivy2/local"))(Resolver.ivyStylePatterns)
+    version in ThisBuild := "1.0-SNAPSHOT"
   )
 
 lazy val main = project.


### PR DESCRIPTION
Some scripted tests override the default local repository, which
produces errors with the compiler because sbt cannot find the sources
for the compiler interface.

This fix proposes to publish the compiler interface sources to an
alternate local repository before running the scripted tests. This
alternate repository is added to the scripted sbt's configuration, so
that sbt is finally able to find the compiler interface sources.

Fixes #2165
