### PR TITLE
Improve `Load` in sbt

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -138,6 +138,11 @@ final case class PluginData(
   val classpath: Seq[Attributed[File]] = definitionClasspath ++ dependencyClasspath
 }
 
+object PluginData {
+  private[sbt] def apply(dependencyClasspath: Def.Classpath): PluginData =
+    PluginData(dependencyClasspath, Nil, None, None, Nil)
+}
+
 object EvaluateTask {
   import std.Transform
   import Keys.state

--- a/main/src/main/scala/sbt/internal/BuildLoader.scala
+++ b/main/src/main/scala/sbt/internal/BuildLoader.scala
@@ -97,6 +97,17 @@ object BuildLoader {
   }
 }
 
+/** Defines the responsible for loading builds.
+  *
+  * @param fail A reporter for failures.
+  * @param state The state.
+  * @param config The current configuration for any build.
+  * @param resolvers The structure responsible of mapping base directories.
+  * @param builders The structure responsible of mapping to build units.
+  * @param transformer An instance to modify the created build unit.
+  * @param full The structure responsible of mapping to loaded build units.
+  * @param transformAll A function specifying which builds units should be transformed.
+  */
 final class BuildLoader(
     val fail: URI => Nothing,
     val state: State,

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1015,12 +1015,18 @@ private[sbt] object Load {
       }
   }
 
+  /** Variable to control the indentation of the timing logs. */
+  private var timedIndentation: Int = 0
+
   /** Debugging method to time how long it takes to run various compilation tasks. */
   private[sbt] def timed[T](label: String, log: Logger)(t: => T): T = {
+    timedIndentation += 1
     val start = System.nanoTime
     val result = t
     val elapsed = System.nanoTime - start
-    log.debug(label + " took " + (elapsed / 1e6) + " ms")
+    timedIndentation -= 1
+    val prefix = " " * 2 * timedIndentation
+    log.debug(s"$prefix$label took ${elapsed / 1e6}ms")
     result
   }
 }


### PR DESCRIPTION
It mainly does three things:

* Clean up the implementation, removing unused values like
  `globalPluginDefs`.
* Make the implementation more readable.
* And the big one: Remove the creation of a classloader that we were
  instantiating but whose value we were throwing away. This has an impact
  in performance, but I'm yet to benchmark how much it is.
  
The second commit reduces the complexity around `loadPluginDefinition` et al.
`pluginDefinitionLoader` is not used anywhere in sbt, so the extra definitions are removed.

Both the implementation of `loadPluginDefinition` and `pluginDefinitionLoader` are reduced to a bare minimum where the components at hand (definition classpath, dependency classpath) are properly defined.

Documentation to the three main methods has been added.