### PR TITLE
[sbt 1.0] Improve `show` when key returns a `Seq`

### DIFF
--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -22,8 +22,9 @@ object Aggregation {
   def defaultShow(state: State, showTasks: Boolean): ShowConfig = ShowConfig(settingValues = true, taskValues = showTasks, s => state.log.info(s), success = true)
   def printSettings(xs: Seq[KeyValue[_]], print: String => Unit)(implicit display: Show[ScopedKey[_]]) =
     xs match {
-      case KeyValue(_, x) :: Nil => print(x.toString)
-      case _                     => xs foreach { case KeyValue(key, value) => print(display(key) + "\n\t" + value.toString) }
+      case KeyValue(_, x: Seq[_]) :: Nil => print(x.mkString("* ", "\n* ", ""))
+      case KeyValue(_, x) :: Nil         => print(x.toString)
+      case _                             => xs foreach { case KeyValue(key, value) => print(display(key) + "\n\t" + value.toString) }
     }
   type Values[T] = Seq[KeyValue[T]]
   type AnyKeys = Values[_]


### PR DESCRIPTION
This changes the output to:

```
> show externalDependencyClasspath
[info] Updating {file:/xxx/hello/}root...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] * Attributed(/Users/xxx/.sbt/boot/scala-2.11.8/lib/scala-library.jar)
[info] * Attributed(/Users/xxx/.ivy2/cache/commons-io/commons-io/jars/commons-io-
2.4.jar)
```

/review @dwijnand, @Duhemm 
