### PR TITLE
Change ivy home when running scripted tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,38 +33,13 @@ def commonSettings: Seq[Setting[_]] = Seq(
 
 def minimalSettings: Seq[Setting[_]] =
   commonSettings ++ customCommands ++
-  publishPomSettings ++ Release.javaVersionCheckSettings
+  publishPomSettings ++ scriptedSettings ++ Release.javaVersionCheckSettings
 
 def baseSettings: Seq[Setting[_]] =
   minimalSettings ++ Seq(projectComponent) ++ baseScalacOptions ++ Licensed.settings ++ Formatting.settings
 
 def testedBaseSettings: Seq[Setting[_]] =
   baseSettings ++ testDependencies
-
-
-val altLocalRepoName = "alternative-local"
-val altLocalRepoPath = sys.props("user.home") + "/.ivy2/sbt-alternative"
-lazy val altLocalResolver = Resolver.file(altLocalRepoName, file(sys.props("user.home") + "/.ivy2/sbt-alternative"))(Resolver.ivyStylePatterns)
-lazy val altLocalPublish = TaskKey[Unit]("alt-local-publish", "Publishes an artifact locally to an alternative location.")
-def altPublishSettings: Seq[Setting[_]] = Seq(
-  resolvers += altLocalResolver,
-  altLocalPublish := {
-    val config = (Keys.publishLocalConfiguration).value
-    val moduleSettings = (Keys.moduleSettings).value
-    val ivy = new IvySbt((ivyConfiguration.value))
-
-    val module =
-        new ivy.Module(moduleSettings)
-    val newConfig =
-       new PublishConfiguration(
-           config.ivyFile,
-           altLocalRepoName,
-           config.artifacts,
-           config.checksums,
-           config.logging)
-    streams.value.log.info("Publishing " + module + " to local repo: " + altLocalRepoName)
-    IvyActions.publish(module, newConfig, streams.value.log)
-  })
 
 lazy val sbtRoot: Project = (project in file(".")).
   configs(Sxr.sxrConf).
@@ -118,8 +93,7 @@ lazy val interfaceProj = (project in file("interface")).
       sourceManaged in Compile,
       mainClass in datatypeProj in Compile,
       runner,
-      streams) map generateAPICached,
-    altPublishSettings
+      streams) map generateAPICached
   )
 
 // defines operations on the API of a source, including determining whether it has changed and converting it to a string
@@ -333,8 +307,7 @@ lazy val compileInterfaceProj = (project in compilePath / "interface").
     // needed because we fork tests and tests are ran in parallel so we have multiple Scala
     // compiler instances that are memory hungry
     javaOptions in Test += "-Xmx1G",
-    publishArtifact in (Compile, packageSrc) := true,
-    altPublishSettings
+    publishArtifact in (Compile, packageSrc) := true
   )
 
 // Implements the core functionality of detecting and propagating changes incrementally.
@@ -463,23 +436,22 @@ lazy val mavenResolverPluginProj = (project in file("sbt-maven-resolver")).
 
 def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => scriptedParser(dir)).parsed
-  publishAll.value
+  scriptedPublishAllLocal.value
   // These two projects need to be visible in a repo even if the default
   // local repository is hidden, so we publish them to an alternate location and add
   // that alternate repo to the running scripted test (in Scripted.scriptedpreScripted).
-  (altLocalPublish in interfaceProj).value
-  (altLocalPublish in compileInterfaceProj).value
+  (scriptedAltPublishLocal in interfaceProj).value
+  (scriptedAltPublishLocal in compileInterfaceProj).value
   doScripted((sbtLaunchJar in bundledLauncherProj).value, (fullClasspath in scriptedSbtProj in Test).value,
-    (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value)
+    (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value, scriptedIvyHome.value)
 }
 
 def scriptedUnpublishedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => scriptedParser(dir)).parsed
   doScripted((sbtLaunchJar in bundledLauncherProj).value, (fullClasspath in scriptedSbtProj in Test).value,
-    (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value)
+    (scalaInstance in scriptedSbtProj).value, scriptedSource.value, result, scriptedPrescripted.value, scriptedIvyHome.value)
 }
 
-lazy val publishAll = TaskKey[Unit]("publish-all")
 lazy val publishLauncher = TaskKey[Unit]("publish-launcher")
 
 lazy val myProvided = config("provided") intransitive
@@ -500,13 +472,10 @@ def rootSettings = fullDocSettings ++
   Util.publishPomSettings ++ otherRootSettings ++ Formatting.sbtFilesSettings ++
   Transform.conscriptSettings(bundledLauncherProj)
 def otherRootSettings = Seq(
-  Scripted.scriptedPrescripted := { addSbtAlternateResolver _ },
+  Scripted.scriptedPrescripted := { (Scripted.scriptedAddAltLocalResolver.value)(_) },
   Scripted.scripted <<= scriptedTask,
   Scripted.scriptedUnpublished <<= scriptedUnpublishedTask,
   Scripted.scriptedSource := (sourceDirectory in sbtProj).value / "sbt-test",
-  publishAll := {
-    val _ = (publishLocal).all(ScopeFilter(inAnyProject)).value
-  },
   aggregate in bintrayRelease := false
 ) ++ inConfig(Scripted.MavenResolverPluginTest)(Seq(
   Scripted.scripted <<= scriptedTask,
@@ -518,26 +487,9 @@ def otherRootSettings = Seq(
       // sLog.value.info(s"""Injected project/maven.sbt to $f""")
     }
 
-    addSbtAlternateResolver(f)
+    (Scripted.scriptedAddAltLocalResolver.value)(f)
   }
 ))
-
-def addSbtAlternateResolver(scriptedRoot: File) = {
-  val resolver = scriptedRoot / "project" / "AddResolverPlugin.scala"
-  if (!resolver.exists) {
-    IO.write(resolver, s"""import sbt._
-                          |import Keys._
-                          |
-                          |object AddResolverPlugin extends AutoPlugin {
-                          |  override def requires = sbt.plugins.JvmPlugin
-                          |  override def trigger = allRequirements
-                          |
-                          |  override lazy val projectSettings = Seq(resolvers += alternativeLocalResolver)
-                          |  lazy val alternativeLocalResolver = Resolver.file("$altLocalRepoName", file("$altLocalRepoPath"))(Resolver.ivyStylePatterns)
-                          |}
-                          |""".stripMargin)
-  }
-}
 
 lazy val docProjects: ScopeFilter = ScopeFilter(
   inAnyProject -- inProjects(sbtRoot, sbtProj, scriptedBaseProj, scriptedSbtProj, scriptedPluginProj, mavenResolverPluginProj),

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -10,6 +10,70 @@ object Scripted {
   lazy val scriptedUnpublished = InputKey[Unit]("scripted-unpublished", "Execute scripted without publishing SBT first. Saves you some time when only your test has changed.")
   lazy val scriptedSource = SettingKey[File]("scripted-source")
   lazy val scriptedPrescripted = TaskKey[File => Unit]("scripted-prescripted")
+  lazy val scriptedAltLocalResolverRoot = settingKey[File]("Root of the alternative local repository")
+  lazy val scriptedAltLocalResolver = settingKey[Resolver]("Alternative local resolver for scripted tests that override the local resolver.")
+  lazy val scriptedAltPublishLocal = taskKey[Unit]("Publishes to the alternative local resolver.")
+  lazy val scriptedPublishAllLocal = taskKey[Unit]("Publish all projects to scripted-only repository")
+  lazy val scriptedPublishLocal = taskKey[Unit]("Published to the scripted-only local resolver.")
+  lazy val scriptedAddAltLocalResolver = taskKey[File => Unit]("Adds the alternative local repository to a scripted test.")
+  lazy val scriptedIvy = taskKey[IvySbt]("Ivy instance to use for scripted tests")
+  lazy val scriptedIvyHome = settingKey[File]("Ivy home to use for scripted tests")
+  lazy val scriptedSettings: Seq[Setting[_]] = inThisBuild(Seq(
+    scriptedIvyHome := baseDirectory.value / "target" / "scripted-ivy",
+    scriptedAltLocalResolverRoot := scriptedIvyHome.value / "sbt-alternative",
+    scriptedAltLocalResolver := Resolver.file("alternative-local", scriptedAltLocalResolverRoot.value)(Resolver.ivyStylePatterns))) ++ Seq(
+    scriptedIvy := {
+      val ivyConf = ivyConfiguration.value match {
+        case inline: InlineIvyConfiguration =>
+          val newPaths = new IvyPaths(inline.paths.baseDirectory, Some(scriptedIvyHome.value))
+          new InlineIvyConfiguration(newPaths, inline.resolvers, inline.otherResolvers, inline.moduleConfigurations, inline.localOnly, inline.lock,
+            inline.checksums, inline.resolutionCacheDir, inline.updateOptions, inline.log)
+        case external: ExternalIvyConfiguration =>
+          error("Expected `InlineIvyConfiguration`.")
+      }
+      new IvySbt(ivyConf)
+    },
+    scriptedPublishLocal := {
+      val ivy = scriptedIvy.value
+      val module = new ivy.Module(moduleSettings.value)
+      IvyActions.publish(module, publishLocalConfiguration.value, streams.value.log)
+    },
+    scriptedPublishAllLocal := {
+      val _ = (scriptedPublishLocal).all(ScopeFilter(inAnyProject)).value
+    },
+    resolvers += scriptedAltLocalResolver.value,
+    scriptedAltPublishLocal := {
+      val config = publishLocalConfiguration.value
+      val ivy = scriptedIvy.value
+      val module = new ivy.Module(moduleSettings.value)
+      val newConfig =
+        new PublishConfiguration(
+          config.ivyFile,
+          scriptedAltLocalResolver.value.name,
+          config.artifacts,
+          config.checksums,
+          config.logging)
+      streams.value.log.info("Publishing " + name.value + " to local resolver: " + scriptedAltLocalResolver.value.name)
+
+      IvyActions.publish(module, newConfig, streams.value.log)
+    },
+    scriptedAddAltLocalResolver := { (root: File) =>
+      if (!root.exists) error(s"Couldn't add alternative local resolver: $root doesn't exist.")
+      val plugin = root / "project" / "AddResolverPlugin.scala"
+      if (!plugin.exists) {
+        IO.write(plugin, s"""import sbt._
+                            |import Keys._
+                            |
+                            |object AddResolverPlugin extends AutoPlugin {
+                            |  override def requires = sbt.plugins.JvmPlugin
+                            |  override def trigger = allRequirements
+                            |
+                            |  override lazy val projectSettings = Seq(resolvers += alternativeLocalResolver)
+                            |  lazy val alternativeLocalResolver = Resolver.file("${scriptedAltLocalResolver.value.name}", file("${scriptedAltLocalResolverRoot.value.getAbsolutePath}"))(Resolver.ivyStylePatterns)
+                            |}
+                            |""".stripMargin)
+      }
+    })
 
   lazy val MavenResolverPluginTest = config("mavenResolverPluginTest") extend Compile
 
@@ -66,13 +130,16 @@ object Scripted {
       launchOpts: Array[String], prescripted: java.util.List[File]): Unit
   }
 
-  def doScripted(launcher: File, scriptedSbtClasspath: Seq[Attributed[File]], scriptedSbtInstance: ScalaInstance, sourcePath: File, args: Seq[String], prescripted: File => Unit): Unit = {
+  def doScripted(launcher: File, scriptedSbtClasspath: Seq[Attributed[File]], scriptedSbtInstance: ScalaInstance, sourcePath: File, args: Seq[String], prescripted: File => Unit, ivyHome: File): Unit = {
     System.err.println(s"About to run tests: ${args.mkString("\n * ", "\n * ", "\n")}")
     val noJLine = new classpath.FilteredLoader(scriptedSbtInstance.loader, "jline." :: Nil)
     val loader = classpath.ClasspathUtilities.toLoader(scriptedSbtClasspath.files, noJLine)
     val bridgeClass = Class.forName("sbt.test.ScriptedRunner", true, loader)
     val bridge = bridgeClass.newInstance.asInstanceOf[SbtScriptedRunner]
-    val launcherVmOptions = Array("-XX:MaxPermSize=256M", "-Xmx1G") // increased after a failure in scripted source-dependencies/macro
+    val launcherVmOptions = Array(
+      "-XX:MaxPermSize=256M", "-Xmx1G", // increased after a failure in scripted source-dependencies/macro
+      s"-Dsbt.ivy.home=$ivyHome" // don't use the default ivy home, so that we don't depend on the machine's ivy cache
+    )
     try {
       // Using java.util.List to encode File => Unit.
       val callback = new java.util.AbstractList[File] {


### PR DESCRIPTION
This commit changes the build so that when running `scripted`:
- sbt is published to a local repository in a different ivy home. We
  publish using the ivy home `/path/to/sbt/sbt/target/scripted-ivy`
  (instead of `~/.ivy2`).
- this custom ivy home is explicitly specified at when sbt is launcher.

Fixes sbt/sbt#2539
