### PR TITLE
FPORT: Fixes #2302. Don't check pre and post conditions in sbt.Execute by default.

### DIFF
--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -22,6 +22,8 @@ private[sbt] object Execute {
 
   def config(checkCycles: Boolean, overwriteNode: Incomplete => Boolean = const(false)): Config = new Config(checkCycles, overwriteNode)
   final class Config private[sbt] (val checkCycles: Boolean, val overwriteNode: Incomplete => Boolean)
+
+  final val checkPreAndPostConditions = sys.props.get("sbt.execute.extrachecks").exists(java.lang.Boolean.parseBoolean)
 }
 sealed trait Completed {
   def process(): Unit
@@ -342,8 +344,6 @@ private[sbt] final class Execute[A[_] <: AnyRef](config: Config, triggers: Trigg
   def added(d: A[_]) = state contains d
   def complete = state.values.forall(_ == Done)
 
-  import scala.annotation.elidable
-  import elidable._
-  @elidable(ASSERTION) def pre(f: => Unit) = f
-  @elidable(ASSERTION) def post(f: => Unit) = f
+  def pre(f: => Unit) = if (checkPreAndPostConditions) f
+  def post(f: => Unit) = if (checkPreAndPostConditions) f
 }


### PR DESCRIPTION
Forward-port of #2303.

The checking code has bad run time characteristics and would need to be fixed
for large projects with deep task dependency chains.

The code in sbt.Execute has been in production for a long time so it seems safe
enough to drop the extra checks by default. To debug issues, you can set
`-Dsbt.execute.extrachecks=true` to revert to the old behavior.
