### PR TITLE
Fix instability of self variable API representation

### DIFF
--- a/compile/api/src/main/scala/xsbt/api/SameAPI.scala
+++ b/compile/api/src/main/scala/xsbt/api/SameAPI.scala
@@ -46,7 +46,7 @@ object SameAPI {
   def apply(a: Source, b: Source): Boolean =
     a.apiHash == b.apiHash && (a.hash.nonEmpty && b.hash.nonEmpty) && apply(a.api, b.api)
 
-  def apply(a: Def, b: Def): Boolean =
+  def apply(a: Definition, b: Definition): Boolean =
     (new SameAPI(false, true)).sameDefinitions(List(a), List(b), true)
 
   def apply(a: SourceAPI, b: SourceAPI): Boolean =

--- a/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
+++ b/compile/interface/src/main/scala/xsbt/ExtractAPI.scala
@@ -578,7 +578,7 @@ class ExtractAPI[GlobalType <: CallbackGlobal](val global: GlobalType,
     // as that invariant is established on completing the class symbol (`mkClassLike` calls `s.initialize` before calling us).
     // Technically, we could even ignore a self type that's a supertype of the class's type,
     // as it does not contribute any information relevant outside of the class definition.
-    if ((s.thisSym eq s) || s.typeOfThis == s.info) Constants.emptyType else processType(in, s.typeOfThis)
+    if ((s.thisSym eq s) || (s.thisSym.tpeHK == s.tpeHK)) Constants.emptyType else processType(in, s.typeOfThis)
 
   def classLike(in: Symbol, c: Symbol): ClassLike = classLikeCache.getOrElseUpdate((in, c), mkClassLike(in, c))
   private def mkClassLike(in: Symbol, c: Symbol): ClassLike = {

--- a/compile/interface/src/test/scala/xsbt/ExtractAPISpecification.scala
+++ b/compile/interface/src/test/scala/xsbt/ExtractAPISpecification.scala
@@ -90,15 +90,17 @@ class ExtractAPISpecification extends Specification {
     val srcC4 = "class C4 { thisC: X => }"
     val srcC5 = "class C5 extends AnyRef with X with Y { self: X with Y => }"
     val srcC6 = "class C6 extends AnyRef with X { self: X with Y => }"
+    val srcC7 = "class C7 { _ => }"
+    val srcC8 = "class C8 { self => }"
     val compilerForTesting = new ScalaCompilerForUnitTesting
     val apis = compilerForTesting.extractApisFromSrcs(reuseCompilerInstance = true)(
-      List(srcX, srcY, srcC1, srcC2, srcC3, srcC4, srcC5, srcC6)
+      List(srcX, srcY, srcC1, srcC2, srcC3, srcC4, srcC5, srcC6, srcC7, srcC8)
     ).map(x => collectFirstClass(x.definitions))
     val emptyType = new EmptyType
     def hasSelfType(c: ClassLike): Boolean =
       c.selfType != emptyType
     val (withSelfType, withoutSelfType) = apis.partition(hasSelfType)
     withSelfType.map(_.name).toSet === Set("C3", "C4", "C5", "C6")
-    withoutSelfType.map(_.name).toSet === Set("X", "Y", "C1", "C2")
+    withoutSelfType.map(_.name).toSet === Set("X", "Y", "C1", "C2", "C7", "C8")
   }
 }

--- a/compile/interface/src/test/scala/xsbt/ExtractAPISpecification.scala
+++ b/compile/interface/src/test/scala/xsbt/ExtractAPISpecification.scala
@@ -1,8 +1,7 @@
 package xsbt
 
 import org.junit.runner.RunWith
-import xsbti.api.ClassLike
-import xsbti.api.Def
+import xsbti.api.{ Definition, SourceAPI, ClassLike, Def }
 import xsbt.api.SameAPI
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -39,4 +38,37 @@ class ExtractAPISpecification extends Specification {
     val fooMethodApi2 = compileAndGetFooMethodApi(src2)
     SameAPI.apply(fooMethodApi1, fooMethodApi2)
   }
+
+  /**
+    * Checks if representation of the inherited Namer class (with a declared self variable) in Global.Foo
+    * is stable between compiling from source and unpickling. We compare extracted APIs of Global when Global
+    * is compiled together with Namers or Namers is compiled first and then Global refers
+    * to Namers by unpickling types from class files.
+    */
+  "Self variable and no self type" in {
+    def selectNamer(api: SourceAPI): ClassLike = {
+      def selectClass(defs: Iterable[Definition], name: String): ClassLike = defs.collectFirst {
+        case cls: ClassLike if cls.name == name => cls
+      }.get
+      val global = selectClass(api.definitions, "Global")
+      val foo = selectClass(global.structure.declared, "Global.Foo")
+      selectClass(foo.structure.inherited, "Namers.Namer")
+    }
+    val src1 =
+      """|class Namers {
+         |  class Namer { thisNamer => }
+         |}
+         |""".stripMargin
+    val src2 =
+      """|class Global {
+         |  class Foo extends Namers
+         |}
+         |""".stripMargin
+    val compilerForTesting = new ScalaCompilerForUnitTesting
+    val apis = compilerForTesting.extractApisFromSrcs(reuseCompilerInstance = false)(List(src1, src2), List(src2))
+    val _ :: src2Api1 :: src2Api2 :: Nil = apis.toList
+    val namerApi1 = selectNamer(src2Api1)
+    val namerApi2 = selectNamer(src2Api2)
+    SameAPI(namerApi1, namerApi2)
+  }.pendingUntilFixed("have unstable representation (#2504)")
 }

--- a/compile/interface/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
+++ b/compile/interface/src/test/scala/xsbt/ScalaCompilerForUnitTesting.scala
@@ -31,6 +31,15 @@ class ScalaCompilerForUnitTesting(nameHashing: Boolean = false) {
     analysisCallback.apis(tempSrcFile)
   }
 
+  /**
+   * Compiles given source code using Scala compiler and returns API representation
+   * extracted by ExtractAPI class.
+   */
+  def extractApisFromSrcs(reuseCompilerInstance: Boolean)(srcs: List[String]*): Seq[SourceAPI] = {
+    val (tempSrcFiles, analysisCallback) = compileSrcs(srcs.toList, reuseCompilerInstance)
+    tempSrcFiles.map(analysisCallback.apis)
+  }
+
   def extractUsedNamesFromSrc(src: String): Set[String] = {
     val (Seq(tempSrcFile), analysisCallback) = compileSrcs(src)
     analysisCallback.usedNames(tempSrcFile)


### PR DESCRIPTION
The reason for instability is a bit tricky so let's unpack what the previous code checking if there's self type declared was doing. It would check if `thisSym` of a class is equal to a symbol representing the class. If that's true, we know that there's no self type. If it's false, then `thisSym` represents either a self type or a self variable. The second (type test) was supposed to check whether the type of `thisSym` is different from a type of the class. However, it would always yield false because TypeRef of `thisSym` was compared to ClassInfoType of a class. So if you had a self variable the logic would see a self type (and that's what API representation would give you).

Now the tricky bit: `thisSym` is not pickled when it's representing just a self variable because self variable doesn't affect other classes referring to a class. If you looked at a type after unpickling, the
symbol equality test would yield true and we would not see self type when just a self variable was declared.

The fix is to check equality of type refs on both side of the type equality check. This makes the pending test passing.

Also, I added another test that checks if self types are represented in various combinations of declaring a self variable or/and self type.

Fixes #2504.
