### PR TITLE
change EvictionWarningOptions.default to include callers and transitives

### DIFF
--- a/ivy/src/main/scala/sbt/EvictionWarning.scala
+++ b/ivy/src/main/scala/sbt/EvictionWarning.scala
@@ -47,11 +47,29 @@ final class EvictionWarningOptions private[sbt] (
 
 object EvictionWarningOptions {
   def empty: EvictionWarningOptions =
-    new EvictionWarningOptions(Vector(), false, false, false, false, false, defaultGuess)
+    new EvictionWarningOptions(Vector(),
+      warnScalaVersionEviction = false,
+      warnDirectEvictions = false,
+      warnTransitiveEvictions = false,
+      infoAllEvictions = false,
+      showCallers = false,
+      defaultGuess)
   def default: EvictionWarningOptions =
-    new EvictionWarningOptions(Vector(Compile), true, true, false, false, false, defaultGuess)
+    new EvictionWarningOptions(Vector(Compile),
+      warnScalaVersionEviction = true,
+      warnDirectEvictions = true,
+      warnTransitiveEvictions = true,
+      infoAllEvictions = false,
+      showCallers = true,
+      defaultGuess)
   def full: EvictionWarningOptions =
-    new EvictionWarningOptions(Vector(Compile), true, true, true, true, true, defaultGuess)
+    new EvictionWarningOptions(Vector(Compile),
+      warnScalaVersionEviction = true,
+      warnDirectEvictions = true,
+      warnTransitiveEvictions = true,
+      infoAllEvictions = true,
+      showCallers = true,
+      defaultGuess)
 
   lazy val defaultGuess: Function1[(ModuleID, Option[ModuleID], Option[IvyScala]), Boolean] =
     guessSecondSegment orElse guessSemVer orElse guessFalse

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2151,16 +2151,18 @@ trait BuildExtra extends BuildCommon with DefExtra {
   def fullRunInputTask(scoped: InputKey[Unit], config: Configuration, mainClass: String, baseArguments: String*): Setting[InputTask[Unit]] =
     scoped := (inputTask { result =>
       (initScoped(scoped.scopedKey, runnerInit) zipWith (fullClasspath in config, streams, result).identityMap) { (rTask, t) =>
-        (t, rTask) map { case ((cp, s, args), r) =>
-          r.run(mainClass, data(cp), baseArguments ++ args, s.log) foreach sys.error
+        (t, rTask) map {
+          case ((cp, s, args), r) =>
+            r.run(mainClass, data(cp), baseArguments ++ args, s.log) foreach sys.error
         }
       }
     }).evaluated
   def fullRunTask(scoped: TaskKey[Unit], config: Configuration, mainClass: String, arguments: String*): Setting[Task[Unit]] =
     scoped := ((initScoped(scoped.scopedKey, runnerInit) zipWith (fullClasspath in config, streams).identityMap) {
       case (rTask, t) =>
-        (t, rTask) map { case ((cp, s), r) =>
-          r.run(mainClass, data(cp), arguments, s.log) foreach sys.error
+        (t, rTask) map {
+          case ((cp, s), r) =>
+            r.run(mainClass, data(cp), arguments, s.log) foreach sys.error
         }
     }).value
   def initScoped[T](sk: ScopedKey[_], i: Initialize[T]): Initialize[T] = initScope(fillTaskAxis(sk.scope, sk.key), i)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16-M1

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -70,9 +70,12 @@ class JUnitXmlTestsListener(val outputDir: String) extends TestsListener {
                      {
                        for (e <- events) yield <testcase classname={ name } name={
                          e.selector match {
-                           case selector: TestSelector => selector.testName.split('.').last
-                           case nested: NestedTestSelector => nested.suiteId().split('.').last + "." + nested.testName()
-                           case other => s"(It is not a test it is a ${other.getClass.getCanonicalName})"
+                           case selector: TestSelector =>
+                             selector.testName.split('.').last
+                           case nested: NestedTestSelector =>
+                             nested.suiteId().split('.').last + "." + nested.testName()
+                           case other =>
+                             s"(It is not a test it is a ${other.getClass.getCanonicalName})"
                          }
                        } time={ (e.duration() / 1000.0).toString }>
                                                  {


### PR DESCRIPTION
Fixes sbt/sbt#3171

Change EvictionWarningOptions.default to include transitive evictions and caller info.

/cc @patrick-premont
