### PR TITLE
Preliminary compatibility with JDK 9

### DIFF
--- a/compile/persist/src/main/scala/sbt/inc/Base64.scala
+++ b/compile/persist/src/main/scala/sbt/inc/Base64.scala
@@ -1,0 +1,61 @@
+package sbt
+package inc
+
+import java.lang.reflect.InvocationTargetException
+import javax.xml.bind.DatatypeConverter
+
+private[sbt] trait Base64 {
+  def encode(bytes: Array[Byte]): String
+
+  def decode(string: String): Array[Byte]
+}
+
+private[sbt] object Base64 {
+  lazy val factory: () => Base64 = {
+    try {
+      new Java678Encoder().encode(Array[Byte]())
+      () => new Java678Encoder()
+    } catch {
+      case _: LinkageError =>
+        () => new Java89Encoder
+    }
+  }
+}
+
+private[sbt] class Java678Encoder extends Base64 {
+  def encode(bytes: Array[Byte]): String = DatatypeConverter.printBase64Binary(bytes)
+
+  def decode(string: String): Array[Byte] = DatatypeConverter.parseBase64Binary(string)
+}
+
+private[sbt] object Java89Encoder {
+
+  import scala.runtime.ScalaRunTime.ensureAccessible
+
+  private val Base64_class = Class.forName("java.util.Base64")
+  private val Base64_getEncoder = ensureAccessible(Base64_class.getMethod("getEncoder"))
+  private val Base64_getDecoder = ensureAccessible(Base64_class.getMethod("getEncoder"))
+  private val Base64_Encoder_class = Class.forName("java.util.Base64$Encoder")
+  private val Base64_Decoder_class = Class.forName("java.util.Base64$Decoder")
+  private val Base64_Encoder_encodeToString = ensureAccessible(Base64_Encoder_class.getMethod("encodeToString", classOf[Array[Byte]]))
+  private val Base64_Decoder_decode = ensureAccessible(Base64_Decoder_class.getMethod("decode", classOf[String]))
+}
+
+private[sbt] class Java89Encoder extends Base64 {
+
+  import Java89Encoder._
+
+  def encode(bytes: Array[Byte]): String = try {
+    val encoder = Base64_getEncoder.invoke(null)
+    Base64_Encoder_encodeToString.invoke(encoder, bytes).asInstanceOf[String]
+  } catch {
+    case ex: InvocationTargetException => throw ex.getCause
+  }
+
+  def decode(string: String): Array[Byte] = try {
+    val decoder = Base64_getDecoder.invoke(null)
+    Base64_Decoder_decode.invoke(decoder, string).asInstanceOf[Array[Byte]]
+  } catch {
+    case ex: InvocationTargetException => throw ex.getCause
+  }
+}

--- a/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
+++ b/compile/persist/src/main/scala/sbt/inc/TextAnalysisFormat.scala
@@ -5,7 +5,6 @@ import java.io._
 import sbt.{ CompileSetup, Relation }
 import xsbti.api.{ Compilation, Source }
 import xsbti.compile.{ MultipleOutput, SingleOutput }
-import javax.xml.bind.DatatypeConverter
 
 // Very simple timer for timing repeated code sections.
 // TODO: Temporary. Remove once we've milked all available performance gains.
@@ -328,11 +327,11 @@ object TextAnalysisFormat {
       val out = new sbinary.JavaOutput(baos)
       FormatTimer.aggregate("sbinary write") { try { fmt.writes(out, o) } finally { baos.close() } }
       val bytes = FormatTimer.aggregate("byte copy") { baos.toByteArray }
-      FormatTimer.aggregate("bytes -> base64") { DatatypeConverter.printBase64Binary(bytes) }
+      FormatTimer.aggregate("bytes -> base64") { Base64.factory().encode(bytes) }
     }
 
     def stringToObj[T](s: String)(implicit fmt: sbinary.Format[T]) = {
-      val bytes = FormatTimer.aggregate("base64 -> bytes") { DatatypeConverter.parseBase64Binary(s) }
+      val bytes = FormatTimer.aggregate("base64 -> bytes") { Base64.factory().decode(s) }
       val in = new sbinary.JavaInput(new ByteArrayInputStream(bytes))
       FormatTimer.aggregate("sbinary read") { fmt.reads(in) }
     }

--- a/compile/src/main/scala/sbt/compiler/CompilerArguments.scala
+++ b/compile/src/main/scala/sbt/compiler/CompilerArguments.scala
@@ -63,7 +63,7 @@ final class CompilerArguments(scalaInstance: xsbti.compile.ScalaInstance, cp: xs
   def bootClasspathFor(classpath: Seq[File]) = bootClasspath(hasLibrary(classpath))
 
   import Path._
-  def extClasspath: Seq[File] = (IO.parseClasspath(System.getProperty("java.ext.dirs")) * "*.jar").get
+  def extClasspath: Seq[File] = (IO.parseClasspath(System.getProperty("java.ext.dirs", "")) * "*.jar").get
 }
 object CompilerArguments {
   val BootClasspathOption = "-bootclasspath"


### PR DESCRIPTION
This pull request cleans up two small issues that stood in the way of using the soon-to-be-released Java 9 with SBT.

 - No more `java.ext.dirs`
 - `java.xml.bind` not part of the `java.base` default classpath

Scala compiler versions prior to 2.12.1 do not tolerate the absence of `rt.jar` from the JDK. But we can appease them a little manual setup.

First, we can extract an equivalent JAR with a [tool](https://github.com/retronym/java9-rt-export) I've written:

```
% git clone https://github.com/retronym/java9-rt-export
% cd java9-rt-export/
% java_use 1.8
% sbt package
% java_use 9
% mkdir -p $HOME/.sbt/0.13/java9-rt-ext; java -jar target/java9-rt-export-*.jar $HOME/.sbt/0.13/java9-rt-ext/rt.jar
% jar tf $HOME/.sbt/0.13/java9-rt-ext/rt.jar | grep java/lang/Object
```

Then, we can feed that to the compilation classpath of Scala compilers used within SBT with the `scala.ext.dirs` System property.

```
% java_use 9
% sbt -Dscala.ext.dirs=$HOME/.sbt/0.13/java9-rt-ext clean compile console
[info] Loading global plugins from /Users/jason/.sbt/0.13/plugins
[info] Compiling 1 Scala source to /Users/jason/.sbt/0.13/plugins/target/scala-2.10/sbt-0.13/classes...
[info] Loading project definition from /Users/jason/code/scratch1/project
[info] Set current project to scratch1 (in build file:/Users/jason/code/scratch1/)
[info] Defining *:scalaVersion
[info] The new value will be used by *:allDependencies, *:crossScalaVersions and 13 others.
[info] 	Run `last` for details.
[info] Reapplying settings...
[info] Set current project to scratch1 (in build file:/Users/jason/code/scratch1/)
[success] Total time: 0 s, completed 4 Feb. 2017, 10:37:59 pm
[info] Updating {file:/Users/jason/code/scratch1/}scratch1...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 1 Scala source and 1 Java source to /Users/jason/code/scratch1/target/scala-2.11/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.11.8. Compiling...
[info]   Compilation completed in 7.315 s
[success] Total time: 9 s, completed 4 Feb. 2017, 10:38:08 pm
[info] Compiling 1 Scala source to /Users/jason/code/scratch1/target/scala-2.11/classes...
[info] Starting scala interpreter...
[info]
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 9-ea).
Type in expressions for evaluation. Or try :help.

scala> java.lang.invoke.VarHandle.fullFence _
res0: () => Unit = <function0>
```

Note that this doesn't actually require you to use Scala 2.12.1 in your application, 2.11.8 is able to use Java 9.

Also note that `scalac` does not [yet](https://github.com/scala/scala-dev/issues/139) enforce the stricter module accessibility rules imposed by [JEP-261](http://openjdk.java.net/jeps/261), so your code might typecheck and compile but incur `LinkageError`-s at runtime if you are calling non-exported APIs. 
