### PR TITLE
Upgrade to latest sbt/librarymanagement

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val utilVersion = "0.1.0-M5"
   val ioVersion = "1.0.0-M3"
   val incremenalcompilerVersion = "0.1.0-M1-168cb7a4877917e01917e35b9b82a62afe5c2a01"
-  val librarymanagementVersion = "0.1.0-M4"
+  val librarymanagementVersion = "0.1.0-d017e2603ea7f381a4d2d716a58f480a74881e28"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   lazy val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion


### PR DESCRIPTION
Brings in among other things:
- sbt/librarymanagement#17 FPORT: Make JCenter opt in
- sbt/librarymanagement#18 FPORT: Make sbt aware of Dotty
- sbt/librarymanagement#19 FPORT: Maven compatibility changes (intransitive warnings and "configuration not public")
- sbt/librarymanagement#20 FPORT: Refix snapshots
