### PR TITLE
Inform the build user about macro recompilation

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Incremental.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Incremental.scala
@@ -23,7 +23,11 @@ object Incremental {
   class PrefixingLogger(val prefix: String)(orig: Logger) extends Logger {
     def trace(t: => Throwable): Unit = orig.trace(t)
     def success(message: => String): Unit = orig.success(message)
-    def log(level: sbt.Level.Value, message: => String): Unit = orig.log(level, message.replaceAll("(?m)^", prefix))
+    def log(level: sbt.Level.Value, message: => String): Unit =
+      level match {
+        case Level.Debug => orig.log(level, message.replaceAll("(?m)^", prefix))
+        case _           => orig.log(level, message)
+      }
   }
 
   /**


### PR DESCRIPTION
Ref #2614

Since RecompileOnMacroDef is enabled by default, let the build user know that incremental compiler just invalidate a bunch of stuff because of macro.
### sample

```
hello-world> compile
[info] Compiling 1 Scala source to /Users/eugene/work/helloworld/target/scala-2.11/classes...
[info] Because /Users/eugene/work/helloworld/src/main/scala/A.scala contains a macro definition, the following dependencies are invalidated unconditionally:
[info]  /Users/eugene/work/helloworld/src/main/scala/D.scala
[info] Compiling 1 Scala source to /Users/eugene/work/helloworld/target/scala-2.11/classes...
```

/review @Duhemm, @gkossakowski 
