### PR TITLE
Don't pass `-J<flag>` to local java, improve javac's error parsing

### DIFF
--- a/compile/src/main/scala/sbt/compiler/javac/JavaErrorParser.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/JavaErrorParser.scala
@@ -44,6 +44,7 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
 
   override val skipWhitespace = false
 
+  val JAVAC: Parser[String] = literal("javac")
   val CHARAT: Parser[String] = literal("^")
   val SEMICOLON: Parser[String] = literal(":") | literal("\uff1a")
   val SYMBOL: Parser[String] = allUntilChar(':') // We ignore whether it actually says "symbol" for i18n
@@ -161,8 +162,16 @@ class JavaErrorParser(relativeDir: File = new File(new File(".").getAbsolutePath
         msg
       )
     }
+  val javacError: Parser[Problem] =
+    JAVAC ~ SEMICOLON ~ restOfLine ^^ {
+      case _ ~ _ ~ error =>
+        new JavaProblem(
+          JavaNoPosition,
+          Severity.Error,
+          s"javac:$error")
+    }
 
-  val potentialProblem: Parser[Problem] = warningMessage | errorMessage | noteMessage
+  val potentialProblem: Parser[Problem] = warningMessage | errorMessage | noteMessage | javacError
 
   val javacOutput: Parser[Seq[Problem]] = rep(potentialProblem)
   /**

--- a/compile/src/main/scala/sbt/compiler/javac/LocalJava.scala
+++ b/compile/src/main/scala/sbt/compiler/javac/LocalJava.scala
@@ -66,6 +66,14 @@ final class LocalJavaCompiler(compiler: javax.tools.JavaCompiler) extends JavaCo
     val diagnostics = new DiagnosticsReporter(reporter)
     val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
     val jfiles = fileManager.getJavaFileObjectsFromFiles(sources.asJava)
-    compiler.getTask(logWriter, fileManager, diagnostics, options.asJava, null, jfiles).call()
+
+    // Local Java compiler doesn't accept `-J<flag>` options. We emit a warning if we find
+    // such options and don't pass them to the compiler.
+    val (invalidOptions, cleanedOptions) = options partition (_ startsWith "-J")
+    if (invalidOptions.nonEmpty) {
+      log.warn("Javac is running in 'local' mode. These flags have been removed:")
+      log.warn(invalidOptions.mkString("\t", ", ", ""))
+    }
+    compiler.getTask(logWriter, fileManager, diagnostics, cleanedOptions.asJava, null, jfiles).call()
   }
 }

--- a/compile/src/test/scala/sbt/compiler/javac/javaErrorParserSpec.scala
+++ b/compile/src/test/scala/sbt/compiler/javac/javaErrorParserSpec.scala
@@ -18,7 +18,7 @@ object JavaErrorParserSpec extends Specification {
      be able to parse javac errors $parseSampleJavac
   """
 
-  def parseSampleLinux = {
+  def parseSampleLinux: MatchResult[_] = {
     val parser = new JavaErrorParser()
     val logger = Logger.Null
     val problems = parser.parseProblems(sampleLinuxMessage, logger)
@@ -27,7 +27,7 @@ object JavaErrorParserSpec extends Specification {
     rightSize and rightFile
   }
 
-  def parseSampleWindows = {
+  def parseSampleWindows: MatchResult[_] = {
     val parser = new JavaErrorParser()
     val logger = Logger.Null
     val problems = parser.parseProblems(sampleWindowsMessage, logger)
@@ -46,7 +46,7 @@ object JavaErrorParserSpec extends Specification {
     }
   }
 
-  def parseSampleJavac = {
+  def parseSampleJavac: MatchResult[_] = {
     val parser = new JavaErrorParser()
     val logger = Logger.Null
     val problems = parser.parseProblems(sampleJavacMessage, logger)
@@ -55,7 +55,7 @@ object JavaErrorParserSpec extends Specification {
     rightSize and rightError
   }
 
-  def sampleLinuxMessage =
+  def sampleLinuxMessage: String =
     """
       |/home/me/projects/sample/src/main/Test.java:4: cannot find symbol
       |symbol  : method baz()
@@ -63,7 +63,7 @@ object JavaErrorParserSpec extends Specification {
       |return baz();
     """.stripMargin
 
-  def sampleWindowsMessage =
+  def sampleWindowsMessage: String =
     s"""
       |$windowsFile:4: cannot find symbol
       |symbol  : method baz()
@@ -71,8 +71,8 @@ object JavaErrorParserSpec extends Specification {
       |return baz();
     """.stripMargin
 
-  def windowsFile = """C:\Projects\sample\src\main\java\Test.java"""
-  def windowsFileAndLine = s"""$windowsFile:4"""
+  def windowsFile: String = """C:\Projects\sample\src\main\java\Test.java"""
+  def windowsFileAndLine: String = s"""$windowsFile:4"""
 
   def sampleJavacMessage = "javac: invalid flag: -foobar"
 }

--- a/compile/src/test/scala/sbt/compiler/javac/javaErrorParserSpec.scala
+++ b/compile/src/test/scala/sbt/compiler/javac/javaErrorParserSpec.scala
@@ -15,6 +15,7 @@ object JavaErrorParserSpec extends Specification {
      be able to parse linux errors    $parseSampleLinux
      be able to parse windows file names $parseWindowsFile
      be able to parse windows errors  $parseSampleWindows
+     be able to parse javac errors $parseSampleJavac
   """
 
   def parseSampleLinux = {
@@ -45,6 +46,15 @@ object JavaErrorParserSpec extends Specification {
     }
   }
 
+  def parseSampleJavac = {
+    val parser = new JavaErrorParser()
+    val logger = Logger.Null
+    val problems = parser.parseProblems(sampleJavacMessage, logger)
+    def rightSize = problems must haveSize(1)
+    def rightError = problems(0).message must beEqualTo(sampleJavacMessage)
+    rightSize and rightError
+  }
+
   def sampleLinuxMessage =
     """
       |/home/me/projects/sample/src/main/Test.java:4: cannot find symbol
@@ -63,4 +73,6 @@ object JavaErrorParserSpec extends Specification {
 
   def windowsFile = """C:\Projects\sample\src\main\java\Test.java"""
   def windowsFileAndLine = s"""$windowsFile:4"""
+
+  def sampleJavacMessage = "javac: invalid flag: -foobar"
 }

--- a/notes/0.13.10/dont-pass-jflag-to-local-java.md
+++ b/notes/0.13.10/dont-pass-jflag-to-local-java.md
@@ -1,0 +1,11 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [1968]: https://github.com/sbt/sbt/issues/1968
+  [2272]: https://github.com/sbt/sbt/pull/2272
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+- Don't pass `-J<flag>` options to the local java compiler (issue [#1968][1968]) [#2272][2272] by [@Duhemm][@Duhemm]

--- a/notes/0.13.10/parse-non-compile-errors.md
+++ b/notes/0.13.10/parse-non-compile-errors.md
@@ -1,0 +1,11 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [2256]: https://github.com/sbt/sbt/issues/2256
+  [2272]: https://github.com/sbt/sbt/pull/2272
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+- Improve `JavaErrorParser` to parse non-compile-errors (issue [#2256][2256]) [#2272][2272] by [@Duhemm][@Duhemm]


### PR DESCRIPTION
This PR provides a fix for sbt/sbt#1968 by not passing `-J<flag>` options to the local Java compiler and emitting a warning.

It also fixes sbt/sbt#2256. Error messages were not displayed because they were not correctly parsed by `JavaErrorParser`.
