### PR TITLE
[sbt 1.0] Rename early command to `early(command)`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,8 @@ Migration notes
 - Removed the pre-0.13.7 *.sbt file parser (previously available under `-Dsbt.parser.simple=true`)
 - Removed old, hyphen-separated key names (use `publishLocal` instead of `publish-local`)
 - Removes no-longer-documented old operators `<<=`, `<+=`, and `<++=`.
+- Renames early command feature from `--<command>` to `early(<command>)`.
+- Log options `-error`, `-warn`, `-info`, `-debug` are added as shorthand for `"early(error)"` etc.
 
 #### Additional import required
 

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -60,21 +60,18 @@ ${runEarly(level.toString)}
 		* if no other commands are passed, interactive mode is still entered
 """
 
-  def runEarly(command: String) = {
-    val sep = if (command.isEmpty || Character.isLetter(command.charAt(0))) "" else " "
-    s"$EarlyCommand$sep$command"
-  }
+  def runEarly(command: String) = s"$EarlyCommand($command)"
   private[sbt] def isEarlyCommand(s: String): Boolean = {
-    s.startsWith(EarlyCommand) && s != Compat.FailureWall && s != Compat.ClearOnFailure
+    s.startsWith(EarlyCommand + "(") && s.endsWith(")")
   }
 
-  val EarlyCommand = "--"
-  val EarlyCommandBrief = (s"$EarlyCommand<command>", "Schedules a command to run before other commands on startup.")
+  val EarlyCommand = "early"
+  val EarlyCommandBrief = (s"$EarlyCommand(<command>)", "Schedules a command to run before other commands on startup.")
   val EarlyCommandDetailed =
-    s"""$EarlyCommand<command>
+    s"""$EarlyCommand(<command>)
 
 	Schedules an early command, which will be run before other commands on the command line.
-	The order is preserved between all early commands, so `sbt --a --b` executes `a` and `b` in order.
+	The order is preserved between all early commands, so `sbt "early(a)" "early(b)"` executes `a` and `b` in order.
 """
 
   def ReadCommand = "<"

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -52,7 +52,7 @@ object BasicCommandStrings {
 	This will be used as the default level for logging from commands, settings, and tasks.
 	Any explicit `logLevel` configuration in a project overrides this setting.
 
-${runEarly(level.toString)}
+-$level
 
 	Sets the global logging level as described above, but does so before any other commands are executed on startup, including project loading.
 	This is useful as a startup option:
@@ -62,7 +62,9 @@ ${runEarly(level.toString)}
 
   def runEarly(command: String) = s"$EarlyCommand($command)"
   private[sbt] def isEarlyCommand(s: String): Boolean = {
-    s.startsWith(EarlyCommand + "(") && s.endsWith(")")
+    val levelOptions = Level.values.toSeq map { "-" + _ }
+    (s.startsWith(EarlyCommand + "(") && s.endsWith(")")) ||
+      (levelOptions contains s)
   }
 
   val EarlyCommand = "early"

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -24,7 +24,10 @@ object BasicCommands {
   def ignore = Command.command(FailureWall)(idFun)
 
   def early = Command.arb(earlyParser, earlyHelp) { (s, other) => other :: s }
-  private[this] def earlyParser = (s: State) => token(EarlyCommand).flatMap(_ => otherCommandParser(s))
+  private[this] def earlyParser = (s: State) =>
+    token(EarlyCommand + "(") flatMap { _ =>
+      otherCommandParser(s) <~ token(")")
+    }
   private[this] def earlyHelp = Help(EarlyCommand, EarlyCommandBrief, EarlyCommandDetailed)
 
   def help = Command.make(HelpCommand, helpBrief, helpDetailed)(helpParser)

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -1,5 +1,6 @@
 package sbt
 
+import sbt.util.Level
 import sbt.internal.util.{ AttributeKey, FullReader }
 import sbt.internal.util.complete.{ Completion, Completions, DefaultParsers, History => CHistory, HistoryCommands, Parser, TokenCompletions }
 import sbt.internal.util.Types.{ const, idFun }
@@ -24,10 +25,15 @@ object BasicCommands {
   def ignore = Command.command(FailureWall)(idFun)
 
   def early = Command.arb(earlyParser, earlyHelp) { (s, other) => other :: s }
-  private[this] def earlyParser = (s: State) =>
-    token(EarlyCommand + "(") flatMap { _ =>
+  private[this] def levelParser: Parser[String] =
+    token(Level.Debug.toString) | token(Level.Info.toString) | token(Level.Warn.toString) | token(Level.Error.toString)
+  private[this] def earlyParser: State => Parser[String] = (s: State) =>
+    (token(EarlyCommand + "(") flatMap { _ =>
       otherCommandParser(s) <~ token(")")
-    }
+    }) |
+      (token("-") flatMap { _ =>
+        levelParser
+      })
   private[this] def earlyHelp = Help(EarlyCommand, EarlyCommandBrief, EarlyCommandDetailed)
 
   def help = Command.make(HelpCommand, helpBrief, helpDetailed)(helpParser)

--- a/sbt/src/sbt-test/actions/early-command/build.sbt
+++ b/sbt/src/sbt-test/actions/early-command/build.sbt
@@ -1,0 +1,1 @@
+lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/actions/early-command/test
+++ b/sbt/src/sbt-test/actions/early-command/test
@@ -1,1 +1,2 @@
+> -error
 > early(error)

--- a/sbt/src/sbt-test/actions/early-command/test
+++ b/sbt/src/sbt-test/actions/early-command/test
@@ -1,0 +1,1 @@
+> early(error)


### PR DESCRIPTION
Fixes #2734, Ref #1041

e93c4450a1a06fe6c67df821c65fea302cecca84 added a feature called _early command_, which uses `--` as a prefix to denote some commands that runs ahead of session loading. While the feature might be useful especially for logging, `--` is too useful just for this purpose.

In addition, this adds log level commands with single `-`, such as `-error` to treat them as early commands.

/review @dwijnand, @Duhemm 
