### PR TITLE
Speed up startup and reload times

### DIFF
--- a/main/src/main/scala/sbt/internals/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtParser.scala
@@ -6,7 +6,12 @@ import java.io.File
 
 import sbt.internals.parser.SbtParser._
 
-import scala.reflect.runtime.universe._
+import scala.compat.Platform.EOL
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.io.VirtualDirectory
+import scala.tools.nsc.interactive.RangePositions
+import scala.tools.nsc.{ CompilerCommand, Global }
+import scala.tools.nsc.reporters.StoreReporter
 
 private[sbt] object SbtParser {
   val END_OF_LINE_CHAR = '\n'
@@ -15,12 +20,85 @@ private[sbt] object SbtParser {
   private[sbt] val FAKE_FILE = new File("fake")
   private[parser] val XML_ERROR = "';' expected but 'val' found."
 
-  import scala.reflect.runtime._
-  import scala.tools.reflect.ToolBox
-  private[parser] lazy val toolbox =
-    universe.rootMirror.mkToolBox(options = "-Yrangepos")
-  private[parser] def parse(code: String) = synchronized {
-    toolbox.parse(code)
+  private val XmlErrorMessage =
+    """Probably problem with parsing xml group, please add parens or semicolons:
+      |Replace:
+      |val xmlGroup = <a/><b/>
+      |with:
+      |val xmlGroup = (<a/><b/>)
+      |or
+      |val xmlGroup = <a/><b/>;
+    """.stripMargin
+
+  private final val defaultClasspath =
+    Path.makeString(IO.classLocationFile[Product] :: Nil)
+
+  /**
+   * Provides the previous error reporting functionality in
+   * [[scala.tools.reflect.ToolBox]].
+   *
+   * This is a sign that this whole parser should be rewritten.
+   * There are exceptions everywhere and the logic to work around
+   * the scalac parser bug heavily relies on them and it's tied
+   * to the test suite. Ideally, we only want to throw exceptions
+   * when we know for a fact that the user-provided snippet doesn't
+   * parse.
+   */
+  private[sbt] class ParserStoreReporter extends StoreReporter {
+    def throwParserErrorsIfAny(fileName: String): Unit = {
+      if (parserReporter.hasErrors) {
+        val seq = parserReporter.infos.map { info =>
+          s"""[$fileName]:${info.pos.line}: ${info.msg}"""
+        }
+        val errorMessage = seq.mkString(EOL)
+        val error: String =
+          if (errorMessage.contains(XML_ERROR))
+            s"$errorMessage\n${SbtParser.XmlErrorMessage}"
+          else errorMessage
+        throw new MessageOnlyException(error)
+      }
+    }
+  }
+
+  private[sbt] final val parserReporter = new ParserStoreReporter
+
+  private[sbt] final lazy val defaultGlobalForParser = {
+    import scala.reflect.internal.util.NoPosition
+    val options = "-cp" :: s"$defaultClasspath" :: "-Yrangepos" :: Nil
+    val reportError = (msg: String) => parserReporter.error(NoPosition, msg)
+    val command = new CompilerCommand(options, reportError)
+    val settings = command.settings
+    settings.outputDirs.setSingleOutput(new VirtualDirectory("(memory)", None))
+
+    // Mixing RangePositions is necessary, otherwise global ignores -Yrangepos
+    val global = new Global(settings, parserReporter) with RangePositions
+    val run = new global.Run
+    // Necessary to have a dummy unit for initialization...
+    val initFile = new BatchSourceFile("<wrapper-init>", "")
+    val _ = new global.CompilationUnit(initFile)
+    global.phase = run.parserPhase
+    global
+  }
+
+  import defaultGlobalForParser.Tree
+
+  /**
+   * Parse code reusing the same [[Run]] instance.
+   *
+   * The access to this method has to be synchronized (no more than one
+   * thread can access to it at the same time since it reuses the same
+   * [[Global]], which mutates the whole universe).
+   */
+  private[sbt] def parse(code: String, fileName: String): Seq[Tree] = synchronized {
+    import defaultGlobalForParser._
+    parserReporter.reset()
+    val wrapperFile = new BatchSourceFile("<wrapper>", code)
+    val unit = new CompilationUnit(wrapperFile)
+    val parser = new syntaxAnalyzer.UnitParser(unit)
+    val parsedTrees = parser.templateStats()
+    parser.accept(scala.tools.nsc.ast.parser.Tokens.EOF)
+    parserReporter.throwParserErrorsIfAny(fileName)
+    parsedTrees
   }
 }
 
@@ -36,7 +114,7 @@ sealed trait ParsedSbtFileExpressions {
   def settings: Seq[(String, LineRange)]
 
   /** The set of scala tree's for parsed definitions/settings and the underlying string representation.. */
-  def settingsTrees: Seq[(String, Tree)]
+  def settingsTrees: Seq[(String, Global#Tree)]
 
 }
 
@@ -65,56 +143,20 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
   // parsed trees.
   val (imports, settings, settingsTrees) = splitExpressions(file, lines)
 
+  import SbtParser.defaultGlobalForParser._
+
   private def splitExpressions(file: File, lines: Seq[String]): (Seq[(String, Int)], Seq[(String, LineRange)], Seq[(String, Tree)]) = {
     import sbt.internals.parser.MissingBracketHandler.findMissingText
-
-    import scala.compat.Platform.EOL
-    import scala.tools.reflect.ToolBoxError
 
     val indexedLines = lines.toIndexedSeq
     val content = indexedLines.mkString(END_OF_LINE)
     val fileName = file.getAbsolutePath
-
-    val parsed =
-      try {
-        SbtParser.parse(content)
-      } catch {
-        case e: ToolBoxError =>
-          val seq = SbtParser.toolbox.frontEnd.infos.map { i =>
-            s"""[$fileName]:${i.pos.line}: ${i.msg}"""
-          }
-          val errorMessage = seq.mkString(EOL)
-
-          val error = if (errorMessage.contains(XML_ERROR)) {
-            s"""
-               |$errorMessage
-               |Probably problem with parsing xml group, please add parens or semicolons:
-               |Replace:
-               |val xmlGroup = <a/><b/>
-               |with:
-               |val xmlGroup = (<a/><b/>)
-               |or
-               |val xmlGroup = <a/><b/>;
-               |
-             """.stripMargin
-          } else {
-            errorMessage
-          }
-          throw new MessageOnlyException(error)
-      } finally {
-        SbtParser.toolbox.frontEnd.infos.clear()
-      }
-    val parsedTrees = parsed match {
-      case Block(stmt, expr) =>
-        stmt :+ expr
-      case t: Tree =>
-        Seq(t)
-    }
+    val parsedTrees: Seq[Tree] = parse(content, fileName)
 
     // Check No val (a,b) = foo *or* val a,b = foo as these are problematic to range positions and the WHOLE architecture.
     def isBadValDef(t: Tree): Boolean =
       t match {
-        case x @ toolbox.u.ValDef(_, _, _, rhs) if rhs != toolbox.u.EmptyTree =>
+        case x @ ValDef(_, _, _, rhs) if rhs != EmptyTree =>
           val c = content.substring(x.pos.start, x.pos.end)
           !(c contains "=")
         case _ => false
@@ -125,7 +167,7 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
       throw new MessageOnlyException(s"""[$fileName]:$positionLine: Pattern matching in val statements is not supported""".stripMargin)
     }
 
-    val (imports, statements) = parsedTrees partition {
+    val (imports: Seq[Tree], statements: Seq[Tree]) = parsedTrees partition {
       case _: Import => true
       case _         => false
     }
@@ -137,7 +179,7 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
      * @return originalStatement or originalStatement with missing bracket
      */
     def parseStatementAgain(t: Tree, originalStatement: String): String = {
-      val statement = util.Try(SbtParser.parse(originalStatement)) match {
+      val statement = util.Try(parse(originalStatement, fileName)) match {
         case util.Failure(th) =>
           val missingText = findMissingText(content, t.pos.end, t.pos.line, fileName, th)
           originalStatement + missingText
@@ -222,7 +264,7 @@ private[sbt] object MissingBracketHandler {
       case Some(index) =>
         val text = content.substring(positionEnd, index + 1)
         val textWithoutBracket = text.substring(0, text.length - 1)
-        util.Try(SbtParser(FAKE_FILE, textWithoutBracket.lines.toSeq)) match {
+        util.Try(SbtParser.parse(textWithoutBracket, fileName)) match {
           case util.Success(_) =>
             text
           case util.Failure(th) =>

--- a/main/src/main/scala/sbt/internals/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtParser.scala
@@ -14,6 +14,14 @@ private[sbt] object SbtParser {
   private[parser] val NOT_FOUND_INDEX = -1
   private[sbt] val FAKE_FILE = new File("fake")
   private[parser] val XML_ERROR = "';' expected but 'val' found."
+
+  import scala.reflect.runtime._
+  import scala.tools.reflect.ToolBox
+  private[parser] lazy val toolbox =
+    universe.rootMirror.mkToolBox(options = "-Yrangepos")
+  private[parser] def parse(code: String) = synchronized {
+    toolbox.parse(code)
+  }
 }
 
 /**
@@ -58,24 +66,21 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
   val (imports, settings, settingsTrees) = splitExpressions(file, lines)
 
   private def splitExpressions(file: File, lines: Seq[String]): (Seq[(String, Int)], Seq[(String, LineRange)], Seq[(String, Tree)]) = {
-    import sbt.internals.parser.MissingBracketHandler._
+    import sbt.internals.parser.MissingBracketHandler.findMissingText
 
     import scala.compat.Platform.EOL
-    import scala.reflect.runtime._
-    import scala.tools.reflect.{ ToolBox, ToolBoxError }
+    import scala.tools.reflect.ToolBoxError
 
-    val mirror = universe.runtimeMirror(this.getClass.getClassLoader)
-    val toolbox = mirror.mkToolBox(options = "-Yrangepos")
     val indexedLines = lines.toIndexedSeq
     val content = indexedLines.mkString(END_OF_LINE)
     val fileName = file.getAbsolutePath
 
     val parsed =
       try {
-        toolbox.parse(content)
+        SbtParser.parse(content)
       } catch {
         case e: ToolBoxError =>
-          val seq = toolbox.frontEnd.infos.map { i =>
+          val seq = SbtParser.toolbox.frontEnd.infos.map { i =>
             s"""[$fileName]:${i.pos.line}: ${i.msg}"""
           }
           val errorMessage = seq.mkString(EOL)
@@ -96,6 +101,8 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
             errorMessage
           }
           throw new MessageOnlyException(error)
+      } finally {
+        SbtParser.toolbox.frontEnd.infos.clear()
       }
     val parsedTrees = parsed match {
       case Block(stmt, expr) =>
@@ -130,7 +137,7 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
      * @return originalStatement or originalStatement with missing bracket
      */
     def parseStatementAgain(t: Tree, originalStatement: String): String = {
-      val statement = util.Try(toolbox.parse(originalStatement)) match {
+      val statement = util.Try(SbtParser.parse(originalStatement)) match {
         case util.Failure(th) =>
           val missingText = findMissingText(content, t.pos.end, t.pos.line, fileName, th)
           originalStatement + missingText

--- a/main/src/main/scala/sbt/internals/parser/SbtRefactorings.scala
+++ b/main/src/main/scala/sbt/internals/parser/SbtRefactorings.scala
@@ -2,8 +2,6 @@ package sbt
 package internals
 package parser
 
-import scala.reflect.runtime.universe._
-
 private[sbt] object SbtRefactorings {
 
   import sbt.internals.parser.SbtParser.{ END_OF_LINE, FAKE_FILE }
@@ -82,7 +80,8 @@ private[sbt] object SbtRefactorings {
     seq.toMap
   }
 
-  private def extractSettingName(tree: Tree): String =
+  import scala.tools.nsc.Global
+  private def extractSettingName(tree: Global#Tree): String =
     tree.children match {
       case h :: _ =>
         extractSettingName(h)


### PR DESCRIPTION
These changes are optimizations that affect the following sbt subsytems:

1. Sbt parser.
2. Plugin discovery.

A concise explanation for every change is provided in the commit message.  In
short, this PR makes sure that we don't load the whole Scala reflect universe
to check whether a plugin has a `autoImport` member or to parse a sbt file.

In informal measurements, these changes affect around ~12-14% of the whole
startup time. These are the results before:

```
jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11310 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  29.66s user 0.56s system 297% cpu 10.171 total

jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11310 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  30.52s user 0.46s system 299% cpu 10.337 total

jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11310 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  28.85s user 0.43s system 293% cpu 9.988 total
```

And after:

```
jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[warn] Executing in batch mode.
[warn]   For better performance, hit [ENTER] to switch to interactive mode, or
[warn]   consider launching sbt without any commands, or explicitly passing 'shell'
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11355 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  24.83s user 0.51s system 286% cpu 8.831 total

jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[warn] Executing in batch mode.
[warn]   For better performance, hit [ENTER] to switch to interactive mode, or
[warn]   consider launching sbt without any commands, or explicitly passing 'shell'
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11355 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  24.46s user 0.46s system 287% cpu 8.674 total

jvican in /data/rw/code/scala/scala
> $ time sbt "exit"
[warn] Executing in batch mode.
[warn]   For better performance, hit [ENTER] to switch to interactive mode, or
[warn]   consider launching sbt without any commands, or explicitly passing 'shell'
[info] Loading global plugins from /home/jvican/.sbt/0.13/plugins
[info] Loading project definition from /data/rw/code/scala/scala/project/project
[info] Loading project definition from /data/rw/code/scala/scala/project
[info] Resolving key references (11355 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
sbt -mem 2048 "exit"  25.12s user 0.45s system 290% cpu 8.802 total
```