### PR TITLE
[sbt 0.13] Support sourceGenerators += Def.task { ... }

### DIFF
--- a/main/settings/src/main/scala/sbt/Append.scala
+++ b/main/settings/src/main/scala/sbt/Append.scala
@@ -1,8 +1,9 @@
 package sbt
 
 import java.io.File
-import Def.Classpath
+import Def.{ Classpath, Initialize }
 import scala.annotation.implicitNotFound
+import reflect.internal.annotations.compileTimeOnly
 
 object Append {
   @implicitNotFound(msg = "No implicit for Append.Value[${A}, ${B}] found,\n  so ${B} cannot be appended to ${A}")
@@ -22,6 +23,14 @@ object Append {
   implicit def appendSeqImplicit[T, V <% T]: Sequence[Seq[T], Seq[V], V] = new Sequence[Seq[T], Seq[V], V] {
     def appendValues(a: Seq[T], b: Seq[V]): Seq[T] = a ++ (b map { x => (x: T) })
     def appendValue(a: Seq[T], b: V): Seq[T] = a :+ (b: T)
+  }
+  @compileTimeOnly("This can be used in += only.")
+  implicit def appendTaskValueSeq[T, V <: T]: Value[Seq[Task[T]], Initialize[Task[V]]] = new Value[Seq[Task[T]], Initialize[Task[V]]] {
+    def appendValue(a: Seq[Task[T]], b: Initialize[Task[V]]): Seq[Task[T]] = ???
+  }
+  @compileTimeOnly("This can be used in += only.")
+  implicit def appendTaskKeySeq[T, V <: T]: Value[Seq[Task[T]], TaskKey[V]] = new Value[Seq[Task[T]], TaskKey[V]] {
+    def appendValue(a: Seq[Task[T]], b: TaskKey[V]): Seq[Task[T]] = ???
   }
   implicit def appendList[T, V <: T]: Sequence[List[T], List[V], V] = new Sequence[List[T], List[V], V] {
     def appendValues(a: List[T], b: List[V]): List[T] = a ::: b

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -208,7 +208,7 @@ object Defaults extends BuildCommon {
     unmanagedResources := collectFiles(unmanagedResourceDirectories, includeFilter in unmanagedResources, excludeFilter in unmanagedResources).value,
     watchSources in ConfigGlobal ++= unmanagedResources.value,
     resourceGenerators :== Nil,
-    resourceGenerators += ((discoveredSbtPlugins, resourceManaged) map PluginDiscovery.writeDescriptors).taskValue,
+    resourceGenerators += Def.task { PluginDiscovery.writeDescriptors(discoveredSbtPlugins.value, resourceManaged.value) },
     managedResources := generate(resourceGenerators).value,
     resources := Classpaths.concat(managedResources, unmanagedResources).value
   )

--- a/sbt/src/sbt-test/actions/generator/build.sbt
+++ b/sbt/src/sbt-test/actions/generator/build.sbt
@@ -1,0 +1,13 @@
+lazy val buildInfo = taskKey[Seq[File]]("The task that generates the build info.")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.11.8",
+    buildInfo := {
+      val x = sourceManaged.value / "BuildInfo.scala"
+      IO.write(x, """object BuildInfo""")
+      x :: Nil
+    },
+    sourceGenerators in Compile += buildInfo,
+    sourceGenerators in Compile += Def.task { Nil }
+  )

--- a/sbt/src/sbt-test/actions/generator/test
+++ b/sbt/src/sbt-test/actions/generator/test
@@ -1,0 +1,2 @@
+> compile
+$ exists target/scala-2.11/src_managed/BuildInfo.scala

--- a/sbt/src/sbt-test/project/auto-plugins-default-requires-jvmplugin/build.sbt
+++ b/sbt/src/sbt-test/project/auto-plugins-default-requires-jvmplugin/build.sbt
@@ -1,8 +1,8 @@
 val test123 = project in file(".") enablePlugins TestP settings(
-  resourceGenerators in Compile += (Def.task {
+  resourceGenerators in Compile += Def.task {
     streams.value.log info "resource generated in settings"
     Nil
-  }).taskValue
+  }
 )
 
 TaskKey[Unit]("check") := {

--- a/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
+++ b/util/appmacro/src/main/scala/sbt/appmacro/ContextUtil.scala
@@ -126,6 +126,9 @@ final class ContextUtil[C <: Context](val ctx: C) {
   def freshMethodParameter(tpe: Type): ValDef =
     ValDef(parameterModifiers, freshTermName("p"), TypeTree(tpe), EmptyTree)
 
+  def typeArgs(tpe: Type): List[Type] =
+    tpe.asInstanceOf[global.Type].typeArgs map { _.asInstanceOf[Type] }
+
   /** Constructs a ValDef with local modifiers and a unique name. */
   def localValDef(tpt: Tree, rhs: Tree): ValDef =
     ValDef(localModifiers, freshTermName("q"), tpt, rhs)


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/2942

### Adds an Append instance that extracts taskValue

This adds a macro-level hack to support += op for sourceGenerators and resourceGenerators using RHS of Initialize[Task[Seq[File]]].
When the types match up, the macro now calls `.taskValue` automatically.

Before:

```scala
sourceGenerators in Compile += buildInfo.taskValue,
sourceGenerators in Compile += (Def.task { Nil }).taskValue
```

After:

```scala
sourceGenerators in Compile += buildInfo,
sourceGenerators in Compile += Def.task { Nil }
```
