### PR TITLE
Native script support

### DIFF
--- a/main/src/main/scala/sbt/Script.scala
+++ b/main/src/main/scala/sbt/Script.scala
@@ -42,7 +42,7 @@ object Script {
       val append = Load.transformSettings(Load.projectScope(currentRef), currentRef.build, rootProject, scriptSettings ++ embeddedSettings)
 
       val newStructure = Load.reapply(session.original ++ append, structure)
-      val arguments = state.remainingCommands.drop(1).map(arg => "\"" + arg + "\"")
+      val arguments = state.remainingCommands.drop(1)
       val newState = arguments.mkString("run ", " ", "") :: state.copy(remainingCommands = Nil)
       Project.setProject(session, newStructure, newState)
     }

--- a/main/src/main/scala/sbt/Script.scala
+++ b/main/src/main/scala/sbt/Script.scala
@@ -13,10 +13,20 @@ object Script {
   lazy val command =
     Command.command(Name) { state =>
       val scriptArg = state.remainingCommands.headOption getOrElse sys.error("No script file specified")
-      val script = new File(scriptArg).getAbsoluteFile
-      val hash = Hash.halve(Hash.toHex(Hash(script.getAbsolutePath)))
+      val scriptFile = new File(scriptArg).getAbsoluteFile
+      val hash = Hash.halve(Hash.toHex(Hash(scriptFile.getAbsolutePath)))
       val base = new File(CommandUtil.bootDirectory(state), hash)
       IO.createDirectory(base)
+      val src = new File(base, "src_managed")
+      IO.createDirectory(src)
+      // handle any script extension or none
+      val scalaFile = {
+        val dotIndex = scriptArg.lastIndexOf(".")
+        if (dotIndex == -1) scriptArg + ".scala"
+        else scriptArg.substring(0, dotIndex) + ".scala"
+      }
+      val script = new File(src, scalaFile)
+      IO.copyFile(scriptFile, script)
 
       val (eval, structure) = Load.defaultLoad(state, base, state.log)
       val session = Load.initialSession(structure, eval)
@@ -32,7 +42,7 @@ object Script {
       val append = Load.transformSettings(Load.projectScope(currentRef), currentRef.build, rootProject, scriptSettings ++ embeddedSettings)
 
       val newStructure = Load.reapply(session.original ++ append, structure)
-      val arguments = state.remainingCommands.drop(1)
+      val arguments = state.remainingCommands.drop(1).map(arg => "\"" + arg + "\"")
       val newState = arguments.mkString("run ", " ", "") :: state.copy(remainingCommands = Nil)
       Project.setProject(session, newStructure, newState)
     }

--- a/notes/0.13.12/native-script-support.md
+++ b/notes/0.13.12/native-script-support.md
@@ -4,6 +4,6 @@
 
 ### Improvements
 
-- Add Windows script support and native file extensions on Unix platforms. by [@ekrich][@ekrich]
+- Add Windows script support and native file extensions on Unix platforms. By [@ekrich][@ekrich]
 
 ### Bug fixes

--- a/notes/0.13.12/native-script-support.md
+++ b/notes/0.13.12/native-script-support.md
@@ -1,0 +1,9 @@
+  [@ekrich]: https://github.com/ekrich
+
+### Fixes with compatibility implications
+
+### Improvements
+
+- Add Windows script support and native file extensions on Unix platforms. by [@ekrich][@ekrich]
+
+### Bug fixes


### PR DESCRIPTION
Allows for a filename like `hellosbt.bat` in Windows.

```
::#!
@echo off
call xsbt -Dsbt.version=0.13.12 -Dsbt.main.class=sbt.ScriptMain --error %~nx0 %*
goto :eof
::!#

/***
name := "sbt embed"
version := "1.0"
scalaVersion := "2.11.8"
logLevel in Global := Level.Debug
*/

println("Hello, " + args.headOption.getOrElse("World") + "!")
```

Or with Unix, `hellosbt.sh`

```
#!/usr/bin/env sbt -Dsbt.version=0.13.12 -Dsbt.main.class=sbt.ScriptMain --error

/***
name := "sbt embed"
version := "1.0"
scalaVersion := "2.11.8"
logLevel in Global := Level.Debug
*/

println("Hello, " +  args.headOption.getOrElse("World") + "!")
```
