### PR TITLE
Adds bootIvyConfiguration to grab compiler bridge source.

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -262,7 +262,8 @@ object Defaults extends BuildCommon {
       if (plugin) scalaBase / ("sbt-" + sbtv) else scalaBase
     }
 
-  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value, ivyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
+  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value,
+    bootIvyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
 
   lazy val configTasks = docTaskSettings(doc) ++ inTask(compile)(compileInputsSettings) ++ configGlobal ++ compileAnalysisSettings ++ Seq(
     compile <<= compileTask,
@@ -1316,7 +1317,7 @@ object Classpaths {
         IvyActions.transitiveScratch(is, "sbt", GetClassifiersConfiguration(mod, excludes, c, noExplicitCheck), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), s.log)
       }
     } tag (Tags.Update, Tags.Network)
-  ))
+  )) ++ Seq(bootIvyConfiguration := (ivyConfiguration in updateSbtClassifiers).value)
 
   def deliverTask(config: TaskKey[DeliverConfiguration]): Initialize[Task[File]] =
     (ivyModule, config, update, streams) map { (module, config, _, s) => IvyActions.deliver(module, config, s.log) }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -246,6 +246,8 @@ object Keys {
   val classpathConfiguration = TaskKey[Configuration]("classpath-configuration", "The configuration used to define the classpath.", CTask)
   val ivyConfiguration = TaskKey[IvyConfiguration]("ivy-configuration", "General dependency management (Ivy) settings, such as the resolvers and paths to use.", DTask)
   val ivyConfigurations = SettingKey[Seq[Configuration]]("ivy-configurations", "The defined configurations for dependency management.  This may be different from the configurations for Project settings.", BSetting)
+  // This setting was created to workaround the limitation of derived tasks not being able to use task-scoped task: ivyConfiguration in updateSbtClassifiers
+  val bootIvyConfiguration = TaskKey[IvyConfiguration]("boot-ivy-configuration", "General dependency management (Ivy) settings, configured to retrieve sbt's components.", DTask)
   val moduleSettings = TaskKey[ModuleSettings]("module-settings", "Module settings, which configure dependency management for a specific module, such as a project.", DTask)
   val unmanagedBase = SettingKey[File]("unmanaged-base", "The default directory for manually managed libraries.", ASetting)
   val updateConfiguration = SettingKey[UpdateConfiguration]("update-configuration", "Configuration for resolving and retrieving managed dependencies.", DSetting)

--- a/notes/0.13.10.markdown
+++ b/notes/0.13.10.markdown
@@ -63,6 +63,7 @@
   [2264]: https://github.com/sbt/sbt/issues/2264
   [2172]: https://github.com/sbt/sbt/pull/2172
   [2217]: https://github.com/sbt/sbt/issues/2217
+  [2336]: https://github.com/sbt/sbt/issues/2336
 
 ### Fixes with compatibility implications
 
@@ -74,6 +75,7 @@
 - Scala version used by the build is updated to 2.10.6. [#2311][2311] by [@eed3si9n][@eed3si9n]
 - `makePom` warns when it sees intransitive dependencies, which do not translate to Maven. [#2127][2127] by [@jsuereth][@jsuereth]
 - Adds `Def.settings`, which facilitates mixing settings with seq of settings. See below.
+- Adds configurable compiler bridge. See below.
 - sbt Serialization is updated to 0.1.2. [2117][#2117] by [@dwijnand][@dwijnand]
 - Hides the stack trace on compilation error in build definition. [#2071][2071]/[#2091][2091] by [@Duhemm][@Duhemm]
 - Makes the dummy `Logger.Null` public. [#2094][2094] by [@pdalpra][@pdalpra]
@@ -82,7 +84,6 @@
 - Warns when javaOptions are defined but fork is set to false. [#2041][2041]/[#2103][2103] by [@pdalpra][@pdalpra]
 - Adds an `Append.Sequence` instance for `List` to allow `+=`/`++=` on `developers` setting. [#2107][2107]/[#2114][2114] by [@pdalpra][@pdalpra]
 - Fixes warnings, and other clean ups. [#2112][2112]/[#2137][2137]/[#2139][2139]/[#2142][2142] by [@pdalpra][@pdalpra]
-- Adds `scalaCompilerBridgeSource` setting to specify the compiler brigde, and uses Ivy to retrieve it. [#2106][2106]/[#2197][2197] by [@Duhemm][@Duhemm]
 - Adds `localIfFile` to `MavenRepository`, to force artifacts to be copied to the cache. [#2172][2172] by [@dwijnand][@dwijnand]
 - Adds `Resolver.bintrayIvyRepo(owner, repo)`. [#2285][2285] by [@dwijnand][@dwijnand]
 
@@ -121,4 +122,10 @@ Using `Def.settings` it is now possible to nicely define settings as such:
       libraryDependencies += foo
     )
 
-[#2151][2151] by [@dwijnand][@dwijnand].
+[#2151][2151] by [@dwijnand][@dwijnand]
+
+### Configurable Scala compiler bridge
+
+sbt 0.13.10 adds `scalaCompilerBridgeSource` setting to specify the compiler brigde source. This allows different implementation of the bridge for Scala versions, and also allows future versions of Scala compiler implementation to diverge. The source module will be retrieved using library management configured by `bootIvyConfiguration` task.
+
+[#2106][2106]/[#2197][2197]/[#2336][2336] by [@Duhemm][@Duhemm]

--- a/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/project/plugins.sbt
+++ b/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/project/plugins.sbt
@@ -1,0 +1,1 @@
+resolvers += Resolver.file("ivy-local", file(sys.props("user.home")) / ".ivy2" / "local")(Resolver.ivyStylePatterns)


### PR DESCRIPTION
### what this changes

Fixes #2336. This should now use the metabuild's resolvers to download the compiler bridge source.
### details

As described in #2336, I noticed that when using 0.13 nightly from Bintray, sbt was unable to locate the compiler source. Since `updateSbtClassifiers` is already set up to download sbt's own sources, the `ivyConfiguration` should be reused. However, `compilers` is a derived task, which is unable to depend on a scoped key. To workaround this I had to create a new key called `bootIvyConfiguration`. 

/review @Duhemm, @dwijnand, @jsuereth 
