### PR TITLE
Add useJCenter settings and set it to false by default

### DIFF
--- a/ivy/src/main/scala/sbt/Resolver.scala
+++ b/ivy/src/main/scala/sbt/Resolver.scala
@@ -216,16 +216,43 @@ object Resolver {
 
   /** Add the local and Maven Central repositories to the user repositories.  */
   def withDefaultResolvers(userResolvers: Seq[Resolver]): Seq[Resolver] =
-    withDefaultResolvers(userResolvers, true)
+    withDefaultResolvers(userResolvers, false, true)
   /**
    * Add the local Ivy repository to the user repositories.
    * If `mavenCentral` is true, add the Maven Central repository.
    */
   def withDefaultResolvers(userResolvers: Seq[Resolver], mavenCentral: Boolean): Seq[Resolver] =
+    withDefaultResolvers(userResolvers, false, mavenCentral)
+  /**
+   * Add the local Ivy repository to the user repositories.
+   * If `jcenter` is true, add the JCenter.
+   * If `mavenCentral` is true, add the Maven Central repository.
+   */
+  private[sbt] def withDefaultResolvers(userResolvers: Seq[Resolver], jcenter: Boolean, mavenCentral: Boolean): Seq[Resolver] =
     Seq(Resolver.defaultLocal) ++
       userResolvers ++
+      single(JCenterRepository, jcenter) ++
       single(DefaultMavenRepository, mavenCentral)
   private def single[T](value: T, nonEmpty: Boolean): Seq[T] = if (nonEmpty) Seq(value) else Nil
+
+  /**
+   * Reorganize the built-in resolvers that is configured for this application by the sbt launcher.
+   * If `jcenter` is true, add the JCenter.
+   * If `mavenCentral` is true, add the Maven Central repository.
+   */
+  private[sbt] def reorganizeAppResolvers(appResolvers: Seq[Resolver], jcenter: Boolean, mavenCentral: Boolean): Seq[Resolver] =
+    appResolvers.partition(_ == Resolver.defaultLocal) match {
+      case (locals, xs) =>
+        locals ++
+        (xs.partition(_ == JCenterRepository) match {
+          case (jc, xs) =>
+            single(JCenterRepository, jcenter) ++
+            (xs.partition(_ == DefaultMavenRepository) match {
+              case (m, xs) =>
+                single(DefaultMavenRepository, mavenCentral) ++ xs // TODO - Do we need to filter out duplicates?
+            })
+        })
+    }
 
   /** A base class for defining factories for interfaces to Ivy repositories that require a hostname , port, and patterns.  */
   sealed abstract class Define[RepositoryType <: SshBasedRepository] extends NotNull {

--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -12,10 +12,8 @@
 
 [repositories]
   local
-  jcenter: https://jcenter.bintray.com/
-${{repositories}}
   maven-central
-
+${{repositories}}
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1110,6 +1110,7 @@ object Classpaths {
     moduleConfigurations :== Nil,
     publishTo :== None,
     resolvers :== Nil,
+    useJCenter :== false,
     retrievePattern :== Resolver.defaultRetrievePattern,
     transitiveClassifiers :== Seq(SourceClassifier, DocClassifier),
     sbtDependency := {
@@ -1134,10 +1135,10 @@ object Classpaths {
     organizationHomepage <<= organizationHomepage or homepage,
     projectInfo <<= (name, description, homepage, startYear, licenses, organizationName, organizationHomepage, scmInfo, developers) apply ModuleInfo,
     overrideBuildResolvers <<= appConfiguration(isOverrideRepositories),
-    externalResolvers <<= (externalResolvers.task.?, resolvers, appResolvers) {
-      case (Some(delegated), Seq(), _) => delegated
-      case (_, rs, Some(ars))          => task { ars ++ rs } // TODO - Do we need to filter out duplicates?
-      case (_, rs, _)                  => task { Resolver.withDefaultResolvers(rs) }
+    externalResolvers <<= (externalResolvers.task.?, resolvers, appResolvers, useJCenter) {
+      case (Some(delegated), Seq(), _, _) => delegated
+      case (_, rs, Some(ars), uj)         => task { ars ++ Resolver.reorganizeAppResolvers(rs, uj, true) }
+      case (_, rs, _, uj)                 => task { Resolver.withDefaultResolvers(rs, uj) }
     },
     appResolvers <<= appConfiguration apply appRepositories,
     bootResolvers <<= appConfiguration map bootRepositories,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -298,6 +298,7 @@ object Keys {
   val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)
   val fullResolvers = TaskKey[Seq[Resolver]]("full-resolvers", "Combines the project resolver, default resolvers, and user-defined resolvers.", CTask)
   val otherResolvers = SettingKey[Seq[Resolver]]("other-resolvers", "Resolvers not included in the main resolver chain, such as those in module configurations.", CSetting)
+  val useJCenter = SettingKey[Boolean]("use-jcenter", "Use JCenter as the default repository.", BSetting)
   val moduleConfigurations = SettingKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusSetting)
   val retrievePattern = SettingKey[String]("retrieve-pattern", "Pattern used to retrieve managed dependencies to the current build.", DSetting)
   val retrieveConfiguration = SettingKey[Option[RetrieveConfiguration]]("retrieve-configuration", "Configures retrieving dependencies to the current build.", DSetting)

--- a/notes/0.13.10.markdown
+++ b/notes/0.13.10.markdown
@@ -62,9 +62,11 @@
   [1968]: https://github.com/sbt/sbt/issues/1968
   [2264]: https://github.com/sbt/sbt/issues/2264
   [2172]: https://github.com/sbt/sbt/pull/2172
+  [2217]: https://github.com/sbt/sbt/issues/2217
 
 ### Fixes with compatibility implications
 
+- sbt 0.13.10 adds a new setting `useJCenter`, which is set to `false` by default. When set to `true`, JCenter will be placed as the first external resolver to find library dependencies. [#2217][2217] by [@eed3si9n][@eed3si9n]
 - sbt will no longer pass `-J<flag>` options to the local Java compiler. [#1968][1968]/[#2272][2272] by [@Duhemm][@Duhemm]
 
 ### Improvements

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -51,12 +51,14 @@
   [2046]: https://github.com/sbt/sbt/issues/2046
   [2097]: https://github.com/sbt/sbt/pull/2097
   [2129]: https://github.com/sbt/sbt/pull/2129
+  [1938]: https://github.com/sbt/sbt/pull/1938
 
 ### Fixes with compatibility implications
 
 - Starting 0.13.9, `crossScalaVersions` default value is fixed back to the older 0.12.x behavior. See below for details.
 - Starting 0.13.9, the generated POM files no longer include dependencies on source or javadoc jars obtained via `withSources()` or `withJavadoc()`. See below for details.
 - Scala version is bumped to 2.10.5. This brings in the fix for [SI-9027][SI9027]: XML node sequence literal bug. [#1666][1666]/[#2068][2068] by [@eed3si9n][@eed3si9n]
+- Change launcher configuration so [JCenter](https://bintray.com/bintray/jcenter) is looked at first before all other external repositories. [#1938][1938]
 
 ### Improvements
 

--- a/sbt/src/sbt-test/dependency-management/default-resolvers/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/default-resolvers/build.sbt
@@ -1,0 +1,16 @@
+lazy val check = taskKey[Unit]("")
+lazy val check2 = taskKey[Unit]("")
+
+lazy val root = (project in file(".")).
+  settings(
+    check := {
+      val fr = fullResolvers.value
+      assert(!(fr exists { _.name == "jcenter" }))
+      assert(fr exists { _.name == "public" })
+    },
+    check2 := {
+      val fr = fullResolvers.value
+      assert(fr exists { _.name == "jcenter" })
+      assert(fr exists { _.name == "public" })
+    }
+  )

--- a/sbt/src/sbt-test/dependency-management/default-resolvers/test
+++ b/sbt/src/sbt-test/dependency-management/default-resolvers/test
@@ -1,0 +1,5 @@
+> check
+
+> set useJCenter := true
+
+> check2

--- a/src/main/conscript/sbt/launchconfig
+++ b/src/main/conscript/sbt/launchconfig
@@ -12,9 +12,9 @@
 
 [repositories]
   local
-  jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+
 
 
 [boot]

--- a/src/main/conscript/scalas/launchconfig
+++ b/src/main/conscript/scalas/launchconfig
@@ -12,10 +12,8 @@
 
 [repositories]
   local
-  jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}

--- a/src/main/conscript/screpl/launchconfig
+++ b/src/main/conscript/screpl/launchconfig
@@ -12,10 +12,8 @@
 
 [repositories]
   local
-  jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}


### PR DESCRIPTION
Fixes #2217 
### what this changes

Adds a new setting `useJCenter`, which is set to `false` by default. When set to `true`, JCenter will be placed as the first external resolver to find library dependencies.

The implementation of `externalResolvers` is changed to incorporate the setting by calling `Resolver.reorganizeAppResolvers`. These changes were required because `externalResolvers` uses whatever that's in the launchconfig, which the build user may not upgrade.
### notes

sbt 0.13.9 made JCenter the first external resolver "for faster resolution times". #1938 (9261652d41635634a5ca46fc574b90b2a1ec42ab.
From what I tested using Reactive Maps + Play 2.3.10, JCenter takes 212 ~ 251s for update to return on the proper build (excluding plugins) while Maven Central takes 71 ~ 98s for update. Basically 2 ~ 3.5 times slower. ymmv.

/review @Duhemm, @dwijnand, @jsuereth 
