### PR TITLE
[fport] Automatically choose proper compiler bridge for dotty

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -283,7 +283,12 @@ object Defaults extends BuildCommon {
       val _ = clean.value
       IvyActions.cleanCachedResolutionCache(ivyModule.value, streams.value.log)
     },
-    scalaCompilerBridgeSource := Compiler.defaultCompilerBridgeSource(scalaVersion.value)
+    scalaCompilerBridgeSource := {
+      if (ScalaInstance.isDotty(scalaVersion.value))
+        // Maintained at https://github.com/lampepfl/dotty/tree/master/sbt-bridge
+        ModuleID(scalaOrganization.value, "dotty-sbt-bridge", scalaVersion.value).withConfigurations(Some("component")).sources()
+      else Compiler.defaultCompilerBridgeSource(scalaVersion.value)
+    }
   )
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(Seq(

--- a/notes/0.13.14/dotty_bridge.md
+++ b/notes/0.13.14/dotty_bridge.md
@@ -1,0 +1,11 @@
+### Improvements
+
+- When sbt detects that the project is compiled with dotty, it now automatically
+  set `scalaCompilerBridgeSource` correctly, this reduces the boilerplate needed
+  to make a dotty project. Note that dotty support in sbt is still considered
+  experimental and not officially supported, see [dotty.epfl.ch][dotty] for
+  more information. [#2902][2902] by [@smarter][@smarter]
+
+  [dotty]: http://dotty.epfl.ch/
+  [2902]: https://github.com/sbt/sbt/pull/2902
+  [@smarter]: https://github.com/smarter


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/2902

Before this commit, using dotty in your sbt project required to add:

```scala
  scalaCompilerBridgeSource := ("ch.epfl.lamp" % "dotty-sbt-bridge" %
  scalaVersion.value % "component").sources()
```

in your build.sbt. We might as well automatically do this, this reduces
the boilerplate for using dotty in your project to:

```scala
  scalaOrganization := "ch.epfl.lamp"
  scalaVersion := "0.1.1-SNAPSHOT"
  scalaBinaryVersion := "2.11" // dotty itself is only published as a
                               // 2.11 artefact currently
```
