### PR TITLE
Use sbt-giter8-resolver 0.1.2

### DIFF
--- a/main/src/main/scala/sbt/plugins/Giter8ResolverPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/Giter8ResolverPlugin.scala
@@ -13,7 +13,7 @@ object Giter8TemplatePlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Setting[_]] =
     Seq(
       templateResolverInfos +=
-        TemplateResolverInfo(ModuleID("org.scala-sbt.sbt-giter8-resolver", "sbt-giter8-resolver", "0.1.0") cross CrossVersion.binary,
+        TemplateResolverInfo(ModuleID("org.scala-sbt.sbt-giter8-resolver", "sbt-giter8-resolver", "0.1.1") cross CrossVersion.binary,
           "sbtgiter8resolver.Giter8TemplateResolver")
     )
 }

--- a/main/src/main/scala/sbt/plugins/Giter8ResolverPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/Giter8ResolverPlugin.scala
@@ -13,7 +13,7 @@ object Giter8TemplatePlugin extends AutoPlugin {
   override lazy val globalSettings: Seq[Setting[_]] =
     Seq(
       templateResolverInfos +=
-        TemplateResolverInfo(ModuleID("org.scala-sbt.sbt-giter8-resolver", "sbt-giter8-resolver", "0.1.1") cross CrossVersion.binary,
+        TemplateResolverInfo(ModuleID("org.scala-sbt.sbt-giter8-resolver", "sbt-giter8-resolver", "0.1.2") cross CrossVersion.binary,
           "sbtgiter8resolver.Giter8TemplateResolver")
     )
 }


### PR DESCRIPTION
sbt-giter8-resolver has recently been updated to v0.1.1. This PR updates the version used by sbt from 0.1.0 to 0.1.1

