### PR TITLE
Fixes #1514. Enable latest SNAPSHOT option by default

### DIFF
--- a/ivy/src/main/scala/sbt/UpdateOptions.scala
+++ b/ivy/src/main/scala/sbt/UpdateOptions.scala
@@ -75,7 +75,7 @@ object UpdateOptions {
   def apply(): UpdateOptions =
     new UpdateOptions(
       circularDependencyLevel = CircularDependencyLevel.Warn,
-      latestSnapshots = false,
+      latestSnapshots = true,
       consolidatedResolution = false,
       cachedResolution = false,
       resolverConverter = PartialFunction.empty)

--- a/ivy/src/main/scala/sbt/ivyint/SbtChainResolver.scala
+++ b/ivy/src/main/scala/sbt/ivyint/SbtChainResolver.scala
@@ -183,15 +183,11 @@ private[sbt] case class SbtChainResolver(
             // Now that we know the real latest revision, let's force Ivy to use it
             val artifactOpt = findFirstArtifactRef(rmr.getDescriptor, dd, data, resolver)
             artifactOpt match {
-              case None if resolver.getName == "inter-project" => // do nothing
-              case None if resolver.isInstanceOf[CustomMavenResolver] =>
-              // do nothing for now....
-              // We want to see if the maven caching is sufficient and we do not need to duplicate within the ivy cache...
-              case None => throw new RuntimeException(s"\t${resolver.getName}: no ivy file nor artifact found for $rmr")
               case Some(artifactRef) =>
                 val systemMd = toSystem(rmr.getDescriptor)
                 getRepositoryCacheManager.cacheModuleDescriptor(resolver, artifactRef,
                   toSystem(dd), systemMd.getAllArtifacts.head, None.orNull, getCacheOptions(data))
+              case None => // do nothing. There are modules without artifacts
             }
             rmr
         }

--- a/notes/0.13.10/fix-snapshots.md
+++ b/notes/0.13.10/fix-snapshots.md
@@ -1,12 +1,14 @@
 
   [@eed3si9n]: https://github.com/eed3si9n
   [1514]: https://github.com/sbt/sbt/issues/1514
+  [1616]: https://github.com/sbt/sbt/issues/1616
+  [2313]: https://github.com/sbt/sbt/pull/2313
 
 ### Fixes with compatibility implications
+
+- Fixes update option's `withLatestSnapshots` so it handles modules without an artifact. This flag will be enabled by default.
+  [#1514][1514]/[#1616][1616]/[#2313][2313] by [@eed3si9n][@eed3si9n]
 
 ### Improvements
 
 ### Bug fixes
-
-- Turns update option's `withLatestSnapshots` flag `true` by default.
-  [#1514][1514] by [@eed3si9n][@eed3si9n]

--- a/notes/0.13.10/fix-snapshots.md
+++ b/notes/0.13.10/fix-snapshots.md
@@ -1,0 +1,12 @@
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [1514]: https://github.com/sbt/sbt/issues/1514
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Turns update option's `withLatestSnapshots` flag `true` by default.
+  [#1514][1514] by [@eed3si9n][@eed3si9n]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val scala211 = "2.11.7"
 
   lazy val jline = "jline" % "jline" % "2.13"
-  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-d592b1b0f77cf706e882b1b8e0162dee28165fb2"
+  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-39ece6f17e1af62c2e89a9d88b59c0c3aad56145"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"
   lazy val sbtSerialization = "org.scala-sbt" %% "serialization" % "0.1.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val scala211 = "2.11.7"
 
   lazy val jline = "jline" % "jline" % "2.13"
-  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-39ece6f17e1af62c2e89a9d88b59c0c3aad56145"
+  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-2cc8d2761242b072cedb0a04cb39435c4fa24f9a"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.46" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"
   lazy val sbtSerialization = "org.scala-sbt" %% "serialization" % "0.1.2"

--- a/sbt/src/sbt-test/dependency-management/pom-parent-pom/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-parent-pom/build.sbt
@@ -1,44 +1,31 @@
-name := "test-parent-pom"
-
-val localMavenRepo = file("local-repo")
-                                                                                                                                                                                                                                                                                                                        val cleanExampleCache = taskKey[Unit]("Cleans the example cache.")
-
-resolvers +=
-  MavenRepository("Maven2 Local Test", localMavenRepo.toURI.toString)
-
-
-libraryDependencies +=
-  "com.example" % "example-child" % "1.0-SNAPSHOT"
-
-libraryDependencies += "org.apache.geronimo.specs" % "geronimo-jta_1.1_spec" % "1.1.1"
-
-version := "1.0-SNAPSHOT"
-
-
-cleanExampleCache := {
-    ivySbt.value.withIvy(streams.value.log) { ivy =>
-      val cacheDir = ivy.getSettings.getDefaultRepositoryCacheBasedir
-      // TODO - Is this actually ok?
-      IO.delete(cacheDir / "com.example")
-    }
-}
-
 val checkIvyXml = taskKey[Unit]("Checks the ivy.xml transform was correct")
 
+lazy val root = (project in file(".")).
+  settings(
+    name := "test-parent-pom",
+    ivyPaths := new IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),
+    resolvers += MavenCache("Maven2 Local Test", baseDirectory.value / "local-repo"),
+    libraryDependencies += "com.example" % "example-child" % "1.0-SNAPSHOT",
+    libraryDependencies += "org.apache.geronimo.specs" % "geronimo-jta_1.1_spec" % "1.1.1",
+    version := "1.0-SNAPSHOT",
+    autoScalaLibrary := false,
+    checkIvyXml := {
+      ivySbt.value.withIvy(streams.value.log) { ivy =>
+        val cacheDir = ivy.getSettings.getDefaultRepositoryCacheBasedir
+        val xmlFile  =
+          cacheDir / "org.apache.geronimo.specs" / "geronimo-jta_1.1_spec" / "ivy-1.1.1.xml"
+        val lines = IO.read(xmlFile)
+        if(lines.isEmpty) sys.error(s"Unable to read $xmlFile, could not resolve geronimo...")
+        // Note: We do not do this if the maven plguin is enabled, because there is no rewrite of ivy.xml, extra attribtues
+        // are handled in a different mechanism.  This is a hacky mechanism to detect that.
+        val isMavenResolver = updateOptions.value.resolverConverter != PartialFunction.empty
+        if(!isMavenResolver) assert(lines contains "xmlns:e", s"Failed to appropriately modify ivy.xml file for sbt extra attributes!\n$lines")
 
-
-checkIvyXml := {
-  ivySbt.value.withIvy(streams.value.log) { ivy =>
-    val cacheDir = ivy.getSettings.getDefaultRepositoryCacheBasedir
-    // TODO - Is this actually ok?
-    val xmlFile  =
-      cacheDir / "org.apache.geronimo.specs" / "geronimo-jta_1.1_spec" / "ivy-1.1.1.xml"
-      //cacheDir / "com.example" / "example-child" / "ivy-1.0-SNAPSHOT.xml"
-    val lines = IO.read(xmlFile)
-    if(lines.isEmpty) sys.error(s"Unable to read $xmlFile, could not resolve geronimo...")
-    // Note: We do not do this if the maven plguin is enabled, because there is no rewrite of ivy.xml, extra attribtues
-    // are handled in a different mechanism.  This is a hacky mechanism to detect that.
-    val isMavenResolver = updateOptions.value.resolverConverter != PartialFunction.empty
-    if(!isMavenResolver) assert(lines contains "xmlns:e", s"Failed to appropriately modify ivy.xml file for sbt extra attributes!\n$lines")
-  }
-}
+        val xmlFile2 = cacheDir / "com.example" / "example-child" / "ivy-1.0-SNAPSHOT.xml"
+        val lines2 = IO.read(xmlFile2)
+        if (!isMavenResolver) {
+          assert(lines2 contains "Apache-2.0", s"Failed to roll up license from the parent POM!\n$lines2")
+        }
+      }
+    }
+  )

--- a/sbt/src/sbt-test/dependency-management/pom-parent-pom/local-repo/com/example/example-parent/1.0-SNAPSHOT/example-parent-1.0-SNAPSHOT.pom
+++ b/sbt/src/sbt-test/dependency-management/pom-parent-pom/local-repo/com/example/example-parent/1.0-SNAPSHOT/example-parent-1.0-SNAPSHOT.pom
@@ -6,5 +6,10 @@
     <artifactId>example-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-
+    <licenses>
+      <license>
+        <name>Apache-2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+    </licenses>
 </project>

--- a/sbt/src/sbt-test/dependency-management/pom-parent-pom/test
+++ b/sbt/src/sbt-test/dependency-management/pom-parent-pom/test
@@ -1,3 +1,2 @@
-> cleanExampleCache
 > update
 > checkIvyXml

--- a/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
@@ -25,8 +25,8 @@ lazy val common = project.
           case _ => false  // TODO - Handle chain repository?
         }
       case _ => true
-    }),
-    updateOptions := updateOptions.value.withLatestSnapshots(true)
+    })
+    // updateOptions := updateOptions.value.withLatestSnapshots(true)
   )
 
 lazy val dependent = project.
@@ -37,9 +37,9 @@ lazy val dependent = project.
     // Ignore the inter-project resolver, so we force to look remotely.
     resolvers += sharedResolver,
     fullResolvers := fullResolvers.value.filterNot(_==projectResolver.value),
-    libraryDependencies += "com.badexample" % "badexample" % "1.0-SNAPSHOT",
+    libraryDependencies += "com.badexample" % "badexample" % "1.0-SNAPSHOT"
     // Setting this to false fails the test
-    updateOptions := updateOptions.value.withLatestSnapshots(true)
+    // updateOptions := updateOptions.value.withLatestSnapshots(true)
   )
 
 TaskKey[Unit]("dumpResolvers") := {


### PR DESCRIPTION
Fixes #1514
Fixes #1616
#1520 originally fixed #1514 by reimplementing part of chain resolver to check all resolvers to find the latest snapshot artifacts. This behavior did not work well:
1. with Maven repositories where sbt was failing to calculate the correct publication dates.
2. with module doesn't have any artifacts (parent POMs). #1616 
#2075 should fix the publication date issue, and  we should enable this flag back again. 1bf789eb3dc48f8786da326f2ce18793f09faea5 fixes the module without artifacts.

The build user can opt out by:

``` scala
updateOptions := updateOptions.value.withLatestSnapshots(false)
```

/review @jsuereth, @dwijnand, @Duhemm 
