### PR TITLE
Change "Updating" logging from info to debug

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1484,14 +1484,14 @@ object Classpaths {
       def work = (_: In) match {
         case conf :+: settings :+: config :+: HNil =>
           import ShowLines._
-          log.info("Updating " + label + "...")
+          log.debug("Updating " + label + "...")
           val r = IvyActions.updateEither(module, config, uwConfig, logicalClock, depDir, log) match {
             case Right(ur) => ur
             case Left(uw) =>
               uw.lines foreach { log.warn(_) }
               throw uw.resolveException
           }
-          log.info("Done updating.")
+          log.debug("Done updating.")
           val result = transform(r)
           val ew = EvictionWarning(module, ewo, result, log)
           ew.lines foreach { log.warn(_) }


### PR DESCRIPTION
The noise:value ratio of "Updating"/"Done updating" logging is very high.
This changes the log level to debug.

This would result in:

```
[info] Updating {file:/…/scalajs-react/}root...
[info] Updating {file:/…/scalajs-react/}core...
[info] Updating {file:/…/scalajs-react/}gh-pages-macros...
[info] Done updating.
[info] Compiling 2 Scala sources to /…/scalajs-react/gh-pages-macros/…
[info] Done updating.
[info] Updating {file:/…/scalajs-react/}extra...
[info] Done updating.
[info] Done updating.
[info] Updating {file:/…/scalajs-react/}cats...
[info] Updating {file:/…/scalajs-react/}scalaz72...
[info] Compiling 60 Scala sources to /…/scalajs-react/core/…
[info] Done updating.
[info] Done updating.
[info] Updating {file:/…/scalajs-react/}monocle...
[info] Done updating.
[info] Updating {file:/…/scalajs-react/}test...
[info] Updating {file:/…/scalajs-react/}gh-pages...
[info] Done updating.
[info] Done updating.
[info] Compiling 25 Scala sources to /…/scalajs-react/extra/…
[info] Compiling 4 Scala sources to /…/scalajs-react/cats/…
[info] Compiling 4 Scala sources to /…/scalajs-react/scalaz-7.2/…
[info] Compiling 10 Scala sources to /…/scalajs-react/test/…
[info] Compiling 4 Scala sources to /…/scalajs-react/monocle/…
[info] Compiling 23 Scala sources to /…/scalajs-react/gh-pages/…
[info] Compiling 39 Scala sources to /…/scalajs-react/test/…
```

becoming:

```
[info] Compiling 2 Scala sources to /…/scalajs-react/gh-pages-macros/…
[info] Compiling 60 Scala sources to /…/scalajs-react/core/…
[info] Compiling 25 Scala sources to /…/scalajs-react/extra/…
[info] Compiling 4 Scala sources to /…/scalajs-react/cats/…
[info] Compiling 4 Scala sources to /…/scalajs-react/scalaz-7.2/…
[info] Compiling 10 Scala sources to /…/scalajs-react/test/…
[info] Compiling 4 Scala sources to /…/scalajs-react/monocle/…
[info] Compiling 23 Scala sources to /…/scalajs-react/gh-pages/…
[info] Compiling 39 Scala sources to /…/scalajs-react/test/…
```