### PR TITLE
add visualize task to sbt

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -292,7 +292,14 @@ object Defaults extends BuildCommon {
     historyPath := (historyPath or target(t => Option(t / ".history"))).value,
     sourceDirectory := baseDirectory.value / "src",
     sourceManaged := crossTarget.value / "src_managed",
-    resourceManaged := crossTarget.value / "resource_managed"
+    resourceManaged := crossTarget.value / "resource_managed",
+    visualize := {
+      val extracted = Project.extract(state.value)
+      import extracted._
+      val structure = buildStructure.value
+      val baseDir = baseDirectory.value
+      Project.graphSettings(structure, baseDir)
+    }
   )
 
   lazy val configPaths = sourceConfigPaths ++ resourceConfigPaths ++ outputConfigPaths

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -445,6 +445,7 @@ object Keys {
   val settingsData = std.FullInstance.settingsData
   val streams = TaskKey[TaskStreams]("streams", "Provides streams for logging and persisting data.", DTask)
   val taskDefinitionKey = Def.taskDefinitionKey
+  val visualize = TaskKey[Unit]("visualize", "Creates a visualization of sbt tasks of the current build.", DTask)
   val (executionRoots, dummyRoots) = Def.dummy[Seq[ScopedKey[_]]]("execution-roots", "The list of root tasks for this task execution.  Roots are the top-level tasks that were directly requested to be run.")
 
   val state = Def.stateKey

--- a/notes/1.0.0.markdown
+++ b/notes/1.0.0.markdown
@@ -54,6 +54,8 @@ We are working with Scala Center to provide [an automatic migration tool][sbt-mi
 - Add logging of the name of the different `build.sbt` (matching `*.sbt`) files used. [#1911][1911] by [@valydia][@valydia]
 - Add the ability to call `aggregate` for the current project inside a build sbt file. By [@xuwei-k][@xuwei-k]
 - Add new global setting `asciiGraphWidth` that controls the maximum width of the ASCII graphs printed by commands like `inspect tree`. Default value corresponds to the previously hardcoded value of 40 characters. By [@RomanIakovlev][@RomanIakovlev].
+- Add new task `visualize` to sbt. It creates two dot-files, each one for actual and
+  declared dependency graph. By [@zartstrom][@zartstrom]
 
 ### Details of major changes
 

--- a/sbt/src/sbt-test/project/visualize/test
+++ b/sbt/src/sbt-test/project/visualize/test
@@ -1,0 +1,6 @@
+# Run the visualize command and check for the output
+> visualize
+$ exists actual_dependencies.dot 
+$ exists declared_dependencies.dot 
+# $ copy-file actual_dependencies.dot /tmp
+# $ copy-file declared_dependencies.dot /tmp

--- a/sbt/src/sbt-test/project/visualize/test
+++ b/sbt/src/sbt-test/project/visualize/test
@@ -1,6 +1,4 @@
 # Run the visualize command and check for the output
 > visualize
-$ exists actual_dependencies.dot 
-$ exists declared_dependencies.dot 
-# $ copy-file actual_dependencies.dot /tmp
-# $ copy-file declared_dependencies.dot /tmp
+$ exists actual_dependencies.dot
+$ exists declared_dependencies.dot


### PR DESCRIPTION
.. from scala spree in CPH ..

We leverage the existing `graphSettings` function to create a task that writes dependency graphs to .dot-files.

See also this pdf created from `declared_dependencies.dot` output (created with `dot -Tpdf declared_dependencies.dot -o declared_deps.pdf`):
``
[declared_deps.pdf](https://github.com/sbt/sbt/files/1041913/declared_deps.pdf)


 