### PR TITLE
More robustness when using the tasks and settings command

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -16,6 +16,7 @@ import StandardMain._
 import java.io.File
 import java.net.URI
 import java.util.Locale
+import scala.util.control.NonFatal
 
 /** This class is the entry point for sbt.*/
 final class xMain extends xsbti.AppMain {
@@ -177,7 +178,15 @@ object BuiltinCommands {
       val extracted = Project.extract(s)
       import extracted._
       val index = structure.index
-      index.keyIndex.keys(Some(currentRef)).toSeq.map(index.keyMap).distinct
+      index.keyIndex.keys(Some(currentRef)).toSeq.map { key =>
+        try
+          Some(index.keyMap(key))
+        catch {
+          case NonFatal(ex) =>
+            s.log error ex.getMessage
+            None
+        }
+      }.collect { case Some(s) => s }.distinct
     }
 
   def sortByLabel(keys: Seq[AttributeKey[_]]): Seq[AttributeKey[_]] = keys.sortBy(_.label)


### PR DESCRIPTION
Version 0.13.9 of SBT and previous ones, produce this error when using the `tasks` or `settings` command in my project:

```
java.util.NoSuchElementException: key not found: -capture-settings
        at scala.collection.MapLike$class.default(MapLike.scala:228)
        at scala.collection.AbstractMap.default(Map.scala:58)
        at scala.collection.MapLike$class.apply(MapLike.scala:141)
        at scala.collection.AbstractMap.apply(Map.scala:58)
        at .<init>(<console>:145)
        at .<clinit>(<console>)
        at .<init>(<console>:7)
        at .<clinit>(<console>)
        at $print(<console>)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:734)
        at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:983)
        at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:573)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:604)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:568)
        at scala.tools.nsc.interpreter.ILoop.reallyInterpret$1(ILoop.scala:760)
        at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:805)
        at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:717)
        at scala.tools.nsc.interpreter.ILoop.processLine$1(ILoop.scala:581)
        at scala.tools.nsc.interpreter.ILoop.innerLoop$1(ILoop.scala:588)
        at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:591)
        at scala.tools.nsc.interpreter.ILoop$$anonfun$process$1.apply$mcZ$sp(ILoop.scala:882)
        at scala.tools.nsc.interpreter.ILoop$$anonfun$process$1.apply(ILoop.scala:837)
        at scala.tools.nsc.interpreter.ILoop$$anonfun$process$1.apply(ILoop.scala:837)
        at scala.tools.nsc.util.ScalaClassLoader$.savingContextLoader(ScalaClassLoader.scala:135)
        at scala.tools.nsc.interpreter.ILoop.process(ILoop.scala:837)
        at scala.tools.nsc.interpreter.ILoop.main(ILoop.scala:904)
        at xsbt.ConsoleInterface.run(ConsoleInterface.scala:62)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:101)
        at sbt.compiler.AnalyzingCompiler.console(AnalyzingCompiler.scala:76)
        at sbt.Console.sbt$Console$$console0$1(Console.scala:22)
        at sbt.Console$$anonfun$apply$2$$anonfun$apply$1.apply$mcV$sp(Console.scala:23)
        at sbt.Console$$anonfun$apply$2$$anonfun$apply$1.apply(Console.scala:23)
        at sbt.Console$$anonfun$apply$2$$anonfun$apply$1.apply(Console.scala:23)
        at sbt.Logger$$anon$4.apply(Logger.scala:85)
        at sbt.TrapExit$App.run(TrapExit.scala:248)
        at java.lang.Thread.run(Thread.java:745)
```

I don't know the cause of this problem.  I've searched in my code the name `-capture-settings` and I don't find it.

But what I've done is to dealt with unexpected errors, so that even if a misbehaved plugin exists, SBT keeps working ok.
