### PR TITLE
SD-232 Recycle classloaders to be anti-hostile to JIT

### DIFF
--- a/main/actions/src/main/scala/sbt/Compiler.scala
+++ b/main/actions/src/main/scala/sbt/Compiler.scala
@@ -9,6 +9,7 @@ import xsbti.compile.{ CompileOrder, GlobalsCache }
 import CompileOrder.{ JavaThenScala, Mixed, ScalaThenJava }
 import compiler._
 import inc._
+import sbt.classpath.ClassLoaderCache
 import Locate.DefinesClass
 import java.io.File
 
@@ -31,6 +32,8 @@ object Compiler {
         case x: JavaToolWithNewInterface => Some(x.newJavac)
         case _                           => None
       }
+    def withClassLoaderCache(classLoaderCache: ClassLoaderCache) =
+      copy(scalac = scalac.withClassLoaderCache(classLoaderCache))
   }
   /** The previous source dependency analysis result from compilation. */
   final case class PreviousAnalysis(analysis: Analysis, setup: Option[CompileSetup])

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -265,12 +265,15 @@ object Defaults extends BuildCommon {
       if (plugin) scalaBase / ("sbt-" + sbtv) else scalaBase
     }
 
-  def compilersSetting = compilers := {
-    val compilers = Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value,
-      bootIvyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
-    if (!java.lang.Boolean.getBoolean("sbt.disable.interface.classloader.cache"))
-      compilers.scalac.setClassLoaderCache(state.value.classLoaderCache)
-    compilers
+  def compilersSetting = {
+    compilers := {
+      val compilers = Compiler.compilers(
+        scalaInstance.value, classpathOptions.value, javaHome.value, bootIvyConfiguration.value,
+        scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
+      if (java.lang.Boolean.getBoolean("sbt.disable.interface.classloader.cache")) compilers else {
+        compilers.withClassLoaderCache(state.value.classLoaderCache)
+      }
+    }
   }
 
   lazy val configTasks = docTaskSettings(doc) ++ inTask(compile)(compileInputsSettings) ++ configGlobal ++ compileAnalysisSettings ++ Seq(

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -265,8 +265,13 @@ object Defaults extends BuildCommon {
       if (plugin) scalaBase / ("sbt-" + sbtv) else scalaBase
     }
 
-  def compilersSetting = compilers := Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value,
-    bootIvyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
+  def compilersSetting = compilers := {
+    val compilers = Compiler.compilers(scalaInstance.value, classpathOptions.value, javaHome.value,
+      bootIvyConfiguration.value, scalaCompilerBridgeSource.value)(appConfiguration.value, streams.value.log)
+    if (!java.lang.Boolean.getBoolean("sbt.disable.interface.classloader.cache"))
+      compilers.scalac.setClassLoaderCache(state.value.classLoaderCache)
+    compilers
+  }
 
   lazy val configTasks = docTaskSettings(doc) ++ inTask(compile)(compileInputsSettings) ++ configGlobal ++ compileAnalysisSettings ++ Seq(
     compile := compileTask.value,


### PR DESCRIPTION
The compiler interface subclasses `scala.tools.nsc.Global`,
and loading this new subclass before each `compile` task forces
HotSpot JIT to deoptimize larges swathes of compiled code. It's
a bit like SBT has rigged the dice to always descend the longest
ladder in a game of Snakes and Ladders.

The slowdown seems to be larger with Scala 2.12. There are a number
of variables at play, but I think the main factor here is that
we now rely on JIT to devirtualize calls to final methods in traits
whereas we used to emit static calls. JIT does a good job at this,
so long as classloading doesn't undo that good work.

This commit extends the existing `ClassLoaderCache` to encompass
the classloader that includes the compiler interface JAR. I've
resorted to adding a var to `AnalyzingCompiler` to inject the
dependency to get the cache to the spot I need it without binary
incompatible changes to the intervening method signatures.

Here are a few numbers showing the speedup of the peak (warmed up) performance:

| Codebase | Scala Version | Direct | SBT 0.13.12 | This PR |
| --- | --- | --- | --- | --- |
| src/compiler | 2.12.0-SNAPSHOT | 19s | 32s (1.68x) | 24s (1.26x) |
| scalap | 2.11.8 | 1.19 s | 1.72s (1.45x) | 1.39s (1.17x) |
| scalap | 2.12.0-SNAPSHOT | 1.02 s | 1.95s (1.91x) | 1.20s (1.17x) |
