### PR TITLE
Upgrade Scala version in scripted tests

### DIFF
--- a/sbt/src/sbt-test/compiler-project/macro-config/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/macro-config/build.sbt
@@ -22,5 +22,3 @@ mappings in (Compile, packageSrc) <++=
 // This can be omitted if the classes in src/macro/ aren't used at runtime
 mappings in (Compile, packageBin) <++=
   mappings in (config("macro"), packageBin)
-
-scalaVersion := "2.10.0-M7"

--- a/sbt/src/sbt-test/source-dependencies/continuations/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/continuations/build.sbt
@@ -1,7 +1,5 @@
 autoCompilerPlugins := true
 
-addCompilerPlugin("org.scala-lang.plugins" % "continuations" % "2.9.2")
-
-scalaVersion := "2.9.2"
+libraryDependencies += compilerPlugin("org.scala-lang.plugins" % "continuations" % scalaVersion.value)
 
 scalacOptions += "-P:continuations:enable"


### PR DESCRIPTION
Both continuations and macro-config set scalaVersion explicitly but since
sbt relies now on Scala 2.10 it's not needed anymore. In particular, we
can upgrade continuations to 2.10 which makes it easier to work with Java
8.
