### PR TITLE
Fix default scalaBinaryVersion for Dotty

### DIFF
--- a/ivy/src/test/scala/CrossVersionTest.scala
+++ b/ivy/src/test/scala/CrossVersionTest.scala
@@ -122,6 +122,10 @@ object CrossVersionTest extends Specification {
       CrossVersion.binaryScalaVersion("2.20170314093845.0-87654321") must_== "2.20170314093845.0-87654321"
     }
 
+    "return binary Scala version for Dotty 0.1.1 as 0.1" in {
+      CrossVersion.binaryScalaVersion("0.1.1") must_== "0.1"
+    }
+
     "return patch Scala version for 2.11.8 as 2.11.8" in {
       CrossVersion(CrossVersion.patch, "2.11.8", "dummy").map(_("artefact")) must_== Some("artefact_2.11.8")
     }

--- a/util/cross/src/main/input_sources/CrossVersionUtil.scala
+++ b/util/cross/src/main/input_sources/CrossVersionUtil.scala
@@ -8,7 +8,8 @@ object CrossVersionUtil
 	val noneString = "none"
 	val disabledString = "disabled"
 	val binaryString = "binary"
-	val TransitionScalaVersion = "2.10"
+	val TransitionDottyVersion = "" // Dotty always respects binary compatibility
+	val TransitionScalaVersion = "2.10" // ...but scalac doesn't until Scala 2.10
 	val TransitionSbtVersion = "0.12"
 
 	def isFull(s: String): Boolean = (s == trueString) || (s == fullString)
@@ -57,7 +58,15 @@ object CrossVersionUtil
 			case PartialVersion(major, minor) => Some((major.toInt, minor.toInt))
 			case _ => None
 		}
-	def binaryScalaVersion(full: String): String = binaryVersionWithApi(full, TransitionScalaVersion)(scalaApiVersion)
+	def binaryScalaVersion(full: String): String = {
+		val cutoff =
+			if (full.startsWith("0."))
+				TransitionDottyVersion
+			else
+				TransitionScalaVersion
+
+		binaryVersionWithApi(full, cutoff)(scalaApiVersion)
+	}
 	def binarySbtVersion(full: String): String = binaryVersionWithApi(full, TransitionSbtVersion)(sbtApiVersion)
 	private[${{cross.package0}}] def binaryVersion(full: String, cutoff: String): String = binaryVersionWithApi(full, cutoff)(scalaApiVersion)
 	private[this] def isNewer(major: Int, minor: Int, minMajor: Int, minMinor: Int): Boolean =


### PR DESCRIPTION
Dotty is versioned as 0.*, but `CrossVersionUtil#binaryScalaVersion`
will return the full version instead of just major.minor for all
compiler versions < 2.10, add a special case for Dotty to avoid this.