### PR TITLE
Add duplicated settings test

### DIFF
--- a/sbt/src/sbt-test/project/unique-settings-computation/build.sbt
+++ b/sbt/src/sbt-test/project/unique-settings-computation/build.sbt
@@ -1,0 +1,9 @@
+lazy val root = project
+
+val checkComputedOnce = taskKey[Unit]("Check computed once")
+checkComputedOnce := {
+  val buildValue = (foo in ThisBuild).value
+  assert(buildValue == "build 0", "Setting in ThisBuild was computed twice")
+  val globalValue = (foo in Global).value
+  assert(globalValue == "global 0", "Setting in Global was computed twice")
+}

--- a/sbt/src/sbt-test/project/unique-settings-computation/pending
+++ b/sbt/src/sbt-test/project/unique-settings-computation/pending
@@ -1,0 +1,3 @@
+> checkComputedOnce
+> setUpScripted
+> checkComputedOnce

--- a/sbt/src/sbt-test/project/unique-settings-computation/project/A.scala
+++ b/sbt/src/sbt-test/project/unique-settings-computation/project/A.scala
@@ -1,0 +1,27 @@
+import java.util.concurrent.atomic.AtomicInteger
+import sbt._, Keys._
+
+object A extends AutoPlugin {
+  object autoImport {
+    lazy val foo = settingKey[String]("Foo.")
+  }
+  import autoImport._
+  override def trigger = allRequirements
+
+  override def buildSettings: Seq[Setting[_]] =
+    (foo := s"build ${buildCount.getAndIncrement}") ::
+    Nil
+
+  override def globalSettings: Seq[Setting[_]] =
+    (foo := s"global ${globalCount.getAndIncrement}") ::
+    (commands += setUpScripted) ::
+    Nil
+
+  def setUpScripted = Command.command("setUpScripted") { (state0: State) =>
+    Project.extract(state0).append(name := "foo", state0)
+  }
+
+  // used to ensure the build-level and global settings are only added once
+  private[this] val buildCount = new AtomicInteger(0)
+  private[this] val globalCount = new AtomicInteger(0)
+}


### PR DESCRIPTION
This test shows how sbt is recomputing the settings completely (even if
they have side effect) every time a `Project.extract` and settings
manipulations are performed.

This is worrying because it's:

* Inefficient.
* Surprising.
* Incorrect -- settings may produce side effects.

Unless I'm mistaken, this proves that the computation of settings is not
performed once.