### PR TITLE
[sbt 1.0] Quieter ivyLoggingLevel for CI

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1181,7 +1181,11 @@ object Classpaths {
     dependencyOverrides :== Set.empty,
     libraryDependencies :== Nil,
     excludeDependencies :== Nil,
-    ivyLoggingLevel :== UpdateLogging.Default,
+    ivyLoggingLevel :== {
+      // This will suppress "Resolving..." logs on Jenkins and Travis.
+      if (sys.env.get("BUILD_NUMBER").isDefined || sys.env.get("CI").isDefined) UpdateLogging.Quiet
+      else UpdateLogging.Default
+    },
     ivyXML :== NodeSeq.Empty,
     ivyValidate :== false,
     moduleConfigurations :== Nil,

--- a/notes/1.0.0/quieter-log.md
+++ b/notes/1.0.0/quieter-log.md
@@ -1,0 +1,5 @@
+### Improvements
+
+- `ivyLoggingLevel` is dropped to `UpdateLogging.Quiet` when CI environment is detected. [@eed3si9n][@eed3si9n]
+
+  [@eed3si9n]: https://github.com/eed3si9n


### PR DESCRIPTION
`ivyLoggingLevel` is dropped to `UpdateLogging.Quiet` when Jenkins or
Travis is detected.

/review @dwijnand, @Duhemm 
