### PR TITLE
FPORT: Adds bootIvyConfiguration to grab compiler bridge source. Fixes #2336

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -275,7 +275,8 @@ object Defaults extends BuildCommon {
       if (plugin) scalaBase / ("sbt-" + sbtv) else scalaBase
     }
 
-  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value, ivyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
+  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value,
+    bootIvyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
 
   lazy val configTasks = docTaskSettings(doc) ++ inTask(compile)(compileInputsSettings) ++ configGlobal ++ compileAnalysisSettings ++ Seq(
     compile <<= compileTask,
@@ -1334,7 +1335,7 @@ object Classpaths {
         IvyActions.transitiveScratch(is, "sbt", GetClassifiersConfiguration(mod, excludes, c, noExplicitCheck), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), s.log)
       }
     } tag (Tags.Update, Tags.Network)
-  ))
+  )) ++ Seq(bootIvyConfiguration := (ivyConfiguration in updateSbtClassifiers).value)
 
   def deliverTask(config: TaskKey[DeliverConfiguration]): Initialize[Task[File]] =
     (ivyModule, config, update, streams) map { (module, config, _, s) => IvyActions.deliver(module, config, s.log) }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -288,6 +288,8 @@ object Keys {
   val classpathConfiguration = TaskKey[Configuration]("classpath-configuration", "The configuration used to define the classpath.", CTask)
   val ivyConfiguration = TaskKey[IvyConfiguration]("ivy-configuration", "General dependency management (Ivy) settings, such as the resolvers and paths to use.", DTask)
   val ivyConfigurations = SettingKey[Seq[Configuration]]("ivy-configurations", "The defined configurations for dependency management.  This may be different from the configurations for Project settings.", BSetting)
+  // This setting was created to workaround the limitation of derived tasks not being able to use task-scoped task: ivyConfiguration in updateSbtClassifiers
+  val bootIvyConfiguration = TaskKey[IvyConfiguration]("boot-ivy-configuration", "General dependency management (Ivy) settings, configured to retrieve sbt's components.", DTask)
   val moduleSettings = TaskKey[ModuleSettings]("module-settings", "Module settings, which configure dependency management for a specific module, such as a project.", DTask)
   val unmanagedBase = SettingKey[File]("unmanaged-base", "The default directory for manually managed libraries.", ASetting)
   val updateConfiguration = SettingKey[UpdateConfiguration]("update-configuration", "Configuration for resolving and retrieving managed dependencies.", DSetting)

--- a/notes/0.13.10/use-ivyConfiguration-in-updateSbtClassifiers-in-compilers-to-fetch-compiler-bridge-sources.markdown
+++ b/notes/0.13.10/use-ivyConfiguration-in-updateSbtClassifiers-in-compilers-to-fetch-compiler-bridge-sources.markdown
@@ -1,0 +1,19 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [2106]: https://github.com/sbt/sbt/pull/2106
+  [2197]: https://github.com/sbt/sbt/pull/2197
+  [2336]: https://github.com/sbt/sbt/issues/2336
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Adds configurable compiler bridge. See below.
+
+### Bug fixes
+
+### Configurable Scala compiler bridge
+
+sbt 0.13.10 adds `scalaCompilerBridgeSource` setting to specify the compiler brigde source. This allows different implementation of the bridge for Scala versions, and also allows future versions of Scala compiler implementation to diverge. The source module will be retrieved using library management configured by `bootIvyConfiguration` task.
+
+[#2106][2106]/[#2197][2197]/[#2336][2336] by [@Duhemm][@Duhemm]

--- a/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/project/plugins.sbt
+++ b/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/project/plugins.sbt
@@ -1,0 +1,1 @@
+resolvers += Resolver.file("ivy-local", file(sys.props("user.home")) / ".ivy2" / "local")(Resolver.ivyStylePatterns)


### PR DESCRIPTION
Forward-port of #2337.

As described in #2336, I noticed that when using 0.13 nightly from
Bintray, sbt was unable to locate the compiler source.
Since `updateSbtClassifiers` is already set up to download sbt's own
sources, the `ivyConfiguration` should be reused. However, `compilers`
is a derived task, which is unable to depend on a scoped key.
To workaround this I had to create a new key called
`bootIvyConfiguration`. This should now use the metabuild's resolvers
to download the compiler bridge source.
