### PR TITLE
FPORT: Add extraProjects adn derivedProjects. Fixes #2532

### DIFF
--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -93,6 +93,12 @@ abstract class AutoPlugin extends Plugins.Basic with PluginsFunctions {
 
   // TODO?: def commands: Seq[Command]
 
+  /** The [[Project]]s to add to the current build. */
+  def extraProjects: Seq[Project] = Nil
+
+  /** The [[Project]]s to add to the current build based on an existing project. */
+  def derivedProjects(proj: ProjectDefinition[_]): Seq[Project] = Nil
+
   private[sbt] def unary_! : Exclude = Exclude(this)
 
 

--- a/sbt/src/sbt-test/project/extra-projects/project/DatabasePlugin.scala
+++ b/sbt/src/sbt-test/project/extra-projects/project/DatabasePlugin.scala
@@ -1,0 +1,15 @@
+import sbt._, syntax._, Keys._
+
+object DatabasePlugin extends AutoPlugin {
+  override def requires: Plugins = sbt.plugins.JvmPlugin
+  override def trigger = noTrigger
+
+  object autoImport {
+    lazy val databaseName = settingKey[String]("name of the database")
+  }
+  import autoImport._
+  override def projectSettings: Seq[Setting[_]] =
+    Seq(
+      databaseName := "something"
+    )
+}

--- a/sbt/src/sbt-test/project/extra-projects/project/ExtraProjectPluginExample.scala
+++ b/sbt/src/sbt-test/project/extra-projects/project/ExtraProjectPluginExample.scala
@@ -1,0 +1,12 @@
+import sbt._, syntax._, Keys._
+
+object ExtraProjectPluginExample extends AutoPlugin {
+  override def extraProjects: Seq[Project] =
+    List("foo", "bar", "baz") map generateProject
+
+  def generateProject(id: String): Project =
+    Project(id, file(id)).
+      settings(
+        name := id
+      )
+}

--- a/sbt/src/sbt-test/project/extra-projects/project/ExtraProjectPluginExample2.scala
+++ b/sbt/src/sbt-test/project/extra-projects/project/ExtraProjectPluginExample2.scala
@@ -1,0 +1,18 @@
+import sbt._, syntax._, Keys._
+
+object ExtraProjectPluginExample2 extends AutoPlugin {
+  // Enable this plugin by default
+  override def requires: Plugins = sbt.plugins.CorePlugin
+  override def trigger = allRequirements
+
+  override def derivedProjects(proj: ProjectDefinition[_]): Seq[Project] =
+    // Make sure to exclude project extras to avoid recursive generation
+    if (proj.projectOrigin != ProjectOrigin.DerivedProject) {
+      val id = proj.id + "1"
+      Seq(
+        Project(id, file(id)).
+          enablePlugins(DatabasePlugin)
+      )
+    }
+    else Nil
+}

--- a/sbt/src/sbt-test/project/extra-projects/test
+++ b/sbt/src/sbt-test/project/extra-projects/test
@@ -1,0 +1,5 @@
+> bar/compile
+
+> foo1/compile
+
+> foo1/databaseName


### PR DESCRIPTION
This adds support to generate synthetic subprojects from an auto plugin.

In addition, a method called `projectOrigin` is added to distinguish Organic, BuildExtra, ProjectExtra, and GenericRoot.

Forward-port of #2717 and #2738
