### PR TITLE
Fix #2982: Add a parallel Ivy resolve engine

### DIFF
--- a/ivy/src/main/scala/sbt/Ivy.scala
+++ b/ivy/src/main/scala/sbt/Ivy.scala
@@ -4,31 +4,30 @@
 package sbt
 
 import Resolver.PluginPattern
-import ivyint.{ CachedResolutionResolveEngine, CachedResolutionResolveCache, SbtDefaultDependencyDescriptor }
-
+import ivyint.{ CachedResolutionResolveCache, CachedResolutionResolveEngine, ParallelResolveEngine, SbtDefaultDependencyDescriptor }
 import java.io.File
 import java.net.URI
 import java.text.ParseException
 import java.util.concurrent.Callable
-import java.util.{ Collection, Collections => CS, Date }
+import java.util.{ Collection, Date, Collections => CS }
 import CS.singleton
 
 import org.apache.ivy.Ivy
 import org.apache.ivy.core.report.ResolveReport
-import org.apache.ivy.core.{ IvyPatternHelper, LogOptions, IvyContext }
-import org.apache.ivy.core.cache.{ ResolutionCacheManager, CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter }
+import org.apache.ivy.core.{ IvyContext, IvyPatternHelper, LogOptions }
+import org.apache.ivy.core.cache.{ CacheMetadataOptions, DefaultRepositoryCacheManager, ModuleDescriptorWriter, ResolutionCacheManager }
 import org.apache.ivy.core.event.EventManager
-import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact, DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact }
-import org.apache.ivy.core.module.descriptor.{ DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, ModuleDescriptor, License }
+import org.apache.ivy.core.module.descriptor.{ DefaultArtifact, DefaultDependencyArtifactDescriptor, MDArtifact, Artifact => IArtifact }
+import org.apache.ivy.core.module.descriptor.{ DefaultDependencyDescriptor, DefaultModuleDescriptor, DependencyDescriptor, License, ModuleDescriptor }
 import org.apache.ivy.core.module.descriptor.OverrideDependencyDescriptorMediator
 import org.apache.ivy.core.module.id.{ ArtifactId, ModuleId, ModuleRevisionId }
 import org.apache.ivy.core.resolve._
 import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.core.sort.SortEngine
-import org.apache.ivy.plugins.latest.{ LatestStrategy, LatestRevisionStrategy, ArtifactInfo }
+import org.apache.ivy.plugins.latest.{ ArtifactInfo, LatestRevisionStrategy, LatestStrategy }
 import org.apache.ivy.plugins.matcher.PatternMatcher
-import org.apache.ivy.plugins.parser.m2.{ PomModuleDescriptorParser }
-import org.apache.ivy.plugins.resolver.{ ChainResolver, DependencyResolver, BasicResolver }
+import org.apache.ivy.plugins.parser.m2.PomModuleDescriptorParser
+import org.apache.ivy.plugins.resolver.{ BasicResolver, ChainResolver, DependencyResolver }
 import org.apache.ivy.plugins.resolver.util.{ HasLatestStrategy, ResolvedResource }
 import org.apache.ivy.plugins.version.ExactVersionMatcher
 import org.apache.ivy.plugins.repository.file.{ FileResource, FileRepository => IFileRepository }
@@ -88,32 +87,51 @@ final class IvySbt(val configuration: IvyConfiguration) {
       }
       is
     }
-  private[sbt] def mkIvy: Ivy =
-    {
-      val i = new Ivy() {
-        private val loggerEngine = new SbtMessageLoggerEngine
-        override def getLoggerEngine = loggerEngine
-        override def bind(): Unit = {
-          val prOpt = Option(getSettings.getResolver(ProjectResolver.InterProject)) map { case pr: ProjectResolver => pr }
-          // We inject the deps we need before we can hook our resolve engine.
-          setSortEngine(new SortEngine(getSettings))
-          setEventManager(new EventManager())
-          if (configuration.updateOptions.cachedResolution) {
-            setResolveEngine(new ResolveEngine(getSettings, getEventManager, getSortEngine) with CachedResolutionResolveEngine {
-              val cachedResolutionResolveCache = IvySbt.cachedResolutionResolveCache
-              val projectResolver = prOpt
-              def makeInstance = mkIvy
-            })
-          } else setResolveEngine(new ResolveEngine(getSettings, getEventManager, getSortEngine))
-          super.bind()
-        }
+
+  private class CachedParallelResolveEngine(
+    settings: IvySettings,
+    eventManager: EventManager,
+    sortEngine: SortEngine) extends ParallelResolveEngine(settings, eventManager, sortEngine)
+      with CachedResolutionResolveEngine {
+    def makeInstance: Ivy = mkIvy
+    val cachedResolutionResolveCache: CachedResolutionResolveCache =
+      IvySbt.cachedResolutionResolveCache
+    val projectResolver: Option[ProjectResolver] = {
+      val res = settings.getResolver(ProjectResolver.InterProject)
+      Option(res.asInstanceOf[ProjectResolver])
+    }
+  }
+
+  private class IvyImplementation extends Ivy {
+    private val loggerEngine = new SbtMessageLoggerEngine
+    override def getLoggerEngine: SbtMessageLoggerEngine = loggerEngine
+    override def bind(): Unit = {
+      val settings = getSettings
+      val eventManager = new EventManager()
+      val sortEngine = new SortEngine(settings)
+      setSortEngine(sortEngine)
+      setEventManager(eventManager)
+
+      val resolveEngine = {
+        // Decide to use cached resolution if user enabled it
+        if (configuration.updateOptions.cachedResolution)
+          new CachedParallelResolveEngine(settings, eventManager, sortEngine)
+        else new ParallelResolveEngine(settings, eventManager, sortEngine)
       }
 
-      i.setSettings(settings)
-      i.bind()
-      i.getLoggerEngine.pushLogger(new IvyLoggerInterface(configuration.log))
-      i
+      setResolveEngine(resolveEngine)
+      super.bind()
     }
+  }
+
+  private[sbt] def mkIvy: Ivy = {
+    val ivy = new IvyImplementation()
+    ivy.setSettings(settings)
+    ivy.bind()
+    val logger = new IvyLoggerInterface(configuration.log)
+    ivy.getLoggerEngine.pushLogger(logger)
+    ivy
+  }
 
   private lazy val ivy: Ivy = mkIvy
   // Must be the same file as is used in Update in the launcher

--- a/ivy/src/main/scala/sbt/ivyint/ParallelResolveEngine.scala
+++ b/ivy/src/main/scala/sbt/ivyint/ParallelResolveEngine.scala
@@ -1,0 +1,106 @@
+package sbt.ivyint
+
+import org.apache.ivy.core.event.EventManager
+import org.apache.ivy.core.resolve._
+import org.apache.ivy.core.report._
+import org.apache.ivy.util.filter.Filter
+import org.apache.ivy.core.event.download.PrepareDownloadEvent
+import org.apache.ivy.core.module.descriptor.Artifact
+import org.apache.ivy.core.sort.SortEngine
+import org.apache.ivy.util.Message
+
+import scala.collection.parallel.mutable.ParArray
+
+private[ivyint] case class DownloadResult(dep: IvyNode,
+  report: DownloadReport,
+  totalSizeDownloaded: Long)
+
+/** Define an ivy [[ResolveEngine]] that resolves dependencies in parallel. */
+private[sbt] class ParallelResolveEngine(
+    settings: ResolveEngineSettings,
+    eventManager: EventManager,
+    sortEngine: SortEngine) extends ResolveEngine(settings, eventManager, sortEngine) {
+
+  override def downloadArtifacts(report: ResolveReport,
+    artifactFilter: Filter,
+    options: DownloadOptions): Unit = {
+
+    val start = System.currentTimeMillis
+    val dependencies0 = report.getDependencies
+    val dependencies = dependencies0
+      .toArray(new Array[IvyNode](dependencies0.size))
+    val artifacts = report.getArtifacts
+      .toArray(new Array[Artifact](report.getArtifacts.size))
+
+    getEventManager.fireIvyEvent(new PrepareDownloadEvent(artifacts))
+
+    // Farm out the dependencies for parallel download
+    val allDownloads = dependencies.par.flatMap { dep =>
+      if (!(dep.isCompletelyEvicted || dep.hasProblem) &&
+        dep.getModuleRevision != null) {
+        ParArray(downloadNodeArtifacts(dep, artifactFilter, options))
+      } else ParArray.empty[DownloadResult]
+    }
+
+    // Force parallel downloads
+    val forcedDownloads = allDownloads.toArray
+
+    var totalSize = 0L
+    forcedDownloads.foreach { download =>
+      val dependency = download.dep
+      val moduleConfigurations = dependency.getRootModuleConfigurations
+      totalSize += download.totalSizeDownloaded
+
+      moduleConfigurations.foreach { configuration =>
+        val configurationReport = report.getConfigurationReport(configuration)
+
+        // Take into account artifacts required by the given configuration
+        if (dependency.isEvicted(configuration) ||
+          dependency.isBlacklisted(configuration)) {
+          configurationReport.addDependency(dependency)
+        } else configurationReport.addDependency(dependency, download.report)
+      }
+    }
+
+    report.setDownloadTime(System.currentTimeMillis() - start)
+    report.setDownloadSize(totalSize)
+  }
+
+  /**
+   * Download all the artifacts associated with an ivy node.
+   *
+   * Return the report and the total downloaded size.
+   */
+  private def downloadNodeArtifacts(
+    dependency: IvyNode,
+    artifactFilter: Filter,
+    options: DownloadOptions): DownloadResult = {
+
+    val resolver = dependency.getModuleRevision.getArtifactResolver
+    val selectedArtifacts = dependency.getSelectedArtifacts(artifactFilter)
+    val downloadReport = resolver.download(selectedArtifacts, options)
+    val artifactReports = downloadReport.getArtifactsReports
+
+    val totalSize = artifactReports.foldLeft(0L) { (size, artifactReport) =>
+      // Check download status and report resolution failures
+      artifactReport.getDownloadStatus match {
+        case DownloadStatus.SUCCESSFUL =>
+          size + artifactReport.getSize
+        case DownloadStatus.FAILED =>
+          val artifact = artifactReport.getArtifact
+          val mergedAttribute = artifact.getExtraAttribute("ivy:merged")
+          if (mergedAttribute != null) {
+            Message.warn(
+              s"\tMissing merged artifact: $artifact, required by $mergedAttribute.")
+          } else {
+            Message.warn(s"\tDetected merged artifact: $artifactReport.")
+            resolver.reportFailure(artifactReport.getArtifact)
+          }
+          size
+        case _ => size
+      }
+    }
+
+    DownloadResult(dependency, downloadReport, totalSize)
+  }
+}


### PR DESCRIPTION
Ivy downloads have traditionally been single-threaded.

Parallel downloads are a must for a modern build tool. This commit
builds upon the work done by Josh Suereth in the branch
sbt/ivy-parallel-download-artifact.

To avoid adding external dependencies, it uses the Scala parallel
collections. If maintainers consider that is worth it to use a more
modern and appropriate approach, like `Task`, I'm happy to reimplement
the features with it.