### PR TITLE
[fport] Fix += interference with sbt-buildinfo

### DIFF
--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -211,7 +211,9 @@ object TaskMacro {
     val typeArgs = ttpe.typeArgs
     v.tree.tpe match {
       // To allow Initialize[Task[A]] in the position of += RHS, we're going to call "taskValue" automatically.
-      case tpe if typeArgs.nonEmpty && (tpe weak_<:< c.weakTypeOf[Initialize[_]]) =>
+      case tpe
+          if typeArgs.nonEmpty && (typeArgs.head weak_<:< c.weakTypeOf[Task[_]])
+            && (tpe weak_<:< c.weakTypeOf[Initialize[_]]) =>
         c.macroApplication match {
           case Apply(Apply(TypeApply(Select(preT, nmeT), targs), _), _) =>
             val tree = Apply(

--- a/sbt/src/sbt-test/project/plusequals/build.sbt
+++ b/sbt/src/sbt-test/project/plusequals/build.sbt
@@ -1,0 +1,6 @@
+// https://github.com/sbt/sbt/issues/3132
+lazy val root = (project in file(".")).
+  enablePlugins(XBuildInfoPlugin).
+  settings(
+    buildInfoKeys += name
+  )

--- a/sbt/src/sbt-test/project/plusequals/project/XBuildInfoPlugin.scala
+++ b/sbt/src/sbt-test/project/plusequals/project/XBuildInfoPlugin.scala
@@ -1,0 +1,32 @@
+import sbt._
+import Keys._
+
+object XBuildInfoPlugin extends sbt.AutoPlugin {
+  override def requires = plugins.JvmPlugin
+
+  object autoImport {
+    lazy val buildInfoKeys = settingKey[Seq[BuildInfoKey.Entry[_]]]("Entries for build info.")
+  }
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    buildInfoKeys := Seq(name, version, scalaVersion, sbtVersion),
+  )
+}
+
+object BuildInfoKey {
+  implicit def setting[A](key: SettingKey[A]): Entry[A] = Setting(key)
+  implicit def task[A](key: TaskKey[A]): Entry[A] = Task(key)
+  def apply[A](key: SettingKey[A]): Entry[A] = Setting(key)
+  def apply[A](key: TaskKey[A]): Entry[A] = Task(key)
+
+  case class Setting[A](scoped: SettingKey[A]) extends Entry[A] {
+    def manifest = scoped.key.manifest
+  }
+  case class Task[A](scoped: TaskKey[A]) extends Entry[A] {
+    def manifest = scoped.key.manifest.typeArguments.head.asInstanceOf[Manifest[A]]
+  }
+  sealed trait Entry[A] {
+    def manifest: Manifest[A]
+  }
+}

--- a/sbt/src/sbt-test/project/plusequals/test
+++ b/sbt/src/sbt-test/project/plusequals/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/3135

The macro pattern match was too general. This makes it tighter.

Fixes #3132
