### PR TITLE
Fix support for published dotty nightly builds

### DIFF
--- a/ivy/src/main/scala/sbt/IvyScala.scala
+++ b/ivy/src/main/scala/sbt/IvyScala.scala
@@ -29,7 +29,7 @@ object ScalaArtifacts {
 
   private[sbt] def toolDependencies(org: String, version: String, isDotty: Boolean = false): Seq[ModuleID] =
     if (isDotty)
-      Seq(ModuleID(org, DottyIDPrefix, version, Some(Configurations.ScalaTool.name + "->compile"),
+      Seq(ModuleID(org, DottyIDPrefix, version, Some(Configurations.ScalaTool.name + "->default(compile)"),
         crossVersion = CrossVersion.binary))
     else
       Seq(scalaToolDependency(org, ScalaArtifacts.CompilerID, version),


### PR DESCRIPTION
Dotty nightly builds are published to maven, so they end up in
configuration "default", not "compile". We still need to look into
"compile" when dotty is published locally.

You can test this using https://github.com/smarter/dotty-example-project
by updating the sbt version used in project/build.properties and by
replacing "0.1.1-SNAPSHOT" by a nightly version like
"0.1.1-20170109-be64643-NIGHTLY" in build.sbt
