### PR TITLE
[sbt 1.0] We shouldn't cross publish as sbt_2.11 for backward compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,6 +196,7 @@ lazy val sbtProj = (project in sbtPath).
     baseSettings,
     name := "sbt",
     normalizedName := "sbt",
+    crossPaths := false,
     libraryDependencies ++= Seq(compilerBrdige)
   )
 

--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -1,5 +1,5 @@
 [scala]
-  version: 2.11.8
+  version: ${sbt.scala.version-auto}
 
 [app]
   org: ${sbt.organization-${{org}}}
@@ -7,7 +7,7 @@
   version: ${sbt.version-read(sbt.version)[${{sbt.version}}]}
   class: ${sbt.main.class-sbt.xMain}
   components: xsbti,extra
-  cross-versioned: ${sbt.cross.versioned-binary}
+  cross-versioned: ${sbt.cross.versioned-false}
   resources: ${sbt.extraClasspath-}
 
 [repositories]

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1162,9 +1162,9 @@ object Classpaths {
       val id = app.provider.id
       val scalaVersion = app.provider.scalaProvider.version
       val binVersion = binaryScalaVersion(scalaVersion)
-      val cross = CrossVersion.binary
-      ModuleID(id.groupID, id.name, sbtVersion.value, crossVersion = cross)
-      // CrossVersion(scalaVersion, binVersion)(base) // .copy(crossVersion = CrossVersion.Disabled)
+      val cross = if (id.crossVersioned) CrossVersion.binary else CrossVersion.Disabled
+      val base = ModuleID(id.groupID, id.name, sbtVersion.value, crossVersion = cross)
+      CrossVersion(scalaVersion, binVersion)(base).copy(crossVersion = CrossVersion.Disabled)
     }
   ))
 
@@ -1375,7 +1375,7 @@ object Classpaths {
       val depDir = dependencyCacheDirectory.value
       withExcludes(out, mod.classifiers, lock(app)) { excludes =>
         val noExplicitCheck = ivyScala.value.map(_.copy(checkExplicit = false))
-        IvyActions.transitiveScratch(is, "sbt_2.11", GetClassifiersConfiguration(mod, excludes, c.copy(artifactFilter = c.artifactFilter.invert), noExplicitCheck, srcTypes, docTypes), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), s.log)
+        IvyActions.transitiveScratch(is, "sbt", GetClassifiersConfiguration(mod, excludes, c.copy(artifactFilter = c.artifactFilter.invert), noExplicitCheck, srcTypes, docTypes), uwConfig, LogicalClock(state.value.hashCode), Some(depDir), s.log)
       }
     } tag (Tags.Update, Tags.Network)
   )) ++ Seq(bootIvyConfiguration := (ivyConfiguration in updateSbtClassifiers).value)

--- a/sbt/src/sbt-test/actions/compile-time-only/build.sbt
+++ b/sbt/src/sbt-test/actions/compile-time-only/build.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "org.scala-sbt" %% "sbt" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" % "sbt" % sbtVersion.value
 
 
 lazy val expectErrorNotCrash = taskKey[Unit]("Ensures that sbt properly set types on Trees so that the compiler doesn't crash on a bad reference to .value, but gives a proper error instead.")

--- a/sbt/src/sbt-test/project/src-plugins/plugin/build.sbt
+++ b/sbt/src/sbt-test/project/src-plugins/plugin/build.sbt
@@ -1,2 +1,2 @@
 libraryDependencies +=
-	"org.scala-sbt" %% "sbt" % appConfiguration.value.provider.id.version
+	"org.scala-sbt" % "sbt" % appConfiguration.value.provider.id.version


### PR DESCRIPTION
By keeping sbt artifact to be called sbt (as opposed to `sbt_2.11`), the user can try by just
changing the build properties.

Ref #2577

/review @Duhemm, @dwijnand 
