### PR TITLE
Add three slashes (u3) for file URI

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -12,8 +12,8 @@
 
 [repositories]
   local
-  local-preloaded-ivy: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file:${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   maven-central
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly


### PR DESCRIPTION
#3088 attemped to fix #3086, but by putting no slashes in `sbt.boot.properties` the launcher created by 0.13.15-* becomes incompatible for all previous sbt versions.

The uglier but backward compatible fix for #3086 is to use u3 format with three slashes. This on Windows will resolve to `file:///C:/Users/foo/.sbt/preloaded`, and on Mac and Linux `file:////root/.sbt/preloaded/`. Mac and Linux are both tolerant of extra slashes on the front:

```
> eval new File(new URL("file:////Users/foo/.sbt/preloaded/").toURI)
[info] ans: java.io.File = /Users/foo/.sbt/preloaded
```

On Docker...

```
/# /opt/sbt/bin/sbt
Copying runtime jar.
Getting org.scala-sbt sbt 0.13.15-RC1  (this may take some time)...
downloading file:////root/.sbt/preloaded/org.scala-sbt/sbt/0.13.15-RC1/jars/sbt.jar ...
	[SUCCESSFUL ] org.scala-sbt#sbt;0.13.15-RC1!sbt.jar (3ms)
downloading file:////root/.sbt/preloaded/org.scala-lang/scala-library/2.10.6/jars/scala-library.jar ...
	[SUCCESSFUL ] org.scala-lang#scala-library;2.10.6!scala-library.jar (46ms)
downloading file:////root/.sbt/preloaded/org.scala-sbt/main/0.13.15-RC1/jars/main.jar ...
	[SUCCESSFUL ] org.scala-sbt#main;0.13.15-RC1!main.jar (18ms)
downloading file:////root/.sbt/preloaded/org.scala-sbt/compiler-interface/0.13.15-RC1/jars/compiler-interface.jar ...
	[SUCCESSFUL ] org.scala-sbt#compiler-interface;0.13.15-RC1!compiler-interface.jar (4ms)
downloading file:////root/.sbt/preloaded/org.scala-sbt/actions/0.13.15-RC1/jars/actions.jar ...
```
