### PR TITLE
Use getPosition method to get an offset position instead of using a line number

### DIFF
--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -76,11 +76,12 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
               val diagnostic = d.getClass.getField("d").get(d)
               // See com.sun.tools.javac.util.JCDiagnostic#getDiagnosticSource
               val getDiagnosticSourceMethod = diagnostic.getClass.getDeclaredMethod("getDiagnosticSource")
-              Option(getDiagnosticSourceMethod.invoke(diagnostic)) match {
-                case Some(diagnosticSource) =>
+              val getPositionMethod = diagnostic.getClass.getDeclaredMethod("getPosition")
+              (Option(getDiagnosticSourceMethod.invoke(diagnostic)), Option(getPositionMethod.invoke(diagnostic))) match {
+                case (Some(diagnosticSource), Some(position: java.lang.Long)) =>
                   // See com.sun.tools.javac.util.DiagnosticSource
                   val getLineMethod = diagnosticSource.getClass.getMethod("getLine", Integer.TYPE)
-                  Option(getLineMethod.invoke(diagnosticSource, line.get())).map(_.toString)
+                  Option(getLineMethod.invoke(diagnosticSource, new Integer(position.intValue()))).map(_.toString)
                 case _ => None
               }
             } catch {


### PR DESCRIPTION
While testing changes from #2108 it appeared that getLine method takes an absolute offset instead of a line number. Thankfully there is getPosition method to get a position of a report.
