### PR TITLE
Fix key selection for build level keys

### DIFF
--- a/main/src/main/scala/sbt/Act.scala
+++ b/main/src/main/scala/sbt/Act.scala
@@ -77,11 +77,16 @@ object Act {
       selectFromValid(ss filter isValid(data), default)
     }
   def selectFromValid(ss: Seq[ParsedKey], default: Parser[ParsedKey])(implicit show: Show[ScopedKey[_]]): Parser[ParsedKey] =
-    selectByTask(selectByConfig(ss)) match {
-      case Seq()       => default
-      case Seq(single) => success(single)
-      case multi       => failure("Ambiguous keys: " + showAmbiguous(keys(multi)))
+    selectByTask(selectByConfig(ss)) partition isBuildKey match {
+      case (_, Seq(single))         => success(single)
+      case (Seq(single), Seq())     => success(single)
+      case (Seq(), Seq())           => default
+      case (buildKeys, projectKeys) => failure("Ambiguous keys: " + showAmbiguous(keys(buildKeys ++ projectKeys)))
     }
+  private def isBuildKey(parsed: ParsedKey): Boolean = parsed.key.scope.project match {
+    case Select(_: BuildReference) => true
+    case _                         => false
+  }
   private[this] def keys(ss: Seq[ParsedKey]): Seq[ScopedKey[_]] = ss.map(_.key)
   def selectByConfig(ss: Seq[ParsedKey]): Seq[ParsedKey] =
     ss match {

--- a/notes/0.13.13/fix-key-selection-for-build-level-keys.md
+++ b/notes/0.13.13/fix-key-selection-for-build-level-keys.md
@@ -1,0 +1,11 @@
+  [@Duhemm]: https://github.com/Duhemm
+  [#2707]: https://github.com/sbt/sbt/issues/2707
+  [#2708]: https://github.com/sbt/sbt/issues/2708
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fix key selection for build level keys. sbt wrongly reported some keys as ambiguous. Fixes [#2707][#2707]. [#2708][#2708] by [@Duhemm][@Duhemm]

--- a/sbt/src/sbt-test/project/build-level-keys/test
+++ b/sbt/src/sbt-test/project/build-level-keys/test
@@ -1,0 +1,4 @@
+> baseDirectory
+
+> {.}/baseDirectory
+


### PR DESCRIPTION
PR #2469 added build keys to tab completion, with the side effect of
considering them as available candidates in key selection, thus making sbt
think that some inputs were ambiguous (e.g. `baseDirectory`): should it
apply to the current project or to the build level key?

This commit fixes this issue by improving the key selection:
- If there are no candidates, we return the default key
- If there's a single possible project level key, and zero or more
  build level keys, then we select the project level key.
- If there are zero project level keys, and a single build level key,
  then we select the build level key
- If there are multiple candidates, sbt says that the input is
  ambiguous.

Fixes #2707
