### PR TITLE
[sbt 1.0] Better error message if socket is taken

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -8,9 +8,13 @@ package server
 import java.net.{ SocketTimeoutException, InetAddress, ServerSocket, Socket }
 import java.util.concurrent.atomic.AtomicBoolean
 import sbt.util.Logger
+import sbt.internal.util.ErrorHandling
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Try, Success, Failure }
 
 private[sbt] sealed trait ServerInstance {
   def shutdown(): Unit
+  def ready: Future[Unit]
 }
 
 private[sbt] object Server {
@@ -20,23 +24,31 @@ private[sbt] object Server {
 
       // val lock = new AnyRef {}
       // val clients: mutable.ListBuffer[ClientConnection] = mutable.ListBuffer.empty
-      val running = new AtomicBoolean(true)
+      val running = new AtomicBoolean(false)
+      val p: Promise[Unit] = Promise[Unit]()
+      val ready: Future[Unit] = p.future
 
       val serverThread = new Thread("sbt-socket-server") {
-
         override def run(): Unit = {
-          val serverSocket = new ServerSocket(port, 50, InetAddress.getByName(host))
-          serverSocket.setSoTimeout(5000)
-
-          log.info(s"sbt server started at $host:$port")
-          while (running.get()) {
-            try {
-              val socket = serverSocket.accept()
-              onIncomingSocket(socket)
-            } catch {
-              case _: SocketTimeoutException => // its ok
+          Try {
+            ErrorHandling.translate(s"server failed to start on $host:$port. ") {
+              new ServerSocket(port, 50, InetAddress.getByName(host))
             }
-
+          } match {
+            case Failure(e) => p.failure(e)
+            case Success(serverSocket) =>
+              serverSocket.setSoTimeout(5000)
+              log.info(s"sbt server started at $host:$port")
+              running.set(true)
+              p.success(())
+              while (running.get()) {
+                try {
+                  val socket = serverSocket.accept()
+                  onIncomingSocket(socket)
+                } catch {
+                  case _: SocketTimeoutException => // its ok
+                }
+              }
           }
         }
       }


### PR DESCRIPTION
We need to communicate the error states in the thread, so I added a `Future[Unit]` called `ready`.

If something goes wrong during the startup, like if the port is already taken, this can be used to communicate back to the main thread, and display the error accordingly.

So this is how it looks:

```
$ sbt
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
[info] Loading project definition from /xxx/servertestbuild/project (out-3)
[info] Loading settings from build.sbt ... (out-3)
[info] Set current project to foo (in build file:/xxx/servertestbuild/) (out-3)
[info] sbt server started at 127.0.0.1:5173 (out-3)
> clean
[info] Total time: 0 s, completed Apr 12, 2017 6:27:25 PM (out-23)
> compile
[info] Updating {file:/xxx/servertestbuild/}root... (out-44)
[info] Done updating. (out-44)
[info] Compiling 1 Scala source to /xxx/servertestbuild/target/scala-2.11/classes ... (out-48)
[warn] /xxx/servertestbuild/Hello.scala:2:3: a pure expression does nothing in statement position; you may be omitting necessary parentheses (out-34)
[warn]   1 (out-34)
[warn]   ^ (out-34)
[warn] one warning found (out-34)
[info] Done compiling. (out-48)
[info] Total time: 3 s, completed Apr 12, 2017 6:27:30 PM (out-33)
>
```

While this is running, I go on to another tab, and try to call sbt again:

```
$ sbt
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
[info] Loading project definition from /xxx/servertestbuild/project (out-3)
[info] Loading settings from build.sbt ... (out-3)
[info] Set current project to foo (in build file:/xxx/servertestbuild/) (out-3)
[error] server failed to start on 127.0.0.1:5173. java.net.BindException: Address already in use (out-3)
> compile
[info] Total time: 0 s, completed Apr 12, 2017 6:27:43 PM (out-23)
>
```

Not recommended because of the disk state, but just as 0.13, we still will let you run `sbt` (as opposed to failing to start because the port is taken).

