### PR TITLE
Move `appmacro` and `collection` to sbt/sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,21 +146,22 @@ lazy val testAgentProj = (project in file("testing") / "agent").settings(
 
 // Basic task engine
 lazy val taskProj = (project in file("tasks"))
+.dependsOn(settingsDataProj)
   .settings(
     testedBaseSettings,
     name := "Tasks"
   )
-  .configure(addSbtUtilControl, addSbtUtilCollection)
+  .configure(addSbtUtilControl)
 
 // Standard task system.  This provides map, flatMap, join, and more on top of the basic task model.
 lazy val stdTaskProj = (project in file("tasks-standard"))
-  .dependsOn(taskProj % "compile;test->test")
+  .dependsOn(taskProj % "compile;test->test", settingsDataProj)
   .settings(
     testedBaseSettings,
     name := "Task System",
     testExclusive
   )
-  .configure(addSbtUtilCollection, addSbtUtilLogging, addSbtUtilCache, addSbtIO)
+  .configure(addSbtUtilLogging, addSbtUtilCache, addSbtIO)
 
 // Embedded Scala code runner
 lazy val runProj = (project in file("run"))
@@ -242,16 +243,38 @@ lazy val commandProj = (project in file("main-command"))
              addSbtCompilerClasspath,
              addSbtLm)
 
+// The settings collection project defines all the data structures for settings,
+// attributes and init -- the core collection that is used internally to
+// represent the underlying sbt model.
+lazy val settingsDataProj = (project in file("core-settings")).
+  settings(
+    commonSettings,
+    crossScalaVersions := Seq(scala210, scala211, scala212),
+    Util.keywordsSettings,
+    name := "Core Settings",
+    libraryDependencies ++= Seq(sjsonnew)
+  )
+  .configure(addSbtUtilTesting)
+
+// The core macro project defines the main logic of the DSL, abstracted
+// away from several sbt implementators (tasks, settings, et cetera).
+lazy val coreMacrosProj = (project in file("core-macros")).
+  dependsOn(settingsDataProj).
+  settings(
+    commonSettings,
+    name := "Core Macros",
+    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+  )
+
 // Fixes scope=Scope for Setting (core defined in collectionProj) to define the settings system used in build definitions
 lazy val mainSettingsProj = (project in file("main-settings"))
-  .dependsOn(commandProj, stdTaskProj)
+  .dependsOn(commandProj, stdTaskProj, coreMacrosProj)
   .settings(
     testedBaseSettings,
     name := "Main Settings"
   )
   .configure(
     addSbtUtilCache,
-    addSbtUtilApplyMacro,
     addSbtCompilerInterface,
     addSbtUtilRelation,
     addSbtUtilLogging,

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -1,0 +1,275 @@
+package sbt.internal.util
+package appmacro
+
+import scala.reflect._
+import macros._
+import ContextUtil.{ DynamicDependencyError, DynamicReferenceError }
+
+object ContextUtil {
+  final val DynamicDependencyError = "Illegal dynamic dependency"
+  final val DynamicReferenceError = "Illegal dynamic reference"
+
+  /**
+   * Constructs an object with utility methods for operating in the provided macro context `c`.
+   * Callers should explicitly specify the type parameter as `c.type` in order to preserve the path dependent types.
+   */
+  def apply[C <: blackbox.Context with Singleton](c: C): ContextUtil[C] = new ContextUtil(c)
+
+  /**
+   * Helper for implementing a no-argument macro that is introduced via an implicit.
+   * This method removes the implicit conversion and evaluates the function `f` on the target of the conversion.
+   *
+   * Given `myImplicitConversion(someValue).extensionMethod`, where `extensionMethod` is a macro that uses this
+   * method, the result of this method is `f(<Tree of someValue>)`.
+   */
+  def selectMacroImpl[T: c.WeakTypeTag](c: blackbox.Context)(
+      f: (c.Expr[Any], c.Position) => c.Expr[T]): c.Expr[T] = {
+    import c.universe._
+    c.macroApplication match {
+      case s @ Select(Apply(_, t :: Nil), tp) => f(c.Expr[Any](t), s.pos)
+      case x                                  => unexpectedTree(x)
+    }
+  }
+
+  def unexpectedTree[C <: blackbox.Context](tree: C#Tree): Nothing =
+    sys.error("Unexpected macro application tree (" + tree.getClass + "): " + tree)
+}
+
+/**
+ * Utility methods for macros.  Several methods assume that the context's universe is a full compiler
+ * (`scala.tools.nsc.Global`).
+ * This is not thread safe due to the underlying Context and related data structures not being thread safe.
+ * Use `ContextUtil[c.type](c)` to construct.
+ */
+final class ContextUtil[C <: blackbox.Context](val ctx: C) {
+  import ctx.universe.{ Apply => ApplyTree, _ }
+  import internal.decorators._
+
+  val powerContext = ctx.asInstanceOf[reflect.macros.runtime.Context]
+  val global: powerContext.universe.type = powerContext.universe
+  def callsiteTyper: global.analyzer.Typer = powerContext.callsiteTyper
+  val initialOwner: Symbol = callsiteTyper.context.owner.asInstanceOf[ctx.universe.Symbol]
+
+  lazy val alistType = ctx.typeOf[AList[KList]]
+  lazy val alist: Symbol = alistType.typeSymbol.companion
+  lazy val alistTC: Type = alistType.typeConstructor
+
+  /** Modifiers for a local val.*/
+  lazy val localModifiers = Modifiers(NoFlags)
+
+  def getPos(sym: Symbol) = if (sym eq null) NoPosition else sym.pos
+
+  /**
+   * Constructs a unique term name with the given prefix within this Context.
+   * (The current implementation uses Context.freshName, which increments
+   */
+  def freshTermName(prefix: String) = TermName(ctx.freshName("$" + prefix))
+
+  /**
+   * Constructs a new, synthetic, local ValDef Type `tpe`, a unique name,
+   * Position `pos`, an empty implementation (no rhs), and owned by `owner`.
+   */
+  def freshValDef(tpe: Type, pos: Position, owner: Symbol): ValDef = {
+    val SYNTHETIC = (1 << 21).toLong.asInstanceOf[FlagSet]
+    val sym = owner.newTermSymbol(freshTermName("q"), pos, SYNTHETIC)
+    setInfo(sym, tpe)
+    val vd = internal.valDef(sym, EmptyTree)
+    vd.setPos(pos)
+    vd
+  }
+
+  lazy val parameterModifiers = Modifiers(Flag.PARAM)
+
+  /**
+   * Collects all definitions in the tree for use in checkReferences.
+   * This excludes definitions in wrapped expressions because checkReferences won't allow nested dereferencing anyway.
+   */
+  def collectDefs(tree: Tree, isWrapper: (String, Type, Tree) => Boolean): collection.Set[Symbol] = {
+    val defs = new collection.mutable.HashSet[Symbol]
+    // adds the symbols for all non-Ident subtrees to `defs`.
+    val process = new Traverser {
+      override def traverse(t: Tree) = t match {
+        case _: Ident => ()
+        case ApplyTree(TypeApply(Select(_, nme), tpe :: Nil), qual :: Nil)
+            if isWrapper(nme.decodedName.toString, tpe.tpe, qual) =>
+          ()
+        case tree =>
+          if (tree.symbol ne null) defs += tree.symbol;
+          super.traverse(tree)
+      }
+    }
+    process.traverse(tree)
+    defs
+  }
+
+  /**
+   * A reference is illegal if it is to an M instance defined within the scope of the macro call.
+   * As an approximation, disallow referenced to any local definitions `defs`.
+   */
+  def illegalReference(defs: collection.Set[Symbol], sym: Symbol): Boolean =
+    sym != null && sym != NoSymbol && defs.contains(sym)
+
+  /**
+   * A function that checks the provided tree for illegal references to M instances defined in the
+   *  expression passed to the macro and for illegal dereferencing of M instances.
+   */
+  def checkReferences(defs: collection.Set[Symbol],
+                      isWrapper: (String, Type, Tree) => Boolean): Tree => Unit = {
+    case s @ ApplyTree(TypeApply(Select(_, nme), tpe :: Nil), qual :: Nil) =>
+      if (isWrapper(nme.decodedName.toString, tpe.tpe, qual))
+        ctx.error(s.pos, DynamicDependencyError)
+    case id @ Ident(name) if illegalReference(defs, id.symbol) =>
+      ctx.error(id.pos, DynamicReferenceError + ": " + name)
+    case _ => ()
+  }
+
+  /** Constructs a ValDef with a parameter modifier, a unique name, with the provided Type and with an empty rhs. */
+  def freshMethodParameter(tpe: Type): ValDef =
+    ValDef(parameterModifiers, freshTermName("p"), TypeTree(tpe), EmptyTree)
+
+  /** Constructs a ValDef with local modifiers and a unique name. */
+  def localValDef(tpt: Tree, rhs: Tree): ValDef =
+    ValDef(localModifiers, freshTermName("q"), tpt, rhs)
+
+  /** Constructs a tuple value of the right TupleN type from the provided inputs.*/
+  def mkTuple(args: List[Tree]): Tree =
+    global.gen.mkTuple(args.asInstanceOf[List[global.Tree]]).asInstanceOf[ctx.universe.Tree]
+
+  def setSymbol[_Tree](t: _Tree, sym: Symbol): Unit = {
+    t.asInstanceOf[global.Tree].setSymbol(sym.asInstanceOf[global.Symbol])
+    ()
+  }
+  def setInfo(sym: Symbol, tpe: Type): Unit = {
+    sym.asInstanceOf[global.Symbol].setInfo(tpe.asInstanceOf[global.Type])
+    ()
+  }
+
+  /** Creates a new, synthetic type variable with the specified `owner`. */
+  def newTypeVariable(owner: Symbol, prefix: String = "T0"): TypeSymbol =
+    owner
+      .asInstanceOf[global.Symbol]
+      .newSyntheticTypeParam(prefix, 0L)
+      .asInstanceOf[ctx.universe.TypeSymbol]
+
+  /** The type representing the type constructor `[X] X` */
+  lazy val idTC: Type = {
+    val tvar = newTypeVariable(NoSymbol)
+    internal.polyType(tvar :: Nil, refVar(tvar))
+  }
+
+  /** A Type that references the given type variable. */
+  def refVar(variable: TypeSymbol): Type = variable.toTypeConstructor
+
+  /** Constructs a new, synthetic type variable that is a type constructor. For example, in type Y[L[x]], L is such a type variable. */
+  def newTCVariable(owner: Symbol): TypeSymbol = {
+    val tc = newTypeVariable(owner)
+    val arg = newTypeVariable(tc, "x");
+    tc.setInfo(internal.polyType(arg :: Nil, emptyTypeBounds))
+    tc
+  }
+
+  /** >: Nothing <: Any */
+  def emptyTypeBounds: TypeBounds =
+    internal.typeBounds(definitions.NothingClass.toType, definitions.AnyClass.toType)
+
+  /** Creates a new anonymous function symbol with Position `pos`. */
+  def functionSymbol(pos: Position): Symbol =
+    callsiteTyper.context.owner
+      .newAnonymousFunctionValue(pos.asInstanceOf[global.Position])
+      .asInstanceOf[ctx.universe.Symbol]
+
+  def functionType(args: List[Type], result: Type): Type = {
+    val tpe = global.definitions
+      .functionType(args.asInstanceOf[List[global.Type]], result.asInstanceOf[global.Type])
+    tpe.asInstanceOf[Type]
+  }
+
+  /** Create a Tree that references the `val` represented by `vd`, copying attributes from `replaced`. */
+  def refVal(replaced: Tree, vd: ValDef): Tree =
+    treeCopy.Ident(replaced, vd.name).setSymbol(vd.symbol)
+
+  /** Creates a Function tree using `functionSym` as the Symbol and changing `initialOwner` to `functionSym` in `body`.*/
+  def createFunction(params: List[ValDef], body: Tree, functionSym: Symbol): Tree = {
+    changeOwner(body, initialOwner, functionSym)
+    val f = Function(params, body)
+    setSymbol(f, functionSym)
+    f
+  }
+
+  def changeOwner(tree: Tree, prev: Symbol, next: Symbol): Unit =
+    new ChangeOwnerAndModuleClassTraverser(
+      prev.asInstanceOf[global.Symbol],
+      next.asInstanceOf[global.Symbol]).traverse(tree.asInstanceOf[global.Tree])
+
+  // Workaround copied from scala/async:can be removed once https://github.com/scala/scala/pull/3179 is merged.
+  private[this] class ChangeOwnerAndModuleClassTraverser(oldowner: global.Symbol,
+                                                         newowner: global.Symbol)
+      extends global.ChangeOwnerTraverser(oldowner, newowner) {
+    override def traverse(tree: global.Tree): Unit = {
+      tree match {
+        case _: global.DefTree => change(tree.symbol.moduleClass)
+        case _                 =>
+      }
+      super.traverse(tree)
+    }
+  }
+
+  /** Returns the Symbol that references the statically accessible singleton `i`. */
+  def singleton[T <: AnyRef with Singleton](i: T)(implicit it: ctx.TypeTag[i.type]): Symbol =
+    it.tpe match {
+      case SingleType(_, sym) if !sym.isFreeTerm && sym.isStatic => sym
+      case x                                                     => sys.error("Instance must be static (was " + x + ").")
+    }
+
+  def select(t: Tree, name: String): Tree = Select(t, TermName(name))
+
+  /** Returns the symbol for the non-private method named `name` for the class/module `obj`. */
+  def method(obj: Symbol, name: String): Symbol = {
+    val ts: Type = obj.typeSignature
+    val m: global.Symbol = ts.asInstanceOf[global.Type].nonPrivateMember(global.newTermName(name))
+    m.asInstanceOf[Symbol]
+  }
+
+  /**
+   * Returns a Type representing the type constructor tcp.<name>.  For example, given
+   *  `object Demo { type M[x] = List[x] }`, the call `extractTC(Demo, "M")` will return a type representing
+   * the type constructor `[x] List[x]`.
+   */
+  def extractTC(tcp: AnyRef with Singleton, name: String)(
+      implicit it: ctx.TypeTag[tcp.type]): ctx.Type = {
+    val itTpe = it.tpe.asInstanceOf[global.Type]
+    val m = itTpe.nonPrivateMember(global.newTypeName(name))
+    val tc = itTpe.memberInfo(m).asInstanceOf[ctx.universe.Type]
+    assert(tc != NoType && tc.takesTypeArgs, "Invalid type constructor: " + tc)
+    tc
+  }
+
+  /**
+   * Substitutes wrappers in tree `t` with the result of `subWrapper`.
+   * A wrapper is a Tree of the form `f[T](v)` for which isWrapper(<Tree of f>, <Underlying Type>, <qual>.target) returns true.
+   * Typically, `f` is a `Select` or `Ident`.
+   * The wrapper is replaced with the result of `subWrapper(<Type of T>, <Tree of v>, <wrapper Tree>)`
+   */
+  def transformWrappers(t: Tree,
+                        subWrapper: (String, Type, Tree, Tree) => Converted[ctx.type]): Tree = {
+    // the main tree transformer that replaces calls to InputWrapper.wrap(x) with
+    //  plain Idents that reference the actual input value
+    object appTransformer extends Transformer {
+      override def transform(tree: Tree): Tree =
+        tree match {
+          case ApplyTree(TypeApply(Select(_, nme), targ :: Nil), qual :: Nil) =>
+            subWrapper(nme.decodedName.toString, targ.tpe, qual, tree) match {
+              case Converted.Success(t, finalTx) =>
+                changeOwner(qual, currentOwner, initialOwner) // Fixes https://github.com/sbt/sbt/issues/1150
+                finalTx(t)
+              case Converted.Failure(p, m)       => ctx.abort(p, m)
+              case _: Converted.NotApplicable[_] => super.transform(tree)
+            }
+          case _ => super.transform(tree)
+        }
+    }
+    appTransformer.atOwner(initialOwner) {
+      appTransformer.transform(t)
+    }
+  }
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
@@ -1,0 +1,42 @@
+package sbt.internal.util
+package appmacro
+
+import scala.reflect._
+import macros._
+import Types.idFun
+
+abstract class Convert {
+  def apply[T: c.WeakTypeTag](c: blackbox.Context)(nme: String, in: c.Tree): Converted[c.type]
+  def asPredicate(c: blackbox.Context): (String, c.Type, c.Tree) => Boolean =
+    (n, tpe, tree) => {
+      val tag = c.WeakTypeTag(tpe)
+      apply(c)(n, tree)(tag).isSuccess
+    }
+}
+sealed trait Converted[C <: blackbox.Context with Singleton] {
+  def isSuccess: Boolean
+  def transform(f: C#Tree => C#Tree): Converted[C]
+}
+object Converted {
+  def NotApplicable[C <: blackbox.Context with Singleton] = new NotApplicable[C]
+  final case class Failure[C <: blackbox.Context with Singleton](position: C#Position,
+                                                                 message: String)
+      extends Converted[C] {
+    def isSuccess = false
+    def transform(f: C#Tree => C#Tree): Converted[C] = new Failure(position, message)
+  }
+  final class NotApplicable[C <: blackbox.Context with Singleton] extends Converted[C] {
+    def isSuccess = false
+    def transform(f: C#Tree => C#Tree): Converted[C] = this
+  }
+  final case class Success[C <: blackbox.Context with Singleton](tree: C#Tree,
+                                                                 finalTransform: C#Tree => C#Tree)
+      extends Converted[C] {
+    def isSuccess = true
+    def transform(f: C#Tree => C#Tree): Converted[C] = Success(f(tree), finalTransform)
+  }
+  object Success {
+    def apply[C <: blackbox.Context with Singleton](tree: C#Tree): Success[C] =
+      Success(tree, idFun)
+  }
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -1,0 +1,216 @@
+package sbt.internal.util
+package appmacro
+
+import Classes.Applicative
+import Types.Id
+
+/**
+ * The separate hierarchy from Applicative/Monad is for two reasons.
+ *
+ * 1. The type constructor is represented as an abstract type because a TypeTag cannot represent a type constructor directly.
+ * 2. The applicative interface is uncurried.
+ */
+trait Instance {
+  type M[x]
+  def app[K[L[x]], Z](in: K[M], f: K[Id] => Z)(implicit a: AList[K]): M[Z]
+  def map[S, T](in: M[S], f: S => T): M[T]
+  def pure[T](t: () => T): M[T]
+}
+
+trait MonadInstance extends Instance {
+  def flatten[T](in: M[M[T]]): M[T]
+}
+
+import scala.reflect._
+import macros._
+
+object Instance {
+  final val ApplyName = "app"
+  final val FlattenName = "flatten"
+  final val PureName = "pure"
+  final val MapName = "map"
+  final val InstanceTCName = "M"
+
+  final class Input[U <: Universe with Singleton](val tpe: U#Type,
+                                                  val expr: U#Tree,
+                                                  val local: U#ValDef)
+  trait Transform[C <: blackbox.Context with Singleton, N[_]] {
+    def apply(in: C#Tree): C#Tree
+  }
+  def idTransform[C <: blackbox.Context with Singleton]: Transform[C, Id] = new Transform[C, Id] {
+    def apply(in: C#Tree): C#Tree = in
+  }
+
+  /**
+   * Implementation of a macro that provides a direct syntax for applicative functors and monads.
+   * It is intended to be used in conjunction with another macro that conditions the inputs.
+   *
+   * This method processes the Tree `t` to find inputs of the form `wrap[T]( input )`
+   * This form is typically constructed by another macro that pretends to be able to get a value of type `T`
+   * from a value convertible to `M[T]`.  This `wrap(input)` form has two main purposes.
+   * First, it identifies the inputs that should be transformed.
+   * Second, it allows the input trees to be wrapped for later conversion into the appropriate `M[T]` type by `convert`.
+   * This wrapping is necessary because applying the first macro must preserve the original type,
+   * but it is useful to delay conversion until the outer, second macro is called.  The `wrap` method accomplishes this by
+   * allowing the original `Tree` and `Type` to be hidden behind the raw `T` type.  This method will remove the call to `wrap`
+   * so that it is not actually called at runtime.
+   *
+   * Each `input` in each expression of the form `wrap[T]( input )` is transformed by `convert`.
+   * This transformation converts the input Tree to a Tree of type `M[T]`.
+   * The original wrapped expression `wrap(input)` is replaced by a reference to a new local `val $x: T`, where `$x` is a fresh name.
+   * These converted inputs are passed to `builder` as well as the list of these synthetic `ValDef`s.
+   * The `TupleBuilder` instance constructs a tuple (Tree) from the inputs and defines the right hand side of the vals
+   * that unpacks the tuple containing the results of the inputs.
+   *
+   * The constructed tuple of inputs and the code that unpacks the results of the inputs are then passed to the `i`,
+   * which is an implementation of `Instance` that is statically accessible.
+   * An Instance defines a applicative functor associated with a specific type constructor and, if it implements MonadInstance as well, a monad.
+   * Typically, it will be either a top-level module or a stable member of a top-level module (such as a val or a nested module).
+   * The `with Singleton` part of the type verifies some cases at macro compilation time,
+   *  while the full check for static accessibility is done at macro expansion time.
+   * Note: Ideally, the types would verify that `i: MonadInstance` when `t.isRight`.
+   * With the various dependent types involved, this is not worth it.
+   *
+   * The `t` argument is the argument of the macro that will be transformed as described above.
+   * If the macro that calls this method is for a multi-input map (app followed by map),
+   * `t` should be the argument wrapped in Left.
+   * If this is for multi-input flatMap (app followed by flatMap),
+   *  this should be the argument wrapped in Right.
+   */
+  def contImpl[T, N[_]](
+      c: blackbox.Context,
+      i: Instance with Singleton,
+      convert: Convert,
+      builder: TupleBuilder)(t: Either[c.Expr[T], c.Expr[i.M[T]]], inner: Transform[c.type, N])(
+      implicit tt: c.WeakTypeTag[T],
+      nt: c.WeakTypeTag[N[T]],
+      it: c.TypeTag[i.type]
+  ): c.Expr[i.M[N[T]]] = {
+    import c.universe.{ Apply => ApplyTree, _ }
+
+    val util = ContextUtil[c.type](c)
+    val mTC: Type = util.extractTC(i, InstanceTCName)
+    val mttpe: Type = appliedType(mTC, nt.tpe :: Nil).dealias
+
+    // the tree for the macro argument
+    val (tree, treeType) = t match {
+      case Left(l)  => (l.tree, nt.tpe.dealias)
+      case Right(r) => (r.tree, mttpe)
+    }
+    // the Symbol for the anonymous function passed to the appropriate Instance.map/flatMap/pure method
+    // this Symbol needs to be known up front so that it can be used as the owner of synthetic vals
+    val functionSym = util.functionSymbol(tree.pos)
+
+    val instanceSym = util.singleton(i)
+    // A Tree that references the statically accessible Instance that provides the actual implementations of map, flatMap, ...
+    val instance = Ident(instanceSym)
+
+    val isWrapper: (String, Type, Tree) => Boolean = convert.asPredicate(c)
+
+    // Local definitions `defs` in the macro.  This is used to ensure references are to M instances defined outside of the macro call.
+    // Also `refCount` is the number of references, which is used to create the private, synthetic method containing the body
+    val defs = util.collectDefs(tree, isWrapper)
+    val checkQual: Tree => Unit = util.checkReferences(defs, isWrapper)
+
+    type In = Input[c.universe.type]
+    var inputs = List[In]()
+
+    // transforms the original tree into calls to the Instance functions pure, map, ...,
+    //  resulting in a value of type M[T]
+    def makeApp(body: Tree): Tree =
+      inputs match {
+        case Nil      => pure(body)
+        case x :: Nil => single(body, x)
+        case xs       => arbArity(body, xs)
+      }
+
+    // no inputs, so construct M[T] via Instance.pure or pure+flatten
+    def pure(body: Tree): Tree = {
+      val typeApplied = TypeApply(util.select(instance, PureName), TypeTree(treeType) :: Nil)
+      val f = util.createFunction(Nil, body, functionSym)
+      val p = ApplyTree(typeApplied, f :: Nil)
+      if (t.isLeft) p else flatten(p)
+    }
+    // m should have type M[M[T]]
+    // the returned Tree will have type M[T]
+    def flatten(m: Tree): Tree = {
+      val typedFlatten = TypeApply(util.select(instance, FlattenName), TypeTree(tt.tpe) :: Nil)
+      ApplyTree(typedFlatten, m :: Nil)
+    }
+
+    // calls Instance.map or flatmap directly, skipping the intermediate Instance.app that is unnecessary for a single input
+    def single(body: Tree, input: In): Tree = {
+      val variable = input.local
+      val param =
+        treeCopy.ValDef(variable, util.parameterModifiers, variable.name, variable.tpt, EmptyTree)
+      val typeApplied =
+        TypeApply(util.select(instance, MapName), variable.tpt :: TypeTree(treeType) :: Nil)
+      val f = util.createFunction(param :: Nil, body, functionSym)
+      val mapped = ApplyTree(typeApplied, input.expr :: f :: Nil)
+      if (t.isLeft) mapped else flatten(mapped)
+    }
+
+    // calls Instance.app to get the values for all inputs and then calls Instance.map or flatMap to evaluate the body
+    def arbArity(body: Tree, inputs: List[In]): Tree = {
+      val result = builder.make(c)(mTC, inputs)
+      val param = util.freshMethodParameter(appliedType(result.representationC, util.idTC :: Nil))
+      val bindings = result.extract(param)
+      val f = util.createFunction(param :: Nil, Block(bindings, body), functionSym)
+      val ttt = TypeTree(treeType)
+      val typedApp =
+        TypeApply(util.select(instance, ApplyName), TypeTree(result.representationC) :: ttt :: Nil)
+      val app =
+        ApplyTree(ApplyTree(typedApp, result.input :: f :: Nil), result.alistInstance :: Nil)
+      if (t.isLeft) app else flatten(app)
+    }
+
+    // Called when transforming the tree to add an input.
+    //  For `qual` of type M[A], and a `selection` qual.value,
+    //  the call is addType(Type A, Tree qual)
+    // The result is a Tree representing a reference to
+    //  the bound value of the input.
+    def addType(tpe: Type, qual: Tree, selection: Tree): Tree = {
+      qual.foreach(checkQual)
+      val vd = util.freshValDef(tpe, qual.pos, functionSym)
+      inputs ::= new Input(tpe, qual, vd)
+      util.refVal(selection, vd)
+    }
+    def sub(name: String, tpe: Type, qual: Tree, replace: Tree): Converted[c.type] = {
+      val tag = c.WeakTypeTag[T](tpe)
+      convert[T](c)(name, qual)(tag) transform { tree =>
+        addType(tpe, tree, replace)
+      }
+    }
+
+    // applies the transformation
+    val tx = util.transformWrappers(tree, (n, tpe, t, replace) => sub(n, tpe, t, replace))
+    // resetting attributes must be: a) local b) done here and not wider or else there are obscure errors
+    val tr = makeApp(inner(tx))
+    c.Expr[i.M[N[T]]](tr)
+  }
+
+  import Types._
+
+  implicit def applicativeInstance[A[_]](
+      implicit ap: Applicative[A]): Instance { type M[x] = A[x] } = new Instance {
+    type M[x] = A[x]
+    def app[K[L[x]], Z](in: K[A], f: K[Id] => Z)(implicit a: AList[K]) = a.apply[A, Z](in, f)
+    def map[S, T](in: A[S], f: S => T) = ap.map(f, in)
+    def pure[S](s: () => S): M[S] = ap.pure(s())
+  }
+
+  type AI[A[_]] = Instance { type M[x] = A[x] }
+  def compose[A[_], B[_]](implicit a: AI[A], b: AI[B]): Instance { type M[x] = A[B[x]] } =
+    new Composed[A, B](a, b)
+  // made a public, named, unsealed class because of trouble with macros and inference when the Instance is not an object
+  class Composed[A[_], B[_]](a: AI[A], b: AI[B]) extends Instance {
+    type M[x] = A[B[x]]
+    def pure[S](s: () => S): A[B[S]] = a.pure(() => b.pure(s))
+    def map[S, T](in: M[S], f: S => T): M[T] = a.map(in, (bv: B[S]) => b.map(bv, f))
+    def app[K[L[x]], Z](in: K[M], f: K[Id] => Z)(implicit alist: AList[K]): A[B[Z]] = {
+      val g: K[B] => B[Z] = in => b.app[K, Z](in, f)
+      type Split[L[x]] = K[(L ∙ B)#l]
+      a.app[Split, B[Z]](in, g)(AList.asplit(alist))
+    }
+  }
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
@@ -1,0 +1,72 @@
+package sbt.internal.util
+package appmacro
+
+import scala.reflect._
+import macros._
+
+/** A `TupleBuilder` that uses a KList as the tuple representation.*/
+object KListBuilder extends TupleBuilder {
+  def make(c: blackbox.Context)(mt: c.Type,
+                                inputs: Inputs[c.universe.type]): BuilderResult[c.type] =
+    new BuilderResult[c.type] {
+      val ctx: c.type = c
+      val util = ContextUtil[c.type](c)
+      import c.universe.{ Apply => ApplyTree, _ }
+      import util._
+
+      val knilType = c.typeOf[KNil]
+      val knil = Ident(knilType.typeSymbol.companion)
+      val kconsTpe = c.typeOf[KCons[Int, KNil, List]]
+      val kcons = kconsTpe.typeSymbol.companion
+      val mTC: Type = mt.asInstanceOf[c.universe.Type]
+      val kconsTC: Type = kconsTpe.typeConstructor
+
+      /** This is the L in the type function [L[x]] ...  */
+      val tcVariable: TypeSymbol = newTCVariable(util.initialOwner)
+
+      /** Instantiates KCons[h, t <: KList[L], L], where L is the type constructor variable */
+      def kconsType(h: Type, t: Type): Type =
+        appliedType(kconsTC, h :: t :: refVar(tcVariable) :: Nil)
+
+      def bindKList(prev: ValDef, revBindings: List[ValDef], params: List[ValDef]): List[ValDef] =
+        params match {
+          case (x @ ValDef(mods, name, tpt, _)) :: xs =>
+            val rhs = select(Ident(prev.name), "head")
+            val head = treeCopy.ValDef(x, mods, name, tpt, rhs)
+            util.setSymbol(head, x.symbol)
+            val tail = localValDef(TypeTree(), select(Ident(prev.name), "tail"))
+            val base = head :: revBindings
+            bindKList(tail, if (xs.isEmpty) base else tail :: base, xs)
+          case Nil => revBindings.reverse
+        }
+
+      private[this] def makeKList(revInputs: Inputs[c.universe.type],
+                                  klist: Tree,
+                                  klistType: Type): Tree =
+        revInputs match {
+          case in :: tail =>
+            val next = ApplyTree(
+              TypeApply(Ident(kcons),
+                        TypeTree(in.tpe) :: TypeTree(klistType) :: TypeTree(mTC) :: Nil),
+              in.expr :: klist :: Nil)
+            makeKList(tail, next, appliedType(kconsTC, in.tpe :: klistType :: mTC :: Nil))
+          case Nil => klist
+        }
+
+      /** The input trees combined in a KList */
+      val klist = makeKList(inputs.reverse, knil, knilType)
+
+      /**
+       * The input types combined in a KList type.  The main concern is tracking the heterogeneous types.
+       * The type constructor is tcVariable, so that it can be applied to [X] X or M later.
+       * When applied to `M`, this type gives the type of the `input` KList.
+       */
+      val klistType: Type = (inputs :\ knilType)((in, klist) => kconsType(in.tpe, klist))
+
+      val representationC = internal.polyType(tcVariable :: Nil, klistType)
+      val input = klist
+      val alistInstance: ctx.universe.Tree =
+        TypeApply(select(Ident(alist), "klist"), TypeTree(representationC) :: Nil)
+      def extract(param: ValDef) = bindKList(param, Nil, inputs.map(_.local))
+    }
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/MixedBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/MixedBuilder.scala
@@ -1,0 +1,17 @@
+package sbt.internal.util
+package appmacro
+
+import scala.reflect._
+import macros._
+
+/**
+ * A builder that uses `TupleN` as the representation for small numbers of inputs (up to `TupleNBuilder.MaxInputs`)
+ * and `KList` for larger numbers of inputs. This builder cannot handle fewer than 2 inputs.
+ */
+object MixedBuilder extends TupleBuilder {
+  def make(c: blackbox.Context)(mt: c.Type,
+                                inputs: Inputs[c.universe.type]): BuilderResult[c.type] = {
+    val delegate = if (inputs.size > TupleNBuilder.MaxInputs) KListBuilder else TupleNBuilder
+    delegate.make(c)(mt, inputs)
+  }
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleBuilder.scala
@@ -1,0 +1,56 @@
+package sbt.internal.util
+package appmacro
+
+import scala.reflect._
+import macros._
+
+/**
+ * A `TupleBuilder` abstracts the work of constructing a tuple data structure such as a `TupleN` or `KList`
+ * and extracting values from it.  The `Instance` macro implementation will (roughly) traverse the tree of its argument
+ * and ultimately obtain a list of expressions with type `M[T]` for different types `T`.
+ * The macro constructs an `Input` value for each of these expressions that contains the `Type` for `T`,
+ * the `Tree` for the expression, and a `ValDef` that will hold the value for the input.
+ *
+ * `TupleBuilder.apply` is provided with the list of `Input`s and is expected to provide three values in the returned BuilderResult.
+ * First, it returns the constructed tuple data structure Tree in `input`.
+ * Next, it provides the type constructor `representationC` that, when applied to M, gives the type of tuple data structure.
+ * For example, a builder that constructs a `Tuple3` for inputs `M[Int]`, `M[Boolean]`, and `M[String]`
+ * would provide a Type representing `[L[x]] (L[Int], L[Boolean], L[String])`.  The `input` method
+ * would return a value whose type is that type constructor applied to M, or `(M[Int], M[Boolean], M[String])`.
+ *
+ * Finally, the `extract` method provides a list of vals that extract information from the applied input.
+ * The type of the applied input is the type constructor applied to `Id` (`[X] X`).
+ * The returned list of ValDefs should be the ValDefs from `inputs`, but with non-empty right-hand sides.
+ */
+trait TupleBuilder {
+
+  /** A convenience alias for a list of inputs (associated with a Universe of type U). */
+  type Inputs[U <: Universe with Singleton] = List[Instance.Input[U]]
+
+  /** Constructs a one-time use Builder for Context `c` and type constructor `tcType`. */
+  def make(c: blackbox.Context)(tcType: c.Type,
+                                inputs: Inputs[c.universe.type]): BuilderResult[c.type]
+}
+
+trait BuilderResult[C <: blackbox.Context with Singleton] {
+  val ctx: C
+  import ctx.universe._
+
+  /**
+   * Represents the higher-order type constructor `[L[x]] ...` where `...` is the
+   * type of the data structure containing the added expressions,
+   * except that it is abstracted over the type constructor applied to each heterogeneous part of the type .
+   */
+  def representationC: PolyType
+
+  /** The instance of AList for the input.  For a `representationC` of `[L[x]]`, this `Tree` should have a `Type` of `AList[L]`*/
+  def alistInstance: Tree
+
+  /** Returns the completed value containing all expressions added to the builder. */
+  def input: Tree
+
+  /* The list of definitions that extract values from a value of type `$representationC[Id]`.
+	* The returned value should be identical to the `ValDef`s provided to the `TupleBuilder.make` method but with
+	* non-empty right hand sides. Each `ValDef` may refer to `param` and previous `ValDef`s in the list.*/
+  def extract(param: ValDef): List[ValDef]
+}

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleNBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleNBuilder.scala
@@ -1,0 +1,56 @@
+package sbt.internal.util
+package appmacro
+
+import scala.tools.nsc.Global
+import scala.reflect._
+import macros._
+
+/**
+ * A builder that uses a TupleN as the tuple representation.
+ * It is limited to tuples of size 2 to `MaxInputs`.
+ */
+object TupleNBuilder extends TupleBuilder {
+
+  /** The largest number of inputs that this builder can handle. */
+  final val MaxInputs = 11
+  final val TupleMethodName = "tuple"
+
+  def make(c: blackbox.Context)(mt: c.Type,
+                                inputs: Inputs[c.universe.type]): BuilderResult[c.type] =
+    new BuilderResult[c.type] {
+      val util = ContextUtil[c.type](c)
+      import c.universe._
+      import util._
+
+      val global: Global = c.universe.asInstanceOf[Global]
+
+      val ctx: c.type = c
+      val representationC: PolyType = {
+        val tcVariable: Symbol = newTCVariable(util.initialOwner)
+        val tupleTypeArgs = inputs.map(in =>
+          internal.typeRef(NoPrefix, tcVariable, in.tpe :: Nil).asInstanceOf[global.Type])
+        val tuple = global.definitions.tupleType(tupleTypeArgs)
+        internal.polyType(tcVariable :: Nil, tuple.asInstanceOf[Type])
+      }
+
+      val input: Tree = mkTuple(inputs.map(_.expr))
+      val alistInstance: Tree = {
+        val selectTree = select(Ident(alist), TupleMethodName + inputs.size.toString)
+        TypeApply(selectTree, inputs.map(in => TypeTree(in.tpe)))
+      }
+      def extract(param: ValDef): List[ValDef] = bindTuple(param, Nil, inputs.map(_.local), 1)
+
+      def bindTuple(param: ValDef,
+                    revBindings: List[ValDef],
+                    params: List[ValDef],
+                    i: Int): List[ValDef] =
+        params match {
+          case (x @ ValDef(mods, name, tpt, _)) :: xs =>
+            val rhs = select(Ident(param.name), "_" + i.toString)
+            val newVal = treeCopy.ValDef(x, mods, name, tpt, rhs)
+            util.setSymbol(newVal, x.symbol)
+            bindTuple(param, newVal :: revBindings, xs, i + 1)
+          case Nil => revBindings.reverse
+        }
+    }
+}

--- a/core-settings/NOTICE
+++ b/core-settings/NOTICE
@@ -1,0 +1,3 @@
+Simple Build Tool: Collection Component
+Copyright 2010  Mark Harrah
+Licensed under BSD-style license (see LICENSE)

--- a/core-settings/src/main/scala/sbt/internal/util/AList.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/AList.scala
@@ -1,0 +1,212 @@
+package sbt.internal.util
+
+import Classes.Applicative
+import Types._
+
+/**
+ * An abstraction over a higher-order type constructor `K[x[y]]` with the purpose of abstracting
+ * over heterogeneous sequences like `KList` and `TupleN` with elements with a common type
+ * constructor as well as homogeneous sequences `Seq[M[T]]`.
+ */
+trait AList[K[L[x]]] {
+  def transform[M[_], N[_]](value: K[M], f: M ~> N): K[N]
+  def traverse[M[_], N[_], P[_]](value: K[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[K[P]]
+  def foldr[M[_], A](value: K[M], f: (M[_], A) => A, init: A): A
+
+  def toList[M[_]](value: K[M]): List[M[_]] = foldr[M, List[M[_]]](value, _ :: _, Nil)
+  def apply[M[_], C](value: K[M], f: K[Id] => C)(implicit a: Applicative[M]): M[C] =
+    a.map(f, traverse[M, M, Id](value, idK[M])(a))
+}
+object AList {
+  type Empty = AList[({ type l[L[x]] = Unit })#l]
+  /** AList for Unit, which represents a sequence that is always empty.*/
+  val empty: Empty = new Empty {
+    def transform[M[_], N[_]](in: Unit, f: M ~> N) = ()
+    def foldr[M[_], T](in: Unit, f: (M[_], T) => T, init: T) = init
+    override def apply[M[_], C](in: Unit, f: Unit => C)(implicit app: Applicative[M]): M[C] = app.pure(f(()))
+    def traverse[M[_], N[_], P[_]](in: Unit, f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[Unit] = np.pure(())
+  }
+
+  type SeqList[T] = AList[({ type l[L[x]] = List[L[T]] })#l]
+  /** AList for a homogeneous sequence. */
+  def seq[T]: SeqList[T] = new SeqList[T] {
+    def transform[M[_], N[_]](s: List[M[T]], f: M ~> N) = s.map(f.fn[T])
+    def foldr[M[_], A](s: List[M[T]], f: (M[_], A) => A, init: A): A = (init /: s.reverse)((t, m) => f(m, t))
+    override def apply[M[_], C](s: List[M[T]], f: List[T] => C)(implicit ap: Applicative[M]): M[C] =
+      {
+        def loop[V](in: List[M[T]], g: List[T] => V): M[V] =
+          in match {
+            case Nil => ap.pure(g(Nil))
+            case x :: xs =>
+              val h = (ts: List[T]) => (t: T) => g(t :: ts)
+              ap.apply(loop(xs, h), x)
+          }
+        loop(s, f)
+      }
+    def traverse[M[_], N[_], P[_]](s: List[M[T]], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[List[P[T]]] = ???
+  }
+
+  /** AList for the arbitrary arity data structure KList. */
+  def klist[KL[M[_]] <: KList[M] { type Transform[N[_]] = KL[N] }]: AList[KL] = new AList[KL] {
+    def transform[M[_], N[_]](k: KL[M], f: M ~> N) = k.transform(f)
+    def foldr[M[_], T](k: KL[M], f: (M[_], T) => T, init: T): T = k.foldr(f, init)
+    override def apply[M[_], C](k: KL[M], f: KL[Id] => C)(implicit app: Applicative[M]): M[C] = k.apply(f)(app)
+    def traverse[M[_], N[_], P[_]](k: KL[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[KL[P]] = k.traverse[N, P](f)(np)
+    override def toList[M[_]](k: KL[M]) = k.toList
+  }
+
+  /** AList for a single value. */
+  type Single[A] = AList[({ type l[L[x]] = L[A] })#l]
+  def single[A]: Single[A] = new Single[A] {
+    def transform[M[_], N[_]](a: M[A], f: M ~> N) = f(a)
+    def foldr[M[_], T](a: M[A], f: (M[_], T) => T, init: T): T = f(a, init)
+    def traverse[M[_], N[_], P[_]](a: M[A], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[P[A]] = f(a)
+  }
+
+  type ASplit[K[L[x]], B[x]] = AList[({ type l[L[x]] = K[(L ∙ B)#l] })#l]
+  /** AList that operates on the outer type constructor `A` of a composition `[x] A[B[x]]` for type constructors `A` and `B`*/
+  def asplit[K[L[x]], B[x]](base: AList[K]): ASplit[K, B] = new ASplit[K, B] {
+    type Split[L[x]] = K[(L ∙ B)#l]
+    def transform[M[_], N[_]](value: Split[M], f: M ~> N): Split[N] =
+      base.transform[(M ∙ B)#l, (N ∙ B)#l](value, nestCon[M, N, B](f))
+
+    def traverse[M[_], N[_], P[_]](value: Split[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[Split[P]] =
+      {
+        val g = nestCon[M, (N ∙ P)#l, B](f)
+        base.traverse[(M ∙ B)#l, N, (P ∙ B)#l](value, g)(np)
+      }
+
+    def foldr[M[_], A](value: Split[M], f: (M[_], A) => A, init: A): A =
+      base.foldr[(M ∙ B)#l, A](value, f, init)
+  }
+
+  // TODO: auto-generate
+  sealed trait T2K[A, B] { type l[L[x]] = (L[A], L[B]) }
+  type T2List[A, B] = AList[T2K[A, B]#l]
+  def tuple2[A, B]: T2List[A, B] = new T2List[A, B] {
+    type T2[M[_]] = (M[A], M[B])
+    def transform[M[_], N[_]](t: T2[M], f: M ~> N): T2[N] = (f(t._1), f(t._2))
+    def foldr[M[_], T](t: T2[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, init))
+    def traverse[M[_], N[_], P[_]](t: T2[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T2[P]] =
+      {
+        val g = (Tuple2.apply[P[A], P[B]] _).curried
+        np.apply(np.map(g, f(t._1)), f(t._2))
+      }
+  }
+
+  sealed trait T3K[A, B, C] { type l[L[x]] = (L[A], L[B], L[C]) }
+  type T3List[A, B, C] = AList[T3K[A, B, C]#l]
+  def tuple3[A, B, C]: T3List[A, B, C] = new T3List[A, B, C] {
+    type T3[M[_]] = (M[A], M[B], M[C])
+    def transform[M[_], N[_]](t: T3[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3))
+    def foldr[M[_], T](t: T3[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, init)))
+    def traverse[M[_], N[_], P[_]](t: T3[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T3[P]] =
+      {
+        val g = (Tuple3.apply[P[A], P[B], P[C]] _).curried
+        np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3))
+      }
+  }
+
+  sealed trait T4K[A, B, C, D] { type l[L[x]] = (L[A], L[B], L[C], L[D]) }
+  type T4List[A, B, C, D] = AList[T4K[A, B, C, D]#l]
+  def tuple4[A, B, C, D]: T4List[A, B, C, D] = new T4List[A, B, C, D] {
+    type T4[M[_]] = (M[A], M[B], M[C], M[D])
+    def transform[M[_], N[_]](t: T4[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4))
+    def foldr[M[_], T](t: T4[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, init))))
+    def traverse[M[_], N[_], P[_]](t: T4[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T4[P]] =
+      {
+        val g = (Tuple4.apply[P[A], P[B], P[C], P[D]] _).curried
+        np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4))
+      }
+  }
+
+  sealed trait T5K[A, B, C, D, E] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E]) }
+  type T5List[A, B, C, D, E] = AList[T5K[A, B, C, D, E]#l]
+  def tuple5[A, B, C, D, E]: T5List[A, B, C, D, E] = new T5List[A, B, C, D, E] {
+    type T5[M[_]] = (M[A], M[B], M[C], M[D], M[E])
+    def transform[M[_], N[_]](t: T5[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5))
+    def foldr[M[_], T](t: T5[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, init)))))
+    def traverse[M[_], N[_], P[_]](t: T5[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T5[P]] =
+      {
+        val g = (Tuple5.apply[P[A], P[B], P[C], P[D], P[E]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5))
+      }
+  }
+
+  sealed trait T6K[A, B, C, D, E, F] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F]) }
+  type T6List[A, B, C, D, E, F] = AList[T6K[A, B, C, D, E, F]#l]
+  def tuple6[A, B, C, D, E, F]: T6List[A, B, C, D, E, F] = new T6List[A, B, C, D, E, F] {
+    type T6[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F])
+    def transform[M[_], N[_]](t: T6[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6))
+    def foldr[M[_], T](t: T6[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, init))))))
+    def traverse[M[_], N[_], P[_]](t: T6[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T6[P]] =
+      {
+        val g = (Tuple6.apply[P[A], P[B], P[C], P[D], P[E], P[F]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6))
+      }
+  }
+
+  sealed trait T7K[A, B, C, D, E, F, G] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F], L[G]) }
+  type T7List[A, B, C, D, E, F, G] = AList[T7K[A, B, C, D, E, F, G]#l]
+  def tuple7[A, B, C, D, E, F, G]: T7List[A, B, C, D, E, F, G] = new T7List[A, B, C, D, E, F, G] {
+    type T7[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F], M[G])
+    def transform[M[_], N[_]](t: T7[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6), f(t._7))
+    def foldr[M[_], T](t: T7[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, f(t._7, init)))))))
+    def traverse[M[_], N[_], P[_]](t: T7[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T7[P]] =
+      {
+        val g = (Tuple7.apply[P[A], P[B], P[C], P[D], P[E], P[F], P[G]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6)), f(t._7))
+      }
+  }
+  sealed trait T8K[A, B, C, D, E, F, G, H] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F], L[G], L[H]) }
+  type T8List[A, B, C, D, E, F, G, H] = AList[T8K[A, B, C, D, E, F, G, H]#l]
+  def tuple8[A, B, C, D, E, F, G, H]: T8List[A, B, C, D, E, F, G, H] = new T8List[A, B, C, D, E, F, G, H] {
+    type T8[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F], M[G], M[H])
+    def transform[M[_], N[_]](t: T8[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6), f(t._7), f(t._8))
+    def foldr[M[_], T](t: T8[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, f(t._7, f(t._8, init))))))))
+    def traverse[M[_], N[_], P[_]](t: T8[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T8[P]] =
+      {
+        val g = (Tuple8.apply[P[A], P[B], P[C], P[D], P[E], P[F], P[G], P[H]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6)), f(t._7)), f(t._8))
+      }
+  }
+
+  sealed trait T9K[A, B, C, D, E, F, G, H, I] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F], L[G], L[H], L[I]) }
+  type T9List[A, B, C, D, E, F, G, H, I] = AList[T9K[A, B, C, D, E, F, G, H, I]#l]
+  def tuple9[A, B, C, D, E, F, G, H, I]: T9List[A, B, C, D, E, F, G, H, I] = new T9List[A, B, C, D, E, F, G, H, I] {
+    type T9[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F], M[G], M[H], M[I])
+    def transform[M[_], N[_]](t: T9[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6), f(t._7), f(t._8), f(t._9))
+    def foldr[M[_], T](t: T9[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, f(t._7, f(t._8, f(t._9, init)))))))))
+    def traverse[M[_], N[_], P[_]](t: T9[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T9[P]] =
+      {
+        val g = (Tuple9.apply[P[A], P[B], P[C], P[D], P[E], P[F], P[G], P[H], P[I]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6)), f(t._7)), f(t._8)), f(t._9))
+      }
+  }
+
+  sealed trait T10K[A, B, C, D, E, F, G, H, I, J] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F], L[G], L[H], L[I], L[J]) }
+  type T10List[A, B, C, D, E, F, G, H, I, J] = AList[T10K[A, B, C, D, E, F, G, H, I, J]#l]
+  def tuple10[A, B, C, D, E, F, G, H, I, J]: T10List[A, B, C, D, E, F, G, H, I, J] = new T10List[A, B, C, D, E, F, G, H, I, J] {
+    type T10[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F], M[G], M[H], M[I], M[J])
+    def transform[M[_], N[_]](t: T10[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6), f(t._7), f(t._8), f(t._9), f(t._10))
+    def foldr[M[_], T](t: T10[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, f(t._7, f(t._8, f(t._9, f(t._10, init))))))))))
+    def traverse[M[_], N[_], P[_]](t: T10[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T10[P]] =
+      {
+        val g = (Tuple10.apply[P[A], P[B], P[C], P[D], P[E], P[F], P[G], P[H], P[I], P[J]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6)), f(t._7)), f(t._8)), f(t._9)), f(t._10))
+      }
+  }
+
+  sealed trait T11K[A, B, C, D, E, F, G, H, I, J, K] { type l[L[x]] = (L[A], L[B], L[C], L[D], L[E], L[F], L[G], L[H], L[I], L[J], L[K]) }
+  type T11List[A, B, C, D, E, F, G, H, I, J, K] = AList[T11K[A, B, C, D, E, F, G, H, I, J, K]#l]
+  def tuple11[A, B, C, D, E, F, G, H, I, J, K]: T11List[A, B, C, D, E, F, G, H, I, J, K] = new T11List[A, B, C, D, E, F, G, H, I, J, K] {
+    type T11[M[_]] = (M[A], M[B], M[C], M[D], M[E], M[F], M[G], M[H], M[I], M[J], M[K])
+    def transform[M[_], N[_]](t: T11[M], f: M ~> N) = (f(t._1), f(t._2), f(t._3), f(t._4), f(t._5), f(t._6), f(t._7), f(t._8), f(t._9), f(t._10), f(t._11))
+    def foldr[M[_], T](t: T11[M], f: (M[_], T) => T, init: T): T = f(t._1, f(t._2, f(t._3, f(t._4, f(t._5, f(t._6, f(t._7, f(t._8, f(t._9, f(t._10, f(t._11, init)))))))))))
+    def traverse[M[_], N[_], P[_]](t: T11[M], f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[T11[P]] =
+      {
+        val g = (Tuple11.apply[P[A], P[B], P[C], P[D], P[E], P[F], P[G], P[H], P[I], P[J], P[K]] _).curried
+        np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.apply(np.map(g, f(t._1)), f(t._2)), f(t._3)), f(t._4)), f(t._5)), f(t._6)), f(t._7)), f(t._8)), f(t._9)), f(t._10)), f(t._11))
+      }
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Attributes.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Attributes.scala
@@ -1,0 +1,233 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+import Types._
+import scala.reflect.Manifest
+import sbt.util.OptJsonWriter
+
+// T must be invariant to work properly.
+//  Because it is sealed and the only instances go through AttributeKey.apply,
+//  a single AttributeKey instance cannot conform to AttributeKey[T] for different Ts
+
+/**
+ * A key in an [[AttributeMap]] that constrains its associated value to be of type `T`.
+ * The key is uniquely defined by its [[label]] and type `T`, represented at runtime by [[manifest]].
+ */
+sealed trait AttributeKey[T] {
+
+  /** The runtime evidence for `T` */
+  def manifest: Manifest[T]
+
+  /** The label is the identifier for the key and is camelCase by convention. */
+  def label: String
+
+  /** An optional, brief description of the key. */
+  def description: Option[String]
+
+  /**
+   * In environments that support delegation, looking up this key when it has no associated value will delegate to the values associated with these keys.
+   * The delegation proceeds in order the keys are returned here.
+   */
+  def extend: Seq[AttributeKey[_]]
+
+  /**
+   * Specifies whether this key is a local, anonymous key (`true`) or not (`false`).
+   * This is typically only used for programmatic, intermediate keys that should not be referenced outside of a specific scope.
+   */
+  def isLocal: Boolean
+
+  /** Identifies the relative importance of a key among other keys.*/
+  def rank: Int
+
+  def optJsonWriter: OptJsonWriter[T]
+}
+private[sbt] abstract class SharedAttributeKey[T] extends AttributeKey[T] {
+  override final def toString = label
+  override final def hashCode = label.hashCode
+  override final def equals(o: Any) =
+    (this eq o.asInstanceOf[AnyRef]) || (o match {
+      case a: SharedAttributeKey[t] => a.label == this.label && a.manifest == this.manifest
+      case _                        => false
+    })
+  final def isLocal: Boolean = false
+}
+object AttributeKey {
+  def apply[T](name: String)(implicit mf: Manifest[T], ojw: OptJsonWriter[T]): AttributeKey[T] =
+    make(name, None, Nil, Int.MaxValue)
+
+  def apply[T](name: String, rank: Int)(implicit mf: Manifest[T],
+                                        ojw: OptJsonWriter[T]): AttributeKey[T] =
+    make(name, None, Nil, rank)
+
+  def apply[T](name: String, description: String)(implicit mf: Manifest[T],
+                                                  ojw: OptJsonWriter[T]): AttributeKey[T] =
+    apply(name, description, Nil)
+
+  def apply[T](name: String, description: String, rank: Int)(
+      implicit mf: Manifest[T],
+      ojw: OptJsonWriter[T]): AttributeKey[T] =
+    apply(name, description, Nil, rank)
+
+  def apply[T](name: String, description: String, extend: Seq[AttributeKey[_]])(
+      implicit mf: Manifest[T],
+      ojw: OptJsonWriter[T]): AttributeKey[T] =
+    apply(name, description, extend, Int.MaxValue)
+
+  def apply[T](name: String, description: String, extend: Seq[AttributeKey[_]], rank: Int)(
+      implicit mf: Manifest[T],
+      ojw: OptJsonWriter[T]): AttributeKey[T] =
+    make(name, Some(description), extend, rank)
+
+  private[this] def make[T](
+      name: String,
+      description0: Option[String],
+      extend0: Seq[AttributeKey[_]],
+      rank0: Int)(implicit mf: Manifest[T], ojw: OptJsonWriter[T]): AttributeKey[T] =
+    new SharedAttributeKey[T] {
+      def manifest = mf
+      val label = Util.hyphenToCamel(name)
+      def description = description0
+      def extend = extend0
+      def rank = rank0
+      def optJsonWriter = ojw
+    }
+  private[sbt] def local[T](implicit mf: Manifest[T], ojw: OptJsonWriter[T]): AttributeKey[T] =
+    new AttributeKey[T] {
+      def manifest = mf
+      def label = LocalLabel
+      def description = None
+      def extend = Nil
+      override def toString = label
+      def isLocal: Boolean = true
+      def rank = Int.MaxValue
+      val optJsonWriter = ojw
+    }
+  private[sbt] final val LocalLabel = "$" + "local"
+}
+
+/**
+ * An immutable map where a key is the tuple `(String,T)` for a fixed type `T` and can only be associated with values of type `T`.
+ * It is therefore possible for this map to contain mappings for keys with the same label but different types.
+ * Excluding this possibility is the responsibility of the client if desired.
+ */
+trait AttributeMap {
+
+  /**
+   * Gets the value of type `T` associated with the key `k`.
+   * If a key with the same label but different type is defined, this method will fail.
+   */
+  def apply[T](k: AttributeKey[T]): T
+
+  /**
+   * Gets the value of type `T` associated with the key `k` or `None` if no value is associated.
+   * If a key with the same label but a different type is defined, this method will return `None`.
+   */
+  def get[T](k: AttributeKey[T]): Option[T]
+
+  /**
+   * Returns this map without the mapping for `k`.
+   * This method will not remove a mapping for a key with the same label but a different type.
+   */
+  def remove[T](k: AttributeKey[T]): AttributeMap
+
+  /**
+   * Returns true if this map contains a mapping for `k`.
+   * If a key with the same label but a different type is defined in this map, this method will return `false`.
+   */
+  def contains[T](k: AttributeKey[T]): Boolean
+
+  /**
+   * Adds the mapping `k -> value` to this map, replacing any existing mapping for `k`.
+   * Any mappings for keys with the same label but different types are unaffected.
+   */
+  def put[T](k: AttributeKey[T], value: T): AttributeMap
+
+  /** All keys with defined mappings.  There may be multiple keys with the same `label`, but different types. */
+  def keys: Iterable[AttributeKey[_]]
+
+  /** Adds the mappings in `o` to this map, with mappings in `o` taking precedence over existing mappings.*/
+  def ++(o: Iterable[AttributeEntry[_]]): AttributeMap
+
+  /** Combines the mappings in `o` with the mappings in this map, with mappings in `o` taking precedence over existing mappings.*/
+  def ++(o: AttributeMap): AttributeMap
+
+  /** All mappings in this map.  The [[AttributeEntry]] type preserves the typesafety of mappings, although the specific types are unknown.*/
+  def entries: Iterable[AttributeEntry[_]]
+
+  /** `true` if there are no mappings in this map, `false` if there are. */
+  def isEmpty: Boolean
+}
+object AttributeMap {
+
+  /** An [[AttributeMap]] without any mappings. */
+  val empty: AttributeMap = new BasicAttributeMap(Map.empty)
+
+  /** Constructs an [[AttributeMap]] containing the given `entries`. */
+  def apply(entries: Iterable[AttributeEntry[_]]): AttributeMap = empty ++ entries
+
+  /** Constructs an [[AttributeMap]] containing the given `entries`.*/
+  def apply(entries: AttributeEntry[_]*): AttributeMap = empty ++ entries
+
+  /** Presents an `AttributeMap` as a natural transformation. */
+  implicit def toNatTrans(map: AttributeMap): AttributeKey ~> Id = new (AttributeKey ~> Id) {
+    def apply[T](key: AttributeKey[T]): T = map(key)
+  }
+}
+private class BasicAttributeMap(private val backing: Map[AttributeKey[_], Any])
+    extends AttributeMap {
+  def isEmpty: Boolean = backing.isEmpty
+  def apply[T](k: AttributeKey[T]) = backing(k).asInstanceOf[T]
+  def get[T](k: AttributeKey[T]) = backing.get(k).asInstanceOf[Option[T]]
+  def remove[T](k: AttributeKey[T]): AttributeMap = new BasicAttributeMap(backing - k)
+  def contains[T](k: AttributeKey[T]) = backing.contains(k)
+  def put[T](k: AttributeKey[T], value: T): AttributeMap =
+    new BasicAttributeMap(backing.updated(k, value))
+  def keys: Iterable[AttributeKey[_]] = backing.keys
+  def ++(o: Iterable[AttributeEntry[_]]): AttributeMap = {
+    val newBacking = (backing /: o) {
+      case (b, AttributeEntry(key, value)) => b.updated(key, value)
+    }
+    new BasicAttributeMap(newBacking)
+  }
+  def ++(o: AttributeMap): AttributeMap =
+    o match {
+      case bam: BasicAttributeMap => new BasicAttributeMap(backing ++ bam.backing)
+      case _                      => o ++ this
+    }
+  def entries: Iterable[AttributeEntry[_]] =
+    for ((k: AttributeKey[kt], v) <- backing) yield AttributeEntry(k, v.asInstanceOf[kt])
+  override def toString = entries.mkString("(", ", ", ")")
+}
+
+// type inference required less generality
+/** A map entry where `key` is constrained to only be associated with a fixed value of type `T`. */
+final case class AttributeEntry[T](key: AttributeKey[T], value: T) {
+  override def toString = key.label + ": " + value
+}
+
+/** Associates a `metadata` map with `data`. */
+final case class Attributed[D](data: D)(val metadata: AttributeMap) {
+
+  /** Retrieves the associated value of `key` from the metadata. */
+  def get[T](key: AttributeKey[T]): Option[T] = metadata.get(key)
+
+  /** Defines a mapping `key -> value` in the metadata. */
+  def put[T](key: AttributeKey[T], value: T): Attributed[D] =
+    Attributed(data)(metadata.put(key, value))
+
+  /** Transforms the data by applying `f`. */
+  def map[T](f: D => T): Attributed[T] = Attributed(f(data))(metadata)
+}
+object Attributed {
+
+  /** Extracts the underlying data from the sequence `in`. */
+  def data[T](in: Seq[Attributed[T]]): Seq[T] = in.map(_.data)
+
+  /** Associates empty metadata maps with each entry of `in`.*/
+  def blankSeq[T](in: Seq[T]): Seq[Attributed[T]] = in map blank
+
+  /** Associates an empty metadata map with `data`. */
+  def blank[T](data: T): Attributed[T] = Attributed(data)(AttributeMap.empty)
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Classes.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Classes.scala
@@ -1,0 +1,26 @@
+package sbt.internal.util
+
+object Classes {
+  trait Applicative[M[_]] {
+    def apply[S, T](f: M[S => T], v: M[S]): M[T]
+    def pure[S](s: => S): M[S]
+    def map[S, T](f: S => T, v: M[S]): M[T]
+  }
+  trait Monad[M[_]] extends Applicative[M] {
+    def flatten[T](m: M[M[T]]): M[T]
+  }
+  implicit val optionMonad: Monad[Option] = new Monad[Option] {
+    def apply[S, T](f: Option[S => T], v: Option[S]) = (f, v) match {
+      case (Some(fv), Some(vv)) => Some(fv(vv)); case _ => None
+    }
+    def pure[S](s: => S) = Some(s)
+    def map[S, T](f: S => T, v: Option[S]) = v map f
+    def flatten[T](m: Option[Option[T]]): Option[T] = m.flatten
+  }
+  implicit val listMonad: Monad[List] = new Monad[List] {
+    def apply[S, T](f: List[S => T], v: List[S]) = for (fv <- f; vv <- v) yield fv(vv)
+    def pure[S](s: => S) = s :: Nil
+    def map[S, T](f: S => T, v: List[S]) = v map f
+    def flatten[T](m: List[List[T]]): List[T] = m.flatten
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Dag.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Dag.scala
@@ -1,0 +1,131 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2008, 2009, 2010 David MacIver, Mark Harrah
+ */
+package sbt.internal.util
+
+trait Dag[Node <: Dag[Node]] { self: Node =>
+
+  def dependencies: Iterable[Node]
+  def topologicalSort = Dag.topologicalSort(self)(_.dependencies)
+}
+object Dag {
+  import scala.collection.{ mutable, JavaConverters }
+  import JavaConverters.asScalaSetConverter
+
+  def topologicalSort[T](root: T)(dependencies: T => Iterable[T]): List[T] =
+    topologicalSort(root :: Nil)(dependencies)
+
+  def topologicalSort[T](nodes: Iterable[T])(dependencies: T => Iterable[T]): List[T] = {
+    val discovered = new mutable.HashSet[T]
+    val finished = (new java.util.LinkedHashSet[T]).asScala
+
+    def visitAll(nodes: Iterable[T]) = nodes foreach visit
+    def visit(node: T): Unit = {
+      if (!discovered(node)) {
+        discovered(node) = true;
+        try { visitAll(dependencies(node)); } catch { case c: Cyclic => throw node :: c }
+        finished += node
+        ()
+      } else if (!finished(node))
+        throw new Cyclic(node)
+    }
+
+    visitAll(nodes)
+
+    finished.toList
+  }
+  // doesn't check for cycles
+  def topologicalSortUnchecked[T](node: T)(dependencies: T => Iterable[T]): List[T] =
+    topologicalSortUnchecked(node :: Nil)(dependencies)
+
+  def topologicalSortUnchecked[T](nodes: Iterable[T])(dependencies: T => Iterable[T]): List[T] = {
+    val discovered = new mutable.HashSet[T]
+    var finished: List[T] = Nil
+
+    def visitAll(nodes: Iterable[T]) = nodes foreach visit
+    def visit(node: T): Unit = {
+      if (!discovered(node)) {
+        discovered(node) = true
+        visitAll(dependencies(node))
+        finished ::= node
+      }
+    }
+
+    visitAll(nodes);
+    finished;
+  }
+  final class Cyclic(val value: Any, val all: List[Any], val complete: Boolean)
+      extends Exception(
+        "Cyclic reference involving " +
+          (if (complete) all.mkString("\n   ", "\n   ", "") else value)) {
+    def this(value: Any) = this(value, value :: Nil, false)
+    override def toString = getMessage
+    def ::(a: Any): Cyclic =
+      if (complete)
+        this
+      else if (a == value)
+        new Cyclic(value, all, true)
+      else
+        new Cyclic(value, a :: all, false)
+  }
+
+  /** A directed graph with edges labeled positive or negative. */
+  private[sbt] trait DirectedSignedGraph[Node] {
+
+    /**
+     * Directed edge type that tracks the sign and target (head) vertex.
+     * The sign can be obtained via [[isNegative]] and the target vertex via [[head]].
+     */
+    type Arrow
+
+    /** List of initial nodes. */
+    def nodes: List[Arrow]
+
+    /** Outgoing edges for `n`. */
+    def dependencies(n: Node): List[Arrow]
+
+    /** `true` if the edge `a` is "negative", false if it is "positive". */
+    def isNegative(a: Arrow): Boolean
+
+    /** The target of the directed edge `a`. */
+    def head(a: Arrow): Node
+  }
+
+  /**
+   * Traverses a directed graph defined by `graph` looking for a cycle that includes a "negative" edge.
+   * The directed edges are weighted by the caller as "positive" or "negative".
+   * If a cycle containing a "negative" edge is detected, its member edges are returned in order.
+   * Otherwise, the empty list is returned.
+   */
+  private[sbt] def findNegativeCycle[Node](graph: DirectedSignedGraph[Node]): List[graph.Arrow] = {
+    import graph._
+    val finished = new mutable.HashSet[Node]
+    val visited = new mutable.HashSet[Node]
+
+    def visit(edges: List[Arrow], stack: List[Arrow]): List[Arrow] = edges match {
+      case Nil => Nil
+      case edge :: tail =>
+        val node = head(edge)
+        if (!visited(node)) {
+          visited += node
+          visit(dependencies(node), edge :: stack) match {
+            case Nil =>
+              finished += node
+              visit(tail, stack)
+            case cycle => cycle
+          }
+        } else if (!finished(node)) {
+          // cycle. If a negative edge is involved, it is an error.
+          val between = edge :: stack.takeWhile(f => head(f) != node)
+          if (between exists isNegative)
+            between
+          else
+            visit(tail, stack)
+        } else
+          visit(tail, stack)
+    }
+
+    visit(graph.nodes, Nil)
+  }
+
+}

--- a/core-settings/src/main/scala/sbt/internal/util/HList.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/HList.scala
@@ -1,0 +1,33 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+import Types._
+
+/**
+ * A minimal heterogeneous list type.  For background, see
+ * http://apocalisp.wordpress.com/2010/07/06/type-level-programming-in-scala-part-6a-heterogeneous-list basics/
+ */
+sealed trait HList {
+  type Wrap[M[_]] <: HList
+}
+sealed trait HNil extends HList {
+  type Wrap[M[_]] = HNil
+  def :+:[G](g: G): G :+: HNil = HCons(g, this)
+
+  override def toString = "HNil"
+}
+object HNil extends HNil
+final case class HCons[H, T <: HList](head: H, tail: T) extends HList {
+  type Wrap[M[_]] = M[H] :+: T#Wrap[M]
+  def :+:[G](g: G): G :+: H :+: T = HCons(g, this)
+
+  override def toString = head + " :+: " + tail.toString
+}
+
+object HList {
+  // contains no type information: not even A
+  implicit def fromList[A](list: Traversable[A]): HList =
+    ((HNil: HList) /: list)((hl, v) => HCons(v, hl))
+}

--- a/core-settings/src/main/scala/sbt/internal/util/IDSet.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/IDSet.scala
@@ -1,0 +1,45 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+/** A mutable set interface that uses object identity to test for set membership.*/
+trait IDSet[T] {
+  def apply(t: T): Boolean
+  def contains(t: T): Boolean
+  def +=(t: T): Unit
+  def ++=(t: Iterable[T]): Unit
+  def -=(t: T): Boolean
+  def all: collection.Iterable[T]
+  def toList: List[T]
+  def isEmpty: Boolean
+  def foreach(f: T => Unit): Unit
+  def process[S](t: T)(ifSeen: S)(ifNew: => S): S
+}
+
+object IDSet {
+  implicit def toTraversable[T]: IDSet[T] => Traversable[T] = _.all
+  def apply[T](values: T*): IDSet[T] = apply(values)
+  def apply[T](values: Iterable[T]): IDSet[T] = {
+    val s = create[T]
+    s ++= values
+    s
+  }
+  def create[T]: IDSet[T] = new IDSet[T] {
+    private[this] val backing = new java.util.IdentityHashMap[T, AnyRef]
+    private[this] val Dummy: AnyRef = ""
+
+    def apply(t: T) = contains(t)
+    def contains(t: T) = backing.containsKey(t)
+    def foreach(f: T => Unit) = all foreach f
+    def +=(t: T) = { backing.put(t, Dummy); () }
+    def ++=(t: Iterable[T]) = t foreach +=
+    def -=(t: T) = if (backing.remove(t) eq null) false else true
+    def all = collection.JavaConversions.collectionAsScalaIterable(backing.keySet)
+    def toList = all.toList
+    def isEmpty = backing.isEmpty
+    def process[S](t: T)(ifSeen: S)(ifNew: => S) =
+      if (contains(t)) ifSeen else { this += t; ifNew }
+    override def toString = backing.toString
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/INode.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/INode.scala
@@ -1,0 +1,191 @@
+package sbt.internal.util
+
+import java.lang.Runnable
+import java.util.concurrent.{ atomic, Executor, LinkedBlockingQueue }
+import atomic.{ AtomicBoolean, AtomicInteger }
+import Types.{ ConstK, Id }
+
+object EvaluationState extends Enumeration {
+  val New, Blocked, Ready, Calling, Evaluated = Value
+}
+
+abstract class EvaluateSettings[Scope] {
+  protected val init: Init[Scope]
+  import init._
+  protected def executor: Executor
+  protected def compiledSettings: Seq[Compiled[_]]
+
+  import EvaluationState.{ Value => EvaluationState, _ }
+
+  private[this] val complete = new LinkedBlockingQueue[Option[Throwable]]
+  private[this] val static = PMap.empty[ScopedKey, INode]
+  private[this] val allScopes: Set[Scope] = compiledSettings.map(_.key.scope).toSet
+  private[this] def getStatic[T](key: ScopedKey[T]): INode[T] =
+    static get key getOrElse sys.error("Illegal reference to key " + key)
+
+  private[this] val transform: Initialize ~> INode = new (Initialize ~> INode) {
+    def apply[T](i: Initialize[T]): INode[T] = i match {
+      case k: Keyed[s, T] @unchecked => single(getStatic(k.scopedKey), k.transform)
+      case a: Apply[k, T] @unchecked =>
+        new MixedNode[k, T](a.alist.transform[Initialize, INode](a.inputs, transform),
+                            a.f,
+                            a.alist)
+      case b: Bind[s, T] @unchecked           => new BindNode[s, T](transform(b.in), x => transform(b.f(x)))
+      case v: Value[T] @unchecked             => constant(v.value)
+      case v: ValidationCapture[T] @unchecked => strictConstant(v.key)
+      case t: TransformCapture                => strictConstant(t.f)
+      case o: Optional[s, T] @unchecked =>
+        o.a match {
+          case None    => constant(() => o.f(None))
+          case Some(i) => single[s, T](transform(i), x => o.f(Some(x)))
+        }
+      case x if x == StaticScopes =>
+        strictConstant(allScopes.asInstanceOf[T]) // can't convince scalac that StaticScopes => T == Set[Scope]
+    }
+  }
+  private[this] lazy val roots: Seq[INode[_]] = compiledSettings flatMap { cs =>
+    (cs.settings map { s =>
+      val t = transform(s.init)
+      static(s.key) = t
+      t
+    }): Seq[INode[_]]
+  }
+  private[this] var running = new AtomicInteger
+  private[this] var cancel = new AtomicBoolean(false)
+
+  def run(implicit delegates: Scope => Seq[Scope]): Settings[Scope] = {
+    assert(running.get() == 0, "Already running")
+    startWork()
+    roots.foreach(_.registerIfNew())
+    workComplete()
+    complete.take() foreach { ex =>
+      cancel.set(true)
+      throw ex
+    }
+    getResults(delegates)
+  }
+  private[this] def getResults(implicit delegates: Scope => Seq[Scope]) =
+    (empty /: static.toTypedSeq) {
+      case (ss, static.TPair(key, node)) =>
+        if (key.key.isLocal) ss else ss.set(key.scope, key.key, node.get)
+    }
+  private[this] val getValue = new (INode ~> Id) { def apply[T](node: INode[T]) = node.get }
+
+  private[this] def submitEvaluate(node: INode[_]) = submit(node.evaluate())
+  private[this] def submitCallComplete[T](node: BindNode[_, T], value: T) =
+    submit(node.callComplete(value))
+  private[this] def submit(work: => Unit): Unit = {
+    startWork()
+    executor.execute(new Runnable { def run = if (!cancel.get()) run0(work) })
+  }
+  private[this] def run0(work: => Unit): Unit = {
+    try { work } catch { case e: Throwable => complete.put(Some(e)) }
+    workComplete()
+  }
+
+  private[this] def startWork(): Unit = { running.incrementAndGet(); () }
+  private[this] def workComplete(): Unit =
+    if (running.decrementAndGet() == 0)
+      complete.put(None)
+
+  private[this] sealed abstract class INode[T] {
+    private[this] var state: EvaluationState = New
+    private[this] var value: T = _
+    private[this] val blocking = new collection.mutable.ListBuffer[INode[_]]
+    private[this] var blockedOn: Int = 0
+    private[this] val calledBy = new collection.mutable.ListBuffer[BindNode[_, T]]
+
+    override def toString =
+      getClass.getName + " (state=" + state + ",blockedOn=" + blockedOn + ",calledBy=" + calledBy.size + ",blocking=" + blocking.size + "): " +
+        keyString
+
+    private[this] def keyString =
+      (static.toSeq.flatMap {
+        case (key, value) => if (value eq this) init.showFullKey.show(key) :: Nil else Nil
+      }).headOption getOrElse "non-static"
+
+    final def get: T = synchronized {
+      assert(value != null, toString + " not evaluated")
+      value
+    }
+    final def doneOrBlock(from: INode[_]): Boolean = synchronized {
+      val ready = state == Evaluated
+      if (!ready) blocking += from
+      registerIfNew()
+      ready
+    }
+    final def isDone: Boolean = synchronized { state == Evaluated }
+    final def isNew: Boolean = synchronized { state == New }
+    final def isCalling: Boolean = synchronized { state == Calling }
+    final def registerIfNew(): Unit = synchronized { if (state == New) register() }
+    private[this] def register(): Unit = {
+      assert(state == New, "Already registered and: " + toString)
+      val deps = dependsOn
+      blockedOn = deps.size - deps.count(_.doneOrBlock(this))
+      if (blockedOn == 0)
+        schedule()
+      else
+        state = Blocked
+    }
+
+    final def schedule(): Unit = synchronized {
+      assert(state == New || state == Blocked, "Invalid state for schedule() call: " + toString)
+      state = Ready
+      submitEvaluate(this)
+    }
+    final def unblocked(): Unit = synchronized {
+      assert(state == Blocked, "Invalid state for unblocked() call: " + toString)
+      blockedOn -= 1
+      assert(blockedOn >= 0, "Negative blockedOn: " + blockedOn + " for " + toString)
+      if (blockedOn == 0) schedule()
+    }
+    final def evaluate(): Unit = synchronized { evaluate0() }
+    protected final def makeCall(source: BindNode[_, T], target: INode[T]): Unit = {
+      assert(state == Ready, "Invalid state for call to makeCall: " + toString)
+      state = Calling
+      target.call(source)
+    }
+    protected final def setValue(v: T): Unit = {
+      assert(state != Evaluated,
+             "Already evaluated (trying to set value to " + v + "): " + toString)
+      if (v == null) sys.error("Setting value cannot be null: " + keyString)
+      value = v
+      state = Evaluated
+      blocking foreach { _.unblocked() }
+      blocking.clear()
+      calledBy foreach { node =>
+        submitCallComplete(node, value)
+      }
+      calledBy.clear()
+    }
+    final def call(by: BindNode[_, T]): Unit = synchronized {
+      registerIfNew()
+      state match {
+        case Evaluated => submitCallComplete(by, value)
+        case _         => calledBy += by
+      }
+      ()
+    }
+    protected def dependsOn: Seq[INode[_]]
+    protected def evaluate0(): Unit
+  }
+
+  private[this] def strictConstant[T](v: T): INode[T] = constant(() => v)
+  private[this] def constant[T](f: () => T): INode[T] =
+    new MixedNode[ConstK[Unit]#l, T]((), _ => f(), AList.empty)
+  private[this] def single[S, T](in: INode[S], f: S => T): INode[T] =
+    new MixedNode[({ type l[L[x]] = L[S] })#l, T](in, f, AList.single[S])
+  private[this] final class BindNode[S, T](in: INode[S], f: S => INode[T]) extends INode[T] {
+    protected def dependsOn = in :: Nil
+    protected def evaluate0(): Unit = makeCall(this, f(in.get))
+    def callComplete(value: T): Unit = synchronized {
+      assert(isCalling, "Invalid state for callComplete(" + value + "): " + toString)
+      setValue(value)
+    }
+  }
+  private[this] final class MixedNode[K[L[x]], T](in: K[INode], f: K[Id] => T, alist: AList[K])
+      extends INode[T] {
+    protected def dependsOn = alist.toList(in)
+    protected def evaluate0(): Unit = setValue(f(alist.transform(in, getValue)))
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/KList.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/KList.scala
@@ -1,0 +1,52 @@
+package sbt.internal.util
+
+import Types._
+import Classes.Applicative
+
+/** Heterogeneous list with each element having type M[T] for some type T.*/
+sealed trait KList[+M[_]] {
+  type Transform[N[_]] <: KList[N]
+
+  /** Apply the natural transformation `f` to each element. */
+  def transform[N[_]](f: M ~> N): Transform[N]
+
+  /** Folds this list using a function that operates on the homogeneous type of the elements of this list. */
+  def foldr[B](f: (M[_], B) => B, init: B): B = init // had trouble defining it in KNil
+
+  /** Applies `f` to the elements of this list in the applicative functor defined by `ap`. */
+  def apply[N[x] >: M[x], Z](f: Transform[Id] => Z)(implicit ap: Applicative[N]): N[Z]
+
+  /** Equivalent to `transform(f) . apply(x => x)`, this is the essence of the iterator at the level of natural transformations.*/
+  def traverse[N[_], P[_]](f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[Transform[P]]
+
+  /** Discards the heterogeneous type information and constructs a plain List from this KList's elements. */
+  def toList: List[M[_]]
+}
+final case class KCons[H, +T <: KList[M], +M[_]](head: M[H], tail: T) extends KList[M] {
+  final type Transform[N[_]] = KCons[H, tail.Transform[N], N]
+
+  def transform[N[_]](f: M ~> N) = KCons(f(head), tail.transform(f))
+  def toList: List[M[_]] = head :: tail.toList
+  def apply[N[x] >: M[x], Z](f: Transform[Id] => Z)(implicit ap: Applicative[N]): N[Z] = {
+    val g = (t: tail.Transform[Id]) => (h: H) => f(KCons[H, tail.Transform[Id], Id](h, t))
+    ap.apply(tail.apply[N, H => Z](g), head)
+  }
+  def traverse[N[_], P[_]](f: M ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[Transform[P]] = {
+    val tt: N[tail.Transform[P]] = tail.traverse[N, P](f)
+    val g = (t: tail.Transform[P]) => (h: P[H]) => KCons(h, t)
+    np.apply(np.map(g, tt), f(head))
+  }
+  def :^:[A, N[x] >: M[x]](h: N[A]) = KCons(h, this)
+  override def foldr[B](f: (M[_], B) => B, init: B): B = f(head, tail.foldr(f, init))
+}
+sealed abstract class KNil extends KList[Nothing] {
+  final type Transform[N[_]] = KNil
+  final def transform[N[_]](f: Nothing ~> N): Transform[N] = KNil
+  final def toList = Nil
+  final def apply[N[x], Z](f: KNil => Z)(implicit ap: Applicative[N]): N[Z] = ap.pure(f(KNil))
+  final def traverse[N[_], P[_]](f: Nothing ~> (N ∙ P)#l)(implicit np: Applicative[N]): N[KNil] =
+    np.pure(KNil)
+}
+case object KNil extends KNil {
+  def :^:[M[_], H](h: M[H]): KCons[H, KNil, M] = KCons(h, this)
+}

--- a/core-settings/src/main/scala/sbt/internal/util/PMap.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/PMap.scala
@@ -1,0 +1,115 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+import collection.mutable
+
+trait RMap[K[_], V[_]] {
+  def apply[T](k: K[T]): V[T]
+  def get[T](k: K[T]): Option[V[T]]
+  def contains[T](k: K[T]): Boolean
+  def toSeq: Seq[(K[_], V[_])]
+  def toTypedSeq: Seq[TPair[_]] = toSeq.map {
+    case (k: K[t], v) => TPair[t](k, v.asInstanceOf[V[t]])
+  }
+  def keys: Iterable[K[_]]
+  def values: Iterable[V[_]]
+  def isEmpty: Boolean
+
+  sealed case class TPair[T](key: K[T], value: V[T])
+}
+
+trait IMap[K[_], V[_]] extends (K ~> V) with RMap[K, V] {
+  def put[T](k: K[T], v: V[T]): IMap[K, V]
+  def remove[T](k: K[T]): IMap[K, V]
+  def mapValue[T](k: K[T], init: V[T], f: V[T] => V[T]): IMap[K, V]
+  def mapValues[V2[_]](f: V ~> V2): IMap[K, V2]
+  def mapSeparate[VL[_], VR[_]](f: V ~> ({ type l[T] = Either[VL[T], VR[T]] })#l)
+    : (IMap[K, VL], IMap[K, VR])
+}
+trait PMap[K[_], V[_]] extends (K ~> V) with RMap[K, V] {
+  def update[T](k: K[T], v: V[T]): Unit
+  def remove[T](k: K[T]): Option[V[T]]
+  def getOrUpdate[T](k: K[T], make: => V[T]): V[T]
+  def mapValue[T](k: K[T], init: V[T], f: V[T] => V[T]): V[T]
+}
+object PMap {
+  implicit def toFunction[K[_], V[_]](map: PMap[K, V]): K[_] => V[_] = k => map(k)
+  def empty[K[_], V[_]]: PMap[K, V] = new DelegatingPMap[K, V](new mutable.HashMap)
+}
+object IMap {
+
+  /**
+   * Only suitable for K that is invariant in its type parameter.
+   * Option and List keys are not suitable, for example,
+   *  because None &lt;:&lt; Option[String] and None &lt;: Option[Int].
+   */
+  def empty[K[_], V[_]]: IMap[K, V] = new IMap0[K, V](Map.empty)
+
+  private[this] class IMap0[K[_], V[_]](backing: Map[K[_], V[_]])
+      extends AbstractRMap[K, V]
+      with IMap[K, V] {
+    def get[T](k: K[T]): Option[V[T]] = (backing get k).asInstanceOf[Option[V[T]]]
+    def put[T](k: K[T], v: V[T]) = new IMap0[K, V](backing.updated(k, v))
+    def remove[T](k: K[T]) = new IMap0[K, V](backing - k)
+
+    def mapValue[T](k: K[T], init: V[T], f: V[T] => V[T]) =
+      put(k, f(this get k getOrElse init))
+
+    def mapValues[V2[_]](f: V ~> V2) =
+      new IMap0[K, V2](backing.mapValues(x => f(x)))
+
+    def mapSeparate[VL[_], VR[_]](f: V ~> ({ type l[T] = Either[VL[T], VR[T]] })#l) = {
+      val mapped = backing.iterator.map {
+        case (k, v) =>
+          f(v) match {
+            case Left(l)  => Left((k, l))
+            case Right(r) => Right((k, r))
+          }
+      }
+      val (l, r) = Util.separateE[(K[_], VL[_]), (K[_], VR[_])](mapped.toList)
+      (new IMap0[K, VL](l.toMap), new IMap0[K, VR](r.toMap))
+    }
+
+    def toSeq = backing.toSeq
+    def keys = backing.keys
+    def values = backing.values
+    def isEmpty = backing.isEmpty
+
+    override def toString = backing.toString
+  }
+}
+
+abstract class AbstractRMap[K[_], V[_]] extends RMap[K, V] {
+  def apply[T](k: K[T]): V[T] = get(k).get
+  def contains[T](k: K[T]): Boolean = get(k).isDefined
+}
+
+/**
+ * Only suitable for K that is invariant in its type parameter.
+ * Option and List keys are not suitable, for example,
+ *  because None &lt;:&lt; Option[String] and None &lt;: Option[Int].
+ */
+class DelegatingPMap[K[_], V[_]](backing: mutable.Map[K[_], V[_]])
+    extends AbstractRMap[K, V]
+    with PMap[K, V] {
+  def get[T](k: K[T]): Option[V[T]] = cast[T](backing.get(k))
+  def update[T](k: K[T], v: V[T]): Unit = { backing(k) = v }
+  def remove[T](k: K[T]) = cast(backing.remove(k))
+  def getOrUpdate[T](k: K[T], make: => V[T]) = cast[T](backing.getOrElseUpdate(k, make))
+  def mapValue[T](k: K[T], init: V[T], f: V[T] => V[T]): V[T] = {
+    val v = f(this get k getOrElse init)
+    update(k, v)
+    v
+  }
+  def toSeq = backing.toSeq
+  def keys = backing.keys
+  def values = backing.values
+  def isEmpty = backing.isEmpty
+
+  private[this] def cast[T](v: V[_]): V[T] = v.asInstanceOf[V[T]]
+  private[this] def cast[T](o: Option[V[_]]): Option[V[T]] = o map cast[T]
+
+  override def toString = backing.toString
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Param.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Param.scala
@@ -1,0 +1,28 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+// Used to emulate ~> literals
+trait Param[A[_], B[_]] {
+  type T
+  def in: A[T]
+  def ret(out: B[T]): Unit
+  def ret: B[T]
+}
+
+object Param {
+  implicit def pToT[A[_], B[_]](p: Param[A, B] => Unit): A ~> B = new (A ~> B) {
+    def apply[s](a: A[s]): B[s] = {
+      val v: Param[A, B] { type T = s } = new Param[A, B] {
+        type T = s
+        def in = a
+        private var r: B[T] = _
+        def ret(b: B[T]): Unit = { r = b }
+        def ret: B[T] = r
+      }
+      p(v)
+      v.ret
+    }
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Positions.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Positions.scala
@@ -1,0 +1,20 @@
+package sbt.internal.util
+
+sealed trait SourcePosition
+
+sealed trait FilePosition extends SourcePosition {
+  def path: String
+  def startLine: Int
+}
+
+case object NoPosition extends SourcePosition
+
+final case class LinePosition(path: String, startLine: Int) extends FilePosition
+
+final case class LineRange(start: Int, end: Int) {
+  def shift(n: Int) = new LineRange(start + n, end + n)
+}
+
+final case class RangePosition(path: String, range: LineRange) extends FilePosition {
+  def startLine = range.start
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Settings.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Settings.scala
@@ -1,0 +1,731 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2011 Mark Harrah
+ */
+package sbt.internal.util
+
+import scala.language.existentials
+
+import Types._
+import sbt.util.Show
+
+sealed trait Settings[Scope] {
+  def data: Map[Scope, AttributeMap]
+  def keys(scope: Scope): Set[AttributeKey[_]]
+  def scopes: Set[Scope]
+  def definingScope(scope: Scope, key: AttributeKey[_]): Option[Scope]
+  def allKeys[T](f: (Scope, AttributeKey[_]) => T): Seq[T]
+  def get[T](scope: Scope, key: AttributeKey[T]): Option[T]
+  def getDirect[T](scope: Scope, key: AttributeKey[T]): Option[T]
+  def set[T](scope: Scope, key: AttributeKey[T], value: T): Settings[Scope]
+}
+
+private final class Settings0[Scope](val data: Map[Scope, AttributeMap],
+                                     val delegates: Scope => Seq[Scope])
+    extends Settings[Scope] {
+  def scopes: Set[Scope] = data.keySet
+  def keys(scope: Scope) = data(scope).keys.toSet
+  def allKeys[T](f: (Scope, AttributeKey[_]) => T): Seq[T] =
+    data.flatMap { case (scope, map) => map.keys.map(k => f(scope, k)) }.toSeq
+
+  def get[T](scope: Scope, key: AttributeKey[T]): Option[T] =
+    delegates(scope).toStream.flatMap(sc => getDirect(sc, key)).headOption
+  def definingScope(scope: Scope, key: AttributeKey[_]): Option[Scope] =
+    delegates(scope).toStream.find(sc => getDirect(sc, key).isDefined)
+
+  def getDirect[T](scope: Scope, key: AttributeKey[T]): Option[T] =
+    (data get scope).flatMap(_ get key)
+
+  def set[T](scope: Scope, key: AttributeKey[T], value: T): Settings[Scope] = {
+    val map = data getOrElse (scope, AttributeMap.empty)
+    val newData = data.updated(scope, map.put(key, value))
+    new Settings0(newData, delegates)
+  }
+}
+// delegates should contain the input Scope as the first entry
+// this trait is intended to be mixed into an object
+trait Init[Scope] {
+
+  /** The Show instance used when a detailed String needs to be generated.  It is typically used when no context is available.*/
+  def showFullKey: Show[ScopedKey[_]]
+
+  sealed case class ScopedKey[T](scope: Scope, key: AttributeKey[T]) extends KeyedInitialize[T] {
+    def scopedKey = this
+  }
+
+  type SettingSeq[T] = Seq[Setting[T]]
+  type ScopedMap = IMap[ScopedKey, SettingSeq]
+  type CompiledMap = Map[ScopedKey[_], Compiled[_]]
+  type MapScoped = ScopedKey ~> ScopedKey
+  type ValidatedRef[T] = Either[Undefined, ScopedKey[T]]
+  type ValidatedInit[T] = Either[Seq[Undefined], Initialize[T]]
+  type ValidateRef = ScopedKey ~> ValidatedRef
+  type ScopeLocal = ScopedKey[_] => Seq[Setting[_]]
+  type MapConstant = ScopedKey ~> Option
+
+  private[sbt] abstract class ValidateKeyRef {
+    def apply[T](key: ScopedKey[T], selfRefOk: Boolean): ValidatedRef[T]
+  }
+
+  /**
+   * The result of this initialization is the composition of applied transformations.
+   * This can be useful when dealing with dynamic Initialize values.
+   */
+  lazy val capturedTransformations: Initialize[Initialize ~> Initialize] = new TransformCapture(
+    idK[Initialize])
+
+  def setting[T](key: ScopedKey[T],
+                 init: Initialize[T],
+                 pos: SourcePosition = NoPosition): Setting[T] = new Setting[T](key, init, pos)
+  def valueStrict[T](value: T): Initialize[T] = pure(() => value)
+  def value[T](value: => T): Initialize[T] = pure(value _)
+  def pure[T](value: () => T): Initialize[T] = new Value(value)
+  def optional[T, U](i: Initialize[T])(f: Option[T] => U): Initialize[U] = new Optional(Some(i), f)
+  def update[T](key: ScopedKey[T])(f: T => T): Setting[T] =
+    setting[T](key, map(key)(f), NoPosition)
+  def bind[S, T](in: Initialize[S])(f: S => Initialize[T]): Initialize[T] = new Bind(f, in)
+  def map[S, T](in: Initialize[S])(f: S => T): Initialize[T] =
+    new Apply[({ type l[L[x]] = L[S] })#l, T](f, in, AList.single[S])
+  def app[K[L[x]], T](inputs: K[Initialize])(f: K[Id] => T)(
+      implicit alist: AList[K]): Initialize[T] = new Apply[K, T](f, inputs, alist)
+  def uniform[S, T](inputs: Seq[Initialize[S]])(f: Seq[S] => T): Initialize[T] =
+    new Apply[({ type l[L[x]] = List[L[S]] })#l, T](f, inputs.toList, AList.seq[S])
+
+  /**
+   * The result of this initialization is the validated `key`.
+   * No dependency is introduced on `key`.  If `selfRefOk` is true, validation will not fail if the key is referenced by a definition of `key`.
+   * That is, key := f(validated(key).value) is allowed only if `selfRefOk == true`.
+   */
+  private[sbt] final def validated[T](key: ScopedKey[T],
+                                      selfRefOk: Boolean): ValidationCapture[T] =
+    new ValidationCapture(key, selfRefOk)
+
+  /**
+   * Constructs a derived setting that will be automatically defined in every scope where one of its dependencies
+   * is explicitly defined and the where the scope matches `filter`.
+   * A setting initialized with dynamic dependencies is only allowed if `allowDynamic` is true.
+   * Only the static dependencies are tracked, however.  Dependencies on previous values do not introduce a derived setting either.
+   */
+  final def derive[T](s: Setting[T],
+                      allowDynamic: Boolean = false,
+                      filter: Scope => Boolean = const(true),
+                      trigger: AttributeKey[_] => Boolean = const(true),
+                      default: Boolean = false): Setting[T] = {
+    deriveAllowed(s, allowDynamic) foreach sys.error
+    val d = new DerivedSetting[T](s.key, s.init, s.pos, filter, trigger)
+    if (default) d.default() else d
+  }
+
+  def deriveAllowed[T](s: Setting[T], allowDynamic: Boolean): Option[String] = s.init match {
+    case _: Bind[_, _] if !allowDynamic => Some("Cannot derive from dynamic dependencies.")
+    case _                              => None
+  }
+
+  // id is used for equality
+  private[sbt] final def defaultSetting[T](s: Setting[T]): Setting[T] = s.default()
+  private[sbt] def defaultSettings(ss: Seq[Setting[_]]): Seq[Setting[_]] =
+    ss.map(s => defaultSetting(s))
+  private[this] final val nextID = new java.util.concurrent.atomic.AtomicLong
+  private[this] final def nextDefaultID(): Long = nextID.incrementAndGet()
+
+  def empty(implicit delegates: Scope => Seq[Scope]): Settings[Scope] =
+    new Settings0(Map.empty, delegates)
+  def asTransform(s: Settings[Scope]): ScopedKey ~> Id = new (ScopedKey ~> Id) {
+    def apply[T](k: ScopedKey[T]): T = getValue(s, k)
+  }
+  def getValue[T](s: Settings[Scope], k: ScopedKey[T]) =
+    s.get(k.scope, k.key) getOrElse (throw new InvalidReference(k))
+  def asFunction[T](s: Settings[Scope]): ScopedKey[T] => T = k => getValue(s, k)
+  def mapScope(f: Scope => Scope): MapScoped = new MapScoped {
+    def apply[T](k: ScopedKey[T]): ScopedKey[T] = k.copy(scope = f(k.scope))
+  }
+  private final class InvalidReference(val key: ScopedKey[_])
+      extends RuntimeException(
+        "Internal settings error: invalid reference to " + showFullKey.show(key))
+
+  private[this] def applyDefaults(ss: Seq[Setting[_]]): Seq[Setting[_]] = {
+    val (defaults, others) = Util.separate[Setting[_], DefaultSetting[_], Setting[_]](ss) {
+      case u: DefaultSetting[_] => Left(u); case s => Right(s)
+    }
+    defaults.distinct ++ others
+  }
+
+  def compiled(init: Seq[Setting[_]], actual: Boolean = true)(
+      implicit delegates: Scope => Seq[Scope],
+      scopeLocal: ScopeLocal,
+      display: Show[ScopedKey[_]]): CompiledMap = {
+    val initDefaults = applyDefaults(init)
+    // inject derived settings into scopes where their dependencies are directly defined
+    // and prepend per-scope settings
+    val derived = deriveAndLocal(initDefaults)
+    // group by Scope/Key, dropping dead initializations
+    val sMap: ScopedMap = grouped(derived)
+    // delegate references to undefined values according to 'delegates'
+    val dMap: ScopedMap = if (actual) delegate(sMap)(delegates, display) else sMap
+    // merge Seq[Setting[_]] into Compiled
+    compile(dMap)
+  }
+  def make(init: Seq[Setting[_]])(implicit delegates: Scope => Seq[Scope],
+                                  scopeLocal: ScopeLocal,
+                                  display: Show[ScopedKey[_]]): Settings[Scope] = {
+    val cMap = compiled(init)(delegates, scopeLocal, display)
+    // order the initializations.  cyclic references are detected here.
+    val ordered: Seq[Compiled[_]] = sort(cMap)
+    // evaluation: apply the initializations.
+    try { applyInits(ordered) } catch {
+      case rru: RuntimeUndefined =>
+        throw Uninitialized(cMap.keys.toSeq, delegates, rru.undefined, true)
+    }
+  }
+  def sort(cMap: CompiledMap): Seq[Compiled[_]] =
+    Dag.topologicalSort(cMap.values)(_.dependencies.map(cMap))
+
+  def compile(sMap: ScopedMap): CompiledMap =
+    sMap.toTypedSeq.map {
+      case sMap.TPair(k, ss) =>
+        val deps = ss.flatMap(_.dependencies).toSet
+        (k, new Compiled(k, deps, ss))
+    }.toMap
+
+  def grouped(init: Seq[Setting[_]]): ScopedMap =
+    ((IMap.empty: ScopedMap) /: init)((m, s) => add(m, s))
+
+  def add[T](m: ScopedMap, s: Setting[T]): ScopedMap =
+    m.mapValue[T](s.key, Nil, ss => append(ss, s))
+
+  def append[T](ss: Seq[Setting[T]], s: Setting[T]): Seq[Setting[T]] =
+    if (s.definitive) s :: Nil else ss :+ s
+
+  def addLocal(init: Seq[Setting[_]])(implicit scopeLocal: ScopeLocal): Seq[Setting[_]] =
+    init.flatMap(_.dependencies flatMap scopeLocal) ++ init
+
+  def delegate(sMap: ScopedMap)(implicit delegates: Scope => Seq[Scope],
+                                display: Show[ScopedKey[_]]): ScopedMap = {
+    def refMap(ref: Setting[_], isFirst: Boolean) = new ValidateKeyRef {
+      def apply[T](k: ScopedKey[T], selfRefOk: Boolean) =
+        delegateForKey(sMap, k, delegates(k.scope), ref, selfRefOk || !isFirst)
+    }
+    type ValidatedSettings[T] = Either[Seq[Undefined], SettingSeq[T]]
+    val f = new (SettingSeq ~> ValidatedSettings) {
+      def apply[T](ks: Seq[Setting[T]]) = {
+        val (undefs, valid) = Util.separate(ks.zipWithIndex) {
+          case (s, i) => s validateKeyReferenced refMap(s, i == 0)
+        }
+        if (undefs.isEmpty) Right(valid) else Left(undefs.flatten)
+      }
+    }
+    type Undefs[_] = Seq[Undefined]
+    val (undefineds, result) = sMap.mapSeparate[Undefs, SettingSeq](f)
+    if (undefineds.isEmpty)
+      result
+    else
+      throw Uninitialized(sMap.keys.toSeq, delegates, undefineds.values.flatten.toList, false)
+  }
+  private[this] def delegateForKey[T](sMap: ScopedMap,
+                                      k: ScopedKey[T],
+                                      scopes: Seq[Scope],
+                                      ref: Setting[_],
+                                      selfRefOk: Boolean): Either[Undefined, ScopedKey[T]] = {
+    val skeys = scopes.iterator.map(x => ScopedKey(x, k.key))
+    val definedAt = skeys.find(sk => (selfRefOk || ref.key != sk) && (sMap contains sk))
+    definedAt.toRight(Undefined(ref, k))
+  }
+
+  private[this] def applyInits(ordered: Seq[Compiled[_]])(
+      implicit delegates: Scope => Seq[Scope]): Settings[Scope] = {
+    val x =
+      java.util.concurrent.Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors)
+    try {
+      val eval: EvaluateSettings[Scope] = new EvaluateSettings[Scope] {
+        override val init: Init.this.type = Init.this
+        def compiledSettings = ordered
+        def executor = x
+      }
+      eval.run
+    } finally { x.shutdown() }
+  }
+
+  def showUndefined(u: Undefined, validKeys: Seq[ScopedKey[_]], delegates: Scope => Seq[Scope])(
+      implicit display: Show[ScopedKey[_]]): String = {
+    val guessed = guessIntendedScope(validKeys, delegates, u.referencedKey)
+    val derived = u.defining.isDerived
+    val refString = display.show(u.defining.key)
+    val sourceString = if (derived) "" else parenPosString(u.defining)
+    val guessedString =
+      if (derived) ""
+      else guessed.map(g => "\n     Did you mean " + display.show(g) + " ?").toList.mkString
+    val derivedString =
+      if (derived) ", which is a derived setting that needs this key to be defined in this scope."
+      else ""
+    display.show(u.referencedKey) + " from " + refString + sourceString + derivedString + guessedString
+  }
+  private[this] def parenPosString(s: Setting[_]): String =
+    s.positionString match { case None => ""; case Some(s) => " (" + s + ")" }
+
+  def guessIntendedScope(validKeys: Seq[ScopedKey[_]],
+                         delegates: Scope => Seq[Scope],
+                         key: ScopedKey[_]): Option[ScopedKey[_]] = {
+    val distances = validKeys.flatMap { validKey =>
+      refinedDistance(delegates, validKey, key).map(dist => (dist, validKey))
+    }
+    distances.sortBy(_._1).map(_._2).headOption
+  }
+  def refinedDistance(delegates: Scope => Seq[Scope],
+                      a: ScopedKey[_],
+                      b: ScopedKey[_]): Option[Int] =
+    if (a.key != b.key || a == b) None
+    else {
+      val dist = delegates(a.scope).indexOf(b.scope)
+      if (dist < 0) None else Some(dist)
+    }
+
+  final class Uninitialized(val undefined: Seq[Undefined], override val toString: String)
+      extends Exception(toString)
+  final class Undefined private[sbt] (val defining: Setting[_], val referencedKey: ScopedKey[_])
+  final class RuntimeUndefined(val undefined: Seq[Undefined])
+      extends RuntimeException("References to undefined settings at runtime.") {
+    override def getMessage =
+      super.getMessage + undefined.map { u =>
+        "\n" + u.defining + " referenced from " + u.referencedKey
+      }.mkString
+  }
+
+  def Undefined(defining: Setting[_], referencedKey: ScopedKey[_]): Undefined =
+    new Undefined(defining, referencedKey)
+  def Uninitialized(validKeys: Seq[ScopedKey[_]],
+                    delegates: Scope => Seq[Scope],
+                    keys: Seq[Undefined],
+                    runtime: Boolean)(implicit display: Show[ScopedKey[_]]): Uninitialized = {
+    assert(keys.nonEmpty)
+    val suffix = if (keys.length > 1) "s" else ""
+    val prefix = if (runtime) "Runtime reference" else "Reference"
+    val keysString =
+      keys.map(u => showUndefined(u, validKeys, delegates)).mkString("\n\n  ", "\n\n  ", "")
+    new Uninitialized(
+      keys,
+      prefix + suffix + " to undefined setting" + suffix + ": " + keysString + "\n ")
+  }
+  final class Compiled[T](val key: ScopedKey[T],
+                          val dependencies: Iterable[ScopedKey[_]],
+                          val settings: Seq[Setting[T]]) {
+    override def toString = showFullKey.show(key)
+  }
+  final class Flattened(val key: ScopedKey[_], val dependencies: Iterable[ScopedKey[_]])
+
+  def flattenLocals(compiled: CompiledMap): Map[ScopedKey[_], Flattened] = {
+    val locals = compiled flatMap {
+      case (key, comp) => if (key.key.isLocal) Seq[Compiled[_]](comp) else Nil
+    }
+    val ordered = Dag.topologicalSort(locals)(_.dependencies.flatMap(dep =>
+      if (dep.key.isLocal) Seq[Compiled[_]](compiled(dep)) else Nil))
+    def flatten(cmap: Map[ScopedKey[_], Flattened],
+                key: ScopedKey[_],
+                deps: Iterable[ScopedKey[_]]): Flattened =
+      new Flattened(
+        key,
+        deps.flatMap(dep => if (dep.key.isLocal) cmap(dep).dependencies else dep :: Nil))
+
+    val empty = Map.empty[ScopedKey[_], Flattened]
+    val flattenedLocals = (empty /: ordered) { (cmap, c) =>
+      cmap.updated(c.key, flatten(cmap, c.key, c.dependencies))
+    }
+    compiled flatMap {
+      case (key, comp) =>
+        if (key.key.isLocal)
+          Nil
+        else
+          Seq[(ScopedKey[_], Flattened)]((key, flatten(flattenedLocals, key, comp.dependencies)))
+    }
+  }
+
+  def definedAtString(settings: Seq[Setting[_]]): String = {
+    val posDefined = settings.flatMap(_.positionString.toList)
+    if (posDefined.nonEmpty) {
+      val header =
+        if (posDefined.size == settings.size) "defined at:"
+        else
+          "some of the defining occurrences:"
+      header + (posDefined.distinct mkString ("\n\t", "\n\t", "\n"))
+    } else ""
+  }
+
+  /**
+   * Intersects two scopes, returning the more specific one if they intersect, or None otherwise.
+   */
+  private[sbt] def intersect(s1: Scope, s2: Scope)(
+      implicit delegates: Scope => Seq[Scope]): Option[Scope] =
+    if (delegates(s1).contains(s2)) Some(s1) // s1 is more specific
+    else if (delegates(s2).contains(s1)) Some(s2) // s2 is more specific
+    else None
+
+  private[this] def deriveAndLocal(init: Seq[Setting[_]])(
+      implicit delegates: Scope => Seq[Scope],
+      scopeLocal: ScopeLocal): Seq[Setting[_]] = {
+    import collection.mutable
+
+    final class Derived(val setting: DerivedSetting[_]) {
+      val dependencies = setting.dependencies.map(_.key)
+      def triggeredBy = dependencies.filter(setting.trigger)
+      val inScopes = new mutable.HashSet[Scope]
+      val outputs = new mutable.ListBuffer[Setting[_]]
+    }
+    final class Deriveds(val key: AttributeKey[_], val settings: mutable.ListBuffer[Derived]) {
+      def dependencies = settings.flatMap(_.dependencies)
+      // This is mainly for use in the cyclic reference error message
+      override def toString =
+        s"Derived settings for ${key.label}, ${definedAtString(settings.map(_.setting))}"
+    }
+
+    // separate `derived` settings from normal settings (`defs`)
+    val (derived, rawDefs) = Util.separate[Setting[_], Derived, Setting[_]](init) {
+      case d: DerivedSetting[_] => Left(new Derived(d)); case s => Right(s)
+    }
+    val defs = addLocal(rawDefs)(scopeLocal)
+
+    // group derived settings by the key they define
+    val derivsByDef = new mutable.HashMap[AttributeKey[_], Deriveds]
+    for (s <- derived) {
+      val key = s.setting.key.key
+      derivsByDef.getOrElseUpdate(key, new Deriveds(key, new mutable.ListBuffer)).settings += s
+    }
+
+    // index derived settings by triggering key.  This maps a key to the list of settings potentially derived from it.
+    val derivedBy = new mutable.HashMap[AttributeKey[_], mutable.ListBuffer[Derived]]
+    for (s <- derived; d <- s.triggeredBy)
+      derivedBy.getOrElseUpdate(d, new mutable.ListBuffer) += s
+
+    // Map a DerivedSetting[_] to the `Derived` struct wrapping it. Used to ultimately replace a DerivedSetting with
+    // the `Setting`s that were actually derived from it: `Derived.outputs`
+    val derivedToStruct: Map[DerivedSetting[_], Derived] = (derived map { s =>
+      s.setting -> s
+    }).toMap
+
+    // set of defined scoped keys, used to ensure a derived setting is only added if all dependencies are present
+    val defined = new mutable.HashSet[ScopedKey[_]]
+    def addDefs(ss: Seq[Setting[_]]): Unit = { for (s <- ss) defined += s.key }
+    addDefs(defs)
+
+    // true iff the scoped key is in `defined`, taking delegation into account
+    def isDefined(key: AttributeKey[_], scope: Scope) =
+      delegates(scope).exists(s => defined.contains(ScopedKey(s, key)))
+
+    // true iff all dependencies of derived setting `d` have a value (potentially via delegation) in `scope`
+    def allDepsDefined(d: Derived, scope: Scope, local: Set[AttributeKey[_]]): Boolean =
+      d.dependencies.forall(dep => local(dep) || isDefined(dep, scope))
+
+    // Returns the list of injectable derived settings and their local settings for `sk`.
+    // The settings are to be injected under `outputScope` = whichever scope is more specific of:
+    //   * the dependency's (`sk`) scope
+    //   * the DerivedSetting's scope in which it has been declared, `definingScope`
+    // provided that these two scopes intersect.
+    //  A derived setting is injectable if:
+    //   1. it has not been previously injected into outputScope
+    //   2. it applies to outputScope (as determined by its `filter`)
+    //   3. all of its dependencies are defined for outputScope (allowing for delegation)
+    // This needs to handle local settings because a derived setting wouldn't be injected if it's local setting didn't exist yet.
+    val deriveFor = (sk: ScopedKey[_]) => {
+      val derivedForKey: List[Derived] = derivedBy.get(sk.key).toList.flatten
+      val scope = sk.scope
+      def localAndDerived(d: Derived): Seq[Setting[_]] = {
+        def definingScope = d.setting.key.scope
+        val outputScope = intersect(scope, definingScope)
+        outputScope collect {
+          case s if !d.inScopes.contains(s) && d.setting.filter(s) =>
+            val local = d.dependencies.flatMap(dep => scopeLocal(ScopedKey(s, dep)))
+            if (allDepsDefined(d, s, local.map(_.key.key).toSet)) {
+              d.inScopes.add(s)
+              val out = local :+ d.setting.setScope(s)
+              d.outputs ++= out
+              out
+            } else
+              Nil
+        } getOrElse Nil
+      }
+      derivedForKey.flatMap(localAndDerived)
+    }
+
+    val processed = new mutable.HashSet[ScopedKey[_]]
+
+    // derives settings, transitively so that a derived setting can trigger another
+    def process(rem: List[Setting[_]]): Unit = rem match {
+      case s :: ss =>
+        val sk = s.key
+        val ds = if (processed.add(sk)) deriveFor(sk) else Nil
+        addDefs(ds)
+        process(ds ::: ss)
+      case Nil =>
+    }
+    process(defs.toList)
+
+    // Take all the original defs and DerivedSettings along with locals, replace each DerivedSetting with the actual
+    // settings that were derived.
+    val allDefs = addLocal(init)(scopeLocal)
+    allDefs flatMap {
+      case d: DerivedSetting[_] => (derivedToStruct get d map (_.outputs)).toStream.flatten;
+      case s                    => Stream(s)
+    }
+  }
+
+  sealed trait Initialize[T] {
+    def dependencies: Seq[ScopedKey[_]]
+    def apply[S](g: T => S): Initialize[S]
+
+    private[sbt] def mapReferenced(g: MapScoped): Initialize[T]
+    private[sbt] def mapConstant(g: MapConstant): Initialize[T]
+    private[sbt] def validateReferenced(g: ValidateRef): ValidatedInit[T] =
+      validateKeyReferenced(new ValidateKeyRef {
+        def apply[B](key: ScopedKey[B], selfRefOk: Boolean) = g(key)
+      })
+
+    private[sbt] def validateKeyReferenced(g: ValidateKeyRef): ValidatedInit[T]
+
+    def evaluate(map: Settings[Scope]): T
+    def zip[S](o: Initialize[S]): Initialize[(T, S)] = zipTupled(o)(idFun)
+    def zipWith[S, U](o: Initialize[S])(f: (T, S) => U): Initialize[U] = zipTupled(o)(f.tupled)
+    private[this] def zipTupled[S, U](o: Initialize[S])(f: ((T, S)) => U): Initialize[U] =
+      new Apply[({ type l[L[x]] = (L[T], L[S]) })#l, U](f, (this, o), AList.tuple2[T, S])
+
+    /** A fold on the static attributes of this and nested Initializes. */
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S
+  }
+  object Initialize {
+    implicit def joinInitialize[T](s: Seq[Initialize[T]]): JoinInitSeq[T] = new JoinInitSeq(s)
+    final class JoinInitSeq[T](s: Seq[Initialize[T]]) {
+      def joinWith[S](f: Seq[T] => S): Initialize[S] = uniform(s)(f)
+      def join: Initialize[Seq[T]] = uniform(s)(idFun)
+    }
+    def join[T](inits: Seq[Initialize[T]]): Initialize[Seq[T]] = uniform(inits)(idFun)
+    def joinAny[M[_]](inits: Seq[Initialize[M[T]] forSome { type T }]): Initialize[Seq[M[_]]] =
+      join(inits.asInstanceOf[Seq[Initialize[M[Any]]]])
+        .asInstanceOf[Initialize[Seq[M[T] forSome { type T }]]]
+  }
+  object SettingsDefinition {
+    implicit def unwrapSettingsDefinition(d: SettingsDefinition): Seq[Setting[_]] = d.settings
+    implicit def wrapSettingsDefinition(ss: Seq[Setting[_]]): SettingsDefinition =
+      new SettingList(ss)
+  }
+  sealed trait SettingsDefinition {
+    def settings: Seq[Setting[_]]
+  }
+  final class SettingList(val settings: Seq[Setting[_]]) extends SettingsDefinition
+  sealed class Setting[T] private[Init] (val key: ScopedKey[T],
+                                         val init: Initialize[T],
+                                         val pos: SourcePosition)
+      extends SettingsDefinition {
+    def settings = this :: Nil
+    def definitive: Boolean = !init.dependencies.contains(key)
+    def dependencies: Seq[ScopedKey[_]] = remove(init.dependencies, key)
+    def mapReferenced(g: MapScoped): Setting[T] = make(key, init mapReferenced g, pos)
+    def validateReferenced(g: ValidateRef): Either[Seq[Undefined], Setting[T]] =
+      (init validateReferenced g).right.map(newI => make(key, newI, pos))
+
+    private[sbt] def validateKeyReferenced(g: ValidateKeyRef): Either[Seq[Undefined], Setting[T]] =
+      (init validateKeyReferenced g).right.map(newI => make(key, newI, pos))
+
+    def mapKey(g: MapScoped): Setting[T] = make(g(key), init, pos)
+    def mapInit(f: (ScopedKey[T], T) => T): Setting[T] = make(key, init(t => f(key, t)), pos)
+    def mapConstant(g: MapConstant): Setting[T] = make(key, init mapConstant g, pos)
+    def withPos(pos: SourcePosition) = make(key, init, pos)
+    def positionString: Option[String] = pos match {
+      case pos: FilePosition => Some(pos.path + ":" + pos.startLine)
+      case NoPosition        => None
+    }
+    private[sbt] def mapInitialize(f: Initialize[T] => Initialize[T]): Setting[T] =
+      make(key, f(init), pos)
+    override def toString = "setting(" + key + ") at " + pos
+
+    protected[this] def make[B](key: ScopedKey[B],
+                                init: Initialize[B],
+                                pos: SourcePosition): Setting[B] = new Setting[B](key, init, pos)
+    protected[sbt] def isDerived: Boolean = false
+    private[sbt] def setScope(s: Scope): Setting[T] =
+      make(key.copy(scope = s), init.mapReferenced(mapScope(const(s))), pos)
+
+    /** Turn this setting into a `DefaultSetting` if it's not already, otherwise returns `this` */
+    private[sbt] def default(id: => Long = nextDefaultID()): DefaultSetting[T] =
+      DefaultSetting(key, init, pos, id)
+  }
+  private[Init] sealed class DerivedSetting[T](sk: ScopedKey[T],
+                                               i: Initialize[T],
+                                               p: SourcePosition,
+                                               val filter: Scope => Boolean,
+                                               val trigger: AttributeKey[_] => Boolean)
+      extends Setting[T](sk, i, p) {
+    override def make[B](key: ScopedKey[B], init: Initialize[B], pos: SourcePosition): Setting[B] =
+      new DerivedSetting[B](key, init, pos, filter, trigger)
+    protected[sbt] override def isDerived: Boolean = true
+    override def default(_id: => Long): DefaultSetting[T] =
+      new DerivedSetting[T](sk, i, p, filter, trigger) with DefaultSetting[T] { val id = _id }
+    override def toString = "derived " + super.toString
+  }
+  // Only keep the first occurrence of this setting and move it to the front so that it has lower precedence than non-defaults.
+  //  This is intended for internal sbt use only, where alternatives like Plugin.globalSettings are not available.
+  private[Init] sealed trait DefaultSetting[T] extends Setting[T] {
+    val id: Long
+    override def make[B](key: ScopedKey[B], init: Initialize[B], pos: SourcePosition): Setting[B] =
+      super.make(key, init, pos) default id
+    override final def hashCode = id.hashCode
+    override final def equals(o: Any): Boolean = o match {
+      case d: DefaultSetting[_] => d.id == id; case _ => false
+    }
+    override def toString = s"default($id) " + super.toString
+    override def default(id: => Long) = this
+  }
+
+  object DefaultSetting {
+    def apply[T](sk: ScopedKey[T], i: Initialize[T], p: SourcePosition, _id: Long) =
+      new Setting[T](sk, i, p) with DefaultSetting[T] { val id = _id }
+  }
+
+  private[this] def handleUndefined[T](vr: ValidatedInit[T]): Initialize[T] = vr match {
+    case Left(undefs) => throw new RuntimeUndefined(undefs)
+    case Right(x)     => x
+  }
+
+  private[this] lazy val getValidated =
+    new (ValidatedInit ~> Initialize) { def apply[T](v: ValidatedInit[T]) = handleUndefined[T](v) }
+
+  // mainly for reducing generated class count
+  private[this] def validateKeyReferencedT(g: ValidateKeyRef) =
+    new (Initialize ~> ValidatedInit) {
+      def apply[T](i: Initialize[T]) = i validateKeyReferenced g
+    }
+
+  private[this] def mapReferencedT(g: MapScoped) =
+    new (Initialize ~> Initialize) { def apply[T](i: Initialize[T]) = i mapReferenced g }
+
+  private[this] def mapConstantT(g: MapConstant) =
+    new (Initialize ~> Initialize) { def apply[T](i: Initialize[T]) = i mapConstant g }
+
+  private[this] def evaluateT(g: Settings[Scope]) =
+    new (Initialize ~> Id) { def apply[T](i: Initialize[T]) = i evaluate g }
+
+  private[this] def deps(ls: Seq[Initialize[_]]): Seq[ScopedKey[_]] = ls.flatMap(_.dependencies)
+
+  sealed trait Keyed[S, T] extends Initialize[T] {
+    def scopedKey: ScopedKey[S]
+    def transform: S => T
+    final def dependencies = scopedKey :: Nil
+    final def apply[Z](g: T => Z): Initialize[Z] = new GetValue(scopedKey, g compose transform)
+    final def evaluate(ss: Settings[Scope]): T = transform(getValue(ss, scopedKey))
+    final def mapReferenced(g: MapScoped): Initialize[T] = new GetValue(g(scopedKey), transform)
+    private[sbt] final def validateKeyReferenced(g: ValidateKeyRef): ValidatedInit[T] =
+      g(scopedKey, false) match {
+        case Left(un)  => Left(un :: Nil)
+        case Right(nk) => Right(new GetValue(nk, transform))
+      }
+    final def mapConstant(g: MapConstant): Initialize[T] = g(scopedKey) match {
+      case None        => this
+      case Some(const) => new Value(() => transform(const))
+    }
+    private[sbt] def processAttributes[B](init: B)(f: (B, AttributeMap) => B): B = init
+  }
+  private[this] final class GetValue[S, T](val scopedKey: ScopedKey[S], val transform: S => T)
+      extends Keyed[S, T]
+  trait KeyedInitialize[T] extends Keyed[T, T] {
+    final val transform = idFun[T]
+  }
+
+  private[sbt] final class TransformCapture(val f: Initialize ~> Initialize)
+      extends Initialize[Initialize ~> Initialize] {
+    def dependencies = Nil
+    def apply[Z](g2: (Initialize ~> Initialize) => Z): Initialize[Z] = map(this)(g2)
+    def evaluate(ss: Settings[Scope]): Initialize ~> Initialize = f
+    def mapReferenced(g: MapScoped) = new TransformCapture(mapReferencedT(g) ∙ f)
+    def mapConstant(g: MapConstant) = new TransformCapture(mapConstantT(g) ∙ f)
+    def validateKeyReferenced(g: ValidateKeyRef) =
+      Right(new TransformCapture(getValidated ∙ validateKeyReferencedT(g) ∙ f))
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S = init
+  }
+  private[sbt] final class ValidationCapture[T](val key: ScopedKey[T], val selfRefOk: Boolean)
+      extends Initialize[ScopedKey[T]] {
+    def dependencies = Nil
+    def apply[Z](g2: ScopedKey[T] => Z): Initialize[Z] = map(this)(g2)
+    def evaluate(ss: Settings[Scope]) = key
+    def mapReferenced(g: MapScoped) = new ValidationCapture(g(key), selfRefOk)
+    def mapConstant(g: MapConstant) = this
+    def validateKeyReferenced(g: ValidateKeyRef) = g(key, selfRefOk) match {
+      case Left(un) => Left(un :: Nil)
+      case Right(k) => Right(new ValidationCapture(k, selfRefOk))
+    }
+
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S = init
+  }
+  private[sbt] final class Bind[S, T](val f: S => Initialize[T], val in: Initialize[S])
+      extends Initialize[T] {
+    def dependencies = in.dependencies
+    def apply[Z](g: T => Z): Initialize[Z] = new Bind[S, Z](s => f(s)(g), in)
+    def evaluate(ss: Settings[Scope]): T = f(in evaluate ss) evaluate ss
+    def mapReferenced(g: MapScoped) = new Bind[S, T](s => f(s) mapReferenced g, in mapReferenced g)
+    def validateKeyReferenced(g: ValidateKeyRef) = (in validateKeyReferenced g).right.map {
+      validIn =>
+        new Bind[S, T](s => handleUndefined(f(s) validateKeyReferenced g), validIn)
+    }
+    def mapConstant(g: MapConstant) = new Bind[S, T](s => f(s) mapConstant g, in mapConstant g)
+    private[sbt] def processAttributes[B](init: B)(f: (B, AttributeMap) => B): B =
+      in.processAttributes(init)(f)
+  }
+  private[sbt] final class Optional[S, T](val a: Option[Initialize[S]], val f: Option[S] => T)
+      extends Initialize[T] {
+    def dependencies = deps(a.toList)
+    def apply[Z](g: T => Z): Initialize[Z] = new Optional[S, Z](a, g compose f)
+    def mapReferenced(g: MapScoped) = new Optional(a map mapReferencedT(g).fn, f)
+    def validateKeyReferenced(g: ValidateKeyRef) = a match {
+      case None    => Right(this)
+      case Some(i) => Right(new Optional(i.validateKeyReferenced(g).right.toOption, f))
+    }
+    def mapConstant(g: MapConstant): Initialize[T] = new Optional(a map mapConstantT(g).fn, f)
+    def evaluate(ss: Settings[Scope]): T = f(a.flatMap(i => trapBadRef(evaluateT(ss)(i))))
+    // proper solution is for evaluate to be deprecated or for external use only and a new internal method returning Either be used
+    private[this] def trapBadRef[A](run: => A): Option[A] =
+      try Some(run)
+      catch { case e: InvalidReference => None }
+    private[sbt] def processAttributes[B](init: B)(f: (B, AttributeMap) => B): B = a match {
+      case None    => init
+      case Some(i) => i.processAttributes(init)(f)
+    }
+  }
+  private[sbt] final class Value[T](val value: () => T) extends Initialize[T] {
+    def dependencies = Nil
+    def mapReferenced(g: MapScoped) = this
+    def validateKeyReferenced(g: ValidateKeyRef) = Right(this)
+    def apply[S](g: T => S) = new Value[S](() => g(value()))
+    def mapConstant(g: MapConstant) = this
+    def evaluate(map: Settings[Scope]): T = value()
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S = init
+  }
+  private[sbt] final object StaticScopes extends Initialize[Set[Scope]] {
+    def dependencies = Nil
+    def mapReferenced(g: MapScoped) = this
+    def validateKeyReferenced(g: ValidateKeyRef) = Right(this)
+    def apply[S](g: Set[Scope] => S) = map(this)(g)
+    def mapConstant(g: MapConstant) = this
+    def evaluate(map: Settings[Scope]) = map.scopes
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S = init
+  }
+  private[sbt] final class Apply[K[L[x]], T](val f: K[Id] => T,
+                                             val inputs: K[Initialize],
+                                             val alist: AList[K])
+      extends Initialize[T] {
+    def dependencies = deps(alist.toList(inputs))
+    def mapReferenced(g: MapScoped) = mapInputs(mapReferencedT(g))
+    def apply[S](g: T => S) = new Apply(g compose f, inputs, alist)
+    def mapConstant(g: MapConstant) = mapInputs(mapConstantT(g))
+    def mapInputs(g: Initialize ~> Initialize): Initialize[T] =
+      new Apply(f, alist.transform(inputs, g), alist)
+    def evaluate(ss: Settings[Scope]) = f(alist.transform(inputs, evaluateT(ss)))
+    def validateKeyReferenced(g: ValidateKeyRef) = {
+      val tx = alist.transform(inputs, validateKeyReferencedT(g))
+      val undefs = alist.toList(tx).flatMap(_.left.toSeq.flatten)
+      val get = new (ValidatedInit ~> Initialize) {
+        def apply[B](vr: ValidatedInit[B]) = vr.right.get
+      }
+      if (undefs.isEmpty) Right(new Apply(f, alist.transform(tx, get), alist)) else Left(undefs)
+    }
+
+    private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S =
+      (init /: alist.toList(inputs)) { (v, i) =>
+        i.processAttributes(v)(f)
+      }
+  }
+  private def remove[T](s: Seq[T], v: T) = s filterNot (_ == v)
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Signal.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Signal.scala
@@ -1,0 +1,82 @@
+package sbt.internal.util
+
+object Signals {
+  val CONT = "CONT"
+  val INT = "INT"
+  def withHandler[T](handler: () => Unit, signal: String = INT)(action: () => T): T = {
+    val result =
+      try {
+        val signals = new Signals0
+        signals.withHandler(signal, handler, action)
+      } catch { case e: LinkageError => Right(action()) }
+
+    result match {
+      case Left(e)  => throw e
+      case Right(v) => v
+    }
+  }
+
+  /** Helper interface so we can expose internals of signal-isms to others. */
+  sealed trait Registration {
+    def remove(): Unit
+  }
+
+  /**
+   * Register a signal handler that can be removed later.
+   * NOTE: Does not stack with other signal handlers!!!!
+   */
+  def register(handler: () => Unit, signal: String = INT): Registration =
+    // TODO - Maybe we can just ignore things if not is-supported.
+    if (supported(signal)) {
+      import sun.misc.{ Signal, SignalHandler }
+      val intSignal = new Signal(signal)
+      val newHandler = new SignalHandler {
+        def handle(sig: Signal): Unit = { handler() }
+      }
+      val oldHandler = Signal.handle(intSignal, newHandler)
+      object unregisterNewHandler extends Registration {
+        override def remove(): Unit = {
+          Signal.handle(intSignal, oldHandler)
+          ()
+        }
+      }
+      unregisterNewHandler
+    } else {
+      // TODO - Maybe we should just throw an exception if we don't support signals...
+      object NullUnregisterNewHandler extends Registration {
+        override def remove(): Unit = ()
+      }
+      NullUnregisterNewHandler
+    }
+
+  def supported(signal: String): Boolean =
+    try {
+      val signals = new Signals0
+      signals.supported(signal)
+    } catch { case e: LinkageError => false }
+}
+
+// Must only be referenced using a
+//   try { } catch { case e: LinkageError => ... }
+// block to
+private final class Signals0 {
+  def supported(signal: String): Boolean = {
+    import sun.misc.Signal
+    try { new Signal(signal); true } catch { case e: IllegalArgumentException => false }
+  }
+
+  // returns a LinkageError in `action` as Left(t) in order to avoid it being
+  // incorrectly swallowed as missing Signal/SignalHandler
+  def withHandler[T](signal: String, handler: () => Unit, action: () => T): Either[Throwable, T] = {
+    import sun.misc.{ Signal, SignalHandler }
+    val intSignal = new Signal(signal)
+    val newHandler = new SignalHandler {
+      def handle(sig: Signal): Unit = { handler() }
+    }
+
+    val oldHandler = Signal.handle(intSignal, newHandler)
+
+    try Right(action())
+    catch { case e: LinkageError => Left(e) } finally { Signal.handle(intSignal, oldHandler); () }
+  }
+}

--- a/core-settings/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -1,0 +1,50 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+trait TypeFunctions {
+  type Id[X] = X
+  sealed trait Const[A] { type Apply[B] = A }
+  sealed trait ConstK[A] { type l[L[x]] = A }
+  sealed trait Compose[A[_], B[_]] { type Apply[T] = A[B[T]] }
+  sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
+  sealed trait P1of2[M[_, _], A] { type Apply[B] = M[A, B]; type Flip[B] = M[B, A] }
+
+  final val left = new (Id ~> P1of2[Left, Nothing]#Flip) { def apply[T](t: T) = Left(t) }
+  final val right = new (Id ~> P1of2[Right, Nothing]#Apply) { def apply[T](t: T) = Right(t) }
+  final val some = new (Id ~> Some) { def apply[T](t: T) = Some(t) }
+  final def idFun[T] = (t: T) => t
+  final def const[A, B](b: B): A => B = _ => b
+  final def idK[M[_]]: M ~> M = new (M ~> M) { def apply[T](m: M[T]): M[T] = m }
+
+  def nestCon[M[_], N[_], G[_]](f: M ~> N): (M ∙ G)#l ~> (N ∙ G)#l =
+    f.asInstanceOf[(M ∙ G)#l ~> (N ∙ G)#l] // implemented with a cast to avoid extra object+method call.  castless version:
+  /* new ( (M ∙ G)#l ~> (N ∙ G)#l ) {
+		def apply[T](mg: M[G[T]]): N[G[T]] = f(mg)
+	}*/
+
+  implicit def toFn1[A, B](f: A => B): Fn1[A, B] = new Fn1[A, B] {
+    def ∙[C](g: C => A) = f compose g
+  }
+
+  type Endo[T] = T => T
+  type ~>|[A[_], B[_]] = A ~> Compose[Option, B]#Apply
+}
+object TypeFunctions extends TypeFunctions
+
+trait ~>[-A[_], +B[_]] { outer =>
+  def apply[T](a: A[T]): B[T]
+  // directly on ~> because of type inference limitations
+  final def ∙[C[_]](g: C ~> A): C ~> B = new (C ~> B) { def apply[T](c: C[T]) = outer.apply(g(c)) }
+  final def ∙[C, D](g: C => D)(implicit ev: D <:< A[D]): C => B[D] = i => apply(ev(g(i)))
+  final def fn[T] = (t: A[T]) => apply[T](t)
+}
+object ~> {
+  import TypeFunctions._
+  val Id: Id ~> Id = new (Id ~> Id) { def apply[T](a: T): T = a }
+  implicit def tcIdEquals: (Id ~> Id) = Id
+}
+trait Fn1[A, B] {
+  def ∙[C](g: C => A): C => B
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Types.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Types.scala
@@ -1,0 +1,12 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+object Types extends Types
+
+trait Types extends TypeFunctions {
+  val :^: = KCons
+  type :+:[H, T <: HList] = HCons[H, T]
+  val :+: = HCons
+}

--- a/core-settings/src/main/scala/sbt/internal/util/Util.scala
+++ b/core-settings/src/main/scala/sbt/internal/util/Util.scala
@@ -1,0 +1,40 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2011 Mark Harrah
+ */
+package sbt.internal.util
+
+import java.util.Locale
+
+object Util {
+  def makeList[T](size: Int, value: T): List[T] = List.fill(size)(value)
+
+  def separateE[A, B](ps: Seq[Either[A, B]]): (Seq[A], Seq[B]) =
+    separate(ps)(Types.idFun)
+
+  def separate[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
+    val (a, b) = ((Nil: Seq[A], Nil: Seq[B]) /: ps)((xs, y) => prependEither(xs, f(y)))
+    (a.reverse, b.reverse)
+  }
+
+  def prependEither[A, B](acc: (Seq[A], Seq[B]), next: Either[A, B]): (Seq[A], Seq[B]) =
+    next match {
+      case Left(l)  => (l +: acc._1, acc._2)
+      case Right(r) => (acc._1, r +: acc._2)
+    }
+
+  def pairID[A, B] = (a: A, b: B) => (a, b)
+
+  private[this] lazy val Hyphen = """-(\p{javaLowerCase})""".r
+
+  def hasHyphen(s: String): Boolean = s.indexOf('-') >= 0
+
+  def hyphenToCamel(s: String): String =
+    if (hasHyphen(s)) Hyphen.replaceAllIn(s, _.group(1).toUpperCase(Locale.ENGLISH)) else s
+
+  private[this] lazy val Camel = """(\p{javaLowerCase})(\p{javaUpperCase})""".r
+
+  def camelToHyphen(s: String): String =
+    Camel.replaceAllIn(s, m => m.group(1) + "-" + m.group(2).toLowerCase(Locale.ENGLISH))
+
+  def quoteIfKeyword(s: String): String = if (ScalaKeywords.values(s)) '`' + s + '`' else s
+}

--- a/core-settings/src/main/scala/sbt/util/Eval.scala
+++ b/core-settings/src/main/scala/sbt/util/Eval.scala
@@ -1,0 +1,297 @@
+package sbt.util
+
+import scala.annotation.tailrec
+
+// Copied from Cats (MIT license)
+
+/**
+ * Eval is a monad which controls evaluation.
+ *
+ * This type wraps a value (or a computation that produces a value)
+ * and can produce it on command via the `.value` method.
+ *
+ * There are three basic evaluation strategies:
+ *
+ *  - Now:    evaluated immediately
+ *  - Later:  evaluated once when value is needed
+ *  - Always: evaluated every time value is needed
+ *
+ * The Later and Always are both lazy strategies while Now is eager.
+ * Later and Always are distinguished from each other only by
+ * memoization: once evaluated Later will save the value to be returned
+ * immediately if it is needed again. Always will run its computation
+ * every time.
+ *
+ * Eval supports stack-safe lazy computation via the .map and .flatMap
+ * methods, which use an internal trampoline to avoid stack overflows.
+ * Computation done within .map and .flatMap is always done lazily,
+ * even when applied to a Now instance.
+ *
+ * It is not generally good style to pattern-match on Eval instances.
+ * Rather, use .map and .flatMap to chain computation, and use .value
+ * to get the result when needed. It is also not good style to create
+ * Eval instances whose computation involves calling .value on another
+ * Eval instance -- this can defeat the trampolining and lead to stack
+ * overflows.
+ */
+sealed abstract class Eval[+A] extends Serializable { self =>
+
+  /**
+   * Evaluate the computation and return an A value.
+   *
+   * For lazy instances (Later, Always), any necessary computation
+   * will be performed at this point. For eager instances (Now), a
+   * value will be immediately returned.
+   */
+  def value: A
+
+  /**
+   * Transform an Eval[A] into an Eval[B] given the transformation
+   * function `f`.
+   *
+   * This call is stack-safe -- many .map calls may be chained without
+   * consumed additional stack during evaluation.
+   *
+   * Computation performed in f is always lazy, even when called on an
+   * eager (Now) instance.
+   */
+  def map[B](f: A => B): Eval[B] =
+    flatMap(a => Now(f(a)))
+
+  /**
+   * Lazily perform a computation based on an Eval[A], using the
+   * function `f` to produce an Eval[B] given an A.
+   *
+   * This call is stack-safe -- many .flatMap calls may be chained
+   * without consumed additional stack during evaluation. It is also
+   * written to avoid left-association problems, so that repeated
+   * calls to .flatMap will be efficiently applied.
+   *
+   * Computation performed in f is always lazy, even when called on an
+   * eager (Now) instance.
+   */
+  def flatMap[B](f: A => Eval[B]): Eval[B] =
+    this match {
+      case c: Eval.Compute[A] =>
+        new Eval.Compute[B] {
+          type Start = c.Start
+          // See https://issues.scala-lang.org/browse/SI-9931 for an explanation
+          // of why the type annotations are necessary in these two lines on
+          // Scala 2.12.0.
+          val start: () => Eval[Start] = c.start
+          val run: Start => Eval[B] = (s: c.Start) =>
+            new Eval.Compute[B] {
+              type Start = A
+              val start = () => c.run(s)
+              val run = f
+          }
+        }
+      case c: Eval.Call[A] =>
+        new Eval.Compute[B] {
+          type Start = A
+          val start = c.thunk
+          val run = f
+        }
+      case _ =>
+        new Eval.Compute[B] {
+          type Start = A
+          val start = () => self
+          val run = f
+        }
+    }
+
+  /**
+   * Ensure that the result of the computation (if any) will be
+   * memoized.
+   *
+   * Practically, this means that when called on an Always[A] a
+   * Later[A] with an equivalent computation will be returned.
+   */
+  def memoize: Eval[A]
+}
+
+/**
+ * Construct an eager Eval[A] instance.
+ *
+ * In some sense it is equivalent to using a val.
+ *
+ * This type should be used when an A value is already in hand, or
+ * when the computation to produce an A value is pure and very fast.
+ */
+final case class Now[A](value: A) extends Eval[A] {
+  def memoize: Eval[A] = this
+}
+
+/**
+ * Construct a lazy Eval[A] instance.
+ *
+ * This type should be used for most "lazy" values. In some sense it
+ * is equivalent to using a lazy val.
+ *
+ * When caching is not required or desired (e.g. if the value produced
+ * may be large) prefer Always. When there is no computation
+ * necessary, prefer Now.
+ *
+ * Once Later has been evaluated, the closure (and any values captured
+ * by the closure) will not be retained, and will be available for
+ * garbage collection.
+ */
+final class Later[A](f: () => A) extends Eval[A] {
+  private[this] var thunk: () => A = f
+
+  // The idea here is that `f` may have captured very large
+  // structures, but produce a very small result. In this case, once
+  // we've calculated a value, we would prefer to be able to free
+  // everything else.
+  //
+  // (For situations where `f` is small, but the output will be very
+  // expensive to store, consider using `Always`.)
+  lazy val value: A = {
+    val result = thunk()
+    thunk = null // scalastyle:off
+    result
+  }
+
+  def memoize: Eval[A] = this
+}
+
+object Later {
+  def apply[A](a: => A): Later[A] = new Later(a _)
+}
+
+/**
+ * Construct a lazy Eval[A] instance.
+ *
+ * This type can be used for "lazy" values. In some sense it is
+ * equivalent to using a Function0 value.
+ *
+ * This type will evaluate the computation every time the value is
+ * required. It should be avoided except when laziness is required and
+ * caching must be avoided. Generally, prefer Later.
+ */
+final class Always[A](f: () => A) extends Eval[A] {
+  def value: A = f()
+  def memoize: Eval[A] = new Later(f)
+}
+
+object Always {
+  def apply[A](a: => A): Always[A] = new Always(a _)
+}
+
+object Eval {
+
+  /**
+   * Construct an eager Eval[A] value (i.e. Now[A]).
+   */
+  def now[A](a: A): Eval[A] = Now(a)
+
+  /**
+   * Construct a lazy Eval[A] value with caching (i.e. Later[A]).
+   */
+  def later[A](a: => A): Eval[A] = new Later(a _)
+
+  /**
+   * Construct a lazy Eval[A] value without caching (i.e. Always[A]).
+   */
+  def always[A](a: => A): Eval[A] = new Always(a _)
+
+  /**
+   * Defer a computation which produces an Eval[A] value.
+   *
+   * This is useful when you want to delay execution of an expression
+   * which produces an Eval[A] value. Like .flatMap, it is stack-safe.
+   */
+  def defer[A](a: => Eval[A]): Eval[A] =
+    new Eval.Call[A](a _) {}
+
+  /**
+   * Static Eval instances for some common values.
+   *
+   * These can be useful in cases where the same values may be needed
+   * many times.
+   */
+  val Unit: Eval[Unit] = Now(())
+  val True: Eval[Boolean] = Now(true)
+  val False: Eval[Boolean] = Now(false)
+  val Zero: Eval[Int] = Now(0)
+  val One: Eval[Int] = Now(1)
+
+  /**
+   * Call is a type of Eval[A] that is used to defer computations
+   * which produce Eval[A].
+   *
+   * Users should not instantiate Call instances themselves. Instead,
+   * they will be automatically created when needed.
+   */
+  sealed abstract class Call[A](val thunk: () => Eval[A]) extends Eval[A] {
+    def memoize: Eval[A] = new Later(() => value)
+    def value: A = Call.loop(this).value
+  }
+
+  object Call {
+
+    /** Collapse the call stack for eager evaluations */
+    @tailrec private def loop[A](fa: Eval[A]): Eval[A] = fa match {
+      case call: Eval.Call[A] =>
+        loop(call.thunk())
+      case compute: Eval.Compute[A] =>
+        new Eval.Compute[A] {
+          type Start = compute.Start
+          val start: () => Eval[Start] = () => compute.start()
+          val run: Start => Eval[A] = s => loop1(compute.run(s))
+        }
+      case other => other
+    }
+
+    /**
+     * Alias for loop that can be called in a non-tail position
+     * from an otherwise tailrec-optimized loop.
+     */
+    private def loop1[A](fa: Eval[A]): Eval[A] = loop(fa)
+  }
+
+  /**
+   * Compute is a type of Eval[A] that is used to chain computations
+   * involving .map and .flatMap. Along with Eval#flatMap it
+   * implements the trampoline that guarantees stack-safety.
+   *
+   * Users should not instantiate Compute instances
+   * themselves. Instead, they will be automatically created when
+   * needed.
+   *
+   * Unlike a traditional trampoline, the internal workings of the
+   * trampoline are not exposed. This allows a slightly more efficient
+   * implementation of the .value method.
+   */
+  sealed abstract class Compute[A] extends Eval[A] {
+    type Start
+    val start: () => Eval[Start]
+    val run: Start => Eval[A]
+
+    def memoize: Eval[A] = Later(value)
+
+    def value: A = {
+      type L = Eval[Any]
+      type C = Any => Eval[Any]
+      @tailrec def loop(curr: L, fs: List[C]): Any =
+        curr match {
+          case c: Compute[_] =>
+            c.start() match {
+              case cc: Compute[_] =>
+                loop(
+                  cc.start().asInstanceOf[L],
+                  cc.run.asInstanceOf[C] :: c.run.asInstanceOf[C] :: fs
+                )
+              case xx =>
+                loop(c.run(xx.value), fs)
+            }
+          case x =>
+            fs match {
+              case f :: fs => loop(f(x.value), fs)
+              case Nil     => x.value
+            }
+        }
+      loop(this.asInstanceOf[L], Nil).asInstanceOf[A]
+    }
+  }
+}

--- a/core-settings/src/main/scala/sbt/util/OptJsonWriter.scala
+++ b/core-settings/src/main/scala/sbt/util/OptJsonWriter.scala
@@ -1,0 +1,22 @@
+package sbt.util
+
+import sjsonnew.JsonWriter
+
+sealed trait OptJsonWriter[A]
+final case class NoJsonWriter[A]() extends OptJsonWriter[A]
+final case class SomeJsonWriter[A](value: JsonWriter[A]) extends OptJsonWriter[A]
+
+trait OptJsonWriter0 {
+  implicit def fallback[A]: NoJsonWriter[A] = NoJsonWriter()
+}
+object OptJsonWriter extends OptJsonWriter0 {
+  implicit def lift[A](implicit z: JsonWriter[A]): SomeJsonWriter[A] = SomeJsonWriter(z)
+
+  trait StrictMode0 {
+    implicit def conflictingFallback1[A]: NoJsonWriter[A] = NoJsonWriter()
+    implicit def conflictingFallback2[A]: NoJsonWriter[A] = NoJsonWriter()
+  }
+  object StrictMode extends StrictMode0 {
+    implicit def lift[A](implicit z: JsonWriter[A]): SomeJsonWriter[A] = SomeJsonWriter(z)
+  }
+}

--- a/core-settings/src/main/scala/sbt/util/Show.scala
+++ b/core-settings/src/main/scala/sbt/util/Show.scala
@@ -1,0 +1,12 @@
+package sbt.util
+
+trait Show[A] {
+  def show(a: A): String
+}
+object Show {
+  def apply[A](f: A => String): Show[A] = new Show[A] { def show(a: A): String = f(a) }
+
+  def fromToString[A]: Show[A] = new Show[A] {
+    def show(a: A): String = a.toString
+  }
+}

--- a/core-settings/src/main/scala/sbt/util/ShowLines.scala
+++ b/core-settings/src/main/scala/sbt/util/ShowLines.scala
@@ -1,0 +1,15 @@
+package sbt.util
+
+trait ShowLines[A] {
+  def showLines(a: A): Seq[String]
+}
+object ShowLines {
+  def apply[A](f: A => Seq[String]): ShowLines[A] =
+    new ShowLines[A] {
+      def showLines(a: A): Seq[String] = f(a)
+    }
+
+  implicit class ShowLinesOp[A: ShowLines](a: A) {
+    def lines: Seq[String] = implicitly[ShowLines[A]].showLines(a)
+  }
+}

--- a/core-settings/src/test/scala/DagSpecification.scala
+++ b/core-settings/src/test/scala/DagSpecification.scala
@@ -1,0 +1,53 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2008 Mark Harrah */
+
+package sbt.internal.util
+
+import org.scalacheck._
+import Prop._
+
+import scala.collection.mutable.HashSet
+
+object DagSpecification extends Properties("Dag") {
+  property("No repeated nodes") = forAll { (dag: TestDag) => isSet(dag.topologicalSort) }
+  property("Sort contains node") = forAll { (dag: TestDag) => dag.topologicalSort.contains(dag) }
+  property("Dependencies precede node") = forAll { (dag: TestDag) => dependenciesPrecedeNodes(dag.topologicalSort) }
+
+  implicit lazy val arbTestDag: Arbitrary[TestDag] = Arbitrary(Gen.sized(dagGen))
+  private def dagGen(nodeCount: Int): Gen[TestDag] =
+    {
+      val nodes = new HashSet[TestDag]
+      def nonterminalGen(p: Gen.Parameters): Gen[TestDag] =
+        {
+          val seed = rng.Seed.random()
+          for {
+            i <- 0 until nodeCount
+            nextDeps <- Gen.someOf(nodes).apply(p, seed)
+          } nodes += new TestDag(i, nextDeps)
+          for (nextDeps <- Gen.someOf(nodes)) yield new TestDag(nodeCount, nextDeps)
+        }
+      Gen.parameterized(nonterminalGen)
+    }
+
+  private def isSet[T](c: Seq[T]) = Set(c: _*).size == c.size
+  private def dependenciesPrecedeNodes(sort: List[TestDag]) =
+    {
+      val seen = new HashSet[TestDag]
+      def iterate(remaining: List[TestDag]): Boolean =
+        {
+          remaining match {
+            case Nil => true
+            case node :: tail =>
+              if (node.dependencies.forall(seen.contains) && !seen.contains(node)) {
+                seen += node
+                iterate(tail)
+              } else
+                false
+          }
+        }
+      iterate(sort)
+    }
+}
+class TestDag(id: Int, val dependencies: Iterable[TestDag]) extends Dag[TestDag] {
+  override def toString = id + "->" + dependencies.mkString("[", ",", "]")
+}

--- a/core-settings/src/test/scala/KeyTest.scala
+++ b/core-settings/src/test/scala/KeyTest.scala
@@ -1,0 +1,32 @@
+package sbt.internal.util
+
+import org.scalacheck._
+import Prop._
+
+object KeyTest extends Properties("AttributeKey") {
+  property("equality") = {
+    compare(AttributeKey[Int]("test"), AttributeKey[Int]("test"), true) &&
+      compare(AttributeKey[Int]("test"), AttributeKey[Int]("test", "description"), true) &&
+      compare(AttributeKey[Int]("test", "a"), AttributeKey[Int]("test", "b"), true) &&
+      compare(AttributeKey[Int]("test"), AttributeKey[Int]("tests"), false) &&
+      compare(AttributeKey[Int]("test"), AttributeKey[Double]("test"), false) &&
+      compare(AttributeKey[java.lang.Integer]("test"), AttributeKey[Int]("test"), false) &&
+      compare(AttributeKey[Map[Int, String]]("test"), AttributeKey[Map[Int, String]]("test"), true) &&
+      compare(AttributeKey[Map[Int, String]]("test"), AttributeKey[Map[Int, _]]("test"), false)
+  }
+
+  def compare(a: AttributeKey[_], b: AttributeKey[_], same: Boolean) =
+    ("a.label: " + a.label) |:
+      ("a.manifest: " + a.manifest) |:
+      ("b.label: " + b.label) |:
+      ("b.manifest: " + b.manifest) |:
+      ("expected equal? " + same) |:
+      compare0(a, b, same)
+
+  def compare0(a: AttributeKey[_], b: AttributeKey[_], same: Boolean) =
+    if (same) {
+      ("equality" |: (a == b)) &&
+        ("hash" |: (a.hashCode == b.hashCode))
+    } else
+      ("equality" |: (a != b))
+}

--- a/core-settings/src/test/scala/LiteralTest.scala
+++ b/core-settings/src/test/scala/LiteralTest.scala
@@ -1,0 +1,15 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+// compilation test
+object LiteralTest {
+  def x[A[_], B[_]](f: A ~> B) = f
+
+  import Param._
+  val f = x { (p: Param[Option, List]) => p.ret(p.in.toList) }
+
+  val a: List[Int] = f(Some(3))
+  val b: List[String] = f(Some("aa"))
+}

--- a/core-settings/src/test/scala/PMapTest.scala
+++ b/core-settings/src/test/scala/PMapTest.scala
@@ -1,0 +1,18 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2010 Mark Harrah
+ */
+package sbt.internal.util
+
+import Types._
+
+// compilation test
+object PMapTest {
+  val mp = new DelegatingPMap[Some, Id](new collection.mutable.HashMap)
+  mp(Some("asdf")) = "a"
+  mp(Some(3)) = 9
+  val x = Some(3) :^: Some("asdf") :^: KNil
+  val y = x.transform[Id](mp)
+  assert(y.head == 9)
+  assert(y.tail.head == "a")
+  assert(y.tail.tail == KNil)
+}

--- a/core-settings/src/test/scala/SettingsExample.scala
+++ b/core-settings/src/test/scala/SettingsExample.scala
@@ -1,0 +1,89 @@
+package sbt.internal.util
+
+import sbt.util.Show
+
+/** Define our settings system */
+
+// A basic scope indexed by an integer.
+final case class Scope(nestIndex: Int, idAtIndex: Int = 0)
+
+// Extend the Init trait.
+//  (It is done this way because the Scope type parameter is used everywhere in Init.
+//  Lots of type constructors would become binary, which as you may know requires lots of type lambdas
+//  when you want a type function with only one parameter.
+//  That would be a general pain.)
+case class SettingsExample() extends Init[Scope] {
+  // Provides a way of showing a Scope+AttributeKey[_]
+  val showFullKey: Show[ScopedKey[_]] = Show[ScopedKey[_]]((key: ScopedKey[_]) =>
+    {
+      s"${key.scope.nestIndex}(${key.scope.idAtIndex})/${key.key.label}"
+    })
+
+  // A sample delegation function that delegates to a Scope with a lower index.
+  val delegates: Scope => Seq[Scope] = {
+    case s @ Scope(index, proj) =>
+      s +: (if (index <= 0) Nil else { (if (proj > 0) List(Scope(index)) else Nil) ++: delegates(Scope(index - 1)) })
+  }
+
+  // Not using this feature in this example.
+  val scopeLocal: ScopeLocal = _ => Nil
+
+  // These three functions + a scope (here, Scope) are sufficient for defining our settings system.
+}
+
+/** Usage Example **/
+
+case class SettingsUsage(val settingsExample: SettingsExample) {
+  import settingsExample._
+
+  // Define some keys
+  val a = AttributeKey[Int]("a")
+  val b = AttributeKey[Int]("b")
+
+  // Scope these keys
+  val a3 = ScopedKey(Scope(3), a)
+  val a4 = ScopedKey(Scope(4), a)
+  val a5 = ScopedKey(Scope(5), a)
+
+  val b4 = ScopedKey(Scope(4), b)
+
+  // Define some settings
+  val mySettings: Seq[Setting[_]] = Seq(
+    setting(a3, value(3)),
+    setting(b4, map(a4)(_ * 3)),
+    update(a5)(_ + 1)
+  )
+
+  // "compiles" and applies the settings.
+  //  This can be split into multiple steps to access intermediate results if desired.
+  //  The 'inspect' command operates on the output of 'compile', for example.
+  val applied: Settings[Scope] = make(mySettings)(delegates, scopeLocal, showFullKey)
+
+  // Show results.
+  /*	for(i <- 0 to 5; k <- Seq(a, b)) {
+		println( k.label + i + " = " + applied.get( Scope(i), k) )
+	}*/
+
+  /**
+   * Output:
+   * For the None results, we never defined the value and there was no value to delegate to.
+   * For a3, we explicitly defined it to be 3.
+   * a4 wasn't defined, so it delegates to a3 according to our delegates function.
+   * b4 gets the value for a4 (which delegates to a3, so it is 3) and multiplies by 3
+   * a5 is defined as the previous value of a5 + 1 and
+   *   since no previous value of a5 was defined, it delegates to a4, resulting in 3+1=4.
+   * b5 isn't defined explicitly, so it delegates to b4 and is therefore equal to 9 as well
+   * a0 = None
+   * b0 = None
+   * a1 = None
+   * b1 = None
+   * a2 = None
+   * b2 = None
+   * a3 = Some(3)
+   * b3 = None
+   * a4 = Some(3)
+   * b4 = Some(9)
+   * a5 = Some(4)
+   * b5 = Some(9)
+   */
+}

--- a/core-settings/src/test/scala/SettingsTest.scala
+++ b/core-settings/src/test/scala/SettingsTest.scala
@@ -1,0 +1,198 @@
+package sbt.internal.util
+
+import org.scalacheck._
+import Prop._
+
+object SettingsTest extends Properties("settings") {
+  val settingsExample: SettingsExample = SettingsExample()
+  import settingsExample._
+  val settingsUsage = SettingsUsage(settingsExample)
+  import settingsUsage._
+
+  import scala.reflect.Manifest
+
+  final val ChainMax = 5000
+  lazy val chainLengthGen = Gen.choose(1, ChainMax)
+
+  property("Basic settings test") = secure(all(tests: _*))
+
+  property("Basic chain") = forAll(chainLengthGen) { (i: Int) =>
+    val abs = math.abs(i)
+    singleIntTest(chain(abs, value(0)), abs)
+  }
+  property("Basic bind chain") = forAll(chainLengthGen) { (i: Int) =>
+    val abs = math.abs(i)
+    singleIntTest(chainBind(value(abs)), 0)
+  }
+
+  property("Allows references to completed settings") = forAllNoShrink(30) { allowedReference }
+  final def allowedReference(intermediate: Int): Prop =
+    {
+      val top = value(intermediate)
+      def iterate(init: Initialize[Int]): Initialize[Int] =
+        bind(init) { t =>
+          if (t <= 0)
+            top
+          else
+            iterate(value(t - 1))
+        }
+      evaluate(setting(chk, iterate(top)) :: Nil); true
+    }
+
+  property("Derived setting chain depending on (prev derived, normal setting)") = forAllNoShrink(Gen.choose(1, 100).label("numSettings")) { derivedSettings }
+  final def derivedSettings(nr: Int): Prop =
+    {
+      val genScopedKeys = {
+        // We wan
+        // t to generate lists of keys that DO NOT inclue the "ch" key we use to check things.
+        val attrKeys = mkAttrKeys[Int](nr).filter(_.forall(_.label != "ch"))
+        attrKeys map (_ map (ak => ScopedKey(Scope(0), ak)))
+      }.label("scopedKeys").filter(_.nonEmpty)
+      forAll(genScopedKeys) { scopedKeys =>
+        try {
+          // Note; It's evil to grab last IF you haven't verified the set can't be empty.
+          val last = scopedKeys.last
+          val derivedSettings: Seq[Setting[Int]] = (
+            for {
+              List(scoped0, scoped1) <- chk :: scopedKeys sliding 2
+              nextInit = if (scoped0 == chk) chk
+              else (scoped0 zipWith chk) { (p, _) => p + 1 }
+            } yield derive(setting(scoped1, nextInit))
+          ).toSeq
+
+          {
+            // Note: This causes a cycle refernec error, quite frequently.
+            checkKey(last, Some(nr - 1), evaluate(setting(chk, value(0)) +: derivedSettings)) :| "Not derived?"
+          } && {
+            checkKey(last, None, evaluate(derivedSettings)) :| "Should not be derived"
+          }
+        } catch {
+          case t: Throwable =>
+            // TODO - For debugging only.
+            t.printStackTrace(System.err)
+            throw t
+        }
+      }
+    }
+
+  private def mkAttrKeys[T](nr: Int)(implicit mf: Manifest[T]): Gen[List[AttributeKey[T]]] =
+    {
+      import Gen._
+      val nonEmptyAlphaStr =
+        nonEmptyListOf(alphaChar).map(_.mkString).suchThat(_.forall(_.isLetter))
+
+      (for {
+        list <- Gen.listOfN(nr, nonEmptyAlphaStr) suchThat (l => l.size == l.distinct.size)
+        item <- list
+      } yield AttributeKey[T](item)).label(s"mkAttrKeys($nr)")
+    }
+
+  property("Derived setting(s) replace DerivedSetting in the Seq[Setting[_]]") = derivedKeepsPosition
+  final def derivedKeepsPosition: Prop =
+    {
+      val a: ScopedKey[Int] = ScopedKey(Scope(0), AttributeKey[Int]("a"))
+      val b: ScopedKey[Int] = ScopedKey(Scope(0), AttributeKey[Int]("b"))
+      val prop1 = {
+        val settings: Seq[Setting[_]] = Seq(
+          setting(a, value(3)),
+          setting(b, value(6)),
+          derive(setting(b, a)),
+          setting(a, value(5)),
+          setting(b, value(8))
+        )
+        val ev = evaluate(settings)
+        checkKey(a, Some(5), ev) && checkKey(b, Some(8), ev)
+      }
+      val prop2 = {
+        val settings: Seq[Setting[Int]] = Seq(
+          setting(a, value(3)),
+          setting(b, value(6)),
+          derive(setting(b, a)),
+          setting(a, value(5))
+        )
+        val ev = evaluate(settings)
+        checkKey(a, Some(5), ev) && checkKey(b, Some(5), ev)
+      }
+      prop1 && prop2
+    }
+
+  property("DerivedSetting in ThisBuild scopes derived settings under projects thus allowing safe +=") = forAllNoShrink(Gen.choose(1, 100)) { derivedSettingsScope }
+  final def derivedSettingsScope(nrProjects: Int): Prop =
+    {
+      forAll(mkAttrKeys[Int](2)) {
+        case List(key, derivedKey) =>
+          val projectKeys = for { proj <- 1 to nrProjects } yield ScopedKey(Scope(1, proj), key)
+          val projectDerivedKeys = for { proj <- 1 to nrProjects } yield ScopedKey(Scope(1, proj), derivedKey)
+          val globalKey = ScopedKey(Scope(0), key)
+          val globalDerivedKey = ScopedKey(Scope(0), derivedKey)
+          // Each project defines an initial value, but the update is defined in globalKey.
+          // However, the derived Settings that come from this should be scoped in each project.
+          val settings: Seq[Setting[_]] =
+            derive(setting(globalDerivedKey, settingsExample.map(globalKey)(_ + 1))) +: projectKeys.map(pk => setting(pk, value(0)))
+          val ev = evaluate(settings)
+          // Also check that the key has no value at the "global" scope
+          val props = for { pk <- projectDerivedKeys } yield checkKey(pk, Some(1), ev)
+          checkKey(globalDerivedKey, None, ev) && Prop.all(props: _*)
+      }
+    }
+
+  // Circular (dynamic) references currently loop infinitely.
+  //  This is the expected behavior (detecting dynamic cycles is expensive),
+  //  but it may be necessary to provide an option to detect them (with a performance hit)
+  // This would test that cycle detection.
+  //	property("Catches circular references") = forAll(chainLengthGen) { checkCircularReferences _ }
+  final def checkCircularReferences(intermediate: Int): Prop =
+    {
+      val ccr = new CCR(intermediate)
+      try { evaluate(setting(chk, ccr.top) :: Nil); false }
+      catch { case e: java.lang.Exception => true }
+    }
+
+  def tests =
+    for (i <- 0 to 5; k <- Seq(a, b)) yield {
+      val expected = expectedValues(2 * i + (if (k == a) 0 else 1))
+      checkKey[Int](ScopedKey(Scope(i), k), expected, applied)
+    }
+
+  lazy val expectedValues = None :: None :: None :: None :: None :: None :: Some(3) :: None :: Some(3) :: Some(9) :: Some(4) :: Some(9) :: Nil
+
+  lazy val ch = AttributeKey[Int]("ch")
+  lazy val chk = ScopedKey(Scope(0), ch)
+  def chain(i: Int, prev: Initialize[Int]): Initialize[Int] =
+    if (i <= 0) prev else chain(i - 1, prev(_ + 1))
+
+  def chainBind(prev: Initialize[Int]): Initialize[Int] =
+    bind(prev) { v =>
+      if (v <= 0) prev else chainBind(value(v - 1))
+    }
+  def singleIntTest(i: Initialize[Int], expected: Int) =
+    {
+      val eval = evaluate(setting(chk, i) :: Nil)
+      checkKey(chk, Some(expected), eval)
+    }
+
+  def checkKey[T](key: ScopedKey[T], expected: Option[T], settings: Settings[Scope]) =
+    {
+      val value = settings.get(key.scope, key.key)
+      ("Key: " + key) |:
+        ("Value: " + value) |:
+        ("Expected: " + expected) |:
+        (value == expected)
+    }
+
+  def evaluate(settings: Seq[Setting[_]]): Settings[Scope] =
+    try { make(settings)(delegates, scopeLocal, showFullKey) }
+    catch { case e: Throwable => e.printStackTrace; throw e }
+}
+// This setup is a workaround for module synchronization issues 
+final class CCR(intermediate: Int) {
+  import SettingsTest.settingsExample._
+  lazy val top = iterate(value(intermediate), intermediate)
+  def iterate(init: Initialize[Int], i: Int): Initialize[Int] =
+    bind(init) { t =>
+      if (t <= 0)
+        top
+      else
+        iterate(value(t - 1), t - 1)
+    }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,9 +18,7 @@ object Dependencies {
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 
-  private val utilApplyMacro = "org.scala-sbt" %% "util-apply-macro" % utilVersion
   private val utilCache = "org.scala-sbt" %% "util-cache" % utilVersion
-  private val utilCollection = "org.scala-sbt" %% "util-collection" % utilVersion
   private val utilCompletion = "org.scala-sbt" %% "util-completion" % utilVersion
   private val utilControl = "org.scala-sbt" %% "util-control" % utilVersion
   private val utilLogging = "org.scala-sbt" %% "util-logging" % utilVersion
@@ -71,11 +69,7 @@ object Dependencies {
 
   def addSbtIO(p: Project): Project = addSbtModule(p, sbtIoPath, "io", sbtIO)
 
-  def addSbtUtilApplyMacro(p: Project): Project =
-    addSbtModule(p, sbtUtilPath, "utilApplyMacro", utilApplyMacro)
   def addSbtUtilCache(p: Project): Project = addSbtModule(p, sbtUtilPath, "utilCache", utilCache)
-  def addSbtUtilCollection(p: Project): Project =
-    addSbtModule(p, sbtUtilPath, "utilCollection", utilCollection)
   def addSbtUtilCompletion(p: Project): Project =
     addSbtModule(p, sbtUtilPath, "utilComplete", utilCompletion)
   def addSbtUtilControl(p: Project): Project =
@@ -108,7 +102,10 @@ object Dependencies {
   def addSbtZincCompile(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincCompile", zincCompile)
 
-  val sjsonNewScalaJson = "com.eed3si9n" %% "sjson-new-scalajson" % "0.7.0"
+
+  val sjsonnewVersion = "0.7.0"
+  val sjsonnew = "com.eed3si9n" %% "sjson-new-core" % sjsonnewVersion
+  val sjsonNewScalaJson = "com.eed3si9n" %% "sjson-new-scalajson" % sjsonnewVersion
 
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
   val specs2 = "org.specs2" %% "specs2" % "2.4.17"


### PR DESCRIPTION
This commit moves everything behind the old `util-appmacro` and
`util-collection` over to sbt/sbt.

The reason for this change is because the logic of these modules is
really tight to the implementation of sbt and, I would even say, define
what sbt essentially is. They don't deserve to be called `util` nor to
be in an independent repository.

I have renamed the modules because I do not think they conveyed how
important these are for the sbt project. I don't have strong opinions
here, so I'm happy to pick other names if others consider appropriate.

`appmacro` has been renamed as `core-macros`. It is indeed the project
that defines the main logic to manipulate macros, and defines interfaces
that are then implemented by `main-settings`. Because of this strong
relationship between these two modules, I find that they have to stay
together and be able to be modified in one commit. I've realised this
while hacking on the macro changes for the usability of sbt.

`util-collection` has been renamed as `core-settings`. It defines all
the core structures (like `Init`, `AttributeKey`, `Setting`) that are
the core of sbt. These data structures are used by `appmacro` and the
same argument holds to move this module here. Given the importance of
these data structures, I feel that this should be one of the major
projects of sbt.