### PR TITLE
Improve IO.toFile for Windows (URI has an authority component)

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -12,8 +12,8 @@
 
 [repositories]
   local
-  local-preloaded-ivy: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  local-preloaded-ivy: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   maven-central
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1939,7 +1939,7 @@ object Classpaths {
           i.url.getProtocol match {
             case "file" =>
               // This hackery is to deal suitably with UNC paths on Windows. Once we can assume Java7, Paths should save us from this.
-              val file = try { new File(i.url.toURI) } catch { case e: java.net.URISyntaxException => new File(i.url.getPath) }
+              val file = IO.toFile(i.url)
               Resolver.file(i.id, file)(patterns)
             case _ => Resolver.url(i.id, i.url)(patterns)
           }


### PR DESCRIPTION
The URL encoding of Windows path that works out of the box is:

- `file:///C:/Users/foo` for path on the local machine.
- `file:////unc/Users/foo` for UNC path.

Even thought this is not the most modern/canonical encoding, it allows `file:///` to be used as a cross-platform prefix `file:///${user.home}` since on Mac and Linux `user.home` would look like `/Users/foo`, it would come out as `file:////Users/foo`.

### original PR

This adds support to convert from an `URL` to a `File` on Windows in several ways.

```scala
scala> val u0 = new URL("file:C:\\Users\\foo/.sbt/preloaded")
u0: java.net.URL = file:C:/Users/foo/.sbt/preloaded

scala> toFile(u0)
res0: java.io.File = C:\Users\foo\.sbt\preloaded

scala> val u1 = new URL("file:/C:\\Users\\foo/.sbt/preloaded")
u1: java.net.URL = file:/C:/Users/foo/.sbt/preloaded

scala> toFile(u1)
res2: java.io.File = C:\Users\foo\.sbt\preloaded

scala> val u2 = new URL("file://unc/Users/foo/.sbt/preloaded")
u2: java.net.URL = file://unc/Users/foo/.sbt/preloaded

scala> toFile(u2)
res4: java.io.File = \\unc\Users\foo\.sbt\preloaded

scala> val u3 = new URL("file:///C:\\Users\\foo/.sbt/preloaded")
u3: java.net.URL = file:/C:/Users/foo/.sbt/preloaded

scala> toFile(u3)
res5: java.io.File = C:\Users\foo\.sbt\preloaded

scala> val u4 = new URL("file:////unc/Users/foo/.sbt/preloaded")
u4: java.net.URL = file:////unc/Users/foo/.sbt/preloaded

scala> toFile(u4)
res8: java.io.File = \\unc\Users\foo\.sbt\preloaded
```

This is an improvement over the constructor of `File`, which is unable to handle `u0` and `u2` cases:

```scala
scala> val u0 = new URL("file:C:\\Users\\foo/.sbt/preloaded")
u0: java.net.URL = file:C:/Users/foo/.sbt/preloaded

scala> new File(u0.toURI)
java.lang.IllegalArgumentException: URI is not hierarchical
        at java.io.File.<init>(File.java:418)

scala> val u2 = new URL("file://unc/Users/foo/.sbt/preloaded")
u2: java.net.URL = file://unc/Users/foo/.sbt/preloaded

scala> new File(u2.toURI)
java.lang.IllegalArgumentException: URI has an authority component
        at java.io.File.<init>(File.java:423)
```

The error case for two slashes "URI has an authority component" shows up in many cases, most recently borking 0.13.14 in #3086. Note that it might be intuitive to encode file path by starting with `file://` similar to `http://`, however this is [specified by Microsoft](https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/) to be an UNC path, so the URI `file://C:/Users/foo/.sbt/preloaded` is illegal. Since the *authority component* after `//`, in this case `C:` should denote the remote host name.

This complicates trying to specify sbt global base (default `~/.sbt/`) path in a cross platform way.

```
  local-preloaded-ivy: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
  local-preloaded: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
```

The above original is incorrect because on Windows, `${user.home}` would return `C:\Users\foo\`. The solution is to encode without the prefix slashes like `u0`.

```
  local-preloaded-ivy: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
  local-preloaded: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
```

Fixes #3086
Fixes #2150
