### PR TITLE
Remove implicit formats from Defaults

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -57,6 +57,7 @@ import sbt.librarymanagement.Configurations.{
   Test
 }
 import sbt.librarymanagement.CrossVersion.{ binarySbtVersion, binaryScalaVersion, partialVersion }
+import sbt.internal.librarymanagement.UnsafeLibraryManagementCodec.moduleIdJsonKeyFormat
 import sbt.librarymanagement.{ `package` => _, _ }
 import sbt.librarymanagement.syntax._
 import sbt.util.InterfaceUtil.{ f1, o2m }
@@ -2002,26 +2003,18 @@ object Classpaths {
                            Vector(Configurations.Default),
                            classifiers.toVector)
     }
-  def deliverTask(config: TaskKey[DeliverConfiguration]): Initialize[Task[File]] =
-    Def.task {
-      val _ = update.value
-      IvyActions.deliver(ivyModule.value, config.value, streams.value.log)
-    }
+  def deliverTask(config: TaskKey[DeliverConfiguration]): Initialize[Task[File]] = {
+    Def
+      .task(IvyActions.deliver(ivyModule.value, config.value, streams.value.log))
+      .dependsOn(update)
+  }
+
   def publishTask(config: TaskKey[PublishConfiguration],
-                  deliverKey: TaskKey[_]): Initialize[Task[Unit]] =
-    Def.task {
-      IvyActions.publish(ivyModule.value, config.value, streams.value.log)
-    } tag (Tags.Publish, Tags.Network)
-  val moduleIdJsonKeyFormat: sjsonnew.JsonKeyFormat[ModuleID] =
-    new sjsonnew.JsonKeyFormat[ModuleID] {
-      import sjsonnew.support.scalajson.unsafe._
-      import LibraryManagementCodec._
-      val moduleIdFormat: JsonFormat[ModuleID] = implicitly[JsonFormat[ModuleID]]
-      def write(key: ModuleID): String =
-        CompactPrinter(Converter.toJsonUnsafe(key)(moduleIdFormat))
-      def read(key: String): ModuleID =
-        Converter.fromJsonUnsafe[ModuleID](Parser.parseUnsafe(key))(moduleIdFormat)
-    }
+                  deliverKey: TaskKey[_]): Initialize[Task[Unit]] = {
+    Def
+      .task(IvyActions.publish(ivyModule.value, config.value, streams.value.log))
+      .tag(Tags.Publish, Tags.Network)
+  }
 
   def withExcludes(out: File, classifiers: Seq[String], lock: xsbti.GlobalLock)(
       f: Map[ModuleID, Set[String]] => UpdateReport): UpdateReport = {
@@ -2075,8 +2068,8 @@ object Classpaths {
     val s = streams.value
     val cacheDirectory = streams.value.cacheDirectory
 
-    val isRoot = executionRoots.value contains resolvedScoped.value
-    val shouldForce = isRoot || {
+    val isCalledByUser = executionRoots.value contains resolvedScoped.value
+    val shouldForce = isCalledByUser || {
       forceUpdatePeriod.value match {
         case None => false
         case Some(period) =>
@@ -2138,69 +2131,28 @@ object Classpaths {
     )
   }
 
+  /** Maps module ids (lib dependencies) to positions of the sbt files where they were defined.
+   *
+   * This information is useful for the update task that uses it to report errors. It is usually
+   * wrapped in [[UnresolvedWarningConfiguration]].
+   */
   private[sbt] def dependencyPositionsTask: Initialize[Task[Map[ModuleID, SourcePosition]]] =
     Def.task {
-      val projRef = thisProjectRef.value
-      val st = state.value
-      val s = streams.value
-      val cacheStoreFactory = s.cacheStoreFactory sub updateCacheName.value
+      import sbt.internal.ModulePositions._
       import sbt.librarymanagement.LibraryManagementCodec._
-      def modulePositions: Map[ModuleID, SourcePosition] =
-        try {
-          val extracted = (Project extract st)
-          val sk = (libraryDependencies in (GlobalScope in projRef)).scopedKey
-          val empty = extracted.structure.data set (sk.scope, sk.key, Nil)
-          val settings = extracted.structure.settings filter { s: Setting[_] =>
-            (s.key.key == libraryDependencies.key) &&
-            (s.key.scope.project == Select(projRef))
-          }
-          Map(settings flatMap {
-            case s: Setting[Seq[ModuleID]] @unchecked =>
-              s.init.evaluate(empty) map { _ -> s.pos }
-          }: _*)
-        } catch {
-          case NonFatal(e) => Map()
-        }
-
-      val outCacheStore = cacheStoreFactory make "output_dsp"
-      val f = Tracked.inputChanged(cacheStoreFactory make "input_dsp") {
+      val cacheStoreFactory = streams.value.cacheStoreFactory sub updateCacheName.value
+      val outStore = cacheStoreFactory make "output_dsp"
+      val cached = Tracked.inputChanged(cacheStoreFactory make "input_dsp") {
         (inChanged: Boolean, in: Seq[ModuleID]) =>
-          implicit val NoPositionFormat: JsonFormat[NoPosition.type] = asSingleton(NoPosition)
-          implicit val LinePositionFormat: IsoLList.Aux[LinePosition, String :*: Int :*: LNil] =
-            LList.iso(
-              { l: LinePosition =>
-                ("path", l.path) :*: ("startLine", l.startLine) :*: LNil
-              }, { in: String :*: Int :*: LNil =>
-                LinePosition(in.head, in.tail.head)
-              }
-            )
-          implicit val LineRangeFormat: IsoLList.Aux[LineRange, Int :*: Int :*: LNil] = LList.iso(
-            { l: LineRange =>
-              ("start", l.start) :*: ("end", l.end) :*: LNil
-            }, { in: Int :*: Int :*: LNil =>
-              LineRange(in.head, in.tail.head)
+          Tracked
+            .lastOutput[Seq[ModuleID], Map[ModuleID, SourcePosition]](outStore) {
+              case (_, Some(same)) if !inChanged => same
+              case _ =>
+                modulesToPositions(state.value, thisProjectRef.value, libraryDependencies)
             }
-          )
-          implicit val RangePositionFormat
-            : IsoLList.Aux[RangePosition, String :*: LineRange :*: LNil] = LList.iso(
-            { r: RangePosition =>
-              ("path", r.path) :*: ("range", r.range) :*: LNil
-            }, { in: String :*: LineRange :*: LNil =>
-              RangePosition(in.head, in.tail.head)
-            }
-          )
-          implicit val SourcePositionFormat: JsonFormat[SourcePosition] =
-            unionFormat3[SourcePosition, NoPosition.type, LinePosition, RangePosition]
-
-          implicit val midJsonKeyFmt: sjsonnew.JsonKeyFormat[ModuleID] = moduleIdJsonKeyFormat
-          val outCache =
-            Tracked.lastOutput[Seq[ModuleID], Map[ModuleID, SourcePosition]](outCacheStore) {
-              case (_, Some(out)) if !inChanged => out
-              case _                            => modulePositions
-            }
-          outCache(in)
+            .apply(in)
       }
-      f(libraryDependencies.value)
+      cached(libraryDependencies.value)
     }
 
   /*

--- a/main/src/main/scala/sbt/internal/ModulePositions.scala
+++ b/main/src/main/scala/sbt/internal/ModulePositions.scala
@@ -1,0 +1,63 @@
+package sbt.internal
+
+import sbt._
+import sbt.Def.Setting
+import sbt.internal.util._
+import sbt.librarymanagement.ModuleID
+import sjsonnew.LList.:*:
+import sjsonnew.{ IsoLList, JsonFormat, LList, LNil }
+
+import scala.util.control.NonFatal
+
+object ModulePositions extends ModulePositionsCodec {
+
+  /** Associates a source position to every defined library dependency setting.
+   *
+   * @param state The state.
+   * @param currentProject The current project for which library dependencies are positioned.
+   * @param libraryDependencies The library dependencies setting.
+   * @return A map of module ids to source positions (where the module ids are defined).
+   */
+  def modulesToPositions(
+      state: State,
+      currentProject: ProjectReference,
+      libraryDependencies: SettingKey[Seq[ModuleID]]
+  ): Map[ModuleID, SourcePosition] = {
+    def getModulesAndPositions: Seq[(ModuleID, SourcePosition)] = {
+      val buildStructure = Project.extract(state).structure
+      val scopedKey = (libraryDependencies in (Scope.GlobalScope in currentProject)).scopedKey
+      val emptyScopes = buildStructure.data set (scopedKey.scope, scopedKey.key, Nil)
+      val settings = buildStructure.settings.filter((s: Setting[_]) =>
+        (s.key.key == libraryDependencies.key) && (s.key.scope.project == Select(currentProject)))
+      for {
+        libraryDependencies <- settings.asInstanceOf[Seq[Setting[Seq[ModuleID]]]]
+        moduleID <- libraryDependencies.init.evaluate(emptyScopes)
+      } yield moduleID -> libraryDependencies.pos
+    }
+
+    try Map(getModulesAndPositions: _*)
+    catch { case NonFatal(_) => Map() }
+  }
+}
+
+trait ModulePositionsCodec {
+  import sbt.librarymanagement.LibraryManagementCodec._
+  implicit val NoPositionFormat: JsonFormat[NoPosition.type] = asSingleton(NoPosition)
+  implicit val LinePositionFormat: IsoLList.Aux[LinePosition, String :*: Int :*: LNil] =
+    LList.iso((l: LinePosition) => ("path", l.path) :*: ("startLine", l.startLine) :*: LNil,
+              (in: String :*: Int :*: LNil) => LinePosition(in.head, in.tail.head))
+
+  implicit val LineRangeFormat: IsoLList.Aux[LineRange, Int :*: Int :*: LNil] = LList.iso(
+    (l: LineRange) => ("start", l.start) :*: ("end", l.end) :*: LNil,
+    (in: Int :*: Int :*: LNil) => LineRange(in.head, in.tail.head))
+
+  implicit val RangePositionFormat: IsoLList.Aux[RangePosition, String :*: LineRange :*: LNil] =
+    LList.iso((r: RangePosition) => ("path", r.path) :*: ("range", r.range) :*: LNil,
+              (in: String :*: LineRange :*: LNil) => RangePosition(in.head, in.tail.head))
+
+  implicit val SourcePositionFormat: JsonFormat[SourcePosition] =
+    unionFormat3[SourcePosition, NoPosition.type, LinePosition, RangePosition]
+
+  implicit val midJsonKeyFmt: sjsonnew.JsonKeyFormat[ModuleID] =
+    sbt.internal.librarymanagement.UnsafeLibraryManagementCodec.moduleIdJsonKeyFormat
+}

--- a/main/src/main/scala/sbt/internal/librarymanagement/UnsafeLibraryManagementCodec.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/UnsafeLibraryManagementCodec.scala
@@ -1,0 +1,17 @@
+package sbt.internal.librarymanagement
+
+import sbt.librarymanagement.{ LibraryManagementCodec, ModuleID }
+import sjsonnew.JsonFormat
+
+object UnsafeLibraryManagementCodec {
+  val moduleIdJsonKeyFormat: sjsonnew.JsonKeyFormat[ModuleID] = {
+    new sjsonnew.JsonKeyFormat[ModuleID] {
+      import sjsonnew.support.scalajson.unsafe._
+      val moduleIdFormat: JsonFormat[ModuleID] = LibraryManagementCodec.ModuleIDFormat
+      def write(key: ModuleID): String =
+        CompactPrinter(Converter.toJsonUnsafe(key)(moduleIdFormat))
+      def read(key: String): ModuleID =
+        Converter.fromJsonUnsafe[ModuleID](Parser.parseUnsafe(key))(moduleIdFormat)
+    }
+  }
+}


### PR DESCRIPTION
`Defaults` is not the right place to expose the implicit formats. Since
this file is usually read by people, we should keep it as clean as
possible and hide implementation details.

This commit does a small cleanup in update too:

* Uses `dependsOn` to show idiomatic ways of expressing our previous
  implementation.
* Hides the JsonKeyFormat in an `UnsafeLibraryManagementCodec` file.
  I must admit that I don't know why we have an extra format for
  ModuleID.

Regarding dependency positions, the meat of the implementation has been
moved to an independent file, as well as the implicit formats. The
implementation of `dependencyPositionsTask` is now kept to a bare
minimum. Docs have been added too.