### PR TITLE
FPORT: Bumping Scala version to 2.10.6.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -335,10 +335,10 @@ def customCommands: Seq[Setting[_]] = Seq(
   },
   /** There are several complications with sbt's build.
    * First is the fact that interface project is a Java-only project
-   * that uses source generator from datatype subproject in Scala 2.10.5.
+   * that uses source generator from datatype subproject in Scala 2.10.6.
    *
    * Second is the fact that all subprojects are released with crossPaths
-   * turned off for the sbt's Scala version 2.10.5, but some of them are also
+   * turned off for the sbt's Scala version 2.10.6, but some of them are also
    * cross published against 2.11.1 with crossPaths turned on.
    *
    * `so compile` handles 2.10.x/2.11.x cross building.

--- a/notes/0.13.10/bump-scalaversion.md
+++ b/notes/0.13.10/bump-scalaversion.md
@@ -1,0 +1,10 @@
+
+  [@eed3si9n]: https://github.com/eed3si9n
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Updated Scala version used by the build to 2.10.6.
+
+### Bug fixes

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val scala282 = "2.8.2"
   lazy val scala292 = "2.9.2"
   lazy val scala293 = "2.9.3"
-  lazy val scala210 = "2.10.5"
+  lazy val scala210 = "2.10.6"
   lazy val scala211 = "2.11.7"
 
   // sbt modules


### PR DESCRIPTION
Forward-port of #2311.
