### PR TITLE
Adds CompatibilityWarningOptions

### DIFF
--- a/ivy/src/main/scala/sbt/CompatibilityWarning.scala
+++ b/ivy/src/main/scala/sbt/CompatibilityWarning.scala
@@ -1,20 +1,41 @@
 package sbt
 
+import Configurations._
+
+final class CompatibilityWarningOptions private[sbt] (
+  val configurations: Seq[Configuration],
+  val level: Level.Value)
+
+object CompatibilityWarningOptions {
+  def default: CompatibilityWarningOptions =
+    apply(configurations = List(Compile, Runtime), level = Level.Warn)
+  def apply(configurations: List[Configuration],
+    level: Level.Value): CompatibilityWarningOptions =
+    new CompatibilityWarningOptions(
+      configurations = configurations,
+      level = level)
+}
+
 private[sbt] object CompatibilityWarning {
-  def apply(module: IvySbt#Module, mavenStyle: Boolean, log: Logger): Unit = {
+  def run(config: CompatibilityWarningOptions, module: IvySbt#Module, mavenStyle: Boolean, log: Logger): Unit = {
     if (mavenStyle) {
-      processIntransitive(module, log)
+      processIntransitive(config, module, log)
     }
   }
-
-  def processIntransitive(module: IvySbt#Module, log: Logger): Unit = {
+  def processIntransitive(config: CompatibilityWarningOptions, module: IvySbt#Module, log: Logger): Unit = {
+    val monitoredConfigsStr: Set[String] = (config.configurations map { _.name }).toSet
     val directDependencies: Seq[ModuleID] = module.moduleSettings match {
       case x: InlineConfiguration             => x.dependencies
       case x: InlineConfigurationWithExcludes => x.dependencies
       case _                                  => Seq()
     }
+    def inMonitoredConfigs(configOpt: Option[String]): Boolean =
+      configOpt match {
+        case Some(c) => (c.split(",").toSet intersect monitoredConfigsStr).nonEmpty
+        case None    => monitoredConfigsStr contains "compile"
+      }
     directDependencies foreach { m =>
-      if (!m.isTransitive) {
+      if (!m.isTransitive && inMonitoredConfigs(m.configurations)) {
         log.warn(
           s"""Found intransitive dependency ($m) while publishMavenStyle is true, but Maven repositories
              |  do not support intransitive dependencies. Use exclusions instead so transitive dependencies

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1104,6 +1104,7 @@ object Classpaths {
 
   private[this] def baseGlobalDefaults = Defaults.globalDefaults(Seq(
     conflictWarning :== ConflictWarning.default("global"),
+    compatibilityWarningOptions :== CompatibilityWarningOptions.default,
     homepage :== None,
     startYear :== None,
     licenses :== Nil,
@@ -1397,6 +1398,7 @@ object Classpaths {
     val depDir = dependencyCacheDirectory.value
     val uc0 = updateConfiguration.value
     val ms = publishMavenStyle.value
+    val cw = compatibilityWarningOptions.value
     // Normally, log would capture log messages at all levels.
     // Ivy logs are treated specially using sbt.UpdateConfiguration.logging.
     // This code bumps up the sbt.UpdateConfiguration.logging to Full when logLevel is Debug.
@@ -1412,17 +1414,18 @@ object Classpaths {
     cachedUpdate(s.cacheDirectory / updateCacheName.value, show, ivyModule.value, uc, transform,
       skip = (skip in update).value, force = isRoot || forceUpdateByTime, depsUpdated = depsUpdated,
       uwConfig = uwConfig, logicalClock = logicalClock, depDir = Some(depDir),
-      ewo = ewo, mavenStyle = ms, log = s.log)
+      ewo = ewo, mavenStyle = ms, compatWarning = cw, log = s.log)
   }
   @deprecated("Use cachedUpdate with the variant that takes unresolvedHandler instead.", "0.13.6")
   def cachedUpdate(cacheFile: File, label: String, module: IvySbt#Module, config: UpdateConfiguration,
     transform: UpdateReport => UpdateReport, skip: Boolean, force: Boolean, depsUpdated: Boolean, log: Logger): UpdateReport =
     cachedUpdate(cacheFile, label, module, config, transform, skip, force, depsUpdated,
-      UnresolvedWarningConfiguration(), LogicalClock.unknown, None, EvictionWarningOptions.empty, true, log)
+      UnresolvedWarningConfiguration(), LogicalClock.unknown, None, EvictionWarningOptions.empty, true, CompatibilityWarningOptions.default, log)
   private[sbt] def cachedUpdate(cacheFile: File, label: String, module: IvySbt#Module, config: UpdateConfiguration,
     transform: UpdateReport => UpdateReport, skip: Boolean, force: Boolean, depsUpdated: Boolean,
     uwConfig: UnresolvedWarningConfiguration, logicalClock: LogicalClock, depDir: Option[File],
-    ewo: EvictionWarningOptions, mavenStyle: Boolean, log: Logger): UpdateReport =
+    ewo: EvictionWarningOptions, mavenStyle: Boolean, compatWarning: CompatibilityWarningOptions,
+    log: Logger): UpdateReport =
     {
       implicit val updateCache = updateIC
       type In = IvyConfiguration :+: ModuleSettings :+: UpdateConfiguration :+: HNil
@@ -1441,7 +1444,7 @@ object Classpaths {
           val ew = EvictionWarning(module, ewo, result, log)
           ew.lines foreach { log.warn(_) }
           ew.infoAllTheThings foreach { log.info(_) }
-          val cw = CompatibilityWarning(module, mavenStyle, log)
+          val cw = CompatibilityWarning.run(compatWarning, module, mavenStyle, log)
           result
       }
       def uptodate(inChanged: Boolean, out: UpdateReport): Boolean =

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -336,6 +336,7 @@ object Keys {
   val forceUpdatePeriod = SettingKey[Option[FiniteDuration]]("force-update-period", "Duration after which to force a full update to occur", CSetting)
 
   val classifiersModule = TaskKey[GetClassifiersModule]("classifiers-module", rank = CTask)
+  val compatibilityWarningOptions = SettingKey[CompatibilityWarningOptions]("compatibility-warning", "Configures warnings around Maven incompatibility.", CSetting)
   val conflictWarning = SettingKey[ConflictWarning]("conflict-warning", "Configures warnings for conflicts in dependency management.", CSetting)
   val conflictManager = SettingKey[ConflictManager]("conflict-manager", "Selects the conflict manager to use for dependency management.", CSetting)
   val autoScalaLibrary = SettingKey[Boolean]("auto-scala-library", "Adds a dependency on scala-library if true.", ASetting)


### PR DESCRIPTION
Fixes #2347

This addresses 0.13.10 regression, which currently warns users about
Maven incompatibility on a private configuration. This adds a config
class so the build user can control the level of the warning as well as
the target configuration to be monitored.
By default, we are only going to look at `Compile` and `Runtime`.

/review @dwijnand, @Duhemm 
