### PR TITLE
Fix search result highlighting on Windows

### DIFF
--- a/main/command/src/main/scala/sbt/Highlight.scala
+++ b/main/command/src/main/scala/sbt/Highlight.scala
@@ -6,19 +6,18 @@ import scala.Console.{ BOLD, RESET }
 import sbt.internal.util.ConsoleLogger
 
 object Highlight {
-  final val NormalIntensity = "\033[22m"
-  final val NormalTextColor = "\033[39m"
 
   def showMatches(pattern: Pattern)(line: String): Option[String] =
     {
       val matcher = pattern.matcher(line)
       if (ConsoleLogger.formatEnabled) {
-        val highlighted = matcher.replaceAll(scala.Console.RED + "$0" + NormalTextColor)
+        // ANSI codes like \033[39m (normal text color) don't work on Windows
+        val highlighted = matcher.replaceAll(scala.Console.RED + "$0" + RESET)
         if (highlighted == line) None else Some(highlighted)
       } else if (matcher.find)
         Some(line)
       else
         None
     }
-  def bold(s: String) = if (ConsoleLogger.formatEnabled) BOLD + s + NormalIntensity else s
+  def bold(s: String) = if (ConsoleLogger.formatEnabled) BOLD + s.replace(RESET, RESET + BOLD) + RESET else s
 }

--- a/notes/0.13.10/help-highlighting-windows.markdown
+++ b/notes/0.13.10/help-highlighting-windows.markdown
@@ -1,0 +1,11 @@
+[@eamelink]: https://github.com/eamelink
+[1982]: https://github.com/sbt/sbt/issues/1982
+
+### Changes with compatibility implications
+
+### Improvements
+
+### Fixes
+
+- Highlighting of partial task search results now only uses ANSI color
+codes are supported on Windows [#1982][1982] by [@eamelink][@eamelink]


### PR DESCRIPTION
Use only ANSI color codes that are supported by Windows. Fixes #1982 
