### PR TITLE
[sbt 0.13] Ignore ZipException in cache

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import Sxr.sxr
 // but can be shared across the multi projects.
 def buildLevelSettings: Seq[Setting[_]] = inThisBuild(Seq(
   organization := "org.scala-sbt",
-  version := "0.13.15-SNAPSHOT",
+  version := "0.13.16-SNAPSHOT",
   bintrayOrganization := Some(if (publishStatus.value == "releases") "typesafe" else "sbt"),
   bintrayRepository := s"ivy-${publishStatus.value}",
   bintrayPackage := "sbt",


### PR DESCRIPTION
Fixes #3050, #253 and #2753

This prevents sbt 0.13 from blowing up when opening the same build that sbt 1.0 opened without wiping out `target` directories.
