### PR TITLE
Fixes test content logger dropping out, or displaying twice

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -723,8 +723,6 @@ object Defaults extends BuildCommon {
     new TestLogger.PerTest(s.log, () => s.close(), buffered)
   }
 
-  def buffered(log: Logger): Logger = new BufferedLogger(FullLogger(log))
-
   def testExtra(extra: AttributeMap, tdef: TestDefinition): AttributeMap = {
     val mod = tdef.fingerprint match {
       case f: SubclassFingerprint  => f.isModule

--- a/notes/1.0.0/testlogger.md
+++ b/notes/1.0.0/testlogger.md
@@ -1,0 +1,10 @@
+
+### Bug fixes
+
+- Fixes test content logger dropping out, or displaying twice. [#3117][3117] by [@eed3si9n][@eed3si9n]
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: http://github.com/dwijnand
+  [@jvican]: https://github.com/jvican
+  [@Duhemm]: https://github.com/Duhemm
+  [3117]: https://github.com/sbt/sbt/issues/3117

--- a/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
+++ b/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
@@ -38,6 +38,7 @@ object TestLogger {
         case (_, v) => BufferedAppender(generateBufferName, v)
       }).toList
       val newLog = LogExchange.logger(generateName, l0.channelName, l0.execId)
+      LogExchange.unbindLoggerAppenders(newLog.name)
       LogExchange.bindLoggerAppenders(newLog.name, buffs map { x =>
         (x, Level.Debug)
       })
@@ -49,7 +50,8 @@ object TestLogger {
         () => {
           buffs foreach { _.stopQuietly() }
           per.flush()
-          LogExchange.unbindLoggerAppenders(newLog.name)
+          // do not unbind here. since there's a delay in the async appender,
+          // it will result in missing log output.
         }
       )
     }


### PR DESCRIPTION
Fixes #3117
