### PR TITLE
Bump up libarymanagement

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   // sbt modules
   val ioVersion = "1.0.0-M5"
   val utilVersion = "0.1.0-M12"
-  val librarymanagementVersion = "0.1.0-M9"
+  val librarymanagementVersion = "0.1.0-M10"
   val zincVersion = "1.0.0-M1"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion

--- a/sbt/src/main/scala/Import.scala
+++ b/sbt/src/main/scala/Import.scala
@@ -30,9 +30,6 @@ trait Import {
   type RichFile = sbt.io.RichFile
   type SimpleFileFilter = sbt.io.SimpleFileFilter
   type SimpleFilter = sbt.io.SimpleFilter
-  type TestError = sbt.io.TestError
-  type TestException = sbt.io.TestException
-  type TestRuntimeException = sbt.io.TestRuntimeException
 
   // sbt.util
   type AbstractLogger = sbt.util.AbstractLogger


### PR DESCRIPTION
librarymanagement 0.1.0-M9 was pulling in incorrect dependencies
Fixes sbt/sbt#2597
1.0.0-M2 should be available once Maven Central syncs.
