### PR TITLE
Always export apiURL even if autoAPIMappings is false.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1264,8 +1264,8 @@ object Classpaths {
   private[sbt] def defaultProjectID: Initialize[ModuleID] = Def.setting {
     val base = ModuleID(organization.value, moduleName.value, version.value).cross(crossVersion in projectID value).artifacts(artifacts.value: _*)
     apiURL.value match {
-      case Some(u) if autoAPIMappings.value => base.extra(SbtPomExtraProperties.POM_API_KEY -> u.toExternalForm)
-      case _                                => base
+      case Some(u) => base.extra(SbtPomExtraProperties.POM_API_KEY -> u.toExternalForm)
+      case _       => base
     }
   }
 


### PR DESCRIPTION
This is a simple change to make sbt honor the value of `apiURL` all of the time. It's not clear from reading [the documentation](http://www.scala-sbt.org/0.13/docs/Howto-Scaladoc.html) that this is totally ignored when `autoAPIMappings` is false - and it's also an unintuitive interaction, since one setting affects how you generate Scaladoc, while the other affects how you generate your pom.xml.
