### PR TITLE
Cutting out openjdk7 from PR validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache:
 
 language: scala
 
-# TODO - we'd like to actually test everything, but the process library has a deadlock right now
 jdk:
-  - openjdk7
   - oraclejdk7
 
 matrix:


### PR DESCRIPTION
I was wondering why PR validation takes so long and I realized that we're running all scripted tests twice for Oracle JDK and openjdk.
