### PR TITLE
[0.13.10] ExtractAPI: avoid unnecessary duplication of defs with primitive types

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Compat.scala
+++ b/compile/interface/src/main/scala/xsbt/Compat.scala
@@ -107,8 +107,8 @@ abstract class Compat {
     }
     lazy val AnyValClass = global.rootMirror.getClassIfDefined("scala.AnyVal")
 
-    def isAnyValSubtype(sym: Symbol): Boolean = sym.isNonBottomSubClass(AnyValClass)
-
+    def isDerivedValueClass(sym: Symbol): Boolean =
+      sym.isNonBottomSubClass(AnyValClass) && !definitions.ScalaValueClasses.contains(sym)
   }
 
   object MacroExpansionOf {

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -208,20 +208,14 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
         s.asMethod.paramss.flatten map (_.info) exists (t => isAnyValSubtype(t.typeSymbol))
       }
 
-      // Note: We only inspect the "outermost type" (i.e. no recursion) because we don't need to
-      // inspect after erasure a function that would, for instance, return a function that returns
-      // a subtype of AnyVal.
-      val hasValueClassAsReturnType: Boolean = {
-        val tpe = viewer(in).memberInfo(s)
-        tpe match {
-          case PolyType(_, base) => isAnyValSubtype(base.typeSymbol)
-          case MethodType(_, resultType) => isAnyValSubtype(resultType.typeSymbol)
-          case Nullary(resultType) => isAnyValSubtype(resultType.typeSymbol)
-          case resultType => isAnyValSubtype(resultType.typeSymbol)
-        }
+      def hasValueClassAsReturnType(tpe: Type): Boolean = tpe match {
+        case PolyType(_, base) => hasValueClassAsReturnType(base)
+        case MethodType(_, resultType) => hasValueClassAsReturnType(resultType)
+        case Nullary(resultType) => hasValueClassAsReturnType(resultType)
+        case resultType => isAnyValSubtype(resultType.typeSymbol)
       }
 
-      val inspectPostErasure = hasValueClassAsParameter || hasValueClassAsReturnType
+      val inspectPostErasure = hasValueClassAsParameter || hasValueClassAsReturnType(viewer(in).memberInfo(s))
 
       def build(t: Type, typeParams: Array[xsbti.api.TypeParameter], valueParameters: List[xsbti.api.ParameterList]): List[xsbti.api.Def] =
         {

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -205,14 +205,14 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
 
       val hasValueClassAsParameter: Boolean = {
         import MirrorHelper._
-        s.asMethod.paramss.flatten map (_.info) exists (t => isAnyValSubtype(t.typeSymbol))
+        s.asMethod.paramss.flatten map (_.info) exists (t => isDerivedValueClass(t.typeSymbol))
       }
 
       def hasValueClassAsReturnType(tpe: Type): Boolean = tpe match {
         case PolyType(_, base) => hasValueClassAsReturnType(base)
         case MethodType(_, resultType) => hasValueClassAsReturnType(resultType)
         case Nullary(resultType) => hasValueClassAsReturnType(resultType)
-        case resultType => isAnyValSubtype(resultType.typeSymbol)
+        case resultType => isDerivedValueClass(resultType.typeSymbol)
       }
 
       val inspectPostErasure = hasValueClassAsParameter || hasValueClassAsReturnType(viewer(in).memberInfo(s))

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/B2.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/B2.scala
@@ -1,0 +1,3 @@
+class B {
+  def bar(dummy: String)(dummy2: String): A = new A(0)
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/changes/C2.scala
+++ b/sbt/src/sbt-test/source-dependencies/value-class/changes/C2.scala
@@ -1,0 +1,3 @@
+object C extends App {
+  println(new B().bar("")("").x)
+}

--- a/sbt/src/sbt-test/source-dependencies/value-class/test
+++ b/sbt/src/sbt-test/source-dependencies/value-class/test
@@ -1,3 +1,4 @@
+## Case 1: value class as parameter of method
 $ copy-file changes/A0.scala src/main/scala/A.scala
 $ copy-file changes/B0.scala src/main/scala/B.scala
 $ copy-file changes/C0.scala src/main/scala/C.scala
@@ -13,11 +14,30 @@ $ copy-file changes/A1.scala src/main/scala/A.scala
 # This means that we have invalidated C.scala, as expected!
 -> compile
 
+
+## Case 2: value class as return type of method with no parameter lists
 $ copy-file changes/A0.scala src/main/scala/A.scala
 $ copy-file changes/B1.scala src/main/scala/B.scala
 $ copy-file changes/C1.scala src/main/scala/C.scala
 
 # A is a normal class. B.bar takes no arguments and returns an instance of A. C calls B.bar.
+> compile
+> run
+
+# Make A a value class.
+$ copy-file changes/A1.scala src/main/scala/A.scala
+
+# The code compiles. It will run iff C is recompiled because the signature of B.bar has changed,
+# because A is now a value class.
+> run
+
+
+## Case 3: value class as return type of method with multiple parameter lists
+$ copy-file changes/A0.scala src/main/scala/A.scala
+$ copy-file changes/B2.scala src/main/scala/B.scala
+$ copy-file changes/C2.scala src/main/scala/C.scala
+
+# A is a normal class. B.bar takes two dummy arguments and returns an instance of A. C calls B.bar("")("").
 > compile
 > run
 


### PR DESCRIPTION
NOTE: This PR is based on top of https://github.com/sbt/sbt/pull/2413 for convenience because they conflict with each other, but they could be made independent.

<hr>

If a method's type contains a non-primitive value class then it has two
signatures: one before erasure and one after erasure. Before this
commit, we checked if this was the case using `isAnyValSubtype`, but
this is too crude since primitive value classes are also subtypes of
`AnyVal` but do not change signature after erasure.

This commit replaces `isAnyValSubtype` by `isDerivedValueClass` which
excludes primitive value classes.

In practice, for an empty class, this reduces the size of the output of
`DefaultShowAPI` from 65 lines to 25 lines.
Before:
https://gist.github.com/smarter/cf1d6fe58efda88d6ee6#file-old-api
After:
https://gist.github.com/smarter/cf1d6fe58efda88d6ee6#file-new-api

/cc @Duhemm 
