### PR TITLE
[fport] Add three slashes (u3) for file URI

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -12,8 +12,8 @@
 
 [repositories]
   local
-  local-preloaded-ivy: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file://${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
   maven-central
   sbt-maven-releases: https://repo.scala-sbt.org/scalasbt/maven-releases/, bootOnly
   sbt-maven-snapshots: https://repo.scala-sbt.org/scalasbt/maven-snapshots/, bootOnly

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2290,7 +2290,7 @@ object Classpaths {
           i.url.getProtocol match {
             case "file" =>
               // This hackery is to deal suitably with UNC paths on Windows. Once we can assume Java7, Paths should save us from this.
-              val file = try { new File(i.url.toURI) } catch { case e: java.net.URISyntaxException => new File(i.url.getPath) }
+              val file = IO.toFile(i.url)
               Resolver.file(i.id, file)(patterns)
             case _ => Resolver.url(i.id, i.url)(patterns)
           }


### PR DESCRIPTION
The uglier but backward compatible fix for #3086 is to use u3 format with three slashes. This on Windows will resolve to `file:///C:/Users/foo/.sbt/preloaded`, and on Mac and Linux `file:////root/.sbt/preloaded/`. Mac and Linux are both tolerant of extra slashes on the front:

```
> eval new File(new URL("file:////Users/foo/.sbt/preloaded/").toURI)
[info] ans: java.io.File = /Users/foo/.sbt/preloaded
```
