### PR TITLE
[WIP] Fix #3183: Add `inspect build` to detect unused

### DIFF
--- a/sbt/src/sbt-test/project/inspect-build/build.sbt
+++ b/sbt/src/sbt-test/project/inspect-build/build.sbt
@@ -1,0 +1,1 @@
+name := "Inspect build project"

--- a/sbt/src/sbt-test/project/inspect-build/test
+++ b/sbt/src/sbt-test/project/inspect-build/test
@@ -1,0 +1,1 @@
+> inspect build


### PR DESCRIPTION
The scopes linter tells the users which settings are leafs or unused.
This is useful to find out whether the defined settings are really used
or not, and how scopes delegation is working.

This build up on previous work done by Havoc Pennington referenced here:
https://github.com/sbt/sbt/issues/3183

For now, it adds a command `inspect build` to allow users to know which
tasks are unused or not. The unused tasks are filtered out so that the
ones provided by sbt do not appear. Users only want to know about their
own reimplemented settings/tasks.

This is just a first pass, since some changes have to be done. This is
still experimental and work in progress, do not merge please.