### PR TITLE
Compiler interface sources: Hide Ivy logs & download compiler interface sources in boot directory.

### DIFF
--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -108,7 +108,8 @@ object Compiler {
     {
       val launcher = app.provider.scalaProvider.launcher
       val componentManager = new ComponentManager(launcher.globalLock, app.provider.components, Option(launcher.ivyHome), log)
-      val provider = ComponentCompiler.interfaceProvider(componentManager, ivyConfiguration)
+      val bootDirectory = launcher.bootDirectory
+      val provider = ComponentCompiler.interfaceProvider(componentManager, ivyConfiguration, bootDirectory)
       new AnalyzingCompiler(instance, provider, cpOptions)
     }
 


### PR DESCRIPTION
Replaces #2174.

The Ivy logs for retrieving the compiler interface sources will now:
- Not show anything if some version of the compiler interface sources can be found, or
- Show all the failures if nothing can be found.

This PR also fixes the download location of the compiler interface sources. They will now be downloaded under `~/.sbt/boot/scala-2.11.7/org.scala-sbt/sbt/0.13.10-SNAPSHOT/compiler-interface-srcs` (for instance).
