### PR TITLE
FPORT: Release notes for name hashing private members fix

### DIFF
--- a/notes/0.13.10/fix-inc-compiler-name-hashing-private-members.markdown
+++ b/notes/0.13.10/fix-inc-compiler-name-hashing-private-members.markdown
@@ -1,0 +1,17 @@
+
+  [@Duhemm]: http://github.com/Duhemm
+  [@gkossakowski]: https://github.com/gkossakowski
+  [2155]: https://github.com/sbt/sbt/issues/2155
+  [2160]: https://github.com/sbt/sbt/pull/2160
+  [2324]: https://github.com/sbt/sbt/issues/2324
+  [2325]: https://github.com/sbt/sbt/pull/2325
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes incremental compilation of traits by including private members into the API hash. [#2155][2155]/[#2160][2160] by
+  [@Duhemm][@Duhemm]
+- Fixes name hashing by removing class private members from the hash. [#2324][2324]/[#2325][2325] by [@gkossakowski][@gkossakowski]


### PR DESCRIPTION
Forward-port of #2339.
