### PR TITLE
Fix for https://github.com/sbt/sbt/issues/2254

### DIFF
--- a/main/command/src/main/scala/sbt/BasicCommands.scala
+++ b/main/command/src/main/scala/sbt/BasicCommands.scala
@@ -33,9 +33,10 @@ object BasicCommands {
         a ++
           (try b.help(s) catch { case NonFatal(ex) => Help.empty })
       }
-      val helpCommands = h.detail.keySet
-      val spacedArg = singleArgument(helpCommands).?
-      applyEffect(spacedArg)(runHelp(s, h))
+      val helpData = h ++ s.taskHelpList
+      val helpKeys = helpData.detail.keySet
+      val spacedArg = singleArgument(helpKeys).?
+      applyEffect(spacedArg)(runHelp(s, helpData))
     }
 
   def runHelp(s: State, h: Help)(arg: Option[String]): State =

--- a/main/command/src/main/scala/sbt/State.scala
+++ b/main/command/src/main/scala/sbt/State.scala
@@ -27,7 +27,8 @@ final case class State(
     history: State.History,
     attributes: AttributeMap,
     globalLogging: GlobalLogging,
-    next: State.Next) extends Identity {
+    next: State.Next,
+    taskHelpList: Help = Help.empty) extends Identity {
   lazy val combinedParser = Command.combine(definedCommands)(this)
 }
 

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -394,4 +394,8 @@ object Keys {
   def dummyTask[T](name: String): Task[T] = Def.dummyTask(name)
   @deprecated("Implementation detail.", "0.13.1")
   def isDummy(t: Task[_]): Boolean = Def.isDummy(t)
+
+  val helpList = help(console)
+
+  def help(t: TaskKey[_]): Help = Help((t.key.label, t.key.description.getOrElse("")))
 }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -67,7 +67,7 @@ object StandardMain {
       val (earlyCommands, normalCommands) = (preCommands ++ userCommands).partition(isEarlyCommand)
       val commands = earlyCommands ++ normalCommands
       val initAttrs = BuiltinCommands.initialAttributes
-      val s = State(configuration, initialDefinitions, Set.empty, None, commands, State.newHistory, initAttrs, initialGlobalLogging, State.Continue)
+      val s = State(configuration, initialDefinitions, Set.empty, None, commands, State.newHistory, initAttrs, initialGlobalLogging, State.Continue, Keys.helpList)
       s.initializeClassLoaderCache
     }
 }

--- a/notes/0.13.12/add-console-task-to-help.md
+++ b/notes/0.13.12/add-console-task-to-help.md
@@ -1,0 +1,26 @@
+### Add console task to help output
+
+#### Fix for
+
+https://github.com/sbt/sbt/issues/2254
+
+#### Changes
+
+##### State.scala
+- state - added task help list to state object
+
+##### Main.scala
+- Initialise State with task help list
+
+##### BasicCommands.scala
+- incorporate task help list from state into help
+
+##### Keys.scala
+- Added list of help tasks
+- To add other items to the list of help tasks, it's easy to modify the initialisation of helpList like this:
+
+~~~
+    val helpList = help(console) ++ help(compile)
+~~~
+
+


### PR DESCRIPTION
Add console task to help output

Fix for https://github.com/sbt/sbt/issues/2254

Changes:

State.scala
- state - added task help list to state object

Main.scala
- Initialise State with task help list

BasicCommands.scala
- incorporate task help list from state into help

Keys.scala
- Added list of help tasks
- To add other items to the list of help tasks, it's easy to modify the initialisation of helpList like this:
  
  val helpList = help(console) ++ help(compile)
