### PR TITLE
Bump jline to 2.13

### DIFF
--- a/notes/0.13.10/upgrade-jline.md
+++ b/notes/0.13.10/upgrade-jline.md
@@ -1,10 +1,11 @@
   [JLine2]: https://github.com/jline/jline2
+  [1681]: https://github.com/sbt/sbt/issues/1681
   [2173]: https://github.com/sbt/sbt/pull/2173
 
 ### Fixes with compatibility implications
 
 ### Improvements
 
-- [JLine2][] upgraded to version 2.13 (#[2173][2173]).
+- [JLine2][] upgraded to version 2.13 (#[1681][1681], #[2173][2173]).
 
 ### Bug fixes

--- a/notes/0.13.10/upgrade-jline.md
+++ b/notes/0.13.10/upgrade-jline.md
@@ -1,0 +1,10 @@
+  [JLine2]: https://github.com/jline/jline2
+  [2173]: https://github.com/sbt/sbt/pull/2173
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- [JLine2][] upgraded to version 2.13 (#[2173][2173]).
+
+### Bug fixes

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val scala210 = "2.10.5"
   lazy val scala211 = "2.11.7"
 
-  lazy val jline = "jline" % "jline" % "2.11"
+  lazy val jline = "jline" % "jline" % "2.13"
   lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-927bc9ded7f8fba63297cddd0d5a3d01d6ad5d8d"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val scala211 = "2.11.7"
 
   lazy val jline = "jline" % "jline" % "2.13"
-  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-927bc9ded7f8fba63297cddd0d5a3d01d6ad5d8d"
+  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-d592b1b0f77cf706e882b1b8e0162dee28165fb2"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"
   lazy val sbtSerialization = "org.scala-sbt" %% "serialization" % "0.1.2"


### PR DESCRIPTION
Fixes, amongst other things, Ctrl-Y breaking out of SBT on OS X, and passes "JLine" through as the application name (rather than null), allowing conditionals to be used in `.inputrc`.
