### PR TITLE
Backport #2941 to 0.13.x

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -310,7 +310,8 @@ object Defaults extends BuildCommon {
   )
   private[this] lazy val configGlobal = globalDefaults(Seq(
     initialCommands :== "",
-    cleanupCommands :== ""
+    cleanupCommands :== "",
+    asciiGraphWidth :== 40
   ))
 
   lazy val projectTasks: Seq[Setting[_]] = Seq(

--- a/main/src/main/scala/sbt/Inspect.scala
+++ b/main/src/main/scala/sbt/Inspect.scala
@@ -42,7 +42,7 @@ object Inspect {
           Project.details(structure, actual, sk.scope, sk.key)
         case DependencyTree =>
           val basedir = new File(Project.session(s).current.build)
-          Project.settingGraph(structure, basedir, sk).dependsAscii
+          Project.settingGraph(structure, basedir, sk).dependsAscii(get(sbt.Keys.asciiGraphWidth))
         case Uses =>
           Project.showUses(Project.usedBy(structure, true, sk.key))
         case Definitions =>

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -124,6 +124,7 @@ object Keys {
   val compileOrder = SettingKey[CompileOrder]("compile-order", "Configures the order in which Java and sources within a single compilation are compiled.  Valid values are: JavaThenScala, ScalaThenJava, or Mixed.", BPlusSetting)
   val initialCommands = SettingKey[String]("initial-commands", "Initial commands to execute when starting up the Scala interpreter.", AMinusSetting)
   val cleanupCommands = SettingKey[String]("cleanup-commands", "Commands to execute before the Scala interpreter exits.", BMinusSetting)
+  val asciiGraphWidth = SettingKey[Int]("asciiGraphWidth", "Determines maximum width of the settings graph in ASCII mode", AMinusSetting)
   val compileInputs = TaskKey[Compiler.Inputs]("compile-inputs", "Collects all inputs needed for compilation.", DTask)
   val scalaHome = SettingKey[Option[File]]("scala-home", "If Some, defines the local Scala installation to use for compilation, running, and testing.", ASetting)
   val scalaInstance = TaskKey[ScalaInstance]("scala-instance", "Defines the Scala instance to use for compilation, running, and testing.", DTask)

--- a/main/src/main/scala/sbt/SettingGraph.scala
+++ b/main/src/main/scala/sbt/SettingGraph.scala
@@ -44,9 +44,11 @@ case class SettingGraph(name: String,
       } getOrElse { d.typeName }
     } getOrElse { "" }
 
-  def dependsAscii: String = Graph.toAscii(this,
+  def dependsAscii(defaultWidth: Int) = Graph.toAscii(this,
     (x: SettingGraph) => x.depends.toSeq.sortBy(_.name),
-    (x: SettingGraph) => "%s = %s" format (x.definedIn getOrElse { "" }, x.dataString))
+    (x: SettingGraph) => "%s = %s" format (x.definedIn getOrElse { "" }, x.dataString),
+    defaultWidth
+  )
 }
 
 object Graph {
@@ -55,8 +57,7 @@ object Graph {
   // [info]   | +-baz
   // [info]   |
   // [info]   +-quux
-  def toAscii[A](top: A, children: A => Seq[A], display: A => String): String = {
-    val defaultWidth = 40
+  def toAscii[A](top: A, children: A => Seq[A], display: A => String, defaultWidth: Int): String = {
     val maxColumn = math.max(JLine.usingTerminal(_.getWidth), defaultWidth) - 8
     val twoSpaces = " " + " " // prevent accidentally being converted into a tab
     def limitLine(s: String): String =

--- a/notes/0.13.14/ascii-graph-width.markdown
+++ b/notes/0.13.14/ascii-graph-width.markdown
@@ -1,0 +1,9 @@
+[@RomanIakovlev]: https://github.com/RomanIakovlev
+
+### Fixes with compatibility implications
+
+### Improvements
+
+Add new global setting `asciiGraphWidth` that controls the maximum width of the ASCII graphs printed by commands like `inspect tree`. Default value corresponds to the previously hardcoded value of 40 characters. By [@RomanIakovlev][@RomanIakovlev].
+
+### Bug fixes


### PR DESCRIPTION
Backporting the asciiGraphWidth setting that was merged in 1.0.x recently