### PR TITLE
FPORT: Avoid CCE when scalac internally uses compileLate. Fixes #2452

### DIFF
--- a/sbt/src/sbt-test/apiinfo/source-path/build.sbt
+++ b/sbt/src/sbt-test/apiinfo/source-path/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.11.7"
+
+scalacOptions in Compile ++= "-sourcepath" :: (baseDirectory.value / "srcpath").toString :: Nil
+
+

--- a/sbt/src/sbt-test/apiinfo/source-path/src/main/scala/test.scala
+++ b/sbt/src/sbt-test/apiinfo/source-path/src/main/scala/test.scala
@@ -1,0 +1,18 @@
+
+object Test {
+  // When the refchecks compiler phase checks if Tuple2 has the
+  // @deprecated annotation, it forces the info for the
+  // `@deprecatedInheritance` annotation (the only annotation on
+  // class Tuple2.
+  //
+  // Because we are compiling with `-sourcpath` that contains a
+  // source file for `deprecatedInheritance`, this triggers a
+  // `compileLate` of that file (which basically runs all previous
+  // compiler phases on that file.)
+  //
+  // `compileLate` assumes that all of the phases are subclasses
+  // of `GlobalPhase`, rather than just `Phase`. This triggers a
+  // `ClassCastException` when it encounters SBT's custom
+  // API phase.
+  new Tuple2("", "")
+}

--- a/sbt/src/sbt-test/apiinfo/source-path/srcpath/scala/deprecatedInheritance.scala
+++ b/sbt/src/sbt-test/apiinfo/source-path/srcpath/scala/deprecatedInheritance.scala
@@ -1,0 +1,4 @@
+package scala
+
+private[scala] // for now, this needs to be generalized to communicate other modifier deltas
+class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/sbt/src/sbt-test/apiinfo/source-path/test
+++ b/sbt/src/sbt-test/apiinfo/source-path/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Forward port of sbt/sbt#2453
