### PR TITLE
(Do not merge) Fixes sbt/sbt#2264. Use explicit artifacts if any, fallback to hardcoded

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1254,7 +1254,8 @@ object Classpaths {
         val uwConfig = (unresolvedWarningConfiguration in update).value
         val logicalClock = LogicalClock(state.value.hashCode)
         val depDir = dependencyCacheDirectory.value
-        IvyActions.updateClassifiers(is, GetClassifiersConfiguration(mod, excludes, c, ivyScala.value), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), s.log)
+        val artifacts = update.value.toSeq.toVector
+        IvyActions.updateClassifiers(is, GetClassifiersConfiguration(mod, excludes, c, ivyScala.value), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), artifacts, s.log)
       }
     } tag (Tags.Update, Tags.Network)
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val utilVersion = "0.1.0-M5"
   val ioVersion = "1.0.0-M3"
   val incremenalcompilerVersion = "0.1.0-M1-168cb7a4877917e01917e35b9b82a62afe5c2a01"
-  val librarymanagementVersion = "0.1.0-M4"
+  val librarymanagementVersion = "0.1.0-M6"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   lazy val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion

--- a/sbt/src/sbt-test/dependency-management/update-classifiers/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/update-classifiers/build.sbt
@@ -1,0 +1,46 @@
+val fooFile = taskKey[File]("sample artifact")
+val RuntimeX = config("runtime")
+val check = taskKey[Unit]("check")
+
+lazy val commonSettings = Seq(
+  organization := "com.example",
+  version := "0.1-SNAPSHOT",
+  scalaVersion := "2.11.7",
+  ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),
+  fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project")
+)
+
+lazy val root = (project in file(".")).
+  settings(commonSettings)
+
+lazy val classifierproducer = (project in file("classifierproducer")).
+  settings(
+    commonSettings,
+    fooFile := { baseDirectory.value / "foo.txt" },
+    addArtifact( Artifact("classifierproducer", "text", "txt", "runtime"), fooFile),
+    ivyConfigurations := Seq(RuntimeX, Configurations.ScalaTool),
+    publishArtifact in Compile := false,
+    publishArtifact in Test := false,
+    publishMavenStyle := false,
+    autoScalaLibrary := false,
+    crossPaths := false
+  )
+
+lazy val classifierconsumer = (project in file("classifierconsumer")).
+  settings(
+    commonSettings,
+    libraryDependencies += "com.example" % "classifierproducer" % "0.1-SNAPSHOT" % "compile->runtime",
+    check := {
+      val ur = updateClassifiers.value
+      val mrs = for {
+        cr <- ur.configurations if cr.configuration == "compile"
+        oar <- cr.details if (oar.organization == "com.example") && (oar.name == "classifierproducer")
+        mr <- oar.modules if (mr.module.revision == "0.1-SNAPSHOT")
+      } yield mr
+      val mr = mrs.head
+      if (mr.artifacts exists { case (a: Artifact, f) =>
+        a.extension == "txt"
+      }) ()
+      else sys.error("txt artifact was not found: " + mr.toString)
+    }
+  )

--- a/sbt/src/sbt-test/dependency-management/update-classifiers/test
+++ b/sbt/src/sbt-test/dependency-management/update-classifiers/test
@@ -1,0 +1,3 @@
+> classifierproducer/publishLocal
+
+> classifierconsumer/check


### PR DESCRIPTION
This is a port for sbt/sbt#2297. This won't compile until we have a new release of sbt/librarymanagement that includes both sbt/librarymanagement#9 and sbt/librarymanagement#13.
