### PR TITLE
Fix for sbt/sbt#1933

### DIFF
--- a/ivy/src/test/scala/InconsistentDuplicateSpec.scala
+++ b/ivy/src/test/scala/InconsistentDuplicateSpec.scala
@@ -9,6 +9,7 @@ class InconsistentDuplicateSpec extends Specification {
 
   Duplicate with different version should
     be warned                                                   $warn1
+    not be warned if in different configurations                $nodupe2
 
   Duplicate with same version should
     not be warned                                               $nodupe1
@@ -25,4 +26,8 @@ class InconsistentDuplicateSpec extends Specification {
 
   def nodupe1 =
     IvySbt.inconsistentDuplicateWarning(Seq(akkaActor230Test, akkaActor230)) must_== Nil
+
+  def nodupe2 =
+    IvySbt.inconsistentDuplicateWarning(Seq(akkaActor214, akkaActor230Test)) must_== Nil
+
 }

--- a/notes/0.13.10/fix-duplicate-warnings.markdown
+++ b/notes/0.13.10/fix-duplicate-warnings.markdown
@@ -1,0 +1,13 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [1933]: https://github.com/sbt/sbt/issues/1933
+  [2258]: https://github.com/sbt/sbt/pull/2258
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes [#1933][1933] duplicate warnings for artifacts in distinct configurations [#2258][2258] by
+  [@Duhemm][@Duhemm]


### PR DESCRIPTION
sbt was reporting warning abouts inconsistent versions of dependencies
even if these dependencies didn't have the same configuration (as in
`provided` vs `compile`).

This commit fixes this problem by comparing the dependencies by
organization, artifact name and configuration.

Fixes sbt/sbt#1933
