### PR TITLE
Handle source, docs artifacts correctly for Ivy [1.0.x]

### DIFF
--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -115,9 +115,9 @@ object CacheIvy {
   private[this] val crossToInt = (c: CrossVersion) => c match { case Disabled => 0; case b: Binary => BinaryValue; case f: Full => FullValue }
 
   implicit def moduleIDFormat(implicit sf: Format[String], bf: Format[Boolean]): Format[ModuleID] =
-    wrap[ModuleID, ((String, String, String, Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Map[String, String], CrossVersion))](
-      m => ((m.organization, m.name, m.revision, m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.extraAttributes, m.crossVersion)),
-      { case ((o, n, r, cs), (ch, t, f, as, excl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, x, cv) }
+    wrap[ModuleID, ((String, String, String, Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Seq[InclusionRule], Map[String, String], CrossVersion))](
+      m => ((m.organization, m.name, m.revision, m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.inclusions, m.extraAttributes, m.crossVersion)),
+      { case ((o, n, r, cs), (ch, t, f, as, excl, incl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, incl, x, cv) }
     )
   // For some reason sbinary seems to detect unserialized instance Set[ModuleID] to be not equal. #1620
   implicit def moduleSetIC: InputCache[Set[ModuleID]] =
@@ -169,7 +169,7 @@ object CacheIvy {
     implicit def sftpRToHL = (s: SftpRepository) => s.name :+: s.connection :+: s.patterns :+: HNil
     implicit def rawRToHL = (r: RawRepository) => r.name :+: r.resolver.getClass.getName :+: HNil
     implicit def chainRToHL = (c: ChainedResolver) => c.name :+: c.resolvers :+: HNil
-    implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.exclusions :+: m.extraAttributes :+: m.crossVersion :+: HNil
+    implicit def moduleToHL = (m: ModuleID) => m.organization :+: m.name :+: m.revision :+: m.configurations :+: m.isChanging :+: m.isTransitive :+: m.explicitArtifacts :+: m.exclusions :+: m.inclusions :+: m.extraAttributes :+: m.crossVersion :+: HNil
   }
   import L3._
 

--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -90,8 +90,8 @@ object CacheIvy {
   implicit def callerFormat: Format[Caller] =
     wrap[Caller, (ModuleID, Seq[String], Map[String, String], Boolean, Boolean, Boolean, Boolean)](c => (c.caller, c.callerConfigurations, c.callerExtraAttributes, c.isForceDependency, c.isChangingDependency, c.isTransitiveDependency, c.isDirectlyForceDependency),
       { case (c, cc, ea, fd, cd, td, df) => new Caller(c, cc, ea, fd, cd, td, df) })
-  implicit def exclusionRuleFormat(implicit sf: Format[String]): Format[ExclusionRule] =
-    wrap[ExclusionRule, (String, String, String, Seq[String])](e => (e.organization, e.name, e.artifact, e.configurations), { case (o, n, a, cs) => ExclusionRule(o, n, a, cs) })
+  implicit def exclusionRuleFormat(implicit sf: Format[String]): Format[InclExclRule] =
+    wrap[InclExclRule, (String, String, String, Seq[String])](e => (e.organization, e.name, e.artifact, e.configurations), { case (o, n, a, cs) => InclExclRule(o, n, a, cs) })
   implicit def crossVersionFormat: Format[CrossVersion] = wrap(crossToInt, crossFromInt)
   implicit def sourcePositionFormat: Format[SourcePosition] =
     wrap[SourcePosition, (Int, String, Int, Int)](
@@ -186,7 +186,7 @@ object CacheIvy {
     implicit def sshConnectionToHL = (s: SshConnection) => s.authentication :+: s.hostname :+: s.port :+: HNil
 
     implicit def artifactToHL = (a: Artifact) => a.name :+: a.`type` :+: a.extension :+: a.classifier :+: names(a.configurations) :+: a.url :+: a.extraAttributes :+: HNil
-    implicit def exclusionToHL = (e: ExclusionRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: HNil
+    implicit def inclExclToHL = (e: InclExclRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: HNil
     implicit def sbtExclusionToHL = (e: SbtExclusionRule) => e.organization :+: e.name :+: e.artifact :+: e.configurations :+: e.crossVersion :+: HNil
     implicit def crossToHL = (c: CrossVersion) => crossToInt(c) :+: HNil
 
@@ -200,7 +200,7 @@ object CacheIvy {
   implicit def ivyFileIC: InputCache[IvyFileConfiguration] = wrapIn
   implicit def connectionIC: InputCache[SshConnection] = wrapIn
   implicit def artifactIC: InputCache[Artifact] = wrapIn
-  implicit def exclusionIC: InputCache[ExclusionRule] = wrapIn
+  implicit def exclusionIC: InputCache[InclExclRule] = wrapIn
   implicit def sbtExclusionIC: InputCache[SbtExclusionRule] = wrapIn
   implicit def crossVersionIC: InputCache[CrossVersion] = wrapIn
   /*	implicit def publishConfIC: InputCache[PublishConfiguration] = wrapIn

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -23,7 +23,7 @@ import std.TaskExtra._
 import sbt.internal.inc.{ Analysis, ClassfileManager, ClasspathOptions, CompilerCache, FileValueCache, IncOptions, Locate, LoggerReporter, MixedAnalyzingCompiler, ScalaInstance }
 import testing.{ Framework, Runner, AnnotatedFingerprint, SubclassFingerprint }
 
-import sbt.librarymanagement._
+import sbt.librarymanagement.{ `package` => _, _ }
 import sbt.internal.librarymanagement._
 import sbt.internal.librarymanagement.syntax._
 import sbt.internal.util._

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -679,7 +679,7 @@ object Defaults extends BuildCommon {
         a.copy(classifier = Some(classifierString), `type` = Artifact.classifierType(classifierString), configurations = confs)
       }
   }
-  // TODO bad, remove. The configuration(s) should not be decided from the classifier.
+  @deprecated("The configuration(s) should not be decided based on the classifier.", "1.0")
   def artifactConfigurations(base: Artifact, scope: Configuration, classifier: Option[String]): Iterable[Configuration] =
     classifier match {
       case Some(c) => Artifact.classifierConf(c) :: Nil

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -306,6 +306,8 @@ object Keys {
   val updateClassifiers = TaskKey[UpdateReport]("update-classifiers", "Resolves and optionally retrieves classified artifacts, such as javadocs and sources, for dependency definitions, transitively.", BPlusTask, update)
   val transitiveClassifiers = SettingKey[Seq[String]]("transitive-classifiers", "List of classifiers used for transitively obtaining extra artifacts for sbt or declared dependencies.", BSetting)
   val updateSbtClassifiers = TaskKey[UpdateReport]("update-sbt-classifiers", "Resolves and optionally retrieves classifiers, such as javadocs and sources, for sbt, transitively.", BPlusTask, updateClassifiers)
+  val sourceArtifactTypes = SettingKey[Set[String]]("source-artifact-types", "Ivy artifact types that correspond to source artifacts. Used by IDEs to resolve these resources.", BSetting)
+  val docArtifactTypes = SettingKey[Set[String]]("doc-artifact-types", "Ivy artifact types that correspond to javadoc artifacts. Used by IDEs to resolve these resources.", BSetting)
 
   val publishConfiguration = TaskKey[PublishConfiguration]("publish-configuration", "Configuration for publishing to a repository.", DTask)
   val publishLocalConfiguration = TaskKey[PublishConfiguration]("publish-local-configuration", "Configuration for publishing to the local Ivy repository.", DTask)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val utilVersion = "0.1.0-M5"
   val ioVersion = "1.0.0-M3"
   val incremenalcompilerVersion = "0.1.0-M1-168cb7a4877917e01917e35b9b82a62afe5c2a01"
-  val librarymanagementVersion = "0.1.0-M4"
+  val librarymanagementVersion = "0.1.0-M7"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   lazy val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -34,8 +34,6 @@ package object sbt extends sbt.std.TaskExtra with sbt.internal.util.Types with s
   final val Runtime = C.Runtime
   final val IntegrationTest = C.IntegrationTest
   final val Default = C.Default
-  final val Docs = C.Docs
-  final val Sources = C.Sources
   final val Provided = C.Provided
   // java.lang.System is more important, so don't alias this one
   //	final val System = C.System


### PR DESCRIPTION
This is a re-installment of https://github.com/sbt/sbt/pull/1016 for the 1.0.x branch, sitting on top of changes already merged in https://github.com/sbt/librarymanagement/pull/25.

To reiterate, specifically in this PR we are addressing the following:
- Introduce the SettingKeys `sourceArtifactTypes` and `docArtifactTypes`: Sets which contain the artifact types that would qualify them as either source or doc artifacts.
- Use the new `ArtifactTypeFilter` introduced in https://github.com/sbt/librarymanagement/pull/25 in the `update` task (specifically, I added it to `UpdateConfiguration`) to allow "all artifact types except those found in either `sourceArtifactTypes` or`docArtifactTypes`"
- In `updateClassifiers` / `updateSbtClassifiers`, invert the filter from the `UpdateConfiguration`: it will therefore _only_ let through sources and docs
- `srcTypes` and `docTypes` now have to also be explicitly passed into `GetClassifiersConfiguration` because (since https://github.com/sbt/librarymanagement/pull/25) after finishing the update in `updateClassifiers`, it will map over all artifacts to set their classifier to either `sources` or `javadoc`, if it's not already set, according to a reverse mapping from the `(src|doc)Types` to "source" and "javadoc" respectively (well, `Artifact.SourceClassifier` and `Artifact.DocClassifier`, to be precise). This is because the artifacts retrieved from Ivy publications might well not have this attribute set, and last time I checked, IDE plugins such as IntelliJ's depended exactly on this value to classify the artifacts.

Hopefully, after this, plugins could just look at the artifact's type and see in which of the two sets contains it. That would also resolve a great deal of pain surrounding "e:classifier". For instance, I've discovered that it's impossible to use that attribute in an ivy repository if its value is not either "sources" or "javadoc" (e.g. if it's src), because plugins expect it to be one of those two values as mentioned before.
