### PR TITLE
Fixes #2464. Actually reorganize appResolvers

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1147,10 +1147,14 @@ object Classpaths {
     overrideBuildResolvers <<= appConfiguration(isOverrideRepositories),
     externalResolvers <<= (externalResolvers.task.?, resolvers, appResolvers, useJCenter) {
       case (Some(delegated), Seq(), _, _) => delegated
-      case (_, rs, Some(ars), uj)         => task { ars ++ Resolver.reorganizeAppResolvers(rs, uj, true) }
-      case (_, rs, _, uj)                 => task { Resolver.withDefaultResolvers(rs, uj) }
+      case (_, rs, Some(ars), uj)         => task { ars ++ rs }
+      case (_, rs, _, uj)                 => task { Resolver.withDefaultResolvers(rs, uj, true) }
     },
-    appResolvers <<= appConfiguration apply appRepositories,
+    appResolvers := {
+      val ac = appConfiguration.value
+      val uj = useJCenter.value
+      appRepositories(ac) map { ars => Resolver.reorganizeAppResolvers(ars, uj, true) }
+    },
     bootResolvers <<= appConfiguration map bootRepositories,
     fullResolvers <<= (projectResolver, externalResolvers, sbtPlugin, sbtResolver, bootResolvers, overrideBuildResolvers) map { (proj, rs, isPlugin, sbtr, boot, overrideFlag) =>
       boot match {

--- a/sbt/src/sbt-test/dependency-management/default-resolvers/test
+++ b/sbt/src/sbt-test/dependency-management/default-resolvers/test
@@ -3,3 +3,9 @@
 > set useJCenter := true
 
 > check2
+
+> reload
+
+> set resolvers += Resolver.jcenterRepo
+
+> check2


### PR DESCRIPTION
Fixes #2464 and Fixes #2465

`appResolvers` is a set of resolvers specified in the launcher configuration.
This list fluctuates depending on the version of sbt, and sbt 0.13.10
meant to stabilize it by weeding out JCenter even when it includes it,
which failed when I applied the filter on the wrong list. This should
correct it.

/review @dwijnand 
