### PR TITLE
Configurable explicit list of artifacts for Scala binary version check

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -148,6 +148,7 @@ object Defaults extends BuildCommon {
       retrieveManagedSync :== false,
       configurationsToRetrieve :== None,
       scalaOrganization :== ScalaArtifacts.Organization,
+      scalaArtifacts :== ScalaArtifacts.Artifacts,
       sbtResolver := { if (sbtVersion.value endsWith "-SNAPSHOT") Classpaths.sbtIvySnapshots else Classpaths.typesafeReleases },
       crossVersion :== CrossVersion.Disabled,
       buildDependencies <<= Classpaths.constructBuildDependencies,
@@ -1248,8 +1249,8 @@ object Classpaths {
     allDependencies := {
       projectDependencies.value ++ libraryDependencies.value
     },
-    ivyScala <<= ivyScala or (scalaHome, scalaVersion in update, scalaBinaryVersion in update, scalaOrganization, sbtPlugin) { (sh, fv, bv, so, plugin) =>
-      Some(new IvyScala(fv, bv, Nil, filterImplicit = false, checkExplicit = true, overrideScalaVersion = true, scalaOrganization = so))
+    ivyScala <<= ivyScala or (scalaHome, scalaVersion in update, scalaBinaryVersion in update, scalaOrganization, scalaArtifacts, sbtPlugin) { (sh, fv, bv, so, sa, plugin) =>
+      Some(new IvyScala(fv, bv, Nil, filterImplicit = false, checkExplicit = true, overrideScalaVersion = true, scalaOrganization = so, scalaArtifacts = sa))
     },
     artifactPath in makePom <<= artifactPathSetting(artifact in makePom),
     publishArtifact in makePom := publishMavenStyle.value && publishArtifact.value,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -191,6 +191,7 @@ object Keys {
   val printWarnings = TaskKey[Unit]("print-warnings", "Shows warnings from compilation, including ones that weren't printed initially.", BPlusTask)
   val fileInputOptions = SettingKey[Seq[String]]("file-input-options", "Options that take file input, which may invalidate the cache.", CSetting)
   val scalaCompilerBridgeSource = SettingKey[ModuleID]("scala-compiler-bridge-source", "Configures the module ID of the sources of the compiler bridge.", CSetting)
+  val scalaArtifacts = SettingKey[Seq[String]]("scala-artifacts", "Configures the list of artifacts which should match the Scala binary version", CSetting)
 
   val clean = TaskKey[Unit]("clean", "Deletes files produced by the build, such as generated sources, compiled classes, and task caches.", APlusTask)
   val console = TaskKey[Unit]("console", "Starts the Scala interpreter with the project classes on the classpath.", APlusTask)

--- a/sbt/src/sbt-test/dependency-management/scala-organization-version-check/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/scala-organization-version-check/build.sbt
@@ -1,0 +1,23 @@
+scalaOrganization := "org.other"
+
+scalaArtifacts += "thing"
+
+scalaVersion := "2.11.8"
+
+libraryDependencies ++= Seq(
+  "org.other" % "thing" % "1.2.3",
+  "org.other" %% "wotsit" % "4.5.6"
+)
+
+lazy val check = taskKey[Unit]("Runs the check")
+
+check := {
+  val lastLog = BuiltinCommands lastLogFile state.value
+  val last = IO read lastLog.get
+  def containsWarn1 = last contains "Binary version (1.2.3) for dependency org.other#thing;1.2.3"
+  def containsWarn2 = last contains "Binary version (4.5.6) for dependency org.other#wotsit_2.11;4.5.6"
+  def containsWarn3 = last contains "differs from Scala binary version in project (2.11)."
+  if (!containsWarn1) sys error "thing should not be exempted from the Scala binary version check"
+  if (containsWarn2)  sys error "wotsit should be exempted from the Scala binary version check"
+  if (!containsWarn3) sys error "Binary version check failed"
+}

--- a/sbt/src/sbt-test/dependency-management/scala-organization-version-check/test
+++ b/sbt/src/sbt-test/dependency-management/scala-organization-version-check/test
@@ -1,0 +1,3 @@
+> clean
+
+> check


### PR DESCRIPTION
This is the sbt/sbt part of the forward port of #2702 to 1.0.0.

Nb. this PR won't build until a release of sbt/librarymanagement has been made which includes https://github.com/sbt/librarymanagement/pull/50 and this project has been updated to use it.
