### PR TITLE
Adding column number information into sbt output

### DIFF
--- a/compile/src/main/scala/sbt/LoggerReporter.scala
+++ b/compile/src/main/scala/sbt/LoggerReporter.scala
@@ -93,7 +93,8 @@ class LoggerReporter(maximumErrors: Int, log: Logger, sourcePositionMapper: Posi
       log(msg)
     else {
       val sourcePrefix = m2o(pos.sourcePath).getOrElse("")
-      val lineNumberString = m2o(pos.line).map(":" + _ + ":").getOrElse(":") + " "
+      val columnNumber = m2o(pos.pointer).map(_.toInt + 1).getOrElse(1)
+      val lineNumberString = m2o(pos.line).map(":" + _ + ":" + columnNumber + ":").getOrElse(":") + " "
       log(sourcePrefix + lineNumberString + msg)
       val lineContent = pos.lineContent
       if (!lineContent.isEmpty) {

--- a/notes/0.13.13/column-info-in-output.md
+++ b/notes/0.13.13/column-info-in-output.md
@@ -1,0 +1,13 @@
+### Bug fixes
+
+### Improvements
+
+Currently sbt output lacks column number information easily accessible for cli tools (for example emacs' sbt-mode have this [hack](https://github.com/ensime/emacs-sbt-mode/pull/74/files) to allow jump to proper place in a file when navigating from sbt output compilation error messages).
+
+This change is adding column number just behind line number
+
+```
+[error] /Users/me/column/src/main/scala/Column.scala:5:31: type mismatch;
+```
+
+### Fixes with compatibility implications


### PR DESCRIPTION
Currently sbt output lacks column number information easily
accessible for cli tools.

This change is adding column number just behind line number

```
[error] /Users/me/column/src/main/scala/Column.scala:5:31: type mismatch;
```
