### PR TITLE
Report failed compilation if errors are registered.

### DIFF
--- a/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/DiagnosticsReporter.scala
@@ -14,6 +14,10 @@ import javax.tools.Diagnostic.NOPOS
 final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[JavaFileObject] {
   val END_OF_LINE_MATCHER = "(\r\n)|[\r]|[\n]"
   val EOL = System.getProperty("line.separator")
+
+  private[this] var errorEncountered = false
+  def hasErrors: Boolean = errorEncountered
+
   private def fixedDiagnosticMessage(d: Diagnostic[_ <: JavaFileObject]): String = {
     def getRawMessage = d.getMessage(null)
     def fixWarnOrErrorMessage = {
@@ -110,6 +114,7 @@ final class DiagnosticsReporter(reporter: Reporter) extends DiagnosticListener[J
           if (sourceUri.isDefined) s"${sourceUri.get}:${if (line.isDefined) line.get else -1}"
           else ""
       }
+    if (severity == Severity.Error) errorEncountered = true
     reporter.log(pos, msg, severity)
   }
 }

--- a/compile/src/main/scala/sbt/compiler/javac/LocalJava.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/LocalJava.scala
@@ -66,6 +66,10 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends JavaCo
     val diagnostics = new DiagnosticsReporter(reporter)
     val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
     val jfiles = fileManager.getJavaFileObjectsFromFiles(sources.asJava)
-    compiler.getTask(logWriter, fileManager, diagnostics, options.asJava, null, jfiles).call()
+    val success = compiler.getTask(logWriter, fileManager, diagnostics, options.asJava, null, jfiles).call()
+    // The local compiler may report a successful compilation even though there are errors (e.g. encoding problems in the
+    // source files). In a similar situation, command line javac reports a failed compilation. To have the local java compiler
+    // stick to javac's behavior, we report a failed compilation if there have been errors.
+    success && !diagnostics.hasErrors
   }
 }

--- a/notes/0.13.10/local-java-report-errors.md
+++ b/notes/0.13.10/local-java-report-errors.md
@@ -1,0 +1,12 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [2228]: https://github.com/sbt/sbt/issues/2228
+  [2271]: https://github.com/sbt/sbt/pull/2271
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Report java compilation as failed if the local java compiler reported compilation errors (issue [#2228][2228]) [#2271][2271] by [@Duhemm][@Duhemm]


### PR DESCRIPTION
In some cases, the local java compiler may report compilation errors,
but succeed in compiling the source files (for instance, if there are
encoding problems in the source). However, the command line javac will
report a failed compilation on the same input.

To have the local java compiler behave like the forked java compiler, we
now report the compilation as failed if error messages have been
registered during compilation.

Fixes sbt/sbt#2228
