### PR TITLE
[sbt 1.0] Background run

### DIFF
--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -8,19 +8,20 @@ import sbt.internal.inc.AnalyzingCompiler
 import sbt.util.Logger
 
 import xsbti.compile.{ Inputs, Compilers }
+import scala.util.Try
 
 final class Console(compiler: AnalyzingCompiler) {
   /** Starts an interactive scala interpreter session with the given classpath.*/
-  def apply(classpath: Seq[File], log: Logger): Option[String] =
+  def apply(classpath: Seq[File], log: Logger): Try[Unit] =
     apply(classpath, Nil, "", "", log)
 
-  def apply(classpath: Seq[File], options: Seq[String], initialCommands: String, cleanupCommands: String, log: Logger): Option[String] =
+  def apply(classpath: Seq[File], options: Seq[String], initialCommands: String, cleanupCommands: String, log: Logger): Try[Unit] =
     apply(classpath, options, initialCommands, cleanupCommands)(None, Nil)(log)
 
-  def apply(classpath: Seq[File], options: Seq[String], loader: ClassLoader, initialCommands: String, cleanupCommands: String)(bindings: (String, Any)*)(implicit log: Logger): Option[String] =
+  def apply(classpath: Seq[File], options: Seq[String], loader: ClassLoader, initialCommands: String, cleanupCommands: String)(bindings: (String, Any)*)(implicit log: Logger): Try[Unit] =
     apply(classpath, options, initialCommands, cleanupCommands)(Some(loader), bindings)
 
-  def apply(classpath: Seq[File], options: Seq[String], initialCommands: String, cleanupCommands: String)(loader: Option[ClassLoader], bindings: Seq[(String, Any)])(implicit log: Logger): Option[String] =
+  def apply(classpath: Seq[File], options: Seq[String], initialCommands: String, cleanupCommands: String)(loader: Option[ClassLoader], bindings: Seq[(String, Any)])(implicit log: Logger): Try[Unit] =
     {
       def console0() = compiler.console(classpath, options, initialCommands, cleanupCommands, log)(loader, bindings)
       // TODO: Fix JLine

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -1,0 +1,38 @@
+package sbt
+
+import java.io.Closeable
+import sbt.util.Logger
+import Def.ScopedKey
+import sbt.internal.util.complete._
+
+abstract class BackgroundJobService extends Closeable {
+  /**
+   * Launch a background job which is a function that runs inside another thread;
+   *  killing the job will interrupt() the thread. If your thread blocks on a process,
+   *  then you should get an InterruptedException while blocking on the process, and
+   *  then you could process.destroy() for example.
+   */
+  def runInBackground(spawningTask: ScopedKey[_], state: State)(start: (Logger) => Unit): JobHandle
+  def close: Unit = ()
+  def jobs: Vector[JobHandle]
+  def stop(job: JobHandle): Unit
+  def waitFor(job: JobHandle): Unit
+}
+
+object BackgroundJobService {
+  def jobIdParser: (State, Seq[JobHandle]) => Parser[Seq[JobHandle]] = {
+    import DefaultParsers._
+    (state, handles) => {
+      val stringIdParser: Parser[Seq[String]] = Space ~> token(NotSpace examples handles.map(_.id.toString).toSet, description = "<job id>").+
+      stringIdParser.map { strings =>
+        strings.map(Integer.parseInt(_)).flatMap(id => handles.find(_.id == id))
+      }
+    }
+  }
+}
+
+abstract class JobHandle {
+  def id: Long
+  def humanReadableName: String
+  def spawningTask: ScopedKey[_]
+}

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -2,8 +2,9 @@ package sbt
 
 import java.io.Closeable
 import sbt.util.Logger
-import Def.ScopedKey
+import Def.{ ScopedKey, Classpath }
 import sbt.internal.util.complete._
+import java.io.File
 
 abstract class BackgroundJobService extends Closeable {
   /**
@@ -12,16 +13,20 @@ abstract class BackgroundJobService extends Closeable {
    *  then you should get an InterruptedException while blocking on the process, and
    *  then you could process.destroy() for example.
    */
-  def runInBackground(spawningTask: ScopedKey[_], state: State)(start: (Logger) => Unit): JobHandle
+  def runInBackground(spawningTask: ScopedKey[_], state: State)(start: (Logger, File) => Unit): JobHandle
+  /** Same as shutown. */
   def close(): Unit
+  /** Shuts down all background jobs. */
   def shutdown(): Unit
   def jobs: Vector[JobHandle]
   def stop(job: JobHandle): Unit
   def waitFor(job: JobHandle): Unit
+  /** Copies classpath to temporary directories. */
+  def copyClasspath(products: Classpath, full: Classpath, workingDirectory: File): Classpath
 }
 
 object BackgroundJobService {
-  def jobIdParser: (State, Seq[JobHandle]) => Parser[Seq[JobHandle]] = {
+  private[sbt] def jobIdParser: (State, Seq[JobHandle]) => Parser[Seq[JobHandle]] = {
     import DefaultParsers._
     (state, handles) => {
       val stringIdParser: Parser[Seq[String]] = Space ~> token(NotSpace examples handles.map(_.id.toString).toSet, description = "<job id>").+

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -13,7 +13,8 @@ abstract class BackgroundJobService extends Closeable {
    *  then you could process.destroy() for example.
    */
   def runInBackground(spawningTask: ScopedKey[_], state: State)(start: (Logger) => Unit): JobHandle
-  def close: Unit = ()
+  def close(): Unit
+  def shutdown(): Unit
   def jobs: Vector[JobHandle]
   def stop(job: JobHandle): Unit
   def waitFor(job: JobHandle): Unit

--- a/main/src/main/scala/sbt/BuildSyntax.scala
+++ b/main/src/main/scala/sbt/BuildSyntax.scala
@@ -1,0 +1,20 @@
+package sbt
+
+import sbt.internal.DslEntry
+import sbt.librarymanagement.Configuration
+import sbt.util.Eval
+
+private[sbt] trait BuildSyntax {
+  import language.experimental.macros
+  def settingKey[T](description: String): SettingKey[T] = macro std.KeyMacro.settingKeyImpl[T]
+  def taskKey[T](description: String): TaskKey[T] = macro std.KeyMacro.taskKeyImpl[T]
+  def inputKey[T](description: String): InputKey[T] = macro std.KeyMacro.inputKeyImpl[T]
+
+  def enablePlugins(ps: AutoPlugin*): DslEntry = DslEntry.DslEnablePlugins(ps)
+  def disablePlugins(ps: AutoPlugin*): DslEntry = DslEntry.DslDisablePlugins(ps)
+  def configs(cs: Configuration*): DslEntry = DslEntry.DslConfigs(cs)
+  def dependsOn(deps: Eval[ClasspathDep[ProjectReference]]*): DslEntry = DslEntry.DslDependsOn(deps)
+  // avoid conflict with `sbt.Keys.aggregate`
+  def aggregateProjects(refs: Eval[ProjectReference]*): DslEntry = DslEntry.DslAggregate(refs)
+}
+private[sbt] object BuildSyntax extends BuildSyntax

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -134,12 +134,10 @@ object Defaults extends BuildCommon {
       includeFilter in unmanagedJars :== "*.jar" | "*.so" | "*.dll" | "*.jnilib" | "*.zip",
       includeFilter in unmanagedResources :== AllPassFilter,
       fileToStore :== DefaultFileToStore,
-      bgJobService := { new DefaultBackgroundJobService() },
       bgList := { bgJobService.value.jobs },
       ps := psTask.value,
       bgStop := bgStopTask.evaluated,
-      bgWaitFor := bgWaitForTask.evaluated,
-      onUnload := { s => try onUnload.value(s) finally bgJobService.value.close() }
+      bgWaitFor := bgWaitForTask.evaluated
     )
 
   private[sbt] lazy val globalIvyCore: Seq[Setting[_]] =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -347,6 +347,8 @@ object Defaults extends BuildCommon {
     consoleQuick := consoleQuickTask.value,
     discoveredMainClasses := (compile map discoverMainClasses storeAs discoveredMainClasses xtriggeredBy compile).value,
     discoveredSbtPlugins := discoverSbtPluginNames.value,
+    // This fork options, scoped to the configuration is used for tests
+    forkOptions := forkOptionsTask.value,
     selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
     mainClass in run := (selectMainClass in run).value,
     mainClass := pickMainClassOrWarn(discoveredMainClasses.value, streams.value.log),

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -74,6 +74,7 @@ import sbt.internal.librarymanagement.{
 }
 import sbt.util.{ AbstractLogger, Level, Logger }
 import org.apache.logging.log4j.core.Appender
+import sbt.BuildSyntax._
 
 object Keys {
   val TraceValues = "-1 to disable, 0 for up to the first sbt frame, or a positive number to set the maximum number of frames shown."
@@ -238,11 +239,20 @@ object Keys {
   val trapExit = SettingKey[Boolean]("trap-exit", "If true, enables exit trapping and thread management for 'run'-like tasks.  This is currently only suitable for serially-executed 'run'-like tasks.", CSetting)
 
   val fork = SettingKey[Boolean]("fork", "If true, forks a new JVM when running.  If false, runs in the same JVM as the build.", ASetting)
+  val forkOptions = TaskKey[ForkOptions]("fork-option", "Configures JVM forking.", DSetting)
   val outputStrategy = SettingKey[Option[sbt.OutputStrategy]]("output-strategy", "Selects how to log output when running a main class.", DSetting)
   val connectInput = SettingKey[Boolean]("connect-input", "If true, connects standard input when running a main class forked.", CSetting)
   val javaHome = SettingKey[Option[File]]("java-home", "Selects the Java installation used for compiling and forking.  If None, uses the Java installation running the build.", ASetting)
   val javaOptions = TaskKey[Seq[String]]("java-options", "Options passed to a new JVM when forking.", BPlusTask)
   val envVars = TaskKey[Map[String, String]]("envVars", "Environment variables used when forking a new JVM", BTask)
+
+  val bgJobService = settingKey[BackgroundJobService]("Job manager used to run background jobs.")
+  val bgList = taskKey[Vector[JobHandle]]("List running background jobs.")
+  val ps = taskKey[Vector[JobHandle]]("bgList variant that displays on the log.")
+  val bgStop = inputKey[Unit]("Stop a background job by providing its ID.")
+  val bgWaitFor = inputKey[Unit]("Wait for a background job to finish by providing its ID.")
+  val bgRun = inputKey[JobHandle]("Start an application's default main class as a background job")
+  val bgRunMain = inputKey[JobHandle]("Start a provided main class as a background job")
 
   // Test Keys
   val testLoader = TaskKey[ClassLoader]("test-loader", "Provides the class loader used for testing.", DTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -295,8 +295,6 @@ object Keys {
   val defaultConfiguration = SettingKey[Option[Configuration]]("default-configuration", "Defines the configuration used when none is specified for a dependency in ivyXML.", CSetting)
 
   val products = TaskKey[Seq[File]]("products", "Build products that get packaged.", BMinusTask)
-  // TODO: This is used by exportedProducts, exportedProductsIfMissing, exportedProductsNoTracking..
-  @deprecated("This task is unused by the default project and will be removed.", "0.13.0")
   val productDirectories = TaskKey[Seq[File]]("product-directories", "Base directories of build products.", CTask)
   val exportJars = SettingKey[Boolean]("export-jars", "Determines whether the exported classpath for this project contains classes (false) or a packaged jar (true).", BSetting)
   val exportedProducts = TaskKey[Classpath]("exported-products", "Build products that go on the exported classpath.", CTask)
@@ -311,6 +309,12 @@ object Keys {
   val fullClasspath = TaskKey[Classpath]("full-classpath", "The exported classpath, consisting of build products and unmanaged and managed, internal and external dependencies.", BPlusTask)
   val trackInternalDependencies = SettingKey[TrackLevel]("track-internal-dependencies", "The level of tracking for the internal (inter-project) dependency.", BSetting)
   val exportToInternal = SettingKey[TrackLevel]("export-to-internal", "The level of tracking for this project by the internal callers.", BSetting)
+  val exportedProductJars = taskKey[Classpath]("Build products that go on the exported classpath as JARs.")
+  val exportedProductJarsIfMissing = taskKey[Classpath]("Build products that go on the exported classpath as JARs if missing.")
+  val exportedProductJarsNoTracking = taskKey[Classpath]("Just the exported classpath as JARs without triggering the compilation.")
+  val internalDependencyAsJars = taskKey[Classpath]("The internal (inter-project) classpath as JARs.")
+  val dependencyClasspathAsJars = taskKey[Classpath]("The classpath consisting of internal and external, managed and unmanaged dependencies, all as JARs.")
+  val fullClasspathAsJars = taskKey[Classpath]("The exported classpath, consisting of build products and unmanaged and managed, internal and external dependencies, all as JARs.")
 
   val internalConfigurationMap = SettingKey[Configuration => Configuration]("internal-configuration-map", "Maps configurations to the actual configuration used to define the classpath.", CSetting)
   val classpathConfiguration = TaskKey[Configuration]("classpath-configuration", "The configuration used to define the classpath.", CTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -239,7 +239,7 @@ object Keys {
   val trapExit = SettingKey[Boolean]("trap-exit", "If true, enables exit trapping and thread management for 'run'-like tasks.  This is currently only suitable for serially-executed 'run'-like tasks.", CSetting)
 
   val fork = SettingKey[Boolean]("fork", "If true, forks a new JVM when running.  If false, runs in the same JVM as the build.", ASetting)
-  val forkOptions = TaskKey[ForkOptions]("fork-option", "Configures JVM forking.", DSetting)
+  val forkOptions = TaskKey[ForkOptions]("fork-options", "Configures JVM forking.", DSetting)
   val outputStrategy = SettingKey[Option[sbt.OutputStrategy]]("output-strategy", "Selects how to log output when running a main class.", DSetting)
   val connectInput = SettingKey[Boolean]("connect-input", "If true, connects standard input when running a main class forked.", CSetting)
   val javaHome = SettingKey[Option[File]]("java-home", "Selects the Java installation used for compiling and forking.  If None, uses the Java installation running the build.", ASetting)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -253,6 +253,7 @@ object Keys {
   val bgWaitFor = inputKey[Unit]("Wait for a background job to finish by providing its ID.")
   val bgRun = inputKey[JobHandle]("Start an application's default main class as a background job")
   val bgRunMain = inputKey[JobHandle]("Start a provided main class as a background job")
+  val bgCopyClasspath = settingKey[Boolean]("Copies classpath on bgRun to prevent conflict.")
 
   // Test Keys
   val testLoader = TaskKey[ClassLoader]("test-loader", "Provides the class loader used for testing.", DTask)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -20,7 +20,8 @@ import sbt.internal.{
   Script,
   SessionSettings,
   SettingCompletions,
-  LogManager
+  LogManager,
+  DefaultBackgroundJobService
 }
 import sbt.internal.util.{ AttributeKey, AttributeMap, complete, ConsoleOut, GlobalLogging, LineRange, MainAppender, SimpleReader, Types }
 import sbt.util.{ Level, Logger }
@@ -81,8 +82,11 @@ object StandardMain {
   def runManaged(s: State): xsbti.MainResult =
     {
       val previous = TrapExit.installManager()
-      try MainLoop.runLogged(s)
-      finally TrapExit.uninstallManager(previous)
+      try {
+        try {
+          MainLoop.runLogged(s)
+        } finally DefaultBackgroundJobService.backgroundJobService.shutdown()
+      } finally TrapExit.uninstallManager(previous)
     }
 
   /** The common interface to standard output, used for all built-in ConsoleLoggers. */

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -214,7 +214,9 @@ object BuildStreams {
 
   def mkStreams(units: Map[URI, LoadedBuildUnit], root: URI, data: Settings[Scope]): State => Streams = s => {
     implicit val isoString: sjsonnew.IsoString[scala.json.ast.unsafe.JValue] = sjsonnew.IsoString.iso(sjsonnew.support.scalajson.unsafe.CompactPrinter.apply, sjsonnew.support.scalajson.unsafe.Parser.parseUnsafe)
-    s get Keys.stateStreams getOrElse std.Streams(path(units, root, data), displayFull, LogManager.construct(data, s), sjsonnew.support.scalajson.unsafe.Converter)
+    (s get Keys.stateStreams) getOrElse {
+      std.Streams(path(units, root, data), displayFull, LogManager.construct(data, s), sjsonnew.support.scalajson.unsafe.Converter)
+    }
   }
 
   def path(units: Map[URI, LoadedBuildUnit], root: URI, data: Settings[Scope])(scoped: ScopedKey[_]): File =

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -1,0 +1,268 @@
+package sbt
+package internal
+
+import java.util.concurrent.atomic.{ AtomicLong, AtomicInteger }
+import java.io.Closeable
+import sbt.util.{ Logger, LogExchange, Level }
+import sbt.internal.util.MainAppender
+import Def.ScopedKey
+import scala.concurrent.ExecutionContext
+
+/**
+ * Interface between sbt and a thing running in the background.
+ */
+private[sbt] abstract class BackgroundJob {
+  def humanReadableName: String
+  def awaitTermination(): Unit
+  def shutdown(): Unit
+  // this should be true on construction and stay true until
+  // the job is complete
+  def isRunning(): Boolean
+  // called after stop or on spontaneous exit, closing the result
+  // removes the listener
+  def onStop(listener: () => Unit)(implicit ex: ExecutionContext): Closeable
+  // do we need this or is the spawning task good enough?
+  // def tags: SomeType
+}
+
+private[sbt] abstract class AbstractJobHandle extends JobHandle {
+  override def toString = s"JobHandle(${id}, ${humanReadableName}, ${Def.showFullKey(spawningTask)})"
+}
+
+private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobService {
+  private val nextId = new AtomicLong(1)
+  private val pool = new BackgroundThreadPool()
+
+  // hooks for sending start/stop events
+  protected def onAddJob(job: JobHandle): Unit = {}
+  protected def onRemoveJob(job: JobHandle): Unit = {}
+
+  // this mutable state could conceptually go on State except
+  // that then every task that runs a background job would have
+  // to be a command, so not sure what to do here.
+  @volatile
+  private final var jobSet = Set.empty[ThreadJobHandle]
+  private def addJob(job: ThreadJobHandle): Unit = synchronized {
+    onAddJob(job)
+    jobSet += job
+  }
+
+  private def removeJob(job: ThreadJobHandle): Unit = synchronized {
+    onRemoveJob(job)
+    jobSet -= job
+  }
+  override def jobs: Vector[ThreadJobHandle] = jobSet.toVector
+
+  final class ThreadJobHandle(
+      override val id: Long, override val spawningTask: ScopedKey[_],
+      val logger: Logger, val job: BackgroundJob
+  ) extends AbstractJobHandle {
+    def humanReadableName: String = job.humanReadableName
+    // EC for onStop handler below
+    import ExecutionContext.Implicits.global
+    job.onStop { () =>
+      // TODO: Fix this
+      // logger.close()
+      removeJob(this)
+    }
+    addJob(this)
+    override final def equals(other: Any): Boolean = other match {
+      case handle: JobHandle if handle.id == id => true
+      case _                                    => false
+    }
+    override final def hashCode(): Int = id.hashCode
+  }
+
+  private val unknownTask = TaskKey[Unit]("unknownTask", "Dummy value")
+  // we use this if we deserialize a handle for a job that no longer exists
+  private final class DeadHandle(override val id: Long, override val humanReadableName: String)
+      extends AbstractJobHandle {
+    override val spawningTask: ScopedKey[_] = unknownTask
+  }
+
+  protected def makeContext(id: Long, spawningTask: ScopedKey[_], state: State): Logger
+
+  def doRunInBackground(spawningTask: ScopedKey[_], state: State, start: (Logger) => BackgroundJob): JobHandle = {
+    val id = nextId.getAndIncrement()
+    val logger = makeContext(id, spawningTask, state)
+    val job = try new ThreadJobHandle(id, spawningTask, logger, start(logger))
+    catch {
+      case e: Throwable =>
+        // TODO: Fix this
+        // logger.close()
+        throw e
+    }
+    job
+  }
+
+  override def runInBackground(spawningTask: ScopedKey[_], state: State)(start: (Logger) => Unit): JobHandle = {
+    pool.run(this, spawningTask, state)(start)
+  }
+
+  override def close(): Unit = {
+    while (jobSet.nonEmpty) {
+      jobSet.headOption.foreach {
+        case handle: ThreadJobHandle @unchecked =>
+          handle.job.shutdown()
+          handle.job.awaitTermination()
+        case _ => //
+      }
+    }
+    pool.close()
+  }
+
+  private def withHandle(job: JobHandle)(f: ThreadJobHandle => Unit): Unit = job match {
+    case handle: ThreadJobHandle @unchecked => f(handle)
+    case dead: DeadHandle @unchecked        => () // nothing to stop or wait for
+    case other                              => sys.error(s"BackgroundJobHandle does not originate with the current BackgroundJobService: $other")
+  }
+
+  override def stop(job: JobHandle): Unit =
+    withHandle(job)(_.job.shutdown())
+
+  override def waitFor(job: JobHandle): Unit =
+    withHandle(job)(_.job.awaitTermination())
+
+  override def toString(): String = s"BackgroundJobService(jobs=${jobs.map(_.id).mkString})"
+}
+
+private[sbt] object BackgroundThreadPool {
+  sealed trait Status
+  case object Waiting extends Status
+  final case class Running(thread: Thread) extends Status
+  // the oldThread is None if we never ran
+  final case class Stopped(oldThread: Option[Thread]) extends Status
+}
+
+private[sbt] class BackgroundThreadPool extends java.io.Closeable {
+
+  private val nextThreadId = new java.util.concurrent.atomic.AtomicInteger(1)
+  private val threadGroup = Thread.currentThread.getThreadGroup()
+
+  private val threadFactory = new java.util.concurrent.ThreadFactory() {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(threadGroup, runnable, s"sbt-bg-threads-${nextThreadId.getAndIncrement}")
+      // Do NOT setDaemon because then the code in TaskExit.scala in sbt will insta-kill
+      // the backgrounded process, at least for the case of the run task.
+      thread
+    }
+  }
+
+  private val executor = new java.util.concurrent.ThreadPoolExecutor(
+    0, /* corePoolSize */
+    32, /* maxPoolSize, max # of bg tasks */
+    2, java.util.concurrent.TimeUnit.SECONDS, /* keep alive unused threads this long (if corePoolSize < maxPoolSize) */
+    new java.util.concurrent.SynchronousQueue[Runnable](),
+    threadFactory
+  )
+
+  private class BackgroundRunnable(val taskName: String, body: () => Unit)
+      extends BackgroundJob with Runnable {
+    import BackgroundThreadPool._
+    private val finishedLatch = new java.util.concurrent.CountDownLatch(1)
+    // synchronize to read/write this, no sync to just read
+    @volatile
+    private var status: Status = Waiting
+
+    // double-finally for extra paranoia that we will finishedLatch.countDown
+    override def run() = try {
+      val go = synchronized {
+        status match {
+          case Waiting =>
+            status = Running(Thread.currentThread())
+            true
+          case Stopped(_) =>
+            false
+          case Running(_) =>
+            throw new RuntimeException("Impossible status of bg thread")
+        }
+      }
+      try { if (go) body() }
+      finally cleanup()
+    } finally finishedLatch.countDown()
+
+    private class StopListener(val callback: () => Unit, val executionContext: ExecutionContext) extends Closeable {
+      override def close(): Unit = removeListener(this)
+      override def hashCode: Int = System.identityHashCode(this)
+      override def equals(other: Any): Boolean = other match {
+        case r: AnyRef => this eq r
+        case _         => false
+      }
+    }
+
+    // access is synchronized
+    private var stopListeners = Set.empty[StopListener]
+
+    private def removeListener(listener: StopListener): Unit = synchronized {
+      stopListeners -= listener
+    }
+
+    def cleanup(): Unit = {
+      // avoid holding any lock while invoking callbacks, and
+      // handle callbacks being added by other callbacks, just
+      // to be all fancy.
+      while (synchronized { stopListeners.nonEmpty }) {
+        val listeners = synchronized {
+          val list = stopListeners.toList
+          stopListeners = Set.empty
+          list
+        }
+        listeners.foreach { l =>
+          l.executionContext.execute(new Runnable { override def run = l.callback() })
+        }
+      }
+    }
+
+    override def onStop(listener: () => Unit)(implicit ex: ExecutionContext): Closeable =
+      synchronized {
+        val result = new StopListener(listener, ex)
+        stopListeners += result
+        result
+      }
+    override def awaitTermination(): Unit = finishedLatch.await()
+    override def humanReadableName: String = taskName
+    override def isRunning(): Boolean =
+      status match {
+        case Waiting               => true // we start as running from BackgroundJob perspective
+        case Running(thread)       => thread.isAlive()
+        case Stopped(threadOption) => threadOption.map(_.isAlive()).getOrElse(false)
+      }
+    override def shutdown(): Unit =
+      synchronized {
+        status match {
+          case Waiting =>
+            status = Stopped(None) // makes run() not run the body
+          case Running(thread) =>
+            status = Stopped(Some(thread))
+            thread.interrupt()
+          case Stopped(threadOption) =>
+            // try to interrupt again! woot!
+            threadOption.foreach(_.interrupt())
+        }
+      }
+  }
+
+  def run(manager: AbstractBackgroundJobService, spawningTask: ScopedKey[_], state: State)(work: (Logger) => Unit): JobHandle = {
+    def start(logger: Logger): BackgroundJob = {
+      val runnable = new BackgroundRunnable(spawningTask.key.label, { () =>
+        work(logger)
+      })
+      executor.execute(runnable)
+      runnable
+    }
+    manager.doRunInBackground(spawningTask, state, start _)
+  }
+
+  override def close(): Unit = {
+    executor.shutdown()
+  }
+}
+
+private[sbt] class DefaultBackgroundJobService extends AbstractBackgroundJobService {
+  private val generateId: AtomicInteger = new AtomicInteger
+
+  override def makeContext(id: Long, spawningTask: ScopedKey[_], state: State): Logger = {
+    val extracted = Project.extract(state)
+    LogManager.constructBackgroundLog(extracted.structure.data, state)(spawningTask)
+  }
+}

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -89,6 +89,7 @@ private[sbt] object Load {
   def injectGlobal(state: State): Seq[Setting[_]] =
     (appConfiguration in GlobalScope :== state.configuration) +:
       LogManager.settingsLogger(state) +:
+      DefaultBackgroundJobService.backgroundJobServiceSetting +:
       EvaluateTask.injectSettings
   def defaultWithGlobal(state: State, base: File, rawConfig: LoadBuildConfiguration, globalBase: File, log: Logger): LoadBuildConfiguration =
     {

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.core.Appender
 
 sealed abstract class LogManager {
   def apply(data: Settings[Scope], state: State, task: ScopedKey[_], writer: PrintWriter): Logger
+  def backgroundLog(data: Settings[Scope], state: State, task: ScopedKey[_]): Logger
 }
 
 object LogManager {
@@ -23,10 +24,16 @@ object LogManager {
   private val generateId: AtomicInteger = new AtomicInteger
 
   // This is called by mkStreams
-  def construct(data: Settings[Scope], state: State) = (task: ScopedKey[_], to: PrintWriter) =>
+  def construct(data: Settings[Scope], state: State): (ScopedKey[_], PrintWriter) => Logger = (task: ScopedKey[_], to: PrintWriter) =>
     {
-      val manager = logManager in task.scope get data getOrElse defaultManager(state.globalLogging.console)
+      val manager: LogManager = (logManager in task.scope).get(data) getOrElse { defaultManager(state.globalLogging.console) }
       manager(data, state, task, to)
+    }
+
+  def constructBackgroundLog(data: Settings[Scope], state: State): (ScopedKey[_]) => Logger = (task: ScopedKey[_]) =>
+    {
+      val manager: LogManager = (logManager in task.scope).get(data) getOrElse { defaultManager(state.globalLogging.console) }
+      manager.backgroundLog(data, state, task)
     }
 
   def defaultManager(console: ConsoleOut): LogManager = withLoggers((sk, s) => defaultScreen(console))
@@ -52,6 +59,9 @@ object LogManager {
   ) extends LogManager {
     def apply(data: Settings[Scope], state: State, task: ScopedKey[_], to: PrintWriter): Logger =
       defaultLogger(data, state, task, screen(task, state), backed(to), relay(()), extra(task).toList)
+
+    def backgroundLog(data: Settings[Scope], state: State, task: ScopedKey[_]): Logger =
+      LogManager.backgroundLog(data, state, task, screen(task, state), relay(()), extra(task).toList)
   }
 
   // This is the main function that is used to generate the logger for tasks.
@@ -71,19 +81,21 @@ object LogManager {
       val screenTrace = getOr(traceLevel.key, defaultTraceLevel(state))
       val backingTrace = getOr(persistTraceLevel.key, Int.MaxValue)
       val extraBacked = state.globalLogging.backed :: relay :: Nil
-      val consoleOpt =
-        execOpt match {
-          case Some(x: Exec) =>
-            x.source match {
-              // TODO: Fix this stringliness
-              case Some(x: CommandSource) if x.channelName == "console0" => Option(console)
-              case Some(x: CommandSource)                                => None
-              case _                                                     => Option(console)
-            }
-          case _ => Option(console)
-        }
+      val consoleOpt = consoleLocally(state, console)
       multiLogger(log, MainAppender.MainAppenderConfig(consoleOpt, backed,
         extraBacked ::: extra, screenLevel, backingLevel, screenTrace, backingTrace))
+    }
+  // Return None if the exec is not from console origin.
+  def consoleLocally(state: State, console: Appender): Option[Appender] =
+    state.currentCommand match {
+      case Some(x: Exec) =>
+        x.source match {
+          // TODO: Fix this stringliness
+          case Some(x: CommandSource) if x.channelName == "console0" => Option(console)
+          case Some(x: CommandSource)                                => None
+          case _                                                     => Option(console)
+        }
+      case _ => Option(console)
     }
   def defaultTraceLevel(state: State): Int =
     if (state.interactive) -1 else Int.MaxValue
@@ -98,6 +110,20 @@ object LogManager {
     case Select(task) => ScopedKey(key.scope.copy(task = Global), task)
     case _            => key // should never get here
   }
+
+  def backgroundLog(data: Settings[Scope], state: State, task: ScopedKey[_],
+    console: Appender, /* TODO: backed: Appender,*/ relay: Appender, extra: List[Appender]): Logger =
+    {
+      val execOpt = state.currentCommand
+      val loggerName: String = s"bg-${task.key.label}-${generateId.incrementAndGet}"
+      val channelName: Option[String] = execOpt flatMap { e => e.source map { _.channelName } }
+      // val execId: Option[String] = execOpt flatMap { _.execId }
+      val log = LogExchange.logger(loggerName, channelName, None)
+      LogExchange.unbindLoggerAppenders(loggerName)
+      val consoleOpt = consoleLocally(state, console)
+      LogExchange.bindLoggerAppenders(loggerName, (consoleOpt.toList map { _ -> Level.Info }) ::: (relay -> Level.Debug) :: Nil)
+      log
+    }
 
   // TODO: Fix this
   // if global logging levels are not explicitly set, set them from project settings

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -12,19 +12,17 @@ import sbt.internal.inc.ScalaInstance
 import sbt.io.Path
 
 import sbt.util.Logger
+import scala.util.{ Try, Success, Failure }
+import scala.util.control.NonFatal
+import scala.sys.process.Process
 
-trait ScalaRun {
-  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Option[String]
+sealed trait ScalaRun {
+  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Try[Unit]
 }
 class ForkRun(config: ForkOptions) extends ScalaRun {
-  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Option[String] =
+  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Try[Unit] =
     {
-      log.info("Running " + mainClass + " " + options.mkString(" "))
-
-      val scalaOptions = classpathOption(classpath) ::: mainClass :: options.toList
-      val configLogged = if (config.outputStrategy.isDefined) config else config.copy(outputStrategy = Some(LoggedOutput(log)))
-      // fork with Java because Scala introduces an extra class loader (#702)
-      val process = Fork.java.fork(configLogged, scalaOptions)
+      val process = fork(mainClass, classpath, options, log)
       def cancel() = {
         log.warn("Run canceled.")
         process.destroy()
@@ -33,27 +31,45 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
       val exitCode = try process.exitValue() catch { case e: InterruptedException => cancel() }
       processExitCode(exitCode, "runner")
     }
-  private def classpathOption(classpath: Seq[File]) = "-classpath" :: Path.makeString(classpath) :: Nil
-  private def processExitCode(exitCode: Int, label: String) =
+
+  def fork(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Process =
     {
-      if (exitCode == 0)
-        None
-      else
-        Some("Nonzero exit code returned from " + label + ": " + exitCode)
+      log.info("Running " + mainClass + " " + options.mkString(" "))
+
+      val scalaOptions = classpathOption(classpath) ::: mainClass :: options.toList
+      val configLogged =
+        if (config.outputStrategy.isDefined) config
+        else config.copy(outputStrategy = Some(LoggedOutput(log)))
+      // fork with Java because Scala introduces an extra class loader (#702)
+      Fork.java.fork(configLogged, scalaOptions)
+    }
+  private def classpathOption(classpath: Seq[File]) = "-classpath" :: Path.makeString(classpath) :: Nil
+  private def processExitCode(exitCode: Int, label: String): Try[Unit] =
+    {
+      if (exitCode == 0) Success(())
+      else Failure(new RuntimeException("Nonzero exit code returned from " + label + ": " + exitCode))
     }
 }
 class Run(instance: ScalaInstance, trapExit: Boolean, nativeTmp: File) extends ScalaRun {
   /** Runs the class 'mainClass' using the given classpath and options using the scala runner.*/
-  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger) =
+  def run(mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger): Try[Unit] =
     {
       log.info("Running " + mainClass + " " + options.mkString(" "))
 
       def execute() =
         try { run0(mainClass, classpath, options, log) }
         catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
-      def directExecute() = try { execute(); None } catch { case e: Exception => log.trace(e); Some(e.toString) }
+      def directExecute(): Try[Unit] =
+        Try(execute()) recover {
+          case NonFatal(e) =>
+            // bgStop should not print out stack trace
+            // log.trace(e)
+            throw e
+        }
+      // try { execute(); None } catch { case e: Exception => log.trace(e); Some(e.toString) }
 
-      if (trapExit) Run.executeTrapExit(execute(), log) else directExecute()
+      if (trapExit) Run.executeTrapExit(execute(), log)
+      else directExecute()
     }
   private def run0(mainClassName: String, classpath: Seq[File], options: Seq[String], log: Logger): Unit = {
     log.debug("  Classpath:\n\t" + classpath.mkString("\n\t"))
@@ -88,13 +104,12 @@ object Run {
     runner.run(mainClass, classpath, options, log)
 
   /** Executes the given function, trapping calls to System.exit. */
-  def executeTrapExit(f: => Unit, log: Logger): Option[String] =
+  def executeTrapExit(f: => Unit, log: Logger): Try[Unit] =
     {
       val exitCode = TrapExit(f, log)
       if (exitCode == 0) {
         log.debug("Exited with code 0")
-        None
-      } else
-        Some("Nonzero exit code: " + exitCode)
+        Success(())
+      } else Failure(new RuntimeException("Nonzero exit code: " + exitCode))
     }
 }

--- a/sbt/src/main/scala/syntax.scala
+++ b/sbt/src/main/scala/syntax.scala
@@ -1,14 +1,12 @@
 package sbt
 
-import sbt.internal.DslEntry
-import sbt.util.Eval
-
 object syntax extends syntax
 
 abstract class syntax extends IOSyntax0 with sbt.std.TaskExtra with sbt.internal.util.Types with sbt.ProcessExtra
     with sbt.internal.librarymanagement.impl.DependencyBuilders with sbt.ProjectExtra
     with sbt.internal.librarymanagement.DependencyFilterExtra with sbt.BuildExtra with sbt.TaskMacroExtra
-    with sbt.ScopeFilter.Make {
+    with sbt.ScopeFilter.Make
+    with sbt.BuildSyntax {
 
   // IO
   def uri(s: String): URI = new URI(s)
@@ -43,18 +41,6 @@ abstract class syntax extends IOSyntax0 with sbt.std.TaskExtra with sbt.internal
   //  final val System = C.System
   final val Optional = C.Optional
   def config(s: String): Configuration = C.config(s)
-
-  import language.experimental.macros
-  def settingKey[T](description: String): SettingKey[T] = macro std.KeyMacro.settingKeyImpl[T]
-  def taskKey[T](description: String): TaskKey[T] = macro std.KeyMacro.taskKeyImpl[T]
-  def inputKey[T](description: String): InputKey[T] = macro std.KeyMacro.inputKeyImpl[T]
-
-  def enablePlugins(ps: AutoPlugin*): DslEntry = DslEntry.DslEnablePlugins(ps)
-  def disablePlugins(ps: AutoPlugin*): DslEntry = DslEntry.DslDisablePlugins(ps)
-  def configs(cs: Configuration*): DslEntry = DslEntry.DslConfigs(cs)
-  def dependsOn(deps: Eval[ClasspathDep[ProjectReference]]*): DslEntry = DslEntry.DslDependsOn(deps)
-  // avoid conflict with `sbt.Keys.aggregate`
-  def aggregateProjects(refs: Eval[ProjectReference]*): DslEntry = DslEntry.DslAggregate(refs)
 }
 
 // Todo share this this io.syntax

--- a/sbt/src/sbt-test/run/concurrent/build.sbt
+++ b/sbt/src/sbt-test/run/concurrent/build.sbt
@@ -7,7 +7,7 @@ def runTestTask(pre: Def.Initialize[Task[Unit]]) =
 		val cp = (fullClasspath in Compile).value
 		val main = (mainClass in Compile).value getOrElse sys.error("No main class found")
 		val args = baseDirectory.value.getAbsolutePath :: Nil
-		r.run(main, cp.files, args, streams.value.log) foreach sys.error
+		r.run(main, cp.files, args, streams.value.log).get
 	}
 
 lazy val b = project.settings(


### PR DESCRIPTION
This change adds `BackgroundJobService`, a generic background job manager.
As an example of this service, `bgRun` was implemented, which executes `run` task without blocking the command engine. This could be used in conjunction with server feature for ad-hoc testing. This is based on @havocp's work in https://github.com/sbt/sbt-remote-control/pull/188, which later moved to https://github.com/sbt/sbt-core-next.

There are number of other supporting settings and tasks that were added. The notable ones are `ps` task and `bgStop`.

Fixes #2806

### usage

```scala
object FooServer extends App {
  while (true) {
    Thread.sleep(10 * 1000)
    println("foo")
  }
}
```

Let's say we want to run the above in a background process. We can use the same forking mechanism as `run` as follows:

```scala
lazy val testServer = (project in file("testServer"))
  .settings(
    scalaVersion := "2.11.8",
    name := "foo",
    fork in (Compile, run) := true
  )
```

From the shell you just type `testServer/bgRun`:

```scala
> testServer/bgRun
[info] Compiling 1 Scala source to /xxx/testServer/target/scala-2.11/classes... (out-40)
[info] Done compiling. (out-40)
[info] Packaging /xxx/testServer/target/scala-2.11/foo_2.11-0.1-SNAPSHOT.jar ... (out-46)
[info] Done packaging. (out-46)
[info] Total time: 4 s, completed Jan 20, 2017 12:38:09 PM (out-23)
> [info] Running (fork) FooServer  (out-48)
[info] foo (out-48)
[info] foo (out-48)
```

We can confirm there's a background process running using `ps`:

```
$ ps aux | rg java
...
378:eugene           70755   0.0  0.3  8267016  49672 s005  S+   12:38PM   0:00.50 /Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/jre/bin/java -classpath /var/folders/7g/l96y5q310h90xsz109qqjpmc0000gn/T/sbt_dbdbd68/job-1/target/f1072da7/foo_2.11-0.1-SNAPSHOT.jar:/var/folders/7g/l96y5q310h90xsz109qqjpmc0000gn/T/sbt_dbdbd68/target/ddd5a8bc/scala-library-2.11.8.jar FooServer
...
```

Similarly we can list the background jobs from sbt shell using `ps` task:

```scala
> ps
[info] JobHandle(1, bgRun, {file:/xxx/}testServer/compile:bgRun) (out-51)
[info] Total time: 0 s, completed Jan 20, 2017 12:41:48 PM (out-50)
```

### notes

The heavy lifting of running jobs in the background was originally implemented by Havoc in https://github.com/sbt/sbt-remote-control/pull/188.

I've made a few more changes. First, BackgroundJobService instance is initialized and shutdown outside of the settings system to ensure background jobs are really closed.

Next, `fullClasspathAsJars` task was added. This essentially calculates the `fullClasspath` as if `exportJars` had been enabled. This allows me to get JAR version of the classpath for subproject dependencies.

Finally, `bgRun` will automatically copy the JARs into a temporary directory before running them, so it's not affected by other commands that will continue. The strategy for copying is as follows:
1. `exportedProductJars` (current subproject) are copied to a job specific directory, which is wiped out after the job is done. So this is always copied.
2. Any other JARs in `fullClasspathAsJars` are copied to `serviceTempDir / $hash8` where `hash8` is based on SHA-1 of the file content. This live for the duration of the sbt session, so libraries will not be copied after the first time.

