### PR TITLE
Update jline dependency to 2.14.4 (#3240)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val scala211 = "2.11.8"
   lazy val scala212 = "2.12.0-RC2"
 
-  lazy val jline = "jline" % "jline" % "2.14.3"
+  lazy val jline = "jline" % "jline" % "2.14.4"
   lazy val ivy = "org.scala-sbt.ivy" % "ivy" % "2.3.0-sbt-48dd0744422128446aee9ac31aa356ee203cc9f4"
   lazy val jsch = "com.jcraft" % "jsch" % "0.1.50" intransitive ()
   lazy val sbinary = "org.scala-tools.sbinary" %% "sbinary" % "0.4.2"


### PR DESCRIPTION
### Bug fixes
Fixes #3240 by updating jline dependency to `2.14.4`.