### PR TITLE
[fport] Fixes #2686 by resetting scalaVersion for updateSbtClassifiers

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1413,6 +1413,14 @@ object Classpaths {
       val pluginIDs: Vector[ModuleID] = pluginJars.flatMap(_ get moduleID.key)
       GetClassifiersModule(pid, sbtDep +: pluginIDs, Vector(Configurations.Default), classifiers.toVector)
     }).value,
+    // Redefine scalaVersion and scalaBinaryVersion specifically for the dependency graph used for updateSbtClassifiers task.
+    // to fix https://github.com/sbt/sbt/issues/2686
+    scalaVersion := appConfiguration.value.provider.scalaProvider.version,
+    scalaBinaryVersion := binaryScalaVersion(scalaVersion.value),
+    ivyScala := {
+      Some(IvyScala(scalaVersion.value, scalaBinaryVersion.value, Vector(), checkExplicit = false, filterImplicit = false,
+        overrideScalaVersion = true).withScalaOrganization(scalaOrganization.value))
+    },
     updateSbtClassifiers in TaskGlobal := (Def.task {
       val s = streams.value
       val is = ivySbt.value

--- a/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.9.2"


### PR DESCRIPTION
fport https://github.com/sbt/sbt/pull/2692

Ref #2634

updateSbtClassifiers uses an artificially created dependency graph set
in classifiersModule. The problem is that ivyScala instance is reused
from the outer scope that has the user project's scalaVersion as
demonstrated as follows:

    scala> val is = (ivyScala in updateSbtClassifiers).eval
    is: Option[sbt.IvyScala] =
Some(IvyScala(2.9.3,2.9.3,List(),true,false,true,org.scala-lang))

This change fixes #2686 by redefining ivyScala with scalaVersion and
scalaBinaryVersion scoped to updateSbtClassifiers task. The existing
scripted test was modified to reproduce the bug.

(See the guidelines for contributing, linked above)
