### PR TITLE
Improve the eviction warning presentation.

### DIFF
--- a/ivy/src/main/scala/sbt/EvictionWarning.scala
+++ b/ivy/src/main/scala/sbt/EvictionWarning.scala
@@ -120,18 +120,24 @@ final class EvictionPair private[sbt] (
 object EvictionPair {
   implicit val evictionPairLines: ShowLines[EvictionPair] = ShowLines { a: EvictionPair =>
     val revs = a.evicteds map { _.module.revision }
-    val revsStr = if (revs.size <= 1) revs.mkString else "(" + revs.mkString(", ") + ")"
-    val winnerRev = (a.winner map { r =>
-      val callers: String =
-        if (a.showCallers)
-          r.callers match {
-            case Seq() => ""
-            case cs    => (cs map { _.caller.toString }).mkString(" (caller: ", ", ", ")")
-          }
-        else ""
-      r.module.revision + callers
-    }) map { " -> " + _ } getOrElse ""
-    Seq(s"\t* ${a.organization}:${a.name}:${revsStr}$winnerRev")
+    val revsStr = if (revs.size <= 1) revs.mkString else "{" + revs.mkString(", ") + "}"
+    val seen: mutable.Set[ModuleID] = mutable.Set()
+    val callers: List[String] = (a.evicteds.toList ::: a.winner.toList) flatMap { r =>
+      val rev = r.module.revision
+      r.callers.toList flatMap { caller =>
+        if (seen(caller.caller)) Nil
+        else {
+          seen += caller.caller
+          List(f"\t    +- ${caller}%-50s (depends on $rev)")
+        }
+      }
+    }
+    val winnerRev = a.winner match {
+      case Some(r) => s":${r.module.revision} is selected over ${revsStr}"
+      case _       => " is evicted completely"
+    }
+    val title = s"\t* ${a.organization}:${a.name}$winnerRev"
+    title :: (if (a.showCallers) callers.reverse else Nil) ::: List("")
   }
 }
 
@@ -227,13 +233,13 @@ object EvictionWarning {
     }
 
     if (a.directEvictions.nonEmpty || a.transitiveEvictions.nonEmpty) {
-      out += "There may be incompatibilities among your library dependencies."
-      out += "Here are some of the libraries that were evicted:"
+      out += "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:"
+      out += ""
       out ++= (a.directEvictions flatMap { _.lines })
       out ++= (a.transitiveEvictions flatMap { _.lines })
     }
 
-    if (a.allEvictions.nonEmpty && a.reportedEvictions.nonEmpty && !a.options.showCallers) {
+    if (a.allEvictions.nonEmpty && a.reportedEvictions.nonEmpty) {
       out += "Run 'evicted' to see detailed eviction warnings"
     }
 
@@ -254,6 +260,6 @@ object EvictionWarning {
         }
       }
       if (out.isEmpty) Nil
-      else List("Here are other libraries that were evicted:") ::: out.toList
+      else List("Here are other depedency conflicts that were resolved:", "") ::: out.toList
     } else Nil
 }


### PR DESCRIPTION
Fixes sbt/sbt#2699

Before:

    [warn] There may be incompatibilities among your library dependencies.
    [warn] Here are some of the libraries that were evicted:
    [warn]  * com.google.code.findbugs:jsr305:2.0.1 -> 3.0.0
    [warn] Run 'evicted' to see detailed eviction warnings

After:

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn]
[warn] 	* org.apache.logging.log4j:log4j-api:2.8.2 is selected over 1.4
[warn] 	    +- de.heikoseeberger:akka-log4j_2.12:1.4.0            (depends on 2.8.2)
[warn] 	    +- com.example:hello-world_2.12:0.1-SNAPSHOT          (depends on 1.4)
[warn]
[warn] 	* com.typesafe.akka:akka-actor_2.12:2.5.0 is selected over 2.4.17
[warn] 	    +- de.heikoseeberger:akka-log4j_2.12:1.4.0            (depends on 2.5.0)
[warn] 	    +- com.typesafe.akka:akka-parsing_2.12:10.0.6         (depends on 2.4.17)
[warn] 	    +- com.typesafe.akka:akka-stream_2.12:2.4.17 ()       (depends on 2.4.17)
[warn]
[warn] Run 'evicted' to see detailed eviction warnings
```
