### PR TITLE
Deprecate .value extension method from input tasks

### DIFF
--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -98,7 +98,7 @@ object InputWrapper {
         InputWrapper.wrapInitTask[T](c)(ts, pos)
       else if (tpe <:< c.weakTypeOf[Initialize[T]]) {
         if (c.weakTypeOf[T] <:< c.weakTypeOf[InputTask[_]]) {
-          c.warning(pos, """`value` is deprecated for an input task. Use `evaluated` or `toInputTask`.
+          c.warning(pos, """`value` is deprecated for an input task. Use `evaluated` or `inputTaskValue`.
                            |See http://www.scala-sbt.org/0.13/docs/Input-Tasks.html for more details.""".stripMargin)
         }
         InputWrapper.wrapInit[T](c)(ts, pos)
@@ -112,7 +112,7 @@ object InputWrapper {
       else
         c.abort(pos, s"Internal sbt error. Unexpected type ${tpe.widen}")
     }
-  def toInputTaskMacroImpl[T: c.WeakTypeTag](c: Context): c.Expr[InputTask[T]] =
+  def inputTaskValueMacroImpl[T: c.WeakTypeTag](c: Context): c.Expr[InputTask[T]] =
     ContextUtil.selectMacroImpl[InputTask[T]](c) { (ts, pos) =>
       InputWrapper.wrapInit[InputTask[T]](c)(ts, pos)
     }
@@ -156,8 +156,8 @@ sealed abstract class ParserInput[T] {
 sealed abstract class InputEvaluated[T] {
   @compileTimeOnly("`evaluated` can only be used within an input task macro, such as := or Def.inputTask.")
   def evaluated: T = macro InputWrapper.valueMacroImpl[T]
-  @compileTimeOnly("`toInputTask` can only be used within an input task macro, such as := or Def.inputTask.")
-  def toInputTask: InputTask[T] = macro InputWrapper.toInputTaskMacroImpl[T]
+  @compileTimeOnly("`inputTaskValue` can only be used within an input task macro, such as := or Def.inputTask.")
+  def inputTaskValue: InputTask[T] = macro InputWrapper.inputTaskValueMacroImpl[T]
 }
 sealed abstract class ParserInputTask[T] {
   @compileTimeOnly("`parsed` can only be used within an input task macro, such as := or Def.inputTask.")

--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -109,7 +109,6 @@ object InputWrapper {
     }
   def toInputTaskMacroImpl[T: c.WeakTypeTag](c: Context): c.Expr[InputTask[T]] =
     ContextUtil.selectMacroImpl[InputTask[T]](c) { (ts, pos) =>
-      val tpe = ts.tree.tpe
       InputWrapper.wrapInit[InputTask[T]](c)(ts, pos)
     }
   def taskValueMacroImpl[T: c.WeakTypeTag](c: Context): c.Expr[Task[T]] =

--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -105,6 +105,10 @@ object InputWrapper {
       }
       else if (tpe <:< c.weakTypeOf[Task[T]])
         InputWrapper.wrapTask[T](c)(ts, pos)
+      else if (tpe <:< c.weakTypeOf[InputTask[T]])
+        InputWrapper.wrapInputTask[T](c)(ts, pos)
+      else if (tpe <:< c.weakTypeOf[Initialize[InputTask[T]]])
+        InputWrapper.wrapInitInputTask[T](c)(ts, pos)
       else
         c.abort(pos, s"Internal sbt error. Unexpected type ${tpe.widen}")
     }

--- a/main/settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main/settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -98,9 +98,10 @@ object InputWrapper {
         InputWrapper.wrapInitTask[T](c)(ts, pos)
       else if (tpe <:< c.weakTypeOf[Initialize[T]]) {
         if (c.weakTypeOf[T] <:< c.weakTypeOf[InputTask[_]]) {
-          c.abort(pos, """`value` is no longer allowed for an input task. Use `evaluated` or `toInputTask`.
-                         |See http://www.scala-sbt.org/0.13/docs/Input-Tasks.html for more details.""".stripMargin)
-        } else InputWrapper.wrapInit[T](c)(ts, pos)
+          c.warning(pos, """`value` is deprecated for an input task. Use `evaluated` or `toInputTask`.
+                           |See http://www.scala-sbt.org/0.13/docs/Input-Tasks.html for more details.""".stripMargin)
+        }
+        InputWrapper.wrapInit[T](c)(ts, pos)
       }
       else if (tpe <:< c.weakTypeOf[Task[T]])
         InputWrapper.wrapTask[T](c)(ts, pos)

--- a/notes/0.13.13/inputtask_value.md
+++ b/notes/0.13.13/inputtask_value.md
@@ -1,9 +1,10 @@
 
 ### Fixes with compatibility implications
 
-- `.value` is removed from input tasks. Calling `.value` method on an input task returns `InputTask[A]`,
+- `.value` method is deprecated for input tasks. Calling `.value` method on an input task returns `InputTask[A]`,
   which is completely unintuitive and often results to a bug. In most cases `.evaluated` should be called,
   which returns `A` by evaluating the task.
-  Just in case `InputTask[A]` is needed, `toInputTask` method is now provided.
+  Just in case `InputTask[A]` is needed, `toInputTask` method is now provided. [#2709][2709] by [@eed3si9n][@eed3si9n]
 
   [@eed3si9n]: https://github.com/eed3si9n
+  [2709]: https://github.com/sbt/sbt/pull/2709

--- a/notes/0.13.13/inputtask_value.md
+++ b/notes/0.13.13/inputtask_value.md
@@ -4,7 +4,7 @@
 - `.value` method is deprecated for input tasks. Calling `.value` method on an input task returns `InputTask[A]`,
   which is completely unintuitive and often results to a bug. In most cases `.evaluated` should be called,
   which returns `A` by evaluating the task.
-  Just in case `InputTask[A]` is needed, `toInputTask` method is now provided. [#2709][2709] by [@eed3si9n][@eed3si9n]
+  Just in case `InputTask[A]` is needed, `inputTaskValue` method is now provided. [#2709][2709] by [@eed3si9n][@eed3si9n]
 
   [@eed3si9n]: https://github.com/eed3si9n
   [2709]: https://github.com/sbt/sbt/pull/2709

--- a/notes/0.13.13/inputtask_value.md
+++ b/notes/0.13.13/inputtask_value.md
@@ -1,0 +1,9 @@
+
+### Fixes with compatibility implications
+
+- `.value` is removed from input tasks. Calling `.value` method on an input task returns `InputTask[A]`,
+  which is completely unintuitive and often results to a bug. In most cases `.evaluated` should be called,
+  which returns `A` by evaluating the task.
+  Just in case `InputTask[A]` is needed, `toInputTask` method is now provided.
+
+  [@eed3si9n]: https://github.com/eed3si9n

--- a/sbt/src/sbt-test/actions/input-task/Hello.scala
+++ b/sbt/src/sbt-test/actions/input-task/Hello.scala
@@ -1,0 +1,3 @@
+object Hello extends App {
+  println("hello" + args.toList.toString)
+}

--- a/sbt/src/sbt-test/actions/input-task/build.sbt
+++ b/sbt/src/sbt-test/actions/input-task/build.sbt
@@ -1,0 +1,9 @@
+lazy val foo = inputKey[Unit]("")
+
+lazy val root = (project in file(".")).
+  settings(
+    name := "run-test",
+    foo := {
+      val x = (run in Compile).value
+    }
+  )

--- a/sbt/src/sbt-test/actions/input-task/build.sbt
+++ b/sbt/src/sbt-test/actions/input-task/build.sbt
@@ -1,9 +1,22 @@
-lazy val foo = inputKey[Unit]("")
+import complete.Parser
+
+// http://www.scala-sbt.org/0.13/docs/Input-Tasks.html
+
+val run2 = inputKey[Unit](
+    "Runs the main class twice with different argument lists separated by --")
+val check = taskKey[Unit]("")
+
+val separator: Parser[String] = "--"
 
 lazy val root = (project in file(".")).
   settings(
     name := "run-test",
-    foo := {
-      val x = (run in Compile).value
+    run2 := {
+       val one = (run in Compile).evaluated
+       val sep = separator.parsed
+       val two = (run in Compile).evaluated
+    },
+    check := {
+      val x = run2.toTask(" a b -- c d").value
     }
   )

--- a/sbt/src/sbt-test/actions/input-task/test
+++ b/sbt/src/sbt-test/actions/input-task/test
@@ -1,0 +1,2 @@
+## build.sbt should not load
+-> compile

--- a/sbt/src/sbt-test/actions/input-task/test
+++ b/sbt/src/sbt-test/actions/input-task/test
@@ -1,1 +1,2 @@
-> compile
+> check
+

--- a/sbt/src/sbt-test/actions/input-task/test
+++ b/sbt/src/sbt-test/actions/input-task/test
@@ -1,2 +1,1 @@
-## build.sbt should not load
--> compile
+> compile


### PR DESCRIPTION
Calling `.value` method on an input task returns `InputTask[A]`, which
is completely unintuitive and often results to a bug.
In most cases `.evaluated` should be called, which returns `A` by
evaluating the task. Just in case `InputTask[A]` is needed,
`toInputTask` method is now provided.
### note

Implicit for `.value` is on `Initialize[T]`:

``` scala
  implicit def macroValueI[T](in: Initialize[T]): MacroValue[T] = ???
```

For instance, in case of `Initalize[InputTask[Unit]]`, `T` is `InputTask[Unit]`, so we're checking `tpe` to conform to `Initialize[InputTask[InputTask[Unit]]]`, which I don't think would ever match. Fixing the semantics of `.value` at this juncture is dangerous, so the best we can do is remove it and tell people to use `.evaluated`.

/review @dwijnand, @jsuereth, @Duhemm 
