### PR TITLE
Call the soon-to-exist Global#close when done compiling

### DIFF
--- a/compile/interface/src/main/scala/xsbt/CompilerInterface.scala
+++ b/compile/interface/src/main/scala/xsbt/CompilerInterface.scala
@@ -95,6 +95,14 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
     try { run(sources.toList, changes, callback, log, dreporter, progress) }
     finally { dreporter.dropDelegate() }
   }
+  def close(): Unit = {
+    val c = compiler
+    if (c != null) {
+      class GlobalCloseCompat(g: Global) { def close(): Unit = () }
+      implicit def GlobalCloseCompat(g: Global): GlobalCloseCompat = new GlobalCloseCompat(g)
+      c.close()
+    }
+  }
   private[this] def run(sources: List[File], changes: DependencyChanges, callback: AnalysisCallback, log: Logger, dreporter: DelegatingReporter, compileProgress: CompileProgress): Unit = {
     if (command.shouldStopWithInfo) {
       dreporter.info(null, command.getInfoMessage(compiler), true)
@@ -233,6 +241,7 @@ private final class CachedCompiler0(args: Array[String], output: Output, initial
       callback0 = null
       superDropRun()
       reporter = null
+      close()
     }
 
     def findClass(name: String): Option[(AbstractFile, Boolean)] =

--- a/compile/src/main/scala/sbt/compiler/AnalyzingCompiler.scala
+++ b/compile/src/main/scala/sbt/compiler/AnalyzingCompiler.scala
@@ -43,8 +43,12 @@ final class AnalyzingCompiler private (val scalaInstance: xsbti.compile.ScalaIns
   def compile(sources: Seq[File], changes: DependencyChanges, options: Seq[String], output: Output, callback: AnalysisCallback, reporter: Reporter, cache: GlobalsCache, log: Logger, progressOpt: Option[CompileProgress]): Unit =
     {
       val cached = cache(options.toArray, output, !changes.isEmpty, this, log, reporter)
-      val progress = progressOpt getOrElse IgnoreProgress
-      compile(sources, changes, callback, log, reporter, progress, cached)
+      try {
+        val progress = progressOpt getOrElse IgnoreProgress
+        compile(sources, changes, callback, log, reporter, progress, cached)
+      } finally {
+        cache.relinquish(cached)
+      }
     }
 
   def compile(sources: Seq[File], changes: DependencyChanges, callback: AnalysisCallback, log: Logger, reporter: Reporter, progress: CompileProgress, compiler: CachedCompiler) {

--- a/compile/src/main/scala/sbt/compiler/CompilerCache.scala
+++ b/compile/src/main/scala/sbt/compiler/CompilerCache.scala
@@ -25,6 +25,7 @@ private final class CompilerCache(val maxInstances: Int) extends GlobalsCache {
     }
   }
   def clear(): Unit = synchronized { cache.clear() }
+  def relinquish(compiler: CachedCompiler): Unit = ()
 
   private[this] def dropSources(args: Seq[String]): Seq[String] =
     args.filterNot(arg => arg.endsWith(".scala") || arg.endsWith(".java"))
@@ -42,6 +43,7 @@ object CompilerCache {
   def apply(maxInstances: Int): GlobalsCache = new CompilerCache(maxInstances)
 
   val fresh: GlobalsCache = new GlobalsCache {
+    def relinquish(compiler: CachedCompiler): Unit = compiler.close()
     def clear(): Unit = ()
     def apply(args: Array[String], output: Output, forceNew: Boolean, c: CachedCompilerProvider, log: xLogger, reporter: Reporter): CachedCompiler =
       c.newCachedCompiler(args, output, log, reporter, /*resident = */ false)

--- a/interface/src/main/java/xsbti/compile/CachedCompiler.java
+++ b/interface/src/main/java/xsbti/compile/CachedCompiler.java
@@ -10,4 +10,5 @@ public interface CachedCompiler
 	/** Returns an array of arguments representing the nearest command line equivalent of a call to run but without the command name itself.*/
 	String[] commandArguments(File[] sources);
 	void run(File[] sources, DependencyChanges cpChanges, AnalysisCallback callback, Logger log, Reporter delegate, CompileProgress progress);
+	void close();
 }

--- a/interface/src/main/java/xsbti/compile/GlobalsCache.java
+++ b/interface/src/main/java/xsbti/compile/GlobalsCache.java
@@ -9,5 +9,6 @@ import xsbti.Reporter;
 public interface GlobalsCache
 {
 	CachedCompiler apply(String[] args, Output output, boolean forceNew, CachedCompilerProvider provider, Logger log, Reporter reporter);
+	void relinquish(CachedCompiler compiler);
 	void clear();
 }


### PR DESCRIPTION
Scala 2.13.3 is likely to have a new method, `Global.close`.
This will let the compiler release resources, notably file
handles to JARs on the classpath.

This commit calls changes the compiler interfaces to call this
method, falling back to a no-op extension method for backwards
compatibility.

Furthermore, it changes the API to the global cache to let
the caller hand back the compiler instance. By default, this
compiler cache is a no-op (`GlobalCache.fresh`), and this is
where I've added the `close` call.

The other code path does not close the Global. AFAIK, caching
global instances (enabled with `sbt -Dsbt.resident.limit=<N>`)
a unfinished experiment and and not use in the wild. For instance,
I don't see how the current implementation ensures single threaded
access to the cached global instances, I would have expected a
check-out/check-in protocol to deal with that.

In any case, that code path is untouched under this patch.