### PR TITLE
Link to Stackoverflow ask with sbt tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-  [StackOverflow]: http://stackoverflow.com/tags/sbt  
+  [StackOverflow]: http://stackoverflow.com/tags/sbt
+  [ask]: https://stackoverflow.com/questions/ask?tags=sbt
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [Issues]: https://github.com/sbt/sbt/issues
   [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
@@ -25,7 +26,7 @@ Where to get help and/or file a bug report
 
 sbt project uses GitHub Issues as a publicly visible todo list. Please open a GitHub issue only when asked to do so.
 
-- If you need help with sbt, please ask on [StackOverflow] with the tag "sbt" and the name of the sbt plugin if any.
+- If you need help with sbt, please [ask] on StackOverflow with the tag "sbt" and the name of the sbt plugin if any.
 - If you run into an issue, have an enhancement idea, or a general discussion, bring it up to [sbt-dev] Google Group first.
 - If you need a faster response time, consider one of the [Typesafe subscriptions][subscriptions].
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [FAQ]: http://www.scala-sbt.org/release/docs/Faq.html
   [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
-  [StackOverflow]: http://stackoverflow.com/tags/sbt
+  [searching]: http://stackoverflow.com/tags/sbt
+  [asking]: https://stackoverflow.com/questions/ask?tags=sbt
   [LICENSE]: LICENSE
 
 sbt
@@ -18,7 +19,7 @@ Issues and Pull Requests
 
 Please read [CONTRIBUTING] carefully before opening a GitHub Issue.
 
-The short version: try [StackOverflow] and [sbt-dev]. Don't open an Issue.
+The short version: try [searching] or [asking] on StackOverflow and [sbt-dev]. Don't open an Issue.
 
 sbt 1.0.x
 --------


### PR DESCRIPTION
Copying a good idea I saw in the Lagom readme: link to Stackoverflow's ask,
prepopulated with the right tag.
