### PR TITLE
Fixes incremental compiler missing member ref from macro expansion sbt/sbt#2560

### DIFF
--- a/compile/interface/src/main/scala/xsbt/Dependency.scala
+++ b/compile/interface/src/main/scala/xsbt/Dependency.scala
@@ -146,7 +146,9 @@ final class Dependency(val global: CallbackGlobal) extends LocateClassFile {
       // In some cases (eg. macro annotations), `typeTree.tpe` may be null. See sbt/sbt#1593 and sbt/sbt#1655.
       case typeTree: TypeTree if typeTree.tpe != null => symbolsInType(typeTree.tpe) foreach addDependency
 
-      case MacroExpansionOf(original) if inspectedOriginalTrees.add(original) => traverse(original)
+      case m @ MacroExpansionOf(original) if inspectedOriginalTrees.add(original) =>
+        traverse(original)
+        super.traverse(m)
       case other => super.traverse(other)
     }
 

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
@@ -1,1 +1,5 @@
-incOptions := sbt.inc.IncOptions.Default
+lazy val root = (project in file(".")).
+  settings(
+    incOptions := sbt.inc.IncOptions.Default,
+    scalaVersion := "2.11.7"
+  )

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/test
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/test
@@ -1,9 +1,13 @@
 > compile
+
 # comment out `initialized` method in A
 $ copy-file changes/A1.scala src/main/scala/A.scala
+$ sleep 1000
 # compilation of A.scala succeeds but B.scala gets invalidated (properly) and B.scala fails to compile
 -> compile
+
 # we change A.scala to its original shape so compilation should succeed again
 $ copy-file changes/A2.scala src/main/scala/A.scala
+$ sleep 1000
 # this fails at the moment due to use of stale class file for A, see #958 for details
 > compile

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/build.sbt
@@ -1,0 +1,22 @@
+val defaultSettings = Seq(
+  scalaVersion := "2.11.8",
+  libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ )//,
+  //incOptions := incOptions.value.withNameHashing(true)
+)
+
+lazy val root = (project in file(".")).
+  aggregate(macroProvider, macroClient).
+  settings(
+    defaultSettings
+  )
+
+lazy val macroProvider = (project in file("macro-provider")).
+  settings(
+    defaultSettings
+  )
+
+lazy val macroClient = (project in file("macro-client")).
+  dependsOn(macroProvider).
+  settings(
+    defaultSettings
+  )

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/changes/Bar.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/changes/Bar.scala
@@ -1,0 +1,5 @@
+package example
+
+object Bar {
+  def bar(x: Int, y: Int): Int = x
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-client/Bar.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-client/Bar.scala
@@ -1,0 +1,5 @@
+package example
+
+object Bar {
+  def bar(x: Int): Int = x
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-client/Client.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-client/Client.scala
@@ -1,0 +1,5 @@
+package example
+
+object Client {
+  def foo: Unit = Provider.tree(0)
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-provider/Provider.scala
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/macro-provider/Provider.scala
@@ -1,0 +1,16 @@
+package example
+
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+object Provider {
+  def tree(args: Any): Any = macro treeImpl
+  def treeImpl(c: Context)(args: c.Expr[Any]) = {
+    import c.universe._
+    c.Expr[Any](
+      Apply(
+        Select(Ident(TermName("Bar")), TermName("bar")),
+        List(Literal(Constant(0))))
+    )
+  }
+}

--- a/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/test
+++ b/sbt/src/sbt-test/source-dependencies/macro-nonarg-dep/test
@@ -1,0 +1,11 @@
+> compile
+
+## Replace client-side file Bar.scala to something that should not compile
+$ copy-file changes/Bar.scala macro-client/Bar.scala
+
+## Expect failure here
+-> macroClient/compile
+
+## It should still fail after clean
+> macroClient/clean
+-> macroClient/compile


### PR DESCRIPTION
Fixes #2560

Unlike other scripted macro tests, the call site of the macro I added for this repro is
`Provider.tree(0)`, which itself does not introduce internal member reference.
Instead the macro expansion calls `Bar.bar(0)`. Due to #2560, the expanded
tree is not traversed, and thus the reference to `Bar` is not caught
during incremental compilation.

The fix is a one-liner change to traverse the expanded tree, which we used to do prior to 0.13.11 (0f61629).

/review @gkossakowski, @Duhemm
