### PR TITLE
Fix sbt 1.0 in Intellij

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,8 @@ lazy val testingProj = (project in file("testing")).
     baseSettings,
     name := "Testing",
     libraryDependencies ++= Seq(testInterface,launcherInterface, sjsonNewScalaJson),
+    managedSourceDirectories in Compile +=
+      baseDirectory.value / "src" / "main" / "contraband-scala",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     contrabandFormatsForType in generateContrabands in Compile := ContrabandConfig.getFormats
   ).
@@ -184,6 +186,8 @@ lazy val protocolProj = (project in file("protocol")).
     testedBaseSettings,
     name := "Protocol",
     libraryDependencies ++= Seq(sjsonNewScalaJson),
+    managedSourceDirectories in Compile +=
+      baseDirectory.value / "src" / "main" / "contraband-scala",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     contrabandFormatsForType in generateContrabands in Compile := ContrabandConfig.getFormats
   ).
@@ -197,6 +201,8 @@ lazy val commandProj = (project in file("main-command")).
     testedBaseSettings,
     name := "Command",
     libraryDependencies ++= Seq(launcherInterface, sjsonNewScalaJson, templateResolverApi),
+    managedSourceDirectories in Compile +=
+      baseDirectory.value / "src" / "main" / "contraband-scala",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     contrabandFormatsForType in generateContrabands in Compile := ContrabandConfig.getFormats
   ).


### PR DESCRIPTION
This commit fixes most of the red squiggles created by the lack of
analysis of Contraband-generated Scala files. It does not end with all
the red squiggles but it substantially decreases the amount of them.