### PR TITLE
Default compiler plugins to fully cross versioned

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2014,7 +2014,7 @@ trait BuildExtra extends BuildCommon with DefExtra {
 
   /** Transforms `dependency` to be in the auto-compiler plugin configuration. */
   def compilerPlugin(dependency: ModuleID): ModuleID =
-    dependency.copy(configurations = Some("plugin->default(compile)"))
+    dependency.copy(configurations = Some("plugin->default(compile)")) cross CrossVersion.full
 
   /** Adds `dependency` to `libraryDependencies` in the auto-compiler plugin configuration. */
   def addCompilerPlugin(dependency: ModuleID): Setting[Seq[ModuleID]] =

--- a/sbt/src/sbt-test/project/continuations/build.sbt
+++ b/sbt/src/sbt-test/project/continuations/build.sbt
@@ -2,13 +2,12 @@ scalaVersion := "2.8.1"
 
 autoCompilerPlugins := true
 
-addCompilerPlugin("org.scala-lang.plugins" % "continuations" % "2.8.1")
-
 scalacOptions += "-P:continuations:enable"
 
 libraryDependencies ++= Seq(
-	"junit" % "junit" % "4.7" % "test",
-	"com.novocode" % "junit-interface" % "0.5" % "test"
+  compilerPlugin("org.scala-lang.plugins" % "continuations" % "2.8.1") cross CrossVersion.Disabled,
+  "junit" % "junit" % "4.7" % "test",
+  "com.novocode" % "junit-interface" % "0.5" % "test"
 )
 
 initialCommands := """assert(Example.x == 20)"""

--- a/sbt/src/sbt-test/source-dependencies/continuations/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/continuations/build.sbt
@@ -1,4 +1,5 @@
 scalaVersion := "2.10.6"
 autoCompilerPlugins := true
-libraryDependencies += compilerPlugin("org.scala-lang.plugins" % "continuations" % scalaVersion.value)
+libraryDependencies +=
+  compilerPlugin("org.scala-lang.plugins" % "continuations" % scalaVersion.value) cross CrossVersion.Disabled
 scalacOptions += "-P:continuations:enable"

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
@@ -5,7 +5,7 @@ val commonSettings = Seq(
   scalaVersion := "2.11.4",
   resolvers += Resolver.sonatypeRepo("snapshots"),
   resolvers += Resolver.sonatypeRepo("releases"),
-  addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full),
+  addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion),
   incOptions := incOptions.value.withNameHashing(true)
 )
 


### PR DESCRIPTION
The compiler API is neither source nor binary compatible between minor versions, so this is always required.

Except for ancient continuations, which used to be part of scala and therefore versioned with it.
