### PR TITLE
Add new param to javadoc.run due to interface change

### DIFF
--- a/main-actions/src/main/scala/sbt/DotGraph.scala
+++ b/main-actions/src/main/scala/sbt/DotGraph.scala
@@ -31,7 +31,7 @@ object DotGraph {
     def file(name: String) = new File(outputDir, name)
     IO.createDirectory(outputDir)
     generateGraph(file("int-class-deps"), "dependencies", relations.internalClassDep, identity[String], identity[String])
-    generateGraph(file("binary-dependencies"), "externalDependencies", relations.binaryDep, externalToString, sourceToString)
+    generateGraph(file("binary-dependencies"), "externalDependencies", relations.libraryDep, externalToString, sourceToString)
   }
 
   def generateGraph[K, V](file: File, graphName: String, relation: Relation[K, V],

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -72,6 +72,7 @@ import sbt.internal.inc.{
   Locate,
   LoggerReporter,
   MixedAnalyzingCompiler,
+  NoopClassFileManager,
   ScalaInstance,
   ClasspathOptionsUtil
 }
@@ -853,7 +854,7 @@ object Defaults extends BuildCommon {
           runDoc(srcs, cp, out, options, maxErrors.value, s.log)
         case (_, true) =>
           val javadoc = sbt.inc.Doc.cachedJavadoc(label, s.cacheDirectory / "java", cs.javaTools)
-          javadoc.run(srcs.toList, cp, out, javacOptions.value.toList, s.log, reporter)
+          javadoc.run(srcs.toList, cp, out, javacOptions.value.toList, new NoopClassFileManager(), s.log, reporter)
         case _ => () // do nothing
       }
       out

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -57,6 +57,7 @@ import xsbti.compile.{
   CompileResult,
   DefinesClass,
   IncOptionsUtil,
+  IncToolOptionsUtil,
   Inputs,
   MiniSetup,
   PerClasspathEntryLookup,
@@ -72,7 +73,6 @@ import sbt.internal.inc.{
   Locate,
   LoggerReporter,
   MixedAnalyzingCompiler,
-  NoopClassFileManager,
   ScalaInstance,
   ClasspathOptionsUtil
 }
@@ -855,7 +855,7 @@ object Defaults extends BuildCommon {
           runDoc(srcs, cp, out, options, maxErrors.value, s.log)
         case (_, true) =>
           val javadoc = sbt.inc.Doc.cachedJavadoc(label, s.cacheDirectory / "java", cs.javaTools)
-          javadoc.run(srcs.toList, cp, out, javacOptions.value.toList, new NoopClassFileManager(), s.log, reporter)
+          javadoc.run(srcs.toList, cp, out, javacOptions.value.toList, IncToolOptionsUtil.defaultIncToolOptions(), s.log, reporter)
         case _ => () // do nothing
       }
       out

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val ioVersion = "1.0.0-M6"
   val utilVersion = "0.1.0-M14"
   val librarymanagementVersion = "0.1.0-X1"
-  val zincVersion = "1.0.0-X2-SNAPSHOT-28dadf4c1caac6fe79989420edd0bc03ce73a4f5"
+  val zincVersion = "1.0.0-X5"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   lazy val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val ioVersion = "1.0.0-M6"
   val utilVersion = "0.1.0-M14"
   val librarymanagementVersion = "0.1.0-X1"
-  val zincVersion = "1.0.0-X3"
+  val zincVersion = "1.0.0-X2-SNAPSHOT-28dadf4c1caac6fe79989420edd0bc03ce73a4f5"
   lazy val sbtIO = "org.scala-sbt" %% "io" % ioVersion
   lazy val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   lazy val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion

--- a/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/inc-package-class-dependency/build.sbt
@@ -6,5 +6,5 @@ TaskKey[Unit]("verify-binary-deps") := {
   val base = baseDirectory.value
   val nestedPkgClass = classDir / "test/nested.class"
   val fooSrc = base / "src/main/scala/test/nested/Foo.scala"
-  assert(!a.relations.binaryDeps(fooSrc).contains(nestedPkgClass), a.relations.toString)
+  assert(!a.relations.libraryDeps(fooSrc).contains(nestedPkgClass), a.relations.toString)
 }


### PR DESCRIPTION
This combined with https://github.com/sbt/zinc/pull/186 should fix https://jenkins.scala-sbt.org:8592/job/sbt-standalone-build/40/consoleFull

Test:
- `sbt test` succeeded, previously fail with above error.
