### PR TITLE
Fixes #2686 by resetting scalaVersion for updateSbtClassifiers

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.9.2"

--- a/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/test
+++ b/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/test
@@ -1,1 +1,1 @@
-> update-sbt-classifiers
+> updateSbtClassifiers


### PR DESCRIPTION
Ref #2634

updateSbtClassifiers uses an artificially created dependency graph set
in classifiersModule. The problem is that ivyScala instance is reused
from the outer scope that has the user project's scalaVersion as
demonstrated as follows:

``` scala
> consoleProject
scala> val is = (ivyScala in updateSbtClassifiers).eval
is: Option[sbt.IvyScala] =
Some(IvyScala(2.9.3,2.9.3,List(),true,false,true,org.scala-lang))
```

This change fixes #2686 by redefining ivyScala with scalaVersion and
scalaBinaryVersion scoped to updateSbtClassifiers task. The existing
scripted test was modified to reproduce the bug.

/review @dwijnand, @milessabin 
