### PR TITLE
[sbt 1.0] Make server command the default shell

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -150,10 +150,10 @@ $AliasCommand name=
 	Removes the alias for `name`."""
 
   def Shell = "shell"
-  def ShellDetailed = "Provides an interactive prompt from which commands can be run."
+  def ShellDetailed = "Provides an interactive prompt and network server from which commands can be run."
 
-  def Server = "server"
-  def ServerDetailed = "Provides a network server and an interactive prompt from which commands can be run."
+  def OldShell = "oldshell"
+  def OldShellDetailed = "Provides an interactive prompt from which commands can be run."
 
   def Client = "client"
   def ClientDetailed = "Provides an interactive prompt from which commands can be run on a server."

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -29,7 +29,7 @@ import scala.util.control.NonFatal
 object BasicCommands {
   lazy val allBasicCommands: Seq[Command] = Seq(
     nop, ignore, help, completionsCommand, multi, ifLast, append, setOnFailure, clearOnFailure,
-    stashOnFailure, popOnFailure, reboot, call, early, exit, continuous, history, shell, client,
+    stashOnFailure, popOnFailure, reboot, call, early, exit, continuous, history, oldshell, client,
     read, alias
   ) ++ compatCommands
 
@@ -202,7 +202,7 @@ object BasicCommands {
       }
     }
 
-  def shell: Command = Command.command(Shell, Help.more(Shell, ShellDetailed)) { s =>
+  def oldshell: Command = Command.command(OldShell, Help.more(Shell, OldShellDetailed)) { s =>
     val history = (s get historyPath) getOrElse Some(new File(s.baseDir, ".history"))
     val prompt = (s get shellPrompt) match { case Some(pf) => pf(s); case None => "> " }
     val reader = new FullReader(history, s.combinedParser)
@@ -211,7 +211,7 @@ object BasicCommands {
       case Some(line) =>
         val newState = s.copy(
           onFailure = Some(Exec(Shell, None)),
-          remainingCommands = Exec(line, s.source) +: Exec(Shell, None) +: s.remainingCommands
+          remainingCommands = Exec(line, s.source) +: Exec(OldShell, None) +: s.remainingCommands
         ).setInteractive(true)
         if (line.trim.isEmpty) newState else newState.clearGlobalLog
       case None => s.setInteractive(false)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -31,7 +31,7 @@ import java.net.URI
 import java.util.Locale
 import scala.util.control.NonFatal
 
-import BasicCommandStrings.{ Shell, Server }
+import BasicCommandStrings.{ Shell, OldShell }
 import CommandStrings.BootCommand
 
 /** This class is the entry point for sbt. */
@@ -92,7 +92,7 @@ final class xMain extends xsbti.AppMain {
   private def endsWithBoot(state: State) = state.remainingCommands.lastOption exists (_.commandLine == BootCommand)
 
   private def notifyUsersAboutShell(state: State) =
-    if (isInteractive && !hasCommand(state, Shell) && !hasCommand(state, Server) && !endsWithBoot(state)) {
+    if (isInteractive && !hasCommand(state, Shell) && !hasCommand(state, OldShell) && !endsWithBoot(state)) {
       state.log warn "Executing in batch mode."
       state.log warn "  For better performance, hit [ENTER] to switch to interactive mode, or"
       state.log warn "  consider launching sbt without any commands, or explicitly passing 'shell'"
@@ -168,7 +168,7 @@ object BuiltinCommands {
     templateCommand, projects, project, reboot, read, history, set, sessionCommand,
     inspect, loadProjectImpl, loadFailed, Cross.crossBuild, Cross.switchVersion,
     Cross.crossRestoreSession, setOnFailure, clearOnFailure, stashOnFailure, popOnFailure,
-    setLogLevel, plugin, plugins, ifLast, multi, shell, server, BasicCommands.client,
+    setLogLevel, plugin, plugins, ifLast, multi, shell, oldshell, BasicCommands.client,
     continuous, eval, alias, append, last, lastGrep, export, boot, nop, call, exit,
     early, initialize, act
   ) ++ compatCommands
@@ -614,13 +614,13 @@ object BuiltinCommands {
       s.put(Keys.stateCompilerCache, cache)
     }
 
-  def server: Command = Command.command(Server, Help.more(Server, ServerDetailed)) { s0 =>
+  def shell: Command = Command.command(Shell, Help.more(Shell, ShellDetailed)) { s0 =>
     import sbt.internal.{ ConsolePromptEvent, ConsoleUnpromptEvent }
     val exchange = StandardMain.exchange
     val s1 = exchange run s0
     exchange publishEventMessage ConsolePromptEvent(s0)
     val exec: Exec = exchange.blockUntilNextExec
-    val newState = s1.copy(onFailure = Some(Exec(Server, None)), remainingCommands = exec +: Exec(Server, None) +: s1.remainingCommands).setInteractive(true)
+    val newState = s1.copy(onFailure = Some(Exec(Shell, None)), remainingCommands = exec +: Exec(Shell, None) +: s1.remainingCommands).setInteractive(true)
     exchange publishEventMessage ConsoleUnpromptEvent(exec.source)
     if (exec.commandLine.trim.isEmpty) newState
     else newState.clearGlobalLog


### PR DESCRIPTION
This makes `server` command the default shell.

Note:

There used to be another commit about improving the error handling, but it's moved to another PR - https://github.com/sbt/sbt/pull/3104.
