### PR TITLE
FPORT: Make sbt aware of Dotty

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -403,7 +403,11 @@ object Defaults extends BuildCommon {
     def file(id: String) = files(id).headOption getOrElse sys.error(s"Missing ${id}.jar")
     val allFiles = toolReport.modules.flatMap(_.artifacts.map(_._2))
     val libraryJar = file(ScalaArtifacts.LibraryID)
-    val compilerJar = file(ScalaArtifacts.CompilerID)
+    val compilerJar =
+      if (ScalaInstance.isDotty(scalaVersion.value))
+        file(ScalaArtifacts.dottyID(scalaBinaryVersion.value))
+      else
+        file(ScalaArtifacts.CompilerID)
     val otherJars = allFiles.filterNot(x => x == libraryJar || x == compilerJar)
     new ScalaInstance(scalaVersion.value, makeClassLoader(state.value)(libraryJar :: compilerJar :: otherJars.toList), libraryJar, compilerJar, otherJars.toArray, None)
   }
@@ -1268,8 +1272,11 @@ object Classpaths {
       val pluginAdjust = if (sbtPlugin.value) sbtDependency.value.copy(configurations = Some(Provided.name)) +: base else base
       if (scalaHome.value.isDefined || ivyScala.value.isEmpty || !managedScalaInstance.value)
         pluginAdjust
-      else
-        ScalaArtifacts.toolDependencies(scalaOrganization.value, scalaVersion.value) ++ pluginAdjust
+      else {
+        val version = scalaVersion.value
+        val isDotty = ScalaInstance.isDotty(version)
+        ScalaArtifacts.toolDependencies(scalaOrganization.value, version, isDotty) ++ pluginAdjust
+      }
     }
   )
   @deprecated("Split into ivyBaseSettings and jvmBaseSettings.", "0.13.2")

--- a/notes/0.13.10/dotty-awareness.md
+++ b/notes/0.13.10/dotty-awareness.md
@@ -1,0 +1,16 @@
+
+  [Dotty]: https://github.com/lampepfl/dotty
+  [@smarter]: https://github.com/smarter
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- sbt is now aware of [Dotty][Dotty], it will assume
+  that Dotty is used when `scalaVersion` starts with `0.`, the sbt
+  compiler-bridge does not support Dotty but a separate compiler-bridge is being
+  developed at https://github.com/smarter/dotty-bridge and an example project
+  that uses it is available at https://github.com/smarter/dotty-example-project
+  by [@smarter][@smarter].
+
+### Bug fixes


### PR DESCRIPTION
This small set of changes, together with the compiler-bridge I wrote
(https://github.com/smarter/dotty-bridge) enables us to compile code
using Dotty in sbt, see https://github.com/smarter/dotty-example-project
for an example.

Partial forward port of #2344.
