### PR TITLE
Setting to always select generic compiler interface sources

### DIFF
--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -54,7 +54,7 @@ object Compiler {
   def compilers(instance: ScalaInstance, cpOptions: ClasspathOptions)(implicit app: AppConfiguration, log: Logger): Compilers =
     compilers(instance, cpOptions, None)
 
-  @deprecated("Use `compilers(ScalaInstance, ClasspathOptions, Option[File], IvyConfiguration)`.", "0.13.10")
+  @deprecated("Use `compilers(ScalaInstance, ClasspathOptions, Option[File], IvyConfiguration, Boolean)`.", "0.13.10")
   def compilers(instance: ScalaInstance, cpOptions: ClasspathOptions, javaHome: Option[File])(implicit app: AppConfiguration, log: Logger): Compilers =
     {
       val javac =
@@ -69,7 +69,7 @@ object Compiler {
       }
       compilers(instance, cpOptions, CheaterJavaTool(javac2, javac))
     }
-  def compilers(instance: ScalaInstance, cpOptions: ClasspathOptions, javaHome: Option[File], ivyConfiguration: IvyConfiguration)(implicit app: AppConfiguration, log: Logger): Compilers =
+  def compilers(instance: ScalaInstance, cpOptions: ClasspathOptions, javaHome: Option[File], ivyConfiguration: IvyConfiguration, cascadingVersions: Boolean)(implicit app: AppConfiguration, log: Logger): Compilers =
     {
       val javac =
         AggressiveCompile.directOrFork(instance, cpOptions, javaHome)
@@ -81,7 +81,7 @@ object Compiler {
           javac.compile(contract, sources, classpath, outputDirectory, options)(log)
         def onArgs(f: Seq[String] => Unit): JavaTool = CheaterJavaTool(newJavac, delegate.onArgs(f))
       }
-      val scalac = scalaCompiler(instance, cpOptions, ivyConfiguration)
+      val scalac = scalaCompiler(instance, cpOptions, ivyConfiguration, cascadingVersions)
       new Compilers(scalac, CheaterJavaTool(javac2, javac))
     }
   @deprecated("Deprecated in favor of new sbt.compiler.javac package.", "0.13.8")
@@ -96,7 +96,7 @@ object Compiler {
       val scalac = scalaCompiler(instance, cpOptions)
       new Compilers(scalac, javac)
     }
-  @deprecated("Use `scalaCompiler(ScalaInstance, ClasspathOptions, IvyConfiguration)`.", "0.13.10")
+  @deprecated("Use `scalaCompiler(ScalaInstance, ClasspathOptions, IvyConfiguration, Boolean)`.", "0.13.10")
   def scalaCompiler(instance: ScalaInstance, cpOptions: ClasspathOptions)(implicit app: AppConfiguration, log: Logger): AnalyzingCompiler =
     {
       val launcher = app.provider.scalaProvider.launcher
@@ -104,11 +104,11 @@ object Compiler {
       val provider = ComponentCompiler.interfaceProvider(componentManager)
       new AnalyzingCompiler(instance, provider, cpOptions)
     }
-  def scalaCompiler(instance: ScalaInstance, cpOptions: ClasspathOptions, ivyConfiguration: IvyConfiguration)(implicit app: AppConfiguration, log: Logger): AnalyzingCompiler =
+  def scalaCompiler(instance: ScalaInstance, cpOptions: ClasspathOptions, ivyConfiguration: IvyConfiguration, cascadingVersions: Boolean)(implicit app: AppConfiguration, log: Logger): AnalyzingCompiler =
     {
       val launcher = app.provider.scalaProvider.launcher
       val componentManager = new ComponentManager(launcher.globalLock, app.provider.components, Option(launcher.ivyHome), log)
-      val provider = ComponentCompiler.interfaceProvider(componentManager, ivyConfiguration)
+      val provider = ComponentCompiler.interfaceProvider(componentManager, ivyConfiguration, cascadingVersions)
       new AnalyzingCompiler(instance, provider, cpOptions)
     }
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -84,6 +84,7 @@ object Defaults extends BuildCommon {
       testForkedParallel :== false,
       javaOptions :== Nil,
       sbtPlugin :== false,
+      compilerInterfaceCascadingVersions :== true,
       crossPaths :== true,
       sourcePositionMappers :== Nil,
       artifactClassifier in packageSrc :== Some(SourceClassifier),
@@ -261,7 +262,7 @@ object Defaults extends BuildCommon {
       if (plugin) scalaBase / ("sbt-" + sbtv) else scalaBase
     }
 
-  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value, ivyConfiguration.value)(appConfiguration.value, streams.value.log)
+  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value, ivyConfiguration.value, compilerInterfaceCascadingVersions.value)(appConfiguration.value, streams.value.log)
 
   lazy val configTasks = docTaskSettings(doc) ++ inTask(compile)(compileInputsSettings) ++ configGlobal ++ compileAnalysisSettings ++ Seq(
     compile <<= compileTask,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -137,6 +137,7 @@ object Keys {
   val sbtPlugin = SettingKey[Boolean]("sbt-plugin", "If true, enables adding sbt as a dependency and auto-generation of the plugin descriptor file.", BMinusSetting)
   val printWarnings = TaskKey[Unit]("print-warnings", "Shows warnings from compilation, including ones that weren't printed initially.", BPlusTask)
   val fileInputOptions = SettingKey[Seq[String]]("file-input-options", "Options that take file input, which may invalidate the cache.", CSetting)
+  val compilerInterfaceCascadingVersions = SettingKey[Boolean]("compiler-interface-cascading-versions", "If true, selects the most specific version of the compiler interface sources.")
 
   val clean = TaskKey[Unit]("clean", "Deletes files produced by the build, such as generated sources, compiled classes, and task caches.", APlusTask)
   val console = TaskKey[Unit]("console", "Starts the Scala interpreter with the project classes on the classpath.", APlusTask)


### PR DESCRIPTION
As requested on Gitter by @jaceklaskowski, this PR adds a new setting that enables/disables the cascading versions mechanism for the lookup of compiler-interface sources.

By setting `compilerInterfaceCascadingVersions := false`, sbt will only try to fetch `compiler-interface` when it needs it.
With `compilerInterfaceCascadingVersions := true`, sbt will try to fetch `compiler-interface_2.11.8`, `compiler-interface_2.11` and finally `compiler-interface`. This is the default behavior.
