### PR TITLE
[sbt 0.13] Fix += interference with sbt-buildinfo

### DIFF
--- a/main/settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main/settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -174,7 +174,8 @@ object TaskMacro {
       val typeArgs = util.typeArgs(ttpe)
       v.tree.tpe match {
         // To allow Initialize[Task[A]] in the position of += RHS, we're going to call "taskValue" automatically.
-        case tpe if typeArgs.nonEmpty && (tpe weak_<:< c.weakTypeOf[Initialize[_]]) =>
+        case tpe if typeArgs.nonEmpty && (typeArgs.head weak_<:< c.weakTypeOf[Task[_]])
+          && (tpe weak_<:< c.weakTypeOf[Initialize[_]]) =>
           c.macroApplication match {
             case Apply(Apply(TypeApply(Select(preT, nmeT), targs), _), _) =>
               val tree = Apply(TypeApply(Select(preT, newTermName("+=").encodedName), TypeTree(typeArgs.head) :: Nil), Select(v.tree, newTermName("taskValue").encodedName) :: Nil)

--- a/sbt/src/sbt-test/project/plusequals/build.sbt
+++ b/sbt/src/sbt-test/project/plusequals/build.sbt
@@ -1,0 +1,7 @@
+// https://github.com/sbt/sbt/issues/3132
+lazy val root = (project in file(".")).
+  enablePlugins(BuildInfoPlugin).
+  settings(
+    buildInfoKeys += name,
+    buildInfoPackage := "hello"
+  )

--- a/sbt/src/sbt-test/project/plusequals/project/plugins.sbt
+++ b/sbt/src/sbt-test/project/plusequals/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/sbt/src/sbt-test/project/plusequals/test
+++ b/sbt/src/sbt-test/project/plusequals/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
The macro pattern match was too general. This makes it tighter.

Fixes #3132
