### PR TITLE
Fixes #2427 inter-project dependency interference with sbt-web

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1036,8 +1036,7 @@ object Classpaths {
     internalDependencyClasspath <<= internalDependencies,
     unmanagedClasspath <<= unmanagedDependencies,
     managedClasspath := managedJars(classpathConfiguration.value, classpathTypes.value, update.value),
-    exportedProducts <<= exportProductsTask,
-    exportedProductsAlways <<= trackedExportedProducts(TrackLevel.TrackAlways),
+    exportedProducts <<= trackedExportedProducts(TrackLevel.TrackAlways),
     exportedProductsIfMissing <<= trackedExportedProducts(TrackLevel.TrackIfMissing),
     exportedProductsNoTracking <<= trackedExportedProducts(TrackLevel.NoTracking),
     unmanagedJars := findUnmanagedJars(configuration.value, unmanagedBase.value, includeFilter in unmanagedJars value, excludeFilter in unmanagedJars value)
@@ -1623,6 +1622,7 @@ object Classpaths {
       }
     }
 
+  @deprecated("This is no longer used.", "0.13.10")
   def exportProductsTask: Initialize[Task[Classpath]] = Def.task {
     val art = (artifact in packageBin).value
     val module = projectID.value
@@ -1742,7 +1742,7 @@ object Classpaths {
     track match {
       case TrackLevel.NoTracking     => getClasspath(exportedProductsNoTracking, dep, conf, data)
       case TrackLevel.TrackIfMissing => getClasspath(exportedProductsIfMissing, dep, conf, data)
-      case TrackLevel.TrackAlways    => getClasspath(exportedProductsAlways, dep, conf, data)
+      case TrackLevel.TrackAlways    => getClasspath(exportedProducts, dep, conf, data)
     }
   private[sbt] def unmanagedLibs0(dep: ResolvedReference, conf: String, data: Settings[Scope], track: TrackLevel): Task[Classpath] =
     unmanagedLibs(dep, conf, data)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -234,7 +234,6 @@ object Keys {
   val productDirectories = TaskKey[Seq[File]]("product-directories", "Base directories of build products.", CTask)
   val exportJars = SettingKey[Boolean]("export-jars", "Determines whether the exported classpath for this project contains classes (false) or a packaged jar (true).", BSetting)
   val exportedProducts = TaskKey[Classpath]("exported-products", "Build products that go on the exported classpath.", CTask)
-  val exportedProductsAlways = TaskKey[Classpath]("exported-products-always", "Build products that go on the exported classpath for other projects.", CTask)
   val exportedProductsIfMissing = TaskKey[Classpath]("exported-products-if-missing", "Build products that go on the exported classpath if missing.", CTask)
   val exportedProductsNoTracking = TaskKey[Classpath]("exported-products-no-tracking", "Just the exported classpath without triggering the compilation.", CTask)
   val unmanagedClasspath = TaskKey[Classpath]("unmanaged-classpath", "Classpath entries (deep) that are manually managed.", BPlusTask)


### PR DESCRIPTION
Fixes #2427 

sbt-web uses exportedProducts key as an extension point.
This removes exportedProductsAlways from 0.13.10-RC1,
and uses exportedProducts instead.

/review @dwijnand, @Duhemm 
