### PR TITLE
FPORT: Include sbt-ivy-snapshots to launchconfig

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -13,9 +13,9 @@
 [repositories]
   local
   jcenter: https://jcenter.bintray.com/
-${{repositories}}
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}

--- a/notes/0.13.10/add-sbt-ivy-snapshots-to-launchconfig.markdown
+++ b/notes/0.13.10/add-sbt-ivy-snapshots-to-launchconfig.markdown
@@ -1,0 +1,10 @@
+
+  [@eed3si9n]: https://github.com/eed3si9n
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes launcher configuration to add `sbt-ivy-snapshots` repository to resolve nightly builds. [@eed3si9n][@eed3si9n]

--- a/project/SbtLauncherPlugin.scala
+++ b/project/SbtLauncherPlugin.scala
@@ -28,7 +28,6 @@ object SbtLauncherPlugin extends AutoPlugin {
            if(file.getName == "sbt.boot.properties") "sbt/sbt.boot.properties" -> file
            else file.getName -> file
          }
-      propFileLocations foreach println
       // TODO - We need to inject the appropriate boot.properties file for this version of sbt.
       rebundle(rawSbtLaunchJar.value, propFileLocations.toMap, target.value / "sbt-launch.jar")
     }

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -60,7 +60,7 @@ object Transform {
   }
   def configSettings = transResourceSettings ++ Seq(
     resourceProperties <<= (organization, version, scalaVersion, isSnapshot) map { (org, v, sv, isSnapshot) =>
-      Map("org" -> org, "sbt.version" -> v, "scala.version" -> sv, "repositories" -> repositories(isSnapshot).mkString(IO.Newline))
+      Map("org" -> org, "sbt.version" -> v, "scala.version" -> sv)
     }
   )
   def transResourceSettings = Seq(
@@ -87,13 +87,4 @@ object Transform {
     }
   def read(file: File): Option[String] = try { Some(IO.read(file)) } catch { case _: java.io.IOException => None }
   lazy val Property = """\$\{\{([\w.-]+)\}\}""".r
-
-  def repositories(isSnapshot: Boolean) = Releases :: (if (isSnapshot) Snapshots :: SonatypeSnapshots :: Nil else Nil)
-  lazy val Releases = typesafeRepository("releases")
-  lazy val Snapshots = typesafeRepository("snapshots")
-  lazy val SonatypeSnapshots = sonatypeRepsoitory("snapshots")
-  def sonatypeRepsoitory(status: String) =
-    s"""  sonatype-$status: https://oss.sonatype.org/content/repositories/$status"""
-  def typesafeRepository(status: String) =
-    """  typesafe-ivy-%s: https://repo.typesafe.com/typesafe/ivy-%<s/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly""" format status
 }

--- a/src/main/conscript/sbt/launchconfig
+++ b/src/main/conscript/sbt/launchconfig
@@ -13,9 +13,9 @@
 [repositories]
   local
   jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}

--- a/src/main/conscript/scalas/launchconfig
+++ b/src/main/conscript/scalas/launchconfig
@@ -13,9 +13,9 @@
 [repositories]
   local
   jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}

--- a/src/main/conscript/screpl/launchconfig
+++ b/src/main/conscript/screpl/launchconfig
@@ -13,9 +13,9 @@
 [repositories]
   local
   jcenter: https://jcenter.bintray.com/
-  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
-
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}


### PR DESCRIPTION
Forward-port of #2338.

Include sbt-ivy-snapshots to launchconfig
Prior to this change, the launchconfig for sbt was generated using
Transform's resource generator so releases would include
`typesafe-ivy-releases` repo, and snapshot releases would include
`typesafe-ivy-snapshots` and `sonatype-snapshots` repos in addition.
This is no longer useful since nightly builds are now published to
`sbt-ivy-snapshots` instead, which is backed by Bintray.

This removes the switching logic, so both `typesafe-ivy-releases` and
`sbt-ivy-snapshots` repos are always included into the launchconfig.
This removes the step of needing to download a launcher just to try the
nightly builds.
