### PR TITLE
s/newInstance/getDeclaredConstructor().newInstance()

### DIFF
--- a/main/src/main/scala/sbt/TemplateCommand.scala
+++ b/main/src/main/scala/sbt/TemplateCommand.scala
@@ -69,7 +69,7 @@ private[sbt] object TemplateCommandUtil {
   private def call(interfaceClassName: String, methodName: String, loader: ClassLoader)(argTypes: Class[_]*)(args: AnyRef*): AnyRef =
     {
       val interfaceClass = getInterfaceClass(interfaceClassName, loader)
-      val interface = interfaceClass.newInstance.asInstanceOf[AnyRef]
+      val interface = interfaceClass.getDeclaredConstructor().newInstance().asInstanceOf[AnyRef]
       val method = interfaceClass.getMethod(methodName, argTypes: _*)
       try { method.invoke(interface, args: _*) }
       catch {

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -93,7 +93,7 @@ object Scripted {
     val noJLine = new classpath.FilteredLoader(scriptedSbtInstance.loader, "jline." :: Nil)
     val loader = classpath.ClasspathUtilities.toLoader(scriptedSbtClasspath.files, noJLine)
     val bridgeClass = Class.forName("sbt.test.ScriptedRunner", true, loader)
-    val bridge = bridgeClass.newInstance.asInstanceOf[SbtScriptedRunner]
+    val bridge = bridgeClass.getDeclaredConstructor().newInstance().asInstanceOf[SbtScriptedRunner]
     try {
       // Using java.util.List to encode File => Unit.
       val callback = new java.util.AbstractList[File] {

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -227,7 +227,7 @@ final public class ForkMain {
 				Framework framework = null;
 				for (final String implClassName : implClassNames) {
 					try {
-						final Object rawFramework = Class.forName(implClassName).newInstance();
+						final Object rawFramework = Class.forName(implClassName).getDeclaredConstructor().newInstance();
 						if (rawFramework instanceof Framework)
 							framework = (Framework) rawFramework;
 						else

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -31,7 +31,7 @@ case class TestFramework(implClassNames: String*) {
     frameworkClassNames match {
       case head :: tail =>
         try {
-          Some(Class.forName(head, true, loader).newInstance match {
+          Some(Class.forName(head, true, loader).getDeclaredConstructor().newInstance() match {
             case newFramework: Framework    => newFramework
             case oldFramework: OldFramework => new FrameworkWrapper(oldFramework)
           })


### PR DESCRIPTION
`java.lang.Class#newInstance` deprecated since Java 9

http://download.java.net/java/jdk9/docs/api/java/lang/Class.html#newInstance--
