### PR TITLE
Fix restligeist macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -396,7 +396,8 @@ def allProjects =
     mainSettingsProj,
     mainProj,
     sbtProj,
-    bundledLauncherProj
+    bundledLauncherProj,
+    coreMacrosProj
   )
 
 lazy val nonRoots = allProjects.map(p => LocalProject(p.id))

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -27,6 +27,7 @@ object ContextUtil {
     import c.universe._
     c.macroApplication match {
       case s @ Select(Apply(_, t :: Nil), tp) => f(c.Expr[Any](t), s.pos)
+      case a @ Apply(_, t :: Nil)             => f(c.Expr[Any](t), a.pos)
       case x                                  => unexpectedTree(x)
     }
   }

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -82,12 +82,12 @@ object TaskMacro {
   final val InputTaskCreateDynName = "createDyn"
   final val InputTaskCreateFreeName = "createFree"
   final val append1Migration =
-    "`<+=` operator is deprecated. Try `lhs += { x.value }`\n  or see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html."
+    "`<+=` operator is removed. Try `lhs += { x.value }`\n  or see http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html."
   final val appendNMigration =
-    "`<++=` operator is deprecated. Try `lhs ++= { x.value }`\n  or see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html."
+    "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html."
   final val assignMigration =
-    """`<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
-      |See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html""".stripMargin
+    """`<<=` operator is removed. Use `key := { x.value }` or `key ~= (old => { newValue })`.
+      |See http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html""".stripMargin
 
   import LinterDSL.{ Empty => EmptyLinter }
 


### PR DESCRIPTION
Fixes sbt/sbt#3157

Before:

```scala
PgpSettings.scala:99: exception during macro expansion:
[error] java.lang.RuntimeException: Unexpected macro application tree (class scala.reflect.internal.Trees$Apply): PgpKeys.pgpStaticContext.<<=(sbt.this.Scoped.t2ToApp2[sbt.File, sbt.File](scala.Tuple2.apply[sbt.SettingKey[sbt.File], sbt.SettingKey[sbt.File]](PgpKeys.pgpPublicRing, PgpKeys.pgpSecretRing)).apply[com.jsuereth.pgp.cli.PgpStaticContext]({
[error]   ((publicKeyRingFile: sbt.File, secretKeyRingFile: sbt.File) => SbtPgpStaticContext.apply(publicKeyRingFile, secretKeyRingFile))
```

After:

```scala
build.sbt:18: error: `<<=` operator is removed. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html
    publishLocal <<= foo // publishLocal.dependsOn(foo)
                  ^
[error] sbt.compiler.EvalException: Type error in expression
```