### PR TITLE
Notify & enable users to stay in the warm shell

### DIFF
--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -67,8 +67,10 @@ object MainLoop {
       val loggedState = state.copy(globalLogging = newLogging)
       def isInteractive = System.console() != null
       def hasShell = state.remainingCommands contains "shell"
-      if (isInteractive && !hasShell)
-        state.log warn "Executing in batch mode; for better performance, hit [ENTER] to remain in the sbt shell"
+      if (isInteractive && !hasShell) {
+        state.log warn "BATCH MODE: for better performance hit [ENTER] to switch to interactive mode"
+        state.log warn "  consider launching sbt without any commands, or explicitly passing 'shell'"
+      }
       try run(loggedState) finally out.close()
     }
 

--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -65,6 +65,10 @@ object MainLoop {
       val newLogging = state.globalLogging.newLogger(out, logBacking)
       transferLevels(state, newLogging)
       val loggedState = state.copy(globalLogging = newLogging)
+      def isInteractive = System.console() != null
+      def hasShell = state.remainingCommands contains "shell"
+      if (isInteractive && !hasShell)
+        state.log info "!!! Executing in batch mode !!! For better performance, hit [ENTER] to remain in the sbt shell"
       try run(loggedState) finally out.close()
     }
 

--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -68,7 +68,7 @@ object MainLoop {
       def isInteractive = System.console() != null
       def hasShell = state.remainingCommands contains "shell"
       if (isInteractive && !hasShell)
-        state.log info "!!! Executing in batch mode !!! For better performance, hit [ENTER] to remain in the sbt shell"
+        state.log warn "Executing in batch mode; for better performance, hit [ENTER] to remain in the sbt shell"
       try run(loggedState) finally out.close()
     }
 

--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -68,7 +68,8 @@ object MainLoop {
       def isInteractive = System.console() != null
       def hasShell = state.remainingCommands contains "shell"
       if (isInteractive && !hasShell) {
-        state.log warn "BATCH MODE: for better performance hit [ENTER] to switch to interactive mode"
+        state.log warn "Executing in batch mode."
+        state.log warn "  For better performance, hit [ENTER] to switch to interactive mode, or"
         state.log warn "  consider launching sbt without any commands, or explicitly passing 'shell'"
       }
       try run(loggedState) finally out.close()

--- a/notes/0.13.14/stay-in-shell.md
+++ b/notes/0.13.14/stay-in-shell.md
@@ -1,0 +1,7 @@
+### Improvements
+
+- Notifies & enables users to stay in sbt's shell on the warm JVM by hitting \[ENTER\] while sbt is running. [#2987][]/[#2996][] by [@dwijnand][]
+
+[#2987]: https://github.com/sbt/sbt/issues/2987
+[#2996]: https://github.com/sbt/sbt/pull/2996
+[@dwijnand]: https://github.com/dwijnand


### PR DESCRIPTION
Notify & enable users to stay in sbt's shell on the warm JVM by hitting
[ENTER] while sbt is running.

Looks like this; first I run 'sbt about', then I hit [ENTER]:

    $ sbt about
    [info] !!! Executing in batch mode !!! For better performance, hit [ENTER] to remain in the sbt shell

    [info] Loading global plugins from /Users/dnw/.dotfiles/.sbt/0.13/plugins
    [info] Loading project definition from /s/t/project
    [info] Set current project to t (in build file:/s/t/)
    [info] This is sbt 0.13.14-SNAPSHOT
    [info] The current project is {file:/s/t/}t 0.1.0-SNAPSHOT
    [info] The current project is built against Scala 2.12.1
    [info] Available Plugins: sbt.plugins.IvyPlugin, sbt.plugins.JvmPlugin, sbt.plugins.CorePlugin, sbt.plugins.JUnitXmlReportPlugin, sbt.plugins.Giter8TemplatePlugin
    [info] sbt, sbt plugins, and build definitions are using Scala 2.10.6
    >
    >

Fixes #2987 

![image](https://cloud.githubusercontent.com/assets/344610/23659592/7fbaec68-033e-11e7-8a5f-1efe81879770.png)

