### PR TITLE
Fixes content log not showing up on test task

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -16,7 +16,7 @@ import sbt.protocol.testing._
 
 private[sbt] object ForkTests {
   def apply(runners: Map[TestFramework, Runner],
-            tests: List[TestDefinition],
+            tests: Vector[TestDefinition],
             config: Execution,
             classpath: Seq[File],
             fork: ForkOptions,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -845,7 +845,7 @@ object Defaults extends BuildCommon {
             val forkedConfig = config.copy(parallel = config.parallel && forkedParallelExecution)
             s.log.debug(s"Forking tests - parallelism = ${forkedConfig.parallel}")
             ForkTests(runners,
-                      tests.toList,
+                      tests.toVector,
                       forkedConfig,
                       cp.files,
                       opts,
@@ -855,7 +855,7 @@ object Defaults extends BuildCommon {
             if (javaOptions.nonEmpty) {
               s.log.warn("javaOptions will be ignored, fork is set to false")
             }
-            Tests(frameworks, loader, runners, tests, config, s.log)
+            Tests(frameworks, loader, runners, tests.toVector, config, s.log)
         }
     }
     val output = Tests.foldTasks(groupTasks, config.parallel)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   // sbt modules
   private val ioVersion = "1.0.0-M11"
-  private val utilVersion = "1.0.0-M23"
+  private val utilVersion = "1.0.0-M24"
   private val lmVersion = "1.0.0-X11"
   private val zincVersion = "1.0.0-X14"
 

--- a/reset.sh
+++ b/reset.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf ~/.sbt/boot/scala-2.11.8/org.scala-sbt/sbt/1.0.0-SNAPSHOT/
+rm -rf ~/.sbt/boot/scala-2.12.2/org.scala-sbt/sbt/1.0.0-SNAPSHOT/


### PR DESCRIPTION
Fixes #3198

Bump util to 1.0.0-M24. This fixes content log not showing up on `test`.
Other miscellaneous changes.  

- update reset.sh for debugging
- use Vector around TestFramework
- unbind existing appenders from newLog on cleanup
- register string codec for TestStringEvent
