### PR TITLE
Handle non-shell sbt startup warning

### DIFF
--- a/main/command/src/main/scala/sbt/MainLoop.scala
+++ b/main/command/src/main/scala/sbt/MainLoop.scala
@@ -67,7 +67,12 @@ object MainLoop {
       val loggedState = state.copy(globalLogging = newLogging)
       def isInteractive = System.console() != null
       def hasShell = state.remainingCommands contains "shell"
-      if (isInteractive && !hasShell) {
+      /**
+       * The "boot" command adds "iflast shell" ("if last shell")
+       * which basically means it falls back to shell if there are no further commands
+       */
+      def endsWithBoot = state.remainingCommands.lastOption exists (_ == "boot")
+      if (isInteractive && !hasShell && !endsWithBoot) {
         state.log warn "Executing in batch mode."
         state.log warn "  For better performance, hit [ENTER] to switch to interactive mode, or"
         state.log warn "  consider launching sbt without any commands, or explicitly passing 'shell'"


### PR DESCRIPTION
The sbt/sbt-launcher-package doesn't invoke sbt with the "shell"
command. sbt has a mechanism for handling this in its "boot" command
that adds an "iflast shell" to the commands. Handle this when displaying
the "Executing in batch mode" warning.

Fixes #3004