### PR TITLE
Adding sleep in scripted test to make sure timestamp bumps

### DIFF
--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
@@ -1,1 +1,5 @@
-incOptions := sbt.inc.IncOptions.Default
+lazy val root = (project in file(".")).
+  settings(
+    incOptions := sbt.inc.IncOptions.Default,
+    scalaVersion := "2.11.7"
+  )

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/test
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/test
@@ -1,9 +1,13 @@
 > compile
+
 # comment out `initialized` method in A
 $ copy-file changes/A1.scala src/main/scala/A.scala
+$ sleep 1000
 # compilation of A.scala succeeds but B.scala gets invalidated (properly) and B.scala fails to compile
 -> compile
+
 # we change A.scala to its original shape so compilation should succeed again
 $ copy-file changes/A2.scala src/main/scala/A.scala
+$ sleep 1000
 # this fails at the moment due to use of stale class file for A, see #958 for details
 > compile


### PR DESCRIPTION
Fixes #2546. Ref #958/#965

`scripted compiler-project/error-in-invalidated` has been failing
frequently on Travis CI. It seems like incremental compiler is not
catching the change in source for `changes/A2.scala`.

Perhaps the machines are getting fast enough that we are doing three compilations within 1s?

/review @gkossakowski, @Duhemm
