### PR TITLE
Show deprecations in build.sbt

### DIFF
--- a/main/settings/src/main/scala/sbt/Structure.scala
+++ b/main/settings/src/main/scala/sbt/Structure.scala
@@ -40,9 +40,7 @@ sealed abstract class SettingKey[T] extends ScopedTaskable[T] with KeyedInitiali
   final def :=(v: T): Setting[T] = macro std.TaskMacro.settingAssignMacroImpl[T]
   final def +=[U](v: U)(implicit a: Append.Value[T, U]): Setting[T] = macro std.TaskMacro.settingAppend1Impl[T, U]
   final def ++=[U](vs: U)(implicit a: Append.Values[T, U]): Setting[T] = macro std.TaskMacro.settingAppendNImpl[T, U]
-  @deprecated("Use `lhs += { x.value }`", "0.13.13")
   final def <+=[V](v: Initialize[V])(implicit a: Append.Value[T, V]): Setting[T] = macro std.TaskMacro.settingAppend1Position[T, V]
-  @deprecated("Use `lhs ++= { x.value }`", "0.13.13")
   final def <++=[V](vs: Initialize[V])(implicit a: Append.Values[T, V]): Setting[T] = macro std.TaskMacro.settingAppendNPosition[T, V]
   final def -=[U](v: U)(implicit r: Remove.Value[T, U]): Setting[T] = macro std.TaskMacro.settingRemove1Impl[T, U]
   final def --=[U](vs: U)(implicit r: Remove.Values[T, U]): Setting[T] = macro std.TaskMacro.settingRemoveNImpl[T, U]
@@ -73,9 +71,7 @@ sealed abstract class TaskKey[T] extends ScopedTaskable[T] with KeyedInitialize[
 
   def +=[U](v: U)(implicit a: Append.Value[T, U]): Setting[Task[T]] = macro std.TaskMacro.taskAppend1Impl[T, U]
   def ++=[U](vs: U)(implicit a: Append.Values[T, U]): Setting[Task[T]] = macro std.TaskMacro.taskAppendNImpl[T, U]
-  @deprecated("Use `lhs += { x.value }`", "0.13.13")
   def <+=[V](v: Initialize[Task[V]])(implicit a: Append.Value[T, V]): Setting[Task[T]] = macro std.TaskMacro.taskAppend1Position[T, V]
-  @deprecated("Use `lhs ++= { x.value }`", "0.13.13")
   def <++=[V](vs: Initialize[Task[V]])(implicit a: Append.Values[T, V]): Setting[Task[T]] = macro std.TaskMacro.taskAppendNPosition[T, V]
   final def -=[U](v: U)(implicit r: Remove.Value[T, U]): Setting[Task[T]] = macro std.TaskMacro.taskRemove1Impl[T, U]
   final def --=[U](vs: U)(implicit r: Remove.Values[T, U]): Setting[Task[T]] = macro std.TaskMacro.taskRemoveNImpl[T, U]
@@ -157,10 +153,6 @@ object Scoped {
      * @param app value to bind to this key
      * @return setting binding this key to the given value.
      */
-    @deprecated("""Use `key := { x.value }` or `key ~= (old => { newValue })`.
-                  |The RHS of `<<=` takes an `Initialize[_]` expression, which can be converted to `:=` style
-                  |by wrapping the expression in parenthesis, and calling `.value` at the end.
-                  |For example, `key := (key.dependsOn(compile in Test)).value`.""".stripMargin, "0.13.13")
     final def <<=(app: Initialize[S]): Setting[S] = macro std.TaskMacro.settingAssignPosition[S]
 
     /** Internally used function for setting a value along with the `.sbt` file location where it is defined. */
@@ -207,10 +199,6 @@ object Scoped {
     def :=(v: S): Setting[Task[S]] = macro std.TaskMacro.taskAssignMacroImpl[S]
     def ~=(f: S => S): Setting[Task[S]] = macro std.TaskMacro.taskTransformPosition[S]
 
-    @deprecated("""Use `key := { x.value }` or `key ~= (old => { newValue })`.
-                  |The RHS of `<<=` takes an `Initialize[_]` expression, which can be converted to `:=` style
-                  |by wrapping the expression in parenthesis, and calling `.value` at the end.
-                  |For example, `key := (key.dependsOn(compile in Test)).value`.""".stripMargin, "0.13.13")
     def <<=(app: Initialize[Task[S]]): Setting[Task[S]] = macro std.TaskMacro.itaskAssignPosition[S]
     def set(app: Initialize[Task[S]], source: SourcePosition): Setting[Task[S]] = Def.setting(scopedKey, app, source)
     def transform(f: S => S, source: SourcePosition): Setting[Task[S]] = set(scopedKey(_ map f), source)

--- a/main/settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main/settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -72,13 +72,11 @@ object TaskMacro {
   final val TransformInitName = "transform"
   final val InputTaskCreateDynName = "createDyn"
   final val InputTaskCreateFreeName = "createFree"
-  final val append1Migration = "Use `lhs += { x.value }`."
-  final val appendNMigration = "Use `lhs ++= { x.value }`."
+  final val append1Migration = "`<+=` operator is deprecated. Use `lhs += { x.value }`."
+  final val appendNMigration = "`<++=` operator is deprecated. Use `lhs ++= { x.value }`."
   final val assignMigration =
-    """Use `key := { x.value }` or `key ~= (old => { newValue })`.
-      |The RHS of `<<=` takes an `Initialize[_]` expression, which can be converted to `:=` style
-      |by wrapping the expression in parenthesis, and calling `.value` at the end.
-      |For example, `key := (key.dependsOn(compile in Test)).value`.""".stripMargin
+    """`<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
+      |See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html""".stripMargin
 
   def taskMacroImpl[T: c.WeakTypeTag](c: Context)(t: c.Expr[T]): c.Expr[Initialize[Task[T]]] =
     Instance.contImpl[T, Id](c, FullInstance, FullConvert, MixedBuilder)(Left(t), Instance.idTransform[c.type])

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1009,7 +1009,7 @@ object Defaults extends BuildCommon {
   lazy val baseTasks: Seq[Setting[_]] = projectTasks ++ packageBase
 
   lazy val baseClasspaths: Seq[Setting[_]] = Classpaths.publishSettings ++ Classpaths.baseSettings
-  lazy val configSettings: Seq[Setting[_]] = Classpaths.configSettings ++ configTasks ++ configPaths ++ packageConfig ++ Classpaths.compilerPluginConfig
+  lazy val configSettings: Seq[Setting[_]] = Classpaths.configSettings ++ configTasks ++ configPaths ++ packageConfig ++ Classpaths.compilerPluginConfig ++ deprecationSettings
 
   lazy val compileSettings: Seq[Setting[_]] = configSettings ++ (mainRunMainTask +: mainRunTask +: addBaseSources) ++ Classpaths.addUnmanagedLibrary
   lazy val testSettings: Seq[Setting[_]] = configSettings ++ testTasks
@@ -1028,6 +1028,17 @@ object Defaults extends BuildCommon {
       baseDirectory := thisProject.value.base,
       target := baseDirectory.value / "target"
     )
+  // build.sbt is treated a Scala source of metabuild, so to enable deprecation flag on build.sbt we set the option here.
+  lazy val deprecationSettings: Seq[Setting[_]] =
+    inConfig(Compile)(Seq(
+      scalacOptions := {
+        val old = scalacOptions.value
+        val existing = old.toSet
+        val d = "-deprecation"
+        if (sbtPlugin.value && !existing(d)) d :: old.toList
+        else old
+      }
+    ))
   @deprecated("Default settings split into coreDefaultSettings and IvyModule/JvmModule plugins.", "0.13.2")
   lazy val defaultSettings: Seq[Setting[_]] = projectBaseSettings ++ defaultConfigs
 

--- a/main/src/main/scala/sbt/Load.scala
+++ b/main/src/main/scala/sbt/Load.scala
@@ -847,7 +847,7 @@ object Load {
       (dir * -GlobFilter(DefaultTargetName)).get.nonEmpty
     }
   def noPlugins(dir: File, config: sbt.LoadBuildConfiguration): sbt.LoadedPlugins =
-    loadPluginDefinition(dir, config, PluginData(config.globalPluginClasspath, None, None))
+    loadPluginDefinition(dir, config, PluginData(config.globalPluginClasspath, Nil, None, None, Nil))
   def buildPlugins(dir: File, s: State, config: sbt.LoadBuildConfiguration): sbt.LoadedPlugins =
     loadPluginDefinition(dir, config, buildPluginDefinition(dir, s, config))
 


### PR DESCRIPTION
Fixes #2783
Ref #2716

``` scala
[info] Done updating.
/xxx/build.sbt:21: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
    foo <<= (test in Test)
        ^
/xxx/build.sbt:13: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
    foo <<= (test in Test),
        ^
/xxx/build.sbt:15: warning: `<++=` operator is deprecated. Use `lhs ++= { x.value }`.
    bar <++= (scalacOptions in Compile)
        ^
/xxx/build.sbt:24: warning: method getName in object X is deprecated: Don't use
name := getName()
        ^
[info] Set current project to foo (in build file:/xxx/)
foo>
```
