### PR TITLE
Do not create dir, if trying to output classes to a jar

### DIFF
--- a/compile/integration/src/main/scala/sbt/compiler/MixedAnalyzingCompiler.scala
+++ b/compile/integration/src/main/scala/sbt/compiler/MixedAnalyzingCompiler.scala
@@ -37,7 +37,7 @@ final class MixedAnalyzingCompiler(
    */
   def compile(include: Set[File], changes: DependencyChanges, callback: AnalysisCallback): Unit = {
     val outputDirs = outputDirectories(output)
-    outputDirs foreach (IO.createDirectory)
+    outputDirs foreach (d => if (!d.getPath.endsWith(".jar")) IO.createDirectory(d))
     val incSrc = sources.filter(include)
     val (javaSrcs, scalaSrcs) = incSrc partition javaOnly
     logInputs(log, javaSrcs.size, scalaSrcs.size, outputDirs)


### PR DESCRIPTION
On occasion, it may be useful to manipulate `classDirectory` so that a jar file, rather than a class directory, is used as a destination for the compiled class files (see https://github.com/scala/scala/commit/2700617052).

This tiny change prevents a directory to be created with the same name as a desired jar file, as that would prevent the jar from being correctly created in that case.
