### PR TITLE
Add prompt for sbt version in the issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -14,3 +14,4 @@
 
 ## notes
 
+sbt version: *insert sbt version*


### PR DESCRIPTION
With sbt 1 in beta and the final release coming up bug reports and reproductions will start to diversify between sbt 0.13 and sbt 1. So let's try and get reporters to specify the version they're using.