### PR TITLE
Add Ivy `branch` support to ModuleID [1.0.x] + fix CacheIvy

### DIFF
--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -115,9 +115,9 @@ object CacheIvy {
   private[this] val crossToInt = (c: CrossVersion) => c match { case Disabled => 0; case b: Binary => BinaryValue; case f: Full => FullValue }
 
   implicit def moduleIDFormat(implicit sf: Format[String], bf: Format[Boolean]): Format[ModuleID] =
-    wrap[ModuleID, ((String, String, String, Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Seq[InclusionRule], Map[String, String], CrossVersion))](
-      m => ((m.organization, m.name, m.revision, m.configurations), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.inclusions, m.extraAttributes, m.crossVersion)),
-      { case ((o, n, r, cs), (ch, t, f, as, excl, incl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, incl, x, cv) }
+    wrap[ModuleID, ((String, String, String, Option[String], Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Seq[InclusionRule], Map[String, String], CrossVersion))](
+      m => ((m.organization, m.name, m.revision, m.configurations, m.branchName), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.inclusions, m.extraAttributes, m.crossVersion)),
+      { case ((o, n, r, cs, br), (ch, t, f, as, excl, incl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, incl, x, cv, br) }
     )
   // For some reason sbinary seems to detect unserialized instance Set[ModuleID] to be not equal. #1620
   implicit def moduleSetIC: InputCache[Set[ModuleID]] =

--- a/main/actions/src/main/scala/sbt/CacheIvy.scala
+++ b/main/actions/src/main/scala/sbt/CacheIvy.scala
@@ -115,9 +115,9 @@ object CacheIvy {
   private[this] val crossToInt = (c: CrossVersion) => c match { case Disabled => 0; case b: Binary => BinaryValue; case f: Full => FullValue }
 
   implicit def moduleIDFormat(implicit sf: Format[String], bf: Format[Boolean]): Format[ModuleID] =
-    wrap[ModuleID, ((String, String, String, Option[String], Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[ExclusionRule], Seq[InclusionRule], Map[String, String], CrossVersion))](
-      m => ((m.organization, m.name, m.revision, m.configurations, m.branchName), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.exclusions, m.inclusions, m.extraAttributes, m.crossVersion)),
-      { case ((o, n, r, cs, br), (ch, t, f, as, excl, incl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, excl, incl, x, cv, br) }
+    wrap[ModuleID, ((String, String, String, Option[String], Option[String]), (Boolean, Boolean, Boolean, Seq[Artifact], Seq[InclusionRule], Seq[ExclusionRule], Map[String, String], CrossVersion))](
+      m => ((m.organization, m.name, m.revision, m.configurations, m.branchName), (m.isChanging, m.isTransitive, m.isForce, m.explicitArtifacts, m.inclusions, m.exclusions, m.extraAttributes, m.crossVersion)),
+      { case ((o, n, r, cs, br), (ch, t, f, as, incl, excl, x, cv)) => ModuleID(o, n, r, cs, ch, t, f, as, incl, excl, x, cv, br) }
     )
   // For some reason sbinary seems to detect unserialized instance Set[ModuleID] to be not equal. #1620
   implicit def moduleSetIC: InputCache[Set[ModuleID]] =

--- a/main/actions/src/test/scala/sbt/CacheIvyTest.scala
+++ b/main/actions/src/test/scala/sbt/CacheIvyTest.scala
@@ -1,0 +1,80 @@
+package sbt
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import Prop._
+import sbt.librarymanagement._
+
+class CacheIvyTest extends Properties("CacheIvy") {
+  import CacheIvy._
+  import sbinary.Operations._
+  import sbinary._
+  import sbinary.DefaultProtocol._
+
+  private def cachePreservesEquality[T: Format](m: T, eq: (T, T) => Prop, str: T => String): Prop = {
+    val out = fromByteArray[T](toByteArray(m))
+    eq(out, m) :| s"Expected: ${str(m)}" :| s"Got: ${str(out)}"
+  }
+
+  implicit val arbExclusionRule: Arbitrary[ExclusionRule] = Arbitrary(
+    for {
+      o <- Gen.alphaStr
+      n <- Gen.alphaStr
+      a <- Gen.alphaStr
+      cs <- arbitrary[List[String]]
+    } yield ExclusionRule(o, n, a, cs)
+  )
+
+  implicit val arbCrossVersion: Arbitrary[CrossVersion] = Arbitrary {
+    // Actual functions don't matter, just Disabled vs Binary vs Full
+    import CrossVersion._
+    Gen.oneOf(Disabled, new Binary(identity), new Full(identity))
+  }
+
+  implicit val arbArtifact: Arbitrary[Artifact] = Arbitrary {
+    for {
+      (n, t, e, cls) <- arbitrary[(String, String, String, String)]
+    } yield Artifact(n, t, e, cls) // keep it simple
+  }
+
+  implicit val arbModuleID: Arbitrary[ModuleID] = Arbitrary {
+    for {
+      o <- Gen.identifier
+      n <- Gen.identifier
+      r <- for { n <- Gen.numChar; ns <- Gen.numStr } yield n + ns
+      cs <- arbitrary[Option[String]]
+      branch <- arbitrary[Option[String]]
+      isChanging <- arbitrary[Boolean]
+      isTransitive <- arbitrary[Boolean]
+      isForce <- arbitrary[Boolean]
+      explicitArtifacts <- Gen.listOf(arbitrary[Artifact])
+      exclusions <- Gen.listOf(arbitrary[ExclusionRule])
+      inclusions <- Gen.listOf(arbitrary[InclusionRule])
+      extraAttributes <- Gen.mapOf(arbitrary[(String, String)])
+      crossVersion <- arbitrary[CrossVersion]
+    } yield ModuleID(
+      organization = o, name = n, revision = r, configurations = cs, isChanging = isChanging, isTransitive = isTransitive,
+      isForce = isForce, explicitArtifacts = explicitArtifacts, inclusions = inclusions, exclusions = exclusions,
+      extraAttributes = extraAttributes, crossVersion = crossVersion, branchName = branch)
+  }
+
+  property("moduleIDFormat") = forAll { (m: ModuleID) =>
+    def str(m: ModuleID) = {
+      import m._
+      s"ModuleID($organization, ${m.name}, $revision, $configurations, $isChanging, $isTransitive, $isForce, $explicitArtifacts, $exclusions, " +
+        s"$inclusions, $extraAttributes, $crossVersion, $branchName)"
+    }
+    def eq(a: ModuleID, b: ModuleID): Prop = {
+      import CrossVersion._
+      def rest = a.copy(crossVersion = b.crossVersion) == b
+      (a.crossVersion, b.crossVersion) match {
+        case (Disabled, Disabled)   => rest
+        case (_: Binary, _: Binary) => rest
+        case (_: Full, _: Full)     => rest
+        case (a, b)                 => Prop(false) :| s"CrossVersions don't match: $a vs $b"
+      }
+
+    }
+    cachePreservesEquality(m, eq _, str)
+  }
+}


### PR DESCRIPTION
This is the counterpart to https://github.com/sbt/librarymanagement/pull/26 that I mentioned.
Together with that PR, these are a forward port (to `1.0.x`) of the changes initially proposed in https://github.com/sbt/sbt/pull/1994.

This particular PR:
- includes `branchName` in `Format[ModuleID]`
- swaps incorrect order of inclusions and exclusions in the `CacheIvy` change introduced by #2475 [at this line](https://github.com/sbt/sbt/pull/2475/files#diff-81fb174627e396a0b63b03cadaba2de4L118) (sorry!)
- adds a `CacheIvyTest` that ensures a cached-then-retrieved `ModuleID` remains equal to the original (save for CrossVersion, which is not being cached perfectly)
