### PR TITLE
Fix for #2686

### DIFF
--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -57,6 +57,13 @@ private object IvyScala {
       overrideScalaVersion(module, check.scalaOrganization, check.scalaFullVersion)
   }
 
+  def pre210(scalaVersion: String): Boolean =
+    CrossVersion.scalaApiVersion(scalaVersion) match {
+      case Some((2, y)) if y < 10 => true
+      case Some((x, _)) if x < 2  => true
+      case _                      => false
+    }
+
   class OverrideScalaMediator(scalaOrganization: String, scalaVersion: String) extends DependencyDescriptorMediator {
     def mediate(dd: DependencyDescriptor): DependencyDescriptor = {
       val transformer =
@@ -65,6 +72,7 @@ private object IvyScala {
             if (mrid == null) mrid
             else
               mrid.getName match {
+                case ReflectID | ActorsID if pre210(scalaVersion) => mrid
                 case name @ (CompilerID | LibraryID | ReflectID | ActorsID | ScalapID) =>
                   ModuleRevisionId.newInstance(scalaOrganization, name, mrid.getBranch, scalaVersion, mrid.getQualifiedExtraAttributes)
                 case _ => mrid

--- a/sbt/src/sbt-test/actions/update-sbt-classifiers/build.sbt
+++ b/sbt/src/sbt-test/actions/update-sbt-classifiers/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.9.3"

--- a/sbt/src/sbt-test/actions/update-sbt-classifiers/test
+++ b/sbt/src/sbt-test/actions/update-sbt-classifiers/test
@@ -1,0 +1,1 @@
+> updateSbtClassifiers


### PR DESCRIPTION
The cause of the problem reported in #2686 is that the version clamping that was introduced in #2634 could "downgrade" scala-reflect 2.10.x to scala-reflect 2.9.x ... which doesn't exist of course.

This is a fairly brute force fix for that: if the scalaVersion being clamped to is < 2.10.x then references to scala-reflect and scala-actors artefacts are left unchanged ... this roughly approximates the behaviour you would have seen in this situation prior to #2634 with respect to those two artefacts.

A better fix might work out why such artefacts are being asked for in the first place given that this is a project which specifies 2.9.3 and does nothing other than invoke `updateSbtClassifiers` ... I don't understand the meaning or purpose of `updateSbtClassifiers` sufficiently to be able to attempt that unfortunately.
