### PR TITLE
[fport] Remove the "hit [ENTER] to switch to interactive mode" feature

### DIFF
--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -229,15 +229,8 @@ object State {
                  currentCommand = Some(cmd),
                  history = cmd :: s.history))
       }
-      def isInteractive = System.console != null
-      def hasInput = Option(System.console) exists (_.reader.ready())
-      def hasShellCmd = s.definedCommands exists {
-        case c: SimpleCommand => c.name == Shell; case _ => false
-      }
       s.remainingCommands match {
-        case List() =>
-          if (isInteractive && hasInput && hasShellCmd) runCmd(Exec(Shell, s.source), Nil)
-          else exit(true)
+        case List()           => exit(true)
         case List(x, xs @ _*) => runCmd(x, xs.toList)
       }
     }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -129,6 +129,7 @@ object Keys {
   val serverPort = SettingKey(BasicKeys.serverPort)
   val analysis = AttributeKey[CompileAnalysis]("analysis", "Analysis of compilation, including dependencies and generated outputs.", DSetting)
   val watch = SettingKey(BasicKeys.watch)
+  val suppressSbtShellNotification = SettingKey[Boolean]("suppressSbtShellNotification", """True to suppress the "Executing in batch mode.." message.""", CSetting)
   val pollInterval = SettingKey[Int]("poll-interval", "Interval between checks for modified sources by the continuous execution command.", BMinusSetting)
   val watchSources = TaskKey[Seq[File]]("watch-sources", "Defines the sources in this project for continuous execution to watch for changes.", BMinusSetting)
   val watchTransitiveSources = TaskKey[Seq[File]]("watch-transitive-sources", "Defines the sources in all projects for continuous execution to watch.", CSetting)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -54,7 +54,7 @@ import java.net.URI
 import java.util.Locale
 import scala.util.control.NonFatal
 
-import BasicCommandStrings.{ Shell, OldShell }
+import BasicCommandStrings.{ Shell, OldShell, TemplateCommand }
 import CommandStrings.BootCommand
 
 /** This class is the entry point for sbt. */
@@ -64,67 +64,12 @@ final class xMain extends xsbti.AppMain {
     import BasicCommandStrings.runEarly
     import BuiltinCommands.defaults
     import sbt.internal.CommandStrings.{ BootCommand, DefaultsCommand, InitCommand }
-    if (!java.lang.Boolean.getBoolean("sbt.skip.version.write")) {
-      setSbtVersion(configuration.baseDirectory(), configuration.provider().id().version())
-    }
     val state = initialState(
       configuration,
       Seq(defaults, early),
       runEarly(DefaultsCommand) :: runEarly(InitCommand) :: BootCommand :: Nil)
-    notifyUsersAboutShell(state)
     runManaged(state)
   }
-
-  private val sbtVersionRegex = """sbt\.version\s*=.*""".r
-  private def isSbtVersionLine(s: String) = sbtVersionRegex.pattern matcher s matches ()
-
-  private def isSbtProject(baseDir: File, projectDir: File) =
-    projectDir.exists() || (baseDir * "*.sbt").get.nonEmpty
-
-  private def setSbtVersion(baseDir: File, sbtVersion: String) = {
-    val projectDir = baseDir / "project"
-    val buildProps = projectDir / "build.properties"
-
-    val buildPropsLines = if (buildProps.canRead) IO.readLines(buildProps) else Nil
-
-    val sbtVersionAbsent = buildPropsLines forall (!isSbtVersionLine(_))
-
-    if (sbtVersionAbsent) {
-      val errorMessage =
-        s"WARN: No sbt.version set in project/build.properties, base directory: $baseDir"
-      try {
-        if (isSbtProject(baseDir, projectDir)) {
-          val line = s"sbt.version=$sbtVersion"
-          IO.writeLines(buildProps, line :: buildPropsLines)
-          println(s"Updated file $buildProps setting sbt.version to: $sbtVersion")
-        } else
-          println(errorMessage)
-      } catch {
-        case _: IOException => println(errorMessage)
-      }
-    }
-  }
-
-  private def isInteractive = System.console() != null
-  private def hasCommand(state: State, cmd: String): Boolean =
-    (state.remainingCommands find { x =>
-      x.commandLine == cmd
-    }).isDefined
-
-  /**
-   * The "boot" command adds "iflast shell" ("if last shell")
-   * which basically means it falls back to shell if there are no further commands
-   */
-  private def endsWithBoot(state: State) =
-    state.remainingCommands.lastOption exists (_.commandLine == BootCommand)
-
-  private def notifyUsersAboutShell(state: State) =
-    if (isInteractive && !hasCommand(state, Shell) && !hasCommand(state, OldShell) && !endsWithBoot(
-          state)) {
-      state.log warn "Executing in batch mode."
-      state.log warn "  For better performance, hit [ENTER] to switch to interactive mode, or"
-      state.log warn "  consider launching sbt without any commands, or explicitly passing 'shell'"
-    }
 }
 
 final class ScriptMain extends xsbti.AppMain {
@@ -238,6 +183,8 @@ object BuiltinCommands {
       setLogLevel,
       plugin,
       plugins,
+      writeSbtVersion,
+      notifyUsersAboutShell,
       ifLast,
       multi,
       shell,
@@ -259,7 +206,8 @@ object BuiltinCommands {
       act
     ) ++ compatCommands
 
-  def DefaultBootCommands: Seq[String] = LoadProject :: (IfLast + " " + Shell) :: Nil
+  def DefaultBootCommands: Seq[String] =
+    WriteSbtVersion :: LoadProject :: NotifyUsersAboutShell :: s"$IfLast $Shell" :: Nil
 
   def boot = Command.make(BootCommand)(bootParser)
 
@@ -763,4 +711,66 @@ object BuiltinCommands {
     if (exec.commandLine.trim.isEmpty) newState
     else newState.clearGlobalLog
   }
+
+  private val sbtVersionRegex = """sbt\.version\s*=.*""".r
+  private def isSbtVersionLine(s: String) = sbtVersionRegex.pattern matcher s matches ()
+
+  private def isSbtProject(baseDir: File, projectDir: File) =
+    projectDir.exists() || (baseDir * "*.sbt").get.nonEmpty
+
+  private def writeSbtVersionUnconditionally(state: State) = {
+    val baseDir = state.baseDir
+    val sbtVersion = BuiltinCommands.sbtVersion(state)
+    val projectDir = baseDir / "project"
+    val buildProps = projectDir / "build.properties"
+
+    val buildPropsLines = if (buildProps.canRead) IO.readLines(buildProps) else Nil
+
+    val sbtVersionAbsent = buildPropsLines forall (!isSbtVersionLine(_))
+
+    if (sbtVersionAbsent) {
+      val warnMsg = s"No sbt.version set in project/build.properties, base directory: $baseDir"
+      try {
+        if (isSbtProject(baseDir, projectDir)) {
+          val line = s"sbt.version=$sbtVersion"
+          IO.writeLines(buildProps, line :: buildPropsLines)
+          state.log info s"Updated file $buildProps: set sbt.version to $sbtVersion"
+        } else
+          state.log warn warnMsg
+      } catch {
+        case _: IOException => state.log warn warnMsg
+      }
+    }
+  }
+
+  private def intendsToInvokeNew(state: State) = state.remainingCommands contains TemplateCommand
+
+  private def writeSbtVersion(state: State) =
+    if (!java.lang.Boolean.getBoolean("sbt.skip.version.write") && !intendsToInvokeNew(state))
+      writeSbtVersionUnconditionally(state)
+
+  private def WriteSbtVersion = "write-sbt-version"
+
+  private def writeSbtVersion: Command =
+    Command.command(WriteSbtVersion) { state =>
+      writeSbtVersion(state); state
+    }
+
+  private def isInteractive = System.console() != null
+
+  private def intendsToInvokeCompile(state: State) =
+    state.remainingCommands contains Keys.compile.key.label
+
+  private def notifyUsersAboutShell(state: State): Unit = {
+    val suppress = Project extract state getOpt Keys.suppressSbtShellNotification getOrElse false
+    if (!suppress && isInteractive && intendsToInvokeCompile(state))
+      state.log info "Executing in batch mode. For better performance use sbt's shell; hit [ENTER] to do so now"
+  }
+
+  private def NotifyUsersAboutShell = "notify-users-about-shell"
+
+  private def notifyUsersAboutShell: Command =
+    Command.command(NotifyUsersAboutShell) { state =>
+      notifyUsersAboutShell(state); state
+    }
 }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -756,15 +756,13 @@ object BuiltinCommands {
       writeSbtVersion(state); state
     }
 
-  private def isInteractive = System.console() != null
-
   private def intendsToInvokeCompile(state: State) =
     state.remainingCommands contains Keys.compile.key.label
 
   private def notifyUsersAboutShell(state: State): Unit = {
     val suppress = Project extract state getOpt Keys.suppressSbtShellNotification getOrElse false
-    if (!suppress && isInteractive && intendsToInvokeCompile(state))
-      state.log info "Executing in batch mode. For better performance use sbt's shell; hit [ENTER] to do so now"
+    if (!suppress && intendsToInvokeCompile(state))
+      state.log info "Executing in batch mode. For better performance use sbt's shell"
   }
 
   private def NotifyUsersAboutShell = "notify-users-about-shell"

--- a/notes/0.13.16.markdown
+++ b/notes/0.13.16.markdown
@@ -1,0 +1,93 @@
+### Fixes with compatibility implications
+
+- Removes the "hit \[ENTER\] to switch to interactive mode" feature. See below.
+
+### Improvements
+
+- Improves the new startup messages. See below.
+- Ports sbt-cross-building's `^` and `^^` commands for plugin cross building. See below.
+
+### Bug fixes
+
+- Fixes the new startup messages. See below.
+
+### Improvements and bug fixes to the new startup messages
+
+The two new startup messages introduced in sbt 0.13.15 are:
+
+- when writing out `sbt.version`, for build reproducability, and
+- when informing the user about sbt's shell, for the performance improvement
+
+When writing out `sbt.version` the messaging now:
+
+- correctly uses a logger rather than println
+- honours the log level set, for instance by `--error`
+- never executes when sbt "new" is being run
+
+When informing the user about sbt's shell the messaging now:
+
+- is a 1 line message, rather than 3
+- is at info level, rather than warn level
+- can be suppressed with `suppressSbtShellNotification := true`
+- only triggers when `compile` is being run
+- never shows when sbt `new` is being run
+
+[#3091][3091]/[#3097][3097]/[#3147][3147] by [@dwijnand][@dwijnand]
+
+### Remove the "hit \[ENTER\] to switch to interactive mode" feature
+
+In sbt 0.13.15, in addition to notifying the user about the existence of sbt's shell, a feature was added to
+allow the user to switch to sbt's shell - a more pro-active approach to just displaying a message.
+
+Unfortunately sbt is often unintentionally invoked in shell scripts in "interactive mode" when no interaction is
+expected by, for exmaple, invoking `sbt package` instead of `sbt package < /dev/null`. In that case hitting
+\[ENTER\] would silently trigger sbt to run its shell, easily wrecking the script. In addition to that I was
+unhappy with the implementation as it created a tight coupling between sbt's command processing abstraction to
+sbt's shell command.
+
+If you want to stay in sbt's shell after running a task like `package` then invoke sbt like so:
+
+    sbt package shell
+
+[#3091][3091]/[#3153][3153] by [@dwijnand][@dwijnand]
+
+### sbt-cross-building
+
+[@jrudolph][@jrudolph]'s sbt-cross-building is a plugin author's plugin.
+It adds cross command `^` and sbtVersion switch command `^^`, similar to `+` and `++`,
+but for switching between multiple sbt versions across major versions.
+sbt 0.13.16 merges these commands into sbt because the feature it provides is useful as we migrate plugins to sbt 1.0.
+
+To switch the `sbtVersion in pluginCrossBuild` from the shell use:
+
+```
+^^ 1.0.0-M5
+```
+
+Your plugin will now build with sbt 1.0.0-M5 (and its Scala version 2.12.2).
+
+If you need to make changes specific to a sbt version, you can now include them into `src/main/scala-sbt-0.13`,
+and `src/main/scala-sbt-1.0.0-M5`, where the binary sbt version number is used as postfix.
+
+To run a command across multiple sbt versions, set:
+
+```scala
+crossSbtVersions := Vector("0.13.15", "1.0.0-M5")
+```
+
+Then, run:
+
+```
+^ compile
+```
+
+[#3133][3133] by [@eed3si9n][@eed3si9n]
+
+  [3091]: https://github.com/sbt/sbt/issues/3091
+  [3097]: https://github.com/sbt/sbt/issues/3097
+  [3147]: https://github.com/sbt/sbt/pull/3147
+  [3133]: https://github.com/sbt/sbt/pull/3133
+  [3153]: https://github.com/sbt/sbt/pull/3153
+  [@jrudolph]: https://github.com/jrudolph
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: https://github.com/dwijnand

--- a/notes/0.13.16/tweak-new-startup-messages.markdown
+++ b/notes/0.13.16/tweak-new-startup-messages.markdown
@@ -1,0 +1,36 @@
+### Improvements
+
+- Improves the new startup messages. See below.
+
+### Bug fixes
+
+- Fixes the new startup messages. See below.
+
+### Improvements and bug fixes to the new startup messages
+
+The two new startup messages introduced in sbt 0.13.15 are:
+
++ when writing out `sbt.version` for build reproducability, and
++ when informing the user sbt shell for the performance improvement
+
+When writing out `sbt.version` the messaging now:
+
++ correctly uses a logger rather than println
++ honours the log level set, for instance, by `--error`
++ never runs when sbt "new" is being run
+
+When informing the user about sbt shell the messaging now:
+
++ is a 1 line message, rather than 3
++ is at info level, rather than warn level
++ can be suppressed with `suppressSbtShellNotification := false`
++ only triggers when "compile" is being run
++ never shows when sbt "new" is being run
+
+[#3091][]/[#3097][]/[#3147][] by [@dwijnand][]
+
+[#3091]: https://github.com/sbt/sbt/issues/3091
+[#3097]: https://github.com/sbt/sbt/issues/3097
+[#3147]: https://github.com/sbt/sbt/pull/3147
+
+[@dwijnand]: https://github.com/dwijnand


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/3153

In sbt 0.13.15, in addition to notifying the user about the existence of
sbt's shell, a feature was added to allow the user to switch to sbt's
shell - a more pro-active approach to just displaying a message.

Unfortunately sbt is often unintentionally invoked in shell scripts in
"interactive mode" when no interaction is expected by, for exmaple,
invoking `sbt package` instead of `sbt package < /dev/null`. In that
case hitting [ENTER] would silently trigger sbt to run its shell,
easily wrecking the script. In addition to that I was unhappy with the
implementation as it created a tight coupling between sbt's command
processing abstraction to sbt's shell command.

If you want to stay in sbt's shell after running a task like `package`
then invoke sbt like so:

    sbt package shell

Fixes #3091
