### PR TITLE
Improve time measuring capabilities

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -160,8 +160,15 @@ object EvaluateTask {
   import TaskExtra._
   import Keys.state
 
+  lazy private val sharedProgress = new TaskTimings(shutdown = true)
+
   private[sbt] def defaultProgress: ExecuteProgress[Task] =
-    if (java.lang.Boolean.getBoolean("sbt.task.timings")) new TaskTimings else ExecuteProgress.empty[Task]
+    if (java.lang.Boolean.getBoolean("sbt.task.timings")) {
+      if (java.lang.Boolean.getBoolean("sbt.task.timings.shutdown"))
+        sharedProgress
+      else
+        new TaskTimings(shutdown = false)
+    } else ExecuteProgress.empty[Task]
 
   val SystemProcessors = Runtime.getRuntime.availableProcessors
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -183,7 +183,7 @@ object BuiltinCommands {
           Some(index.keyMap(key))
         catch {
           case NonFatal(ex) =>
-            s.log error ex.getMessage
+            s.log debug ex.getMessage
             None
         }
       }.collect { case Some(s) => s }.distinct

--- a/main/src/main/scala/sbt/TaskTimings.scala
+++ b/main/src/main/scala/sbt/TaskTimings.scala
@@ -60,11 +60,17 @@ private[sbt] final class TaskTimings(shutdown: Boolean) extends ExecuteProgress[
     import collection.JavaConversions._
     def sumTimes(in: Seq[(Task[_], Long)]) = in.map(_._2).sum
     val timingsByName = timings.toSeq.groupBy { case (t, time) => mappedName(t) } mapValues (sumTimes)
-    for (
-      (taskName, time) <- timingsByName.toSeq.sortBy(_._2).reverse
-        .map { case (name, time) => (name, divide(time)) }
-        .filter { _._2 > threshold }
-    ) println(s"  $taskName: $time $unit")
+    val times = timingsByName.toSeq.sortBy(_._2).reverse
+      .map { case (name, time) => (name, divide(time)) }
+      .filter { _._2 > threshold }
+    if (times.size > 0) {
+      val maxTaskNameLength = times.map { _._1.length }.max
+      val maxTime = times.map { _._2 }.max.toString.length
+      times.foreach {
+        case (taskName, time) =>
+          println(s"  ${taskName.padTo(maxTaskNameLength, ' ')}: ${"".padTo(maxTime - time.toString.length, ' ')}$time $unit")
+      }
+    }
   }
   private[this] def inferredName(t: Task[_]): Option[String] = nameDelegate(t) map mappedName
   private[this] def nameDelegate(t: Task[_]): Option[Task[_]] = Option(anonOwners.get(t)) orElse Option(calledBy.get(t))

--- a/main/src/main/scala/sbt/TaskTimings.scala
+++ b/main/src/main/scala/sbt/TaskTimings.scala
@@ -3,15 +3,43 @@ package sbt
 import java.util.concurrent.ConcurrentHashMap
 import TaskName._
 
-private[sbt] final class TaskTimings extends ExecuteProgress[Task] {
+/**
+ * Measure the time elapsed for running tasks.
+ * This class is activated by adding -Dsbt.task.timing=true to the JVM options.
+ * Formatting options:
+ * - -Dsbt.task.timings.shutdown=true|false
+ * - -Dsbt.task.timings.decimals=number
+ * - -Dsbt.task.timings.threshold=number
+ * @param shutdown    Should the report be given when exiting the JVM (true) or immediatelly (false)?
+ */
+private[sbt] final class TaskTimings(shutdown: Boolean) extends ExecuteProgress[Task] {
   private[this] val calledBy = new ConcurrentHashMap[Task[_], Task[_]]
   private[this] val anonOwners = new ConcurrentHashMap[Task[_], Task[_]]
   private[this] val timings = new ConcurrentHashMap[Task[_], Long]
   private[this] var start = 0L
+  private[this] val divider = java.lang.Integer.getInteger("sbt.task.timings.divider", 6).toInt
+  private[this] val threshold = java.lang.Long.getLong("sbt.task.timings.threshold", 0L)
+  private[this] val unit = divider match {
+    case 0 => "ns"
+    case 3 => "µs"
+    case 6 => "ms"
+    case 9 => "sec"
+    case _ => ""
+  }
 
   type S = Unit
 
-  def initial = { start = System.nanoTime }
+  if (shutdown) {
+    start = System.nanoTime
+    Runtime.getRuntime.addShutdownHook(new Thread {
+      override def run() = report()
+    })
+  }
+
+  def initial = {
+    if (!shutdown)
+      start = System.nanoTime
+  }
   def registered(state: Unit, task: Task[_], allDeps: Iterable[Task[_]], pendingDeps: Iterable[Task[_]]) = {
     pendingDeps foreach { t => if (transformNode(t).isEmpty) anonOwners.put(t, task) }
   }
@@ -23,16 +51,23 @@ private[sbt] final class TaskTimings extends ExecuteProgress[Task] {
   }
   def completed[T](state: Unit, task: Task[T], result: Result[T]) = ()
   def allCompleted(state: Unit, results: RMap[Task, Result]) =
-    {
-      val total = System.nanoTime - start
-      println("Total time: " + (total * 1e-6) + " ms")
-      import collection.JavaConversions._
-      def sumTimes(in: Seq[(Task[_], Long)]) = in.map(_._2).sum
-      val timingsByName = timings.toSeq.groupBy { case (t, time) => mappedName(t) } mapValues (sumTimes)
-      for ((taskName, time) <- timingsByName.toSeq.sortBy(_._2).reverse)
-        println("  " + taskName + ": " + (time * 1e-6) + " ms")
-    }
+    if (!shutdown)
+      report()
+
+  private[this] def report() = {
+    val total = divide(System.nanoTime - start)
+    println(s"Total time: $total $unit")
+    import collection.JavaConversions._
+    def sumTimes(in: Seq[(Task[_], Long)]) = in.map(_._2).sum
+    val timingsByName = timings.toSeq.groupBy { case (t, time) => mappedName(t) } mapValues (sumTimes)
+    for (
+      (taskName, time) <- timingsByName.toSeq.sortBy(_._2).reverse
+        .map { case (name, time) => (name, divide(time)) }
+        .filter { _._2 > threshold }
+    ) println(s"  $taskName: $time $unit")
+  }
   private[this] def inferredName(t: Task[_]): Option[String] = nameDelegate(t) map mappedName
   private[this] def nameDelegate(t: Task[_]): Option[Task[_]] = Option(anonOwners.get(t)) orElse Option(calledBy.get(t))
   private[this] def mappedName(t: Task[_]): String = definedName(t) orElse inferredName(t) getOrElse anonymousName(t)
+  private[this] def divide(time: Long) = (1L to divider.toLong).fold(time) { (a, b) => a / 10L }
 }


### PR DESCRIPTION
Currently, by setting `-Dsbt.task.timing=true`, time execution of tasks is measured.

It has the following limitations:
- A very long number of decimals, that makes it unreadable.  Example:

```
{file:/home/d/rds/project/}rds-build/compile:resources: 0.015903999999999998 ms
```
- Some tasks like `compile` are composed of a large number of tasks.  Many of them are quite quick to execute.   Normally, we want to know the long running tasks.
- If you call in the command line `sbt task1 task2 task3`, I'd like the report to be at the end.  Otherwise, I have to read the full output, that can be very verbose, in order to study running times.

Here is my solution:
- By setting the property `-Dsbt.task.timings.divider=number`, we select the power of 10 to divide the shown number.  If it is 0, the result will be nanoseconds.  3=microseconds, 6=milliseconds, 9=seconds.
- Info is aligned for improving readability:

```
Total time: 210 sec
  {file:/home/d/rds/}servision/compile:compileIncremental: 63 sec
  {file:/home/d/rds/}servision/test:compileIncremental   : 37 sec
  {file:/home/d/rds/}servision/*:update                  : 35 sec
  {file:/home/d/rds/}servision/*:compilaJython           : 20 sec
  */*:descargaPylib                                      : 11 sec
  {file:/home/d/rds/}iText/compile:compileIncremental    : 10 sec
  {file:/home/d/rds/}ddlUtils/compile:compileIncremental :  8 sec
```
- By setting the property `-Dsbt.task.timings.threshold=number`, tasks whose duration is lower than the given number will be hidden.  The threshold will take into account the selected unit set by `sbt.task.timings.divider`.  In this way we avoid noise.
- By setting the property `-Dsbt.task.timings.shutdown=true`, the report is generated when finishing the JVM, instead of when finishing running a specified task.

**Note:**

Commit 3fe9809 belongs to pull request https://github.com/sbt/sbt/pull/1940
I forgot to push this commit when doing the pull request.
