### PR TITLE
Stop defining the artifact configuration based on the classifier

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -785,8 +785,8 @@ object Defaults extends BuildCommon {
       val combined = cPart.toList ++ classifier.toList
       if (combined.isEmpty) a.withClassifier(None).withConfigurations(cOpt.toVector) else {
         val classifierString = combined mkString "-"
-        val confs = cOpt.toVector flatMap { c => artifactConfigurations(a, c, classifier) }
-        a.withClassifier(Some(classifierString)).withType(Artifact.classifierType(classifierString)).withConfigurations(confs)
+        a.withClassifier(Some(classifierString)).withType(Artifact.classifierType(classifierString))
+          .withConfigurations(cOpt.toVector)
       }
     }
   @deprecated("The configuration(s) should not be decided based on the classifier.", "1.0")


### PR DESCRIPTION
I believe this was accidentally not forward-ported from the 0.14 branch
to the 1.0.x branch.  Notice the change was present in #1016:

  https://github.com/sbt/sbt/pull/1016/files#diff-6373e7f7122325e753b75fe1cc76ff5fL576

and missing in #2478:

  https://github.com/sbt/sbt/pull/2478/files#diff-6373e7f7122325e753b75fe1cc76ff5fR680