### PR TITLE
Lazily concatenate failed errors for completion

### DIFF
--- a/util/complete/src/main/scala/sbt/complete/Parser.scala
+++ b/util/complete/src/main/scala/sbt/complete/Parser.scala
@@ -559,8 +559,8 @@ trait ParserMain {
   def seq[T](p: Seq[Parser[T]]): Parser[Seq[T]] = seq0(p, Nil)
   def seq0[T](p: Seq[Parser[T]], errors: => Seq[String]): Parser[Seq[T]] =
     {
-      val (newErrors, valid) = separate(p) { case Invalid(f) => Left(f.errors); case ok => Right(ok) }
-      def combinedErrors = errors ++ newErrors.flatten
+      val (newErrors, valid) = separate(p) { case Invalid(f) => Left(f.errors _); case ok => Right(ok) }
+      def combinedErrors = errors ++ newErrors.flatMap(_())
       if (valid.isEmpty) invalid(combinedErrors) else new ParserSeq(valid, combinedErrors)
     }
 


### PR DESCRIPTION
- Fixes [sbt/sbt#2781]
- When using `<TAB>` completion the failed errors were always
  computed for mathcing projects even if there was no failure,
  leading to excessive computation of Levenshtein distances
  and a large lag (seconds) on builds with many matching
  projects.
