### PR TITLE
Apply scalaVersion enforcement to Compile related configs

### DIFF
--- a/ivy/src/main/scala/sbt/Configuration.scala
+++ b/ivy/src/main/scala/sbt/Configuration.scala
@@ -51,6 +51,15 @@ object Configurations {
   private[sbt] def DefaultConfiguration(mavenStyle: Boolean) = if (mavenStyle) DefaultMavenConfiguration else DefaultIvyConfiguration
   private[sbt] def defaultConfiguration(mavenStyle: Boolean) = if (mavenStyle) Configurations.Compile else Configurations.Default
   private[sbt] def removeDuplicates(configs: Iterable[Configuration]) = Set(scala.collection.mutable.Map(configs.map(config => (config.name, config)).toSeq: _*).values.toList: _*)
+
+  /** Returns true if the configuration should be under the influence of scalaVersion. */
+  private[sbt] def underScalaVersion(c: Configuration): Boolean =
+    c match {
+      case Default | Compile | IntegrationTest | Provided | Runtime | Test | Optional |
+        CompilerPlugin | CompileInternal | RuntimeInternal | TestInternal => true
+      case config =>
+        config.extendsConfigs exists underScalaVersion
+    }
 }
 /** Represents an Ivy configuration. */
 final case class Configuration(name: String, description: String, isPublic: Boolean, extendsConfigs: List[Configuration], transitive: Boolean) {

--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -49,24 +49,28 @@ final case class IvyScala(scalaFullVersion: String, scalaBinaryVersion: String, 
 
 private object IvyScala {
   /** Performs checks/adds filters on Scala dependencies (if enabled in IvyScala). */
-  def checkModule(module: DefaultModuleDescriptor, conf: String, log: Logger)(check: IvyScala): Unit = {
+  def checkModule(module: DefaultModuleDescriptor, conf: String, scalaVersionConfigs: Vector[String], log: Logger)(check: IvyScala): Unit = {
     if (check.checkExplicit)
       checkDependencies(module, check.scalaOrganization, check.scalaBinaryVersion, check.configurations, log)
     if (check.filterImplicit)
       excludeScalaJars(module, check.configurations)
     if (check.overrideScalaVersion)
-      overrideScalaVersion(module, check.scalaOrganization, check.scalaFullVersion)
+      overrideScalaVersion(module, check.scalaOrganization, check.scalaFullVersion, scalaVersionConfigs)
   }
 
-  class OverrideScalaMediator(scalaOrganization: String, scalaVersion: String) extends DependencyDescriptorMediator {
+  class OverrideScalaMediator(scalaOrganization: String, scalaVersion: String, scalaVersionConfigs0: Vector[String]) extends DependencyDescriptorMediator {
+    private[this] val scalaVersionConfigs = scalaVersionConfigs0.toSet
     def mediate(dd: DependencyDescriptor): DependencyDescriptor = {
+      // Mediate only for the dependencies in scalaVersion configurations. https://github.com/sbt/sbt/issues/2786
+      def configQualifies: Boolean =
+        (dd.getModuleConfigurations exists { scalaVersionConfigs })
       val transformer =
         new NamespaceTransformer {
           def transform(mrid: ModuleRevisionId): ModuleRevisionId = {
             if (mrid == null) mrid
             else
               mrid.getName match {
-                case name @ (CompilerID | LibraryID | ReflectID | ActorsID | ScalapID) =>
+                case name @ (CompilerID | LibraryID | ReflectID | ActorsID | ScalapID) if configQualifies =>
                   ModuleRevisionId.newInstance(scalaOrganization, name, mrid.getBranch, scalaVersion, mrid.getQualifiedExtraAttributes)
                 case _ => mrid
               }
@@ -79,8 +83,8 @@ private object IvyScala {
     }
   }
 
-  def overrideScalaVersion(module: DefaultModuleDescriptor, organization: String, version: String): Unit = {
-    val mediator = new OverrideScalaMediator(organization, version)
+  def overrideScalaVersion(module: DefaultModuleDescriptor, organization: String, version: String, scalaVersionConfigs: Vector[String]): Unit = {
+    val mediator = new OverrideScalaMediator(organization, version, scalaVersionConfigs)
     module.addDependencyDescriptorMediator(new ModuleId(Organization, "*"), ExactPatternMatcher.INSTANCE, mediator)
     if (organization != Organization)
       module.addDependencyDescriptorMediator(new ModuleId(organization, "*"), ExactPatternMatcher.INSTANCE, mediator)

--- a/ivy/src/test/scala/ScalaOverrideTest.scala
+++ b/ivy/src/test/scala/ScalaOverrideTest.scala
@@ -14,10 +14,12 @@ object ScalaOverrideTest extends Specification {
   val OtherOrgID = "other.org"
 
   def check(org0: String, version0: String)(org1: String, name1: String, version1: String) = {
-    val osm = new OverrideScalaMediator(org0, version0)
+    val scalaConfigs = Configurations.default.toVector filter { Configurations.underScalaVersion } map { _.name }
+    val osm = new OverrideScalaMediator(org0, version0, scalaConfigs)
 
     val mrid = ModuleRevisionId.newInstance(org1, name1, version1)
     val dd = new DefaultDependencyDescriptor(mrid, false)
+    dd.addDependencyConfiguration("compile", "compile")
 
     val res = osm.mediate(dd)
     res.getDependencyRevisionId must_== ModuleRevisionId.newInstance(org0, name1, version0)

--- a/notes/0.13.14/ivyfix.md
+++ b/notes/0.13.14/ivyfix.md
@@ -1,0 +1,9 @@
+### Bug fixes
+
+- Fixes IllegalStateException that Ivy gets into sometimes. [#2827][2827]/[#2015][2015] by [@eed3si9n][@eed3si9n]
+
+  [2015]: https://github.com/sbt/sbt/issues/2015
+  [2827]: https://github.com/sbt/sbt/pull/2827
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: https://github.com/dwijnand
+  [@Duhemm]: https://github.com/Duhemm

--- a/notes/0.13.14/mediator_fix.md
+++ b/notes/0.13.14/mediator_fix.md
@@ -1,0 +1,9 @@
+### Bug fixes
+
+- Fixes a regression in sbt 0.13.12 that was misfiring Scala version enforcement when configuration does not extend `Compile`. [#2827][2827]/[#2786][2786] by [@eed3si9n][@eed3si9n]
+
+  [2786]: https://github.com/sbt/sbt/issues/2786
+  [2827]: https://github.com/sbt/sbt/pull/2827
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: https://github.com/dwijnand
+  [@Duhemm]: https://github.com/Duhemm

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   lazy val scala212 = "2.12.0-RC2"
 
   lazy val jline = "jline" % "jline" % "2.13"
-  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-2cf13e211b2cb31f0d3b317289dca70eca3362f6"
+  lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-48dd0744422128446aee9ac31aa356ee203cc9f4"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.50" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"
   lazy val sbtSerialization = "org.scala-sbt" %% "serialization" % "0.1.2"

--- a/sbt/src/sbt-test/dependency-management/scala-organization/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/scala-organization/build.sbt
@@ -49,6 +49,5 @@ checkDependencies := {
       m <- c.modules
       if !m.evicted
     } yield m.module.copy(extraAttributes = Map.empty)).toSet
-
   assert(resolved == expected)
 }


### PR DESCRIPTION
Fixes #2786. Ref #2634.

sbt 0.13.12 added Ivy mediator that enforces scalaOrganization and
scalaVersion for Scala toolchain artifacts.
This turns out to be a bit too aggressive because Ivy configurations
can be used as an independent dependency graph that does not rely on
the scalaVersion used by Compile configuration. Enforcing
scalaVersion in those graphs causes runtime failure.

This change checks if the configuration extends Default, Compile,
Provided, or Optional before enforcing scalaVersion.

/review @dwijnand 
