### PR TITLE
Consider signatures of methods before and after erasure in ExtractAPI

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -1,6 +1,6 @@
 package xsbt
 
-import scala.tools.nsc.Global
+import scala.tools.nsc.{ Global, Phase }
 import scala.tools.nsc.symtab.Flags
 
 /**
@@ -44,6 +44,11 @@ abstract class Compat {
   val LocalChild = global.tpnme.LOCAL_CHILD
   val Nullary = global.NullaryMethodType
   val ScalaObjectClass = definitions.ScalaObjectClass
+
+  implicit def withExitingPostErasure(global: Global) = new WithExitingPostErasure(global)
+  class WithExitingPostErasure(global: Global) {
+    def exitingPostErasure[T](op: => T) = global afterPostErasure op
+  }
 
   private[this] final class MiscCompat {
     // in 2.9, nme.LOCALCHILD was renamed to tpnme.LOCAL_CHILD

--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -45,9 +45,14 @@ abstract class Compat {
   val Nullary = global.NullaryMethodType
   val ScalaObjectClass = definitions.ScalaObjectClass
 
+  // In 2.11, afterPostErasure has been renamed to exitingPostErasure
+  implicit def withAfterPostErasure(global: Global) = new WithAfterPostErasure(global)
+  class WithAfterPostErasure(global: Global) {
+    def afterPostErasure[T](op: => T): T = sourceCompatibilityOnly
+  }
   implicit def withExitingPostErasure(global: Global) = new WithExitingPostErasure(global)
   class WithExitingPostErasure(global: Global) {
-    def exitingPostErasure[T](op: => T) = global afterPostErasure op
+    def exitingPostErasure[T](op: => T): T = global afterPostErasure op
   }
 
   private[this] final class MiscCompat {

--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -86,6 +86,7 @@ abstract class Compat {
 
     def enclosingTopLevelClass: Symbol = sym.toplevelClass
     def toplevelClass: Symbol = sourceCompatibilityOnly
+    def isMacro: Boolean = false
   }
 
   val DummyValue = 0

--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -46,12 +46,12 @@ abstract class Compat {
   val ScalaObjectClass = definitions.ScalaObjectClass
 
   // `afterPostErasure` doesn't exist in Scala < 2.10
-  implicit def withAfterPostErasure(global: Global) = new WithAfterPostErasure(global)
+  implicit def withAfterPostErasure(global: Global): WithAfterPostErasure = new WithAfterPostErasure(global)
   class WithAfterPostErasure(global: Global) {
     def afterPostErasure[T](op: => T): T = op
   }
   // `exitingPostErasure` was called `afterPostErasure` in 2.10
-  implicit def withExitingPostErasure(global: Global) = new WithExitingPostErasure(global)
+  implicit def withExitingPostErasure(global: Global): WithExitingPostErasure = new WithExitingPostErasure(global)
   class WithExitingPostErasure(global: Global) {
     def exitingPostErasure[T](op: => T): T = global afterPostErasure op
   }
@@ -108,7 +108,7 @@ abstract class Compat {
       def getClassIfDefined(x: String): Symbol = NoSymbol
     }
     private class WithRootMirror(x: Any) {
-      def rootMirror = new DummyMirror
+      def rootMirror: DummyMirror = new DummyMirror
     }
     lazy val AnyValClass = global.rootMirror.getClassIfDefined("scala.AnyVal")
 

--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -45,11 +45,12 @@ abstract class Compat {
   val Nullary = global.NullaryMethodType
   val ScalaObjectClass = definitions.ScalaObjectClass
 
-  // In 2.11, afterPostErasure has been renamed to exitingPostErasure
+  // `afterPostErasure` doesn't exist in Scala < 2.10
   implicit def withAfterPostErasure(global: Global) = new WithAfterPostErasure(global)
   class WithAfterPostErasure(global: Global) {
-    def afterPostErasure[T](op: => T): T = sourceCompatibilityOnly
+    def afterPostErasure[T](op: => T): T = op
   }
+  // `exitingPostErasure` was called `afterPostErasure` in 2.10
   implicit def withExitingPostErasure(global: Global) = new WithExitingPostErasure(global)
   class WithExitingPostErasure(global: Global) {
     def exitingPostErasure[T](op: => T): T = global afterPostErasure op

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -180,11 +180,13 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
   private def printMember(label: String, in: Symbol, t: Type) = println(label + " in " + in + " : " + t + " (debug: " + debugString(t) + " )")
   private def defDef(in: Symbol, s: Symbol): List[xsbti.api.Def] =
     {
-      def isMacro(sym: Symbol): Boolean =
-        sym.isMacro || (sym.info.members.sorted exists isMacro) || (sym.children exists isMacro)
-        //sym.isMacro || (sym.children exists isMacro) || (sym.isType && sym.asType.toType.members.sorted.exists(isMacro))
-      val inspectPostErasure = !isMacro(in.enclosingTopLevelClass)
-
+      def collectAll(acc: Set[Symbol], s: Symbol): Set[Symbol] =
+        if (acc contains s) acc
+        else
+          ((s.info.members.sorted ++ s.children) foldLeft (acc + s)) {
+            case (acc, sym) => collectAll(acc, sym)
+          }
+      val inspectPostErasure = !collectAll(Set.empty, in.enclosingTopLevelClass).exists(_.isMacro)
       def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {
           def parameterList(syms: List[Symbol]): xsbti.api.ParameterList =

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -178,9 +178,9 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
 
   private def viewer(s: Symbol) = (if (s.isModule) s.moduleClass else s).thisType
   private def printMember(label: String, in: Symbol, t: Type) = println(label + " in " + in + " : " + t + " (debug: " + debugString(t) + " )")
-  private def defDef(in: Symbol, s: Symbol) =
+  private def defDef(in: Symbol, s: Symbol): List[xsbti.api.Def] =
     {
-      def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): xsbti.api.Def =
+      def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {
           def parameterList(syms: List[Symbol]): xsbti.api.ParameterList =
             {
@@ -192,13 +192,50 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
               assert(typeParams.isEmpty)
               assert(valueParameters.isEmpty)
               build(base, typeParameters(in, typeParams0), Nil)
-            case MethodType(params, resultType) =>
-              build(resultType, typeParams, parameterList(params) :: valueParameters)
+            case mType @ MethodType(params, resultType) =>
+              // The types of a method's parameters change between phases: For instance, if a
+              // parameter is a subtype of AnyVal, then it won't have the same type before and after
+              // erasure. Therefore we record the type of parameters before AND after erasure to
+              // make sure that we don't miss some API changes.
+              //   class A(val x: Int) extends AnyVal
+              //   def foo(a: A): Int = A.x <- has type (LA)I before erasure
+              //                            <- has type (I)I after erasure
+              // If we change A from value class to normal class, we need to recompile all clients
+              // of def foo.
+              val beforeErasure = parameterList(params) :: valueParameters
+              val afterErasure  = global exitingPostErasure (parameterList(mType.params) :: valueParameters)
+
+              build(resultType, typeParams, beforeErasure) ++ build(resultType, typeParams, afterErasure)
             case Nullary(resultType) => // 2.9 and later
               build(resultType, typeParams, valueParameters)
             case returnType =>
-              val t2 = processType(in, dropConst(returnType))
-              new xsbti.api.Def(valueParameters.reverse.toArray, t2, typeParams, simpleName(s), getAccess(s), getModifiers(s), annotations(in, s))
+              def makeDef(retTpe: xsbti.api.Type): xsbti.api.Def =
+                new xsbti.api.Def(
+                  valueParameters.reverse.toArray,
+                  retTpe,
+                  typeParams,
+                  simpleName(s),
+                  getAccess(s),
+                  getModifiers(s),
+                  annotations(in, s))
+
+              // The return type of a method may change before and after erasure. Consider the
+              // following method:
+              //   class A(val x: Int) extends AnyVal
+              //   def foo(x: Int): A = new A(x) <- has type (I)LA before erasure
+              //                                 <- has type (I)I after erasure
+              // If we change A from value class to normal class, we need to recompile all clients
+              // of def foo.
+              val beforeErasure = processType(in, dropConst(returnType))
+              val afterErasure = {
+                val erasedReturn = dropConst(global exitingPostErasure viewer(in).memberInfo(s)) map {
+                  case MethodType(_, r) => r
+                  case other            => other
+                }
+                processType(in, erasedReturn)
+              }
+
+              makeDef(beforeErasure) :: makeDef(afterErasure) :: Nil
           }
         }
       def parameterS(s: Symbol): xsbti.api.MethodParameter =
@@ -292,22 +329,22 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
     defs
   }
 
-  private def definition(in: Symbol, sym: Symbol): Option[xsbti.api.Definition] =
+  private def definition(in: Symbol, sym: Symbol): List[xsbti.api.Definition] =
     {
-      def mkVar = Some(fieldDef(in, sym, false, new xsbti.api.Var(_, _, _, _, _)))
-      def mkVal = Some(fieldDef(in, sym, true, new xsbti.api.Val(_, _, _, _, _)))
+      def mkVar = List(fieldDef(in, sym, false, new xsbti.api.Var(_, _, _, _, _)))
+      def mkVal = List(fieldDef(in, sym, true, new xsbti.api.Val(_, _, _, _, _)))
       if (isClass(sym))
-        if (ignoreClass(sym)) None else Some(classLike(in, sym))
+        if (ignoreClass(sym)) Nil else List(classLike(in, sym))
       else if (sym.isNonClassType)
-        Some(typeDef(in, sym))
+        List(typeDef(in, sym))
       else if (sym.isVariable)
-        if (isSourceField(sym)) mkVar else None
+        if (isSourceField(sym)) mkVar else Nil
       else if (sym.isStable)
-        if (isSourceField(sym)) mkVal else None
+        if (isSourceField(sym)) mkVal else Nil
       else if (sym.isSourceMethod && !sym.isSetter)
-        if (sym.isGetter) mkVar else Some(defDef(in, sym))
+        if (sym.isGetter) mkVar else defDef(in, sym)
       else
-        None
+        Nil
     }
   private def ignoreClass(sym: Symbol): Boolean =
     sym.isLocalClass || sym.isAnonymousClass || sym.fullName.endsWith(LocalChild.toString)

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -183,16 +183,26 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
     {
       import MirrorHelper._
 
-      // Here we must be careful to also consider the type parameters, because a tuple (Foo, Int)
-      // may become (Int, Int) for instance.
-      def hasValueClassAsParameter(meth: MethodSymbol): Boolean =
-        meth.paramss.flatten map (_.info) exists (t => isAnyValSubtype(t.typeSymbol))
+      val hasValueClassAsParameter: Boolean = {
+        import MirrorHelper._
+        s.asMethod.paramss.flatten map (_.info) exists (t => isAnyValSubtype(t.typeSymbol))
+      }
 
-      // Here too we must care for the type parameters (see above comment).
-      def hasValueClassAsReturnType(meth: MethodSymbol): Boolean =
-        isAnyValSubtype(meth.returnType.typeSymbol)
+      // Note: We only inspect the "outermost type" (i.e. no recursion) because we don't need to
+      // inspect after erasure a function that would, for instance, return a function that returns
+      // a subtype of AnyVal.
+      val hasValueClassAsReturnType: Boolean = {
+        val tpe = viewer(in).memberInfo(s)
+        tpe match {
+          case PolyType(_, base) => isAnyValSubtype(base.typeSymbol)
+          case MethodType(_, resultType) => isAnyValSubtype(resultType.typeSymbol)
+          case Nullary(resultType) => isAnyValSubtype(resultType.typeSymbol)
+          case resultType => isAnyValSubtype(resultType.typeSymbol)
+        }
+      }
 
-      val inspectPostErasure = hasValueClassAsParameter(s.asMethod) || hasValueClassAsReturnType(s.asMethod)
+      val inspectPostErasure = hasValueClassAsParameter || hasValueClassAsReturnType
+
       def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {
           def parameterList(syms: List[Symbol]): xsbti.api.ParameterList =

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -181,11 +181,18 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
 
   private def defDef(in: Symbol, s: Symbol): List[xsbti.api.Def] =
     {
-      import DetectMacroImpls._
-      def hasContextAsParameter(meth: MethodSymbol): Boolean =
-        meth.paramss.flatten exists (p => isContextCompatible(p.info.typeSymbol))
+      import MirrorHelper._
 
-      val inspectPostErasure = !hasContextAsParameter(s.asMethod)
+      // Here we must be careful to also consider the type parameters, because a tuple (Foo, Int)
+      // may become (Int, Int) for instance.
+      def hasValueClassAsParameter(meth: MethodSymbol): Boolean =
+        meth.paramss.flatten map (_.info) exists (t => isAnyValSubtype(t.typeSymbol))
+
+      // Here too we must care for the type parameters (see above comment).
+      def hasValueClassAsReturnType(meth: MethodSymbol): Boolean =
+        isAnyValSubtype(meth.returnType.typeSymbol)
+
+      val inspectPostErasure = hasValueClassAsParameter(s.asMethod) || hasValueClassAsReturnType(s.asMethod)
       def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {
           def parameterList(syms: List[Symbol]): xsbti.api.ParameterList =

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -178,15 +178,14 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
 
   private def viewer(s: Symbol) = (if (s.isModule) s.moduleClass else s).thisType
   private def printMember(label: String, in: Symbol, t: Type) = println(label + " in " + in + " : " + t + " (debug: " + debugString(t) + " )")
+
   private def defDef(in: Symbol, s: Symbol): List[xsbti.api.Def] =
     {
-      def collectAll(acc: Set[Symbol], s: Symbol): Set[Symbol] =
-        if (acc contains s) acc
-        else
-          ((s.info.members.sorted ++ s.children) foldLeft (acc + s)) {
-            case (acc, sym) => collectAll(acc, sym)
-          }
-      val inspectPostErasure = !collectAll(Set.empty, in.enclosingTopLevelClass).exists(_.isMacro)
+      import DetectMacroImpls._
+      def hasContextAsParameter(meth: MethodSymbol): Boolean =
+        meth.paramss.flatten exists (p => isContextCompatible(p.info.typeSymbol))
+
+      val inspectPostErasure = !hasContextAsParameter(s.asMethod)
       def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {
           def parameterList(syms: List[Symbol]): xsbti.api.ParameterList =

--- a/notes/0.13.10/consider-signatures-after-erasure.md
+++ b/notes/0.13.10/consider-signatures-after-erasure.md
@@ -1,0 +1,12 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [1171]: https://github.com/sbt/sbt/issues/1171
+  [2261]: https://github.com/sbt/sbt/pull/2261
+
+### Fixes with compatibility implications
+
+### Improvements
+- Register signatures of method before and after erasure if they involve value classes [#2261][2261] by [@Duhemm][@Duhemm]
+
+### Bug fixes
+- Incremental compiler misses change to value class, and results to NoSuchMethodError at runtime [#1171][1171]

--- a/sbt/src/sbt-test/source-dependencies/value-class/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/value-class/build.sbt
@@ -1,0 +1,2 @@
+incOptions := incOptions.value.withRecompileAllFraction(1.0)
+

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/A0.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/A0.scala
@@ -1,0 +1,1 @@
+class A(val x: Int)

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/A1.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/A1.scala
@@ -1,0 +1,1 @@
+class A(val x: Int) extends AnyVal

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/B0.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/B0.scala
@@ -1,0 +1,3 @@
+class B {
+  def foo(a: A): Int = 1
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/B1.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/B1.scala
@@ -1,0 +1,3 @@
+class B {
+  def bar: A = new A(0)
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/C0.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/C0.scala
@@ -1,0 +1,3 @@
+object C extends App {
+  println(new B().foo(null))
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/C1.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/C1.scala
@@ -1,0 +1,3 @@
+object C extends App {
+  println(new B().bar.x)
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/test
+++ b/sbt/src/sbt-test/source-dependencies/value-class/test
@@ -1,0 +1,30 @@
+$ copy-file changes/A0.scala src/main/scala/A.scala
+$ copy-file changes/B0.scala src/main/scala/B.scala
+$ copy-file changes/C0.scala src/main/scala/C.scala
+
+# A is a normal class. B.foo accepts a parameter of type A. C calls B.foo, giving it `null`.
+> compile
+> run
+
+# Make A a value class.
+$ copy-file changes/A1.scala src/main/scala/A.scala
+
+# The code no longer compiles because B.foo no longer accepts `null` as an argument.
+# This means that we have invalidated C.scala, as expected!
+-> compile
+
+$ copy-file changes/A0.scala src/main/scala/A.scala
+$ copy-file changes/B1.scala src/main/scala/B.scala
+$ copy-file changes/C1.scala src/main/scala/C.scala
+
+# A is a normal class. B.bar takes no arguments and returns an instance of A. C calls B.bar.
+> compile
+> run
+
+# Make A a value class.
+$ copy-file changes/A1.scala src/main/scala/A.scala
+
+# The code compiles. It will run iff C is recompiled because the signature of B.bar has changed,
+# because A is now a value class.
+> run
+


### PR DESCRIPTION
The signatures of methods that have value classes as arguments or return
type change during the erasure phase. Because we only registered
signatures before the erasure, we missed some API changes when a class
was changed to a value class (or a value class changed to a class).

This commit fixes this problem by recording the signatures of method
before and after erasure.

Fixes sbt/sbt#1171
