### PR TITLE
[sbt 0.13] Add local-preloaded repo

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -12,6 +12,8 @@
 
 [repositories]
   local
+  local-preloaded-ivy: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   maven-central
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -49,7 +49,7 @@ lazy val checkPom = (readPom, fullResolvers) map { (pomXML, ivyRepositories) =>
     val repositories =  repositoriesElement \ "repository"
     val writtenRepositories = repositories.map(read).distinct
     val mavenStyleRepositories = ivyRepositories.collect {
-      case x: MavenRepository if (x.name != "public") && (x.name != "jcenter") => normalize(x)
+      case x: MavenRepository if (x.name != "public") && (x.name != "jcenter") && !(x.root startsWith "file:") => normalize(x)
     } distinct;
 
     lazy val explain = (("Written:" +: writtenRepositories) ++ ("Declared:" +: mavenStyleRepositories)).mkString("\n\t")

--- a/sbt/src/sbt-test/dependency-management/pom-advanced/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-advanced/build.sbt
@@ -12,8 +12,13 @@ lazy val root = (project in file(".")).
 
 val local = "local-maven-repo" at "file://" + (Path.userHome / ".m2" /"repository").absolutePath
 
-def pomIncludeRepository(base: File, prev: MavenRepository => Boolean) = (r: MavenRepository) =>
-  if(base / "repo.none" exists) false else if(base / "repo.all" exists) true else prev(r)
+def pomIncludeRepository(base: File, prev: MavenRepository => Boolean): MavenRepository => Boolean =
+  {
+    case r: MavenRepository if (r.name == "local-preloaded") => false
+    case r: MavenRepository if (base  / "repo.none" exists)  => false
+    case r: MavenRepository if (base / "repo.all" exists)    => true
+    case r: MavenRepository => prev(r)
+  }
 
 def addSlash(s: String): String =
   s match {


### PR DESCRIPTION
This adds additional "local-preloaded" repository that we can safely stuff to allow off-the-grid installation.

In conjunction with sbt-export-repo, I was able to launch sbt 0.13.14-SNAPSHOT from an airplane using fresh ivy.home and sbt.global.base.

### fast boot up

As a nice side effect of off-the-grid installation is that the boot up from empty state is going to be very fast. About 10s.

```
$ time java -jar sbt-launch.jar -Dsbt.ivy.home=/tmp/offline/ivy.home -Dsbt.global.base=/tmp/offline/global exit
Getting org.scala-sbt sbt 0.13.14-SNAPSHOT ...
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/sbt/0.13.14-SNAPSHOT/jars/sbt.jar ...
	[SUCCESSFUL ] org.scala-sbt#sbt;0.13.14-SNAPSHOT!sbt.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-lang/scala-library/2.10.6/jars/scala-library.jar ...
	[SUCCESSFUL ] org.scala-lang#scala-library;2.10.6!scala-library.jar (69ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/main/0.13.14-SNAPSHOT/jars/main.jar ...
	[SUCCESSFUL ] org.scala-sbt#main;0.13.14-SNAPSHOT!main.jar (20ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/compiler-interface/0.13.14-SNAPSHOT/jars/compiler-interface.jar ...
	[SUCCESSFUL ] org.scala-sbt#compiler-interface;0.13.14-SNAPSHOT!compiler-interface.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/actions/0.13.14-SNAPSHOT/jars/actions.jar ...
	[SUCCESSFUL ] org.scala-sbt#actions;0.13.14-SNAPSHOT!actions.jar (4ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/main-settings/0.13.14-SNAPSHOT/jars/main-settings.jar ...
	[SUCCESSFUL ] org.scala-sbt#main-settings;0.13.14-SNAPSHOT!main-settings.jar (6ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/interface/0.13.14-SNAPSHOT/jars/interface.jar ...
	[SUCCESSFUL ] org.scala-sbt#interface;0.13.14-SNAPSHOT!interface.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/io/0.13.14-SNAPSHOT/jars/io.jar ...
	[SUCCESSFUL ] org.scala-sbt#io;0.13.14-SNAPSHOT!io.jar (4ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/ivy/0.13.14-SNAPSHOT/jars/ivy.jar ...
	[SUCCESSFUL ] org.scala-sbt#ivy;0.13.14-SNAPSHOT!ivy.jar (15ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/logging/0.13.14-SNAPSHOT/jars/logging.jar ...
	[SUCCESSFUL ] org.scala-sbt#logging;0.13.14-SNAPSHOT!logging.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/logic/0.13.14-SNAPSHOT/jars/logic.jar ...
	[SUCCESSFUL ] org.scala-sbt#logic;0.13.14-SNAPSHOT!logic.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/process/0.13.14-SNAPSHOT/jars/process.jar ...
	[SUCCESSFUL ] org.scala-sbt#process;0.13.14-SNAPSHOT!process.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/run/0.13.14-SNAPSHOT/jars/run.jar ...
	[SUCCESSFUL ] org.scala-sbt#run;0.13.14-SNAPSHOT!run.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/command/0.13.14-SNAPSHOT/jars/command.jar ...
	[SUCCESSFUL ] org.scala-sbt#command;0.13.14-SNAPSHOT!command.jar (4ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/launcher-interface/1.0.0-M1/jars/launcher-interface.jar ...
	[SUCCESSFUL ] org.scala-sbt#launcher-interface;1.0.0-M1!launcher-interface.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/classpath/0.13.14-SNAPSHOT/jars/classpath.jar ...
	[SUCCESSFUL ] org.scala-sbt#classpath;0.13.14-SNAPSHOT!classpath.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/completion/0.13.14-SNAPSHOT/jars/completion.jar ...
	[SUCCESSFUL ] org.scala-sbt#completion;0.13.14-SNAPSHOT!completion.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/api/0.13.14-SNAPSHOT/jars/api.jar ...
	[SUCCESSFUL ] org.scala-sbt#api;0.13.14-SNAPSHOT!api.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/compiler-integration/0.13.14-SNAPSHOT/jars/compiler-integration.jar ...
	[SUCCESSFUL ] org.scala-sbt#compiler-integration;0.13.14-SNAPSHOT!compiler-integration.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/compiler-ivy-integration/0.13.14-SNAPSHOT/jars/compiler-ivy-integration.jar ...
	[SUCCESSFUL ] org.scala-sbt#compiler-ivy-integration;0.13.14-SNAPSHOT!compiler-ivy-integration.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/relation/0.13.14-SNAPSHOT/jars/relation.jar ...
	[SUCCESSFUL ] org.scala-sbt#relation;0.13.14-SNAPSHOT!relation.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/task-system/0.13.14-SNAPSHOT/jars/task-system.jar ...
	[SUCCESSFUL ] org.scala-sbt#task-system;0.13.14-SNAPSHOT!task-system.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/tasks/0.13.14-SNAPSHOT/jars/tasks.jar ...
	[SUCCESSFUL ] org.scala-sbt#tasks;0.13.14-SNAPSHOT!tasks.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/tracking/0.13.14-SNAPSHOT/jars/tracking.jar ...
	[SUCCESSFUL ] org.scala-sbt#tracking;0.13.14-SNAPSHOT!tracking.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/testing/0.13.14-SNAPSHOT/jars/testing.jar ...
	[SUCCESSFUL ] org.scala-sbt#testing;0.13.14-SNAPSHOT!testing.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-lang/scala-compiler/2.10.6/jars/scala-compiler.jar ...
	[SUCCESSFUL ] org.scala-lang#scala-compiler;2.10.6!scala-compiler.jar (95ms)
downloading file:/tmp/offline/global/preloaded/org.scala-lang/scala-reflect/2.10.6/jars/scala-reflect.jar ...
	[SUCCESSFUL ] org.scala-lang#scala-reflect;2.10.6!scala-reflect.jar (22ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/control/0.13.14-SNAPSHOT/jars/control.jar ...
	[SUCCESSFUL ] org.scala-sbt#control;0.13.14-SNAPSHOT!control.jar (1ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/collections/0.13.14-SNAPSHOT/jars/collections.jar ...
	[SUCCESSFUL ] org.scala-sbt#collections;0.13.14-SNAPSHOT!collections.jar (4ms)
downloading file:/tmp/offline/global/preloaded/jline/jline/2.13/jars/jline.jar ...
	[SUCCESSFUL ] jline#jline;2.13!jline.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.fusesource.jansi/jansi/1.11/jars/jansi.jar ...
	[SUCCESSFUL ] org.fusesource.jansi#jansi;1.11!jansi.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/classfile/0.13.14-SNAPSHOT/jars/classfile.jar ...
	[SUCCESSFUL ] org.scala-sbt#classfile;0.13.14-SNAPSHOT!classfile.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/incremental-compiler/0.13.14-SNAPSHOT/jars/incremental-compiler.jar ...
	[SUCCESSFUL ] org.scala-sbt#incremental-compiler;0.13.14-SNAPSHOT!incremental-compiler.jar (4ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/compile/0.13.14-SNAPSHOT/jars/compile.jar ...
	[SUCCESSFUL ] org.scala-sbt#compile;0.13.14-SNAPSHOT!compile.jar (4ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/persist/0.13.14-SNAPSHOT/jars/persist.jar ...
	[SUCCESSFUL ] org.scala-sbt#persist;0.13.14-SNAPSHOT!persist.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-tools.sbinary/sbinary_2.10/0.4.2/jars/sbinary_2.10.jar ...
	[SUCCESSFUL ] org.scala-tools.sbinary#sbinary_2.10;0.4.2!sbinary_2.10.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/cross/0.13.14-SNAPSHOT/jars/cross.jar ...
	[SUCCESSFUL ] org.scala-sbt#cross;0.13.14-SNAPSHOT!cross.jar (1ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt.ivy/ivy/2.3.0-sbt-48dd0744422128446aee9ac31aa356ee203cc9f4/jars/ivy.jar ...
	[SUCCESSFUL ] org.scala-sbt.ivy#ivy;2.3.0-sbt-48dd0744422128446aee9ac31aa356ee203cc9f4!ivy.jar (10ms)
downloading file:/tmp/offline/global/preloaded/com.jcraft/jsch/0.1.50/jars/jsch.jar ...
	[SUCCESSFUL ] com.jcraft#jsch;0.1.50!jsch.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/serialization_2.10/0.1.2/jars/serialization_2.10.jar ...
	[SUCCESSFUL ] org.scala-sbt#serialization_2.10;0.1.2!serialization_2.10.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-lang.modules/scala-pickling_2.10/0.10.1/jars/scala-pickling_2.10.jar ...
	[SUCCESSFUL ] org.scala-lang.modules#scala-pickling_2.10;0.10.1!scala-pickling_2.10.jar (7ms)
downloading file:/tmp/offline/global/preloaded/org.json4s/json4s-core_2.10/3.2.10/jars/json4s-core_2.10.jar ...
	[SUCCESSFUL ] org.json4s#json4s-core_2.10;3.2.10!json4s-core_2.10.jar (5ms)
downloading file:/tmp/offline/global/preloaded/org.spire-math/jawn-parser_2.10/0.6.0/jars/jawn-parser_2.10.jar ...
	[SUCCESSFUL ] org.spire-math#jawn-parser_2.10;0.6.0!jawn-parser_2.10.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.spire-math/json4s-support_2.10/0.6.0/jars/json4s-support_2.10.jar ...
	[SUCCESSFUL ] org.spire-math#json4s-support_2.10;0.6.0!json4s-support_2.10.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scalamacros/quasiquotes_2.10/2.0.1/jars/quasiquotes_2.10.jar ...
	[SUCCESSFUL ] org.scalamacros#quasiquotes_2.10;2.0.1!quasiquotes_2.10.jar (6ms)
downloading file:/tmp/offline/global/preloaded/org.json4s/json4s-ast_2.10/3.2.10/jars/json4s-ast_2.10.jar ...
	[SUCCESSFUL ] org.json4s#json4s-ast_2.10;3.2.10!json4s-ast_2.10.jar (3ms)
downloading file:/tmp/offline/global/preloaded/com.thoughtworks.paranamer/paranamer/2.6/jars/paranamer.jar ...
	[SUCCESSFUL ] com.thoughtworks.paranamer#paranamer;2.6!paranamer.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/cache/0.13.14-SNAPSHOT/jars/cache.jar ...
	[SUCCESSFUL ] org.scala-sbt#cache;0.13.14-SNAPSHOT!cache.jar (2ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/test-agent/0.13.14-SNAPSHOT/jars/test-agent.jar ...
	[SUCCESSFUL ] org.scala-sbt#test-agent;0.13.14-SNAPSHOT!test-agent.jar (1ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/test-interface/1.0/jars/test-interface.jar ...
	[SUCCESSFUL ] org.scala-sbt#test-interface;1.0!test-interface.jar (1ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/apply-macro/0.13.14-SNAPSHOT/jars/apply-macro.jar ...
	[SUCCESSFUL ] org.scala-sbt#apply-macro;0.13.14-SNAPSHOT!apply-macro.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.scala-sbt/template-resolver/0.1/jars/template-resolver.jar ...
	[SUCCESSFUL ] org.scala-sbt#template-resolver;0.1!template-resolver.jar (3ms)
:: retrieving :: org.scala-sbt#boot-app
	confs: [default]
	50 artifacts copied, 0 already retrieved (17652kB/59ms)
Getting Scala 2.10.6 (for sbt)...
downloading file:/tmp/offline/global/preloaded/org.scala-lang/jline/2.10.6/jars/jline.jar ...
	[SUCCESSFUL ] org.scala-lang#jline;2.10.6!jline.jar (3ms)
downloading file:/tmp/offline/global/preloaded/org.fusesource.jansi/jansi/1.4/jars/jansi.jar ...
	[SUCCESSFUL ] org.fusesource.jansi#jansi;1.4!jansi.jar (3ms)
:: retrieving :: org.scala-sbt#boot-scala
	confs: [default]
	5 artifacts copied, 0 already retrieved (24494kB/54ms)
[info] Set current project to offline (in build file:/private/tmp/offline/)
java -jar sbt-launch.jar -Dsbt.ivy.home=/tmp/offline/ivy.home  exit  10.66s user 0.69s system 323% cpu 3.508 total
```

The second run was 5s.

```
$ time java -jar sbt-launch.jar -Dsbt.ivy.home=/tmp/offline/ivy.home -Dsbt.global.base=/tmp/offline/global exit
[info] Set current project to offline (in build file:/private/tmp/offline/)
java -jar sbt-launch.jar -Dsbt.ivy.home=/tmp/offline/ivy.home  exit  5.48s user 0.34s system 268% cpu 2.167 total
```

Ref #2518
