### PR TITLE
Make moduleConfigurations a TaskKey

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -347,7 +347,7 @@ object Keys {
   val fullResolvers = TaskKey[Seq[Resolver]]("full-resolvers", "Combines the project resolver, default resolvers, and user-defined resolvers.", CTask)
   val otherResolvers = SettingKey[Seq[Resolver]]("other-resolvers", "Resolvers not included in the main resolver chain, such as those in module configurations.", CSetting)
   val useJCenter = SettingKey[Boolean]("use-jcenter", "Use JCenter as the default repository.", BSetting)
-  val moduleConfigurations = SettingKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusSetting)
+  val moduleConfigurations = TaskKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusTask)
   val retrievePattern = SettingKey[String]("retrieve-pattern", "Pattern used to retrieve managed dependencies to the current build.", DSetting)
   val retrieveConfiguration = SettingKey[Option[RetrieveConfiguration]]("retrieve-configuration", "Configures retrieving dependencies to the current build.", DSetting)
   val offline = SettingKey[Boolean]("offline", "Configures sbt to work without a network connection where possible.", ASetting)


### PR DESCRIPTION
- Nothing that currently depends on `moduleConfigurations` needs it to be a setting.
- I might want to dynamically create the resolver in `ModuleConfiguration(name, resolver)` , e.g. perhaps based on a setting, the resolver in question might or not might not consult the `projectResolver`, which is a `TaskKey`. If `moduleConfigurations` is a `SettingKey` like now, I can't do that.
