### PR TITLE
Move the tuple enrichments to sbt.TupleSyntax

### DIFF
--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -31,41 +31,58 @@ sealed abstract class SettingKey[T]
     with KeyedInitialize[T]
     with Scoped.ScopingSetting[SettingKey[T]]
     with Scoped.DefinableSetting[T] {
+
   val key: AttributeKey[T]
+
   final def toTask: Initialize[Task[T]] = this apply inlineTask
+
   final def scopedKey: ScopedKey[T] = ScopedKey(scope, key)
+
   final def in(scope: Scope): SettingKey[T] =
     Scoped.scopedSetting(Scope.replaceThis(this.scope)(scope), this.key)
 
   final def :=(v: T): Setting[T] = macro std.TaskMacro.settingAssignMacroImpl[T]
+
   final def +=[U](v: U)(implicit a: Append.Value[T, U]): Setting[T] =
     macro std.TaskMacro.settingAppend1Impl[T, U]
+
   final def ++=[U](vs: U)(implicit a: Append.Values[T, U]): Setting[T] =
     macro std.TaskMacro.settingAppendNImpl[T, U]
+
   final def <+=[V](v: Initialize[V])(implicit a: Append.Value[T, V]): Setting[T] =
     macro std.TaskMacro.fakeSettingAppend1Position[T, V]
+
   final def <++=[V](vs: Initialize[V])(implicit a: Append.Values[T, V]): Setting[T] =
     macro std.TaskMacro.fakeSettingAppendNPosition[T, V]
+
   final def -=[U](v: U)(implicit r: Remove.Value[T, U]): Setting[T] =
     macro std.TaskMacro.settingRemove1Impl[T, U]
+
   final def --=[U](vs: U)(implicit r: Remove.Values[T, U]): Setting[T] =
     macro std.TaskMacro.settingRemoveNImpl[T, U]
+
   final def ~=(f: T => T): Setting[T] = macro std.TaskMacro.settingTransformPosition[T]
 
   final def append1[V](v: Initialize[V], source: SourcePosition)(
-      implicit a: Append.Value[T, V]): Setting[T] = make(v, source)(a.appendValue)
+      implicit a: Append.Value[T, V]
+  ): Setting[T] = make(v, source)(a.appendValue)
+
   final def appendN[V](vs: Initialize[V], source: SourcePosition)(
-      implicit a: Append.Values[T, V]): Setting[T] = make(vs, source)(a.appendValues)
+      implicit a: Append.Values[T, V]
+  ): Setting[T] = make(vs, source)(a.appendValues)
 
   final def remove1[V](v: Initialize[V], source: SourcePosition)(
-      implicit r: Remove.Value[T, V]): Setting[T] = make(v, source)(r.removeValue)
+      implicit r: Remove.Value[T, V]
+  ): Setting[T] = make(v, source)(r.removeValue)
   final def removeN[V](vs: Initialize[V], source: SourcePosition)(
-      implicit r: Remove.Values[T, V]): Setting[T] = make(vs, source)(r.removeValues)
+      implicit r: Remove.Values[T, V]
+  ): Setting[T] = make(vs, source)(r.removeValues)
 
   final def transform(f: T => T, source: SourcePosition): Setting[T] = set(scopedKey(f), source)
 
   protected[this] def make[S](other: Initialize[S], source: SourcePosition)(
-      f: (T, S) => T): Setting[T] =
+      f: (T, S) => T
+  ): Setting[T] =
     set((this, other)(f), source)
 }
 
@@ -80,37 +97,53 @@ sealed abstract class TaskKey[T]
     with KeyedInitialize[Task[T]]
     with Scoped.ScopingSetting[TaskKey[T]]
     with Scoped.DefinableTask[T] {
+
   val key: AttributeKey[Task[T]]
+
   def toTask: Initialize[Task[T]] = this
+
   def scopedKey: ScopedKey[Task[T]] = ScopedKey(scope, key)
+
   def in(scope: Scope): TaskKey[T] =
     Scoped.scopedTask(Scope.replaceThis(this.scope)(scope), this.key)
 
   def +=[U](v: U)(implicit a: Append.Value[T, U]): Setting[Task[T]] =
     macro std.TaskMacro.taskAppend1Impl[T, U]
+
   def ++=[U](vs: U)(implicit a: Append.Values[T, U]): Setting[Task[T]] =
     macro std.TaskMacro.taskAppendNImpl[T, U]
+
   def <+=[V](v: Initialize[Task[V]])(implicit a: Append.Value[T, V]): Setting[Task[T]] =
     macro std.TaskMacro.fakeTaskAppend1Position[T, V]
+
   def <++=[V](vs: Initialize[Task[V]])(implicit a: Append.Values[T, V]): Setting[Task[T]] =
     macro std.TaskMacro.fakeTaskAppendNPosition[T, V]
+
   final def -=[U](v: U)(implicit r: Remove.Value[T, U]): Setting[Task[T]] =
     macro std.TaskMacro.taskRemove1Impl[T, U]
+
   final def --=[U](vs: U)(implicit r: Remove.Values[T, U]): Setting[Task[T]] =
     macro std.TaskMacro.taskRemoveNImpl[T, U]
 
   def append1[V](v: Initialize[Task[V]], source: SourcePosition)(
-      implicit a: Append.Value[T, V]): Setting[Task[T]] = make(v, source)(a.appendValue)
+      implicit a: Append.Value[T, V]
+  ): Setting[Task[T]] = make(v, source)(a.appendValue)
+
   def appendN[V](vs: Initialize[Task[V]], source: SourcePosition)(
-      implicit a: Append.Values[T, V]): Setting[Task[T]] = make(vs, source)(a.appendValues)
+      implicit a: Append.Values[T, V]
+  ): Setting[Task[T]] = make(vs, source)(a.appendValues)
 
   final def remove1[V](v: Initialize[Task[V]], source: SourcePosition)(
-      implicit r: Remove.Value[T, V]): Setting[Task[T]] = make(v, source)(r.removeValue)
+      implicit r: Remove.Value[T, V]
+  ): Setting[Task[T]] = make(v, source)(r.removeValue)
+
   final def removeN[V](vs: Initialize[Task[V]], source: SourcePosition)(
-      implicit r: Remove.Values[T, V]): Setting[Task[T]] = make(vs, source)(r.removeValues)
+      implicit r: Remove.Values[T, V]
+  ): Setting[Task[T]] = make(vs, source)(r.removeValues)
 
   private[this] def make[S](other: Initialize[Task[S]], source: SourcePosition)(
-      f: (T, S) => T): Setting[Task[T]] =
+      f: (T, S) => T
+  ): Setting[Task[T]] =
     set((this, other)((a, b) => (a, b) map f.tupled), source)
 }
 
@@ -126,13 +159,17 @@ sealed trait InputKey[T]
     with KeyedInitialize[InputTask[T]]
     with Scoped.ScopingSetting[InputKey[T]]
     with Scoped.DefinableSetting[InputTask[T]] {
+
   val key: AttributeKey[InputTask[T]]
+
   def scopedKey: ScopedKey[InputTask[T]] = ScopedKey(scope, key)
+
   def in(scope: Scope): InputKey[T] =
     Scoped.scopedInput(Scope.replaceThis(this.scope)(scope), this.key)
 
   final def :=(v: T): Setting[InputTask[T]] = macro std.TaskMacro.inputTaskAssignMacroImpl[T]
   final def ~=(f: T => T): Setting[InputTask[T]] = macro std.TaskMacro.itaskTransformPosition[T]
+
   final def transform(f: T => T, source: SourcePosition): Setting[InputTask[T]] =
     set(scopedKey(_ mapTask { _ map f }), source)
 }
@@ -140,6 +177,7 @@ sealed trait InputKey[T]
 /** Methods and types related to constructing settings, including keys, scopes, and initializations. */
 object Scoped {
   implicit def taskScopedToKey[T](s: TaskKey[T]): ScopedKey[Task[T]] = ScopedKey(s.scope, s.key)
+
   implicit def inputScopedToKey[T](s: InputKey[T]): ScopedKey[InputTask[T]] =
     ScopedKey(s.scope, s.key)
 
@@ -167,22 +205,25 @@ object Scoped {
     def in(c: ConfigKey, t: Scoped): ResultType = in(This, Select(c), Select(t.key))
     def in(p: Reference, c: ConfigKey): ResultType = in(Select(p), Select(c), This)
     def in(p: Reference, t: Scoped): ResultType = in(Select(p), This, Select(t.key))
+
     def in(p: Reference, c: ConfigKey, t: Scoped): ResultType =
       in(Select(p), Select(c), Select(t.key))
-    def in(p: ScopeAxis[Reference],
-           c: ScopeAxis[ConfigKey],
-           t: ScopeAxis[AttributeKey[_]]): ResultType = in(Scope(p, c, t, This))
+
+    def in(
+        p: ScopeAxis[Reference],
+        c: ScopeAxis[ConfigKey],
+        t: ScopeAxis[AttributeKey[_]]
+    ): ResultType = in(Scope(p, c, t, This))
   }
 
-  def scopedSetting[T](s: Scope, k: AttributeKey[T]): SettingKey[T] = new SettingKey[T] {
-    val scope = s; val key = k
-  }
-  def scopedInput[T](s: Scope, k: AttributeKey[InputTask[T]]): InputKey[T] = new InputKey[T] {
-    val scope = s; val key = k
-  }
-  def scopedTask[T](s: Scope, k: AttributeKey[Task[T]]): TaskKey[T] = new TaskKey[T] {
-    val scope = s; val key = k
-  }
+  def scopedSetting[T](s: Scope, k: AttributeKey[T]): SettingKey[T] =
+    new SettingKey[T] { val scope = s; val key = k }
+
+  def scopedInput[T](s: Scope, k: AttributeKey[InputTask[T]]): InputKey[T] =
+    new InputKey[T] { val scope = s; val key = k }
+
+  def scopedTask[T](s: Scope, k: AttributeKey[Task[T]]): TaskKey[T] =
+    new TaskKey[T] { val scope = s; val key = k }
 
   /**
    * Mixin trait for adding convenience vocabulary associated with applying a setting to a configuration item.
@@ -237,27 +278,34 @@ object Scoped {
   sealed trait DefinableTask[S] { self: TaskKey[S] =>
 
     private[sbt] def :==(app: S): Setting[Task[S]] = macro std.TaskMacro.taskAssignPositionPure[S]
+
     private[sbt] def ::=(app: Task[S]): Setting[Task[S]] =
       macro std.TaskMacro.taskAssignPositionT[S]
+
     def :=(v: S): Setting[Task[S]] = macro std.TaskMacro.taskAssignMacroImpl[S]
     def ~=(f: S => S): Setting[Task[S]] = macro std.TaskMacro.taskTransformPosition[S]
 
     def <<=(app: Initialize[Task[S]]): Setting[Task[S]] =
       macro std.TaskMacro.fakeItaskAssignPosition[S]
+
     def set(app: Initialize[Task[S]], source: SourcePosition): Setting[Task[S]] =
       Def.setting(scopedKey, app, source)
+
     def transform(f: S => S, source: SourcePosition): Setting[Task[S]] =
       set(scopedKey(_ map f), source)
 
     @deprecated("No longer needed with new task syntax and SettingKey inheriting from Initialize.",
                 "0.13.2")
     def task: SettingKey[Task[S]] = scopedSetting(scope, key)
+
     def get(settings: Settings[Scope]): Option[Task[S]] = settings.get(scope, key)
 
     def ? : Initialize[Task[Option[S]]] = Def.optional(scopedKey) {
       case None => mktask { None }; case Some(t) => t map some.fn
     }
+
     def ??[T >: S](or: => T): Initialize[Task[T]] = Def.optional(scopedKey)(_ getOrElse mktask(or))
+
     def or[T >: S](i: Initialize[Task[T]]): Initialize[Task[T]] =
       (this.? zipWith i)((x, y) => (x, y) map { case (a, b) => a getOrElse b })
   }
@@ -273,13 +321,17 @@ object Scoped {
 
     def xtriggeredBy[T](tasks: Initialize[Task[T]]*): Initialize[Task[S]] =
       nonLocal(tasks, Def.triggeredBy)
+
     def triggeredBy[T](tasks: Initialize[Task[T]]*): Initialize[Task[S]] =
       nonLocal(tasks, Def.triggeredBy)
+
     def runBefore[T](tasks: Initialize[Task[T]]*): Initialize[Task[S]] =
       nonLocal(tasks, Def.runBefore)
 
-    private[this] def nonLocal(tasks: Seq[AnyInitTask],
-                               key: AttributeKey[Seq[Task[_]]]): Initialize[Task[S]] =
+    private[this] def nonLocal(
+        tasks: Seq[AnyInitTask],
+        key: AttributeKey[Seq[Task[_]]]
+    ): Initialize[Task[S]] =
       (Initialize.joinAny[Task](tasks), i)((ts, i) => i.copy(info = i.info.set(key, ts)))
   }
 
@@ -334,6 +386,7 @@ object Scoped {
     def join: Initialize[Task[Seq[T]]] = tasks(_.join)
     def tasks: Initialize[Seq[Task[T]]] = Initialize.join(keys)
   }
+
   implicit def richAnyTaskSeq(in: Seq[AnyInitTask]): RichAnyTaskSeq = new RichAnyTaskSeq(in)
   final class RichAnyTaskSeq(keys: Seq[AnyInitTask]) {
     def dependOn: Initialize[Task[Unit]] =
@@ -357,13 +410,20 @@ object Scoped {
   // format: on
 
   sealed abstract class RichTaskables[K[L[x]]](final val keys: K[ScopedTaskable])(
-      implicit a: AList[K]) {
+      implicit a: AList[K]
+  ) {
+
     type App[T] = Initialize[Task[T]]
     type Fun[M[_], Ret]
+
     protected def convert[M[_], Ret](f: Fun[M, Ret]): K[M] => Ret
-    private[this] val inputs: K[App] = a.transform(keys, new (ScopedTaskable ~> App) {
-      def apply[T](in: ScopedTaskable[T]): App[T] = in.toTask
-    })
+
+    private[this] val inputs: K[App] =
+      a.transform(
+        keys,
+        new (ScopedTaskable ~> App) { def apply[T](in: ScopedTaskable[T]): App[T] = in.toTask }
+      )
+
     private[this] def onTasks[T](f: K[Task] => Task[T]): App[T] =
       Def.app[({ type l[L[x]] = K[(L ∙ Task)#l] })#l, Task[T]](inputs)(f)(AList.asplit[K, Task](a))
 
@@ -506,22 +566,27 @@ import Scoped.extendScoped
 
 /** Constructs InputKeys, which are associated with input tasks to define a setting.*/
 object InputKey {
-  def apply[T: Manifest](label: String,
-                         description: String = "",
-                         rank: Int = KeyRanks.DefaultInputRank): InputKey[T] =
+  def apply[T: Manifest](
+      label: String,
+      description: String = "",
+      rank: Int = KeyRanks.DefaultInputRank
+  ): InputKey[T] =
     apply(AttributeKey[InputTask[T]](label, description, rank))
 
-  def apply[T: Manifest](label: String,
-                         description: String,
-                         extend1: Scoped,
-                         extendN: Scoped*): InputKey[T] =
-    apply(label, description, KeyRanks.DefaultInputRank, extend1, extendN: _*)
+  def apply[T: Manifest](
+      label: String,
+      description: String,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): InputKey[T] = apply(label, description, KeyRanks.DefaultInputRank, extend1, extendN: _*)
 
-  def apply[T: Manifest](label: String,
-                         description: String,
-                         rank: Int,
-                         extend1: Scoped,
-                         extendN: Scoped*): InputKey[T] =
+  def apply[T: Manifest](
+      label: String,
+      description: String,
+      rank: Int,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): InputKey[T] =
     apply(AttributeKey[InputTask[T]](label, description, extendScoped(extend1, extendN), rank))
 
   def apply[T](akey: AttributeKey[InputTask[T]]): InputKey[T] =
@@ -530,22 +595,28 @@ object InputKey {
 
 /** Constructs TaskKeys, which are associated with tasks to define a setting.*/
 object TaskKey {
-  def apply[T: Manifest](label: String,
-                         description: String = "",
-                         rank: Int = KeyRanks.DefaultTaskRank): TaskKey[T] =
+  def apply[T: Manifest](
+      label: String,
+      description: String = "",
+      rank: Int = KeyRanks.DefaultTaskRank
+  ): TaskKey[T] =
     apply(AttributeKey[Task[T]](label, description, rank))
 
-  def apply[T: Manifest](label: String,
-                         description: String,
-                         extend1: Scoped,
-                         extendN: Scoped*): TaskKey[T] =
+  def apply[T: Manifest](
+      label: String,
+      description: String,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): TaskKey[T] =
     apply(AttributeKey[Task[T]](label, description, extendScoped(extend1, extendN)))
 
-  def apply[T: Manifest](label: String,
-                         description: String,
-                         rank: Int,
-                         extend1: Scoped,
-                         extendN: Scoped*): TaskKey[T] =
+  def apply[T: Manifest](
+      label: String,
+      description: String,
+      rank: Int,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): TaskKey[T] =
     apply(AttributeKey[Task[T]](label, description, extendScoped(extend1, extendN), rank))
 
   def apply[T](akey: AttributeKey[Task[T]]): TaskKey[T] =
@@ -556,22 +627,28 @@ object TaskKey {
 
 /** Constructs SettingKeys, which are associated with a value to define a basic setting.*/
 object SettingKey {
-  def apply[T: Manifest: OptJsonWriter](label: String,
-                                        description: String = "",
-                                        rank: Int = KeyRanks.DefaultSettingRank): SettingKey[T] =
+  def apply[T: Manifest: OptJsonWriter](
+      label: String,
+      description: String = "",
+      rank: Int = KeyRanks.DefaultSettingRank
+  ): SettingKey[T] =
     apply(AttributeKey[T](label, description, rank))
 
-  def apply[T: Manifest: OptJsonWriter](label: String,
-                                        description: String,
-                                        extend1: Scoped,
-                                        extendN: Scoped*): SettingKey[T] =
+  def apply[T: Manifest: OptJsonWriter](
+      label: String,
+      description: String,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): SettingKey[T] =
     apply(AttributeKey[T](label, description, extendScoped(extend1, extendN)))
 
-  def apply[T: Manifest: OptJsonWriter](label: String,
-                                        description: String,
-                                        rank: Int,
-                                        extend1: Scoped,
-                                        extendN: Scoped*): SettingKey[T] =
+  def apply[T: Manifest: OptJsonWriter](
+      label: String,
+      description: String,
+      rank: Int,
+      extend1: Scoped,
+      extendN: Scoped*
+  ): SettingKey[T] =
     apply(AttributeKey[T](label, description, extendScoped(extend1, extendN), rank))
 
   def apply[T](akey: AttributeKey[T]): SettingKey[T] =

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -54,7 +54,7 @@ object FullInstance
                                  KeyRanks.DTask)
 
   def flatten[T](in: Initialize[Task[Initialize[Task[T]]]]): Initialize[Task[T]] = {
-    import Scoped._
+    import Scoped._, TupleSyntax._
     (in, settingsData, Def.capturedTransformations) {
       (a: Task[Initialize[Task[T]]], data: Task[SS], f) =>
         import TaskExtra.multT2Task
@@ -63,7 +63,7 @@ object FullInstance
   }
 
   def flattenFun[S, T](in: Initialize[Task[S => Initialize[Task[T]]]]): Initialize[S => Task[T]] = {
-    import Scoped._
+    import Scoped._, TupleSyntax._
     (in, settingsData, Def.capturedTransformations) {
       (a: Task[S => Initialize[Task[T]]], data: Task[SS], f) => (s: S) =>
         import TaskExtra.multT2Task

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -831,16 +831,20 @@ object Project extends ProjectExtra {
 
     def updateState(f: (State, S) => State): Def.Initialize[Task[S]] = i(t => tx(t, f))
 
-    def storeAs(key: TaskKey[S])(implicit f: JsonFormat[S]): Def.Initialize[Task[S]] =
+    def storeAs(key: TaskKey[S])(implicit f: JsonFormat[S]): Def.Initialize[Task[S]] = {
+      import TupleSyntax._
       (Keys.resolvedScoped, i)(
         (scoped, task) =>
           tx(task,
              (state, value) =>
                persistAndSet(resolveContext(key, scoped.scope, state), state, value)(f)))
+    }
 
-    def keepAs(key: TaskKey[S]): Def.Initialize[Task[S]] =
+    def keepAs(key: TaskKey[S]): Def.Initialize[Task[S]] = {
+      import TupleSyntax._
       (i, Keys.resolvedScoped)((t, scoped) =>
         tx(t, (state, value) => set(resolveContext(key, scoped.scope, state), state, value)))
+    }
   }
 
   import scala.reflect.macros._

--- a/notes/1.0.0/move-tuple-enrichments-to-import.markdown
+++ b/notes/1.0.0/move-tuple-enrichments-to-import.markdown
@@ -1,0 +1,9 @@
+### Changes with compatibility implications
+
+- Moves the old, sbt 0.10 tuple enrichement DSL, which was deprecated in sbt 0.13.13, out of implicit scope and
+    to `sbt.TupleSyntax`, so that it is now an opt-in. [#2762][]/[#3291][] by [@dwijnand][]
+
+[@dwijnand]: https://github.com/dwijnand
+
+[#2762]: https://github.com/sbt/sbt/issues/2762
+[#3291]: https://github.com/sbt/sbt/pull/3291

--- a/sbt/src/sbt-test/dependency-management/classifier/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/classifier/build.sbt
@@ -1,3 +1,3 @@
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 libraryDependencies += "org.testng" % "testng" % "5.7" classifier "jdk15"

--- a/sbt/src/sbt-test/dependency-management/exclude-transitive/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-transitive/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).
   settings(
-    ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value,
+    ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
     libraryDependencies += baseDirectory(transitive("javax.mail" % "mail" % "1.4.1")).value,
     TaskKey[Unit]("checkTransitive") := check(true).value,
     TaskKey[Unit]("checkIntransitive") := check(false).value

--- a/sbt/src/sbt-test/dependency-management/extra/DefineColor.sbt
+++ b/sbt/src/sbt-test/dependency-management/extra/DefineColor.sbt
@@ -1,4 +1,4 @@
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 publishMavenStyle := false
 

--- a/sbt/src/sbt-test/dependency-management/extra/changes/UseColor.sbt
+++ b/sbt/src/sbt-test/dependency-management/extra/changes/UseColor.sbt
@@ -1,4 +1,4 @@
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache")) ).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 publishMavenStyle := false
 

--- a/sbt/src/sbt-test/dependency-management/force/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/force/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).
   settings(
-    ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value,
+    ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
     libraryDependencies ++= baseDirectory (libraryDeps).value,
     TaskKey[Unit]("checkForced") := check("1.2.14").value,
     TaskKey[Unit]("checkDepend") := check("1.2.13").value

--- a/sbt/src/sbt-test/dependency-management/info/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/info/build.sbt
@@ -2,13 +2,13 @@ import scala.xml._
 
 lazy val root = (project in file(".")).
   settings(
-    ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value,
-    ivyXML := ((customInfo, organization, moduleName, version) apply inlineXML).value,
+    ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
+    ivyXML := inlineXML(customInfo.value, organization.value, moduleName.value, version.value),
     scalaVersion := "2.9.1",
     projectID ~= (_ cross false),
-    customInfo := (baseDirectory{_ / "info" exists }).value,
+    customInfo := (baseDirectory.value / "info").exists,
     TaskKey[Unit]("check-download") := checkDownload.value,
-    delivered := (deliverLocal map XML.loadFile).value,
+    delivered := (XML loadFile deliverLocal.value),
     TaskKey[Unit]("check-info") := checkInfo.value
   )
 
@@ -16,7 +16,7 @@ lazy val delivered = taskKey[NodeSeq]("")
 lazy val customInfo = settingKey[Boolean]("")
 
 def inlineXML(addInfo: Boolean, organization: String, moduleID: String, version: String): NodeSeq =
-  if(addInfo)
+  if (addInfo)
     (<info organisation={organization} module={moduleID} revision={version}>
       <license name="Two-clause BSD-style" url="http://github.com/szeiger/scala-query/blob/master/LICENSE.txt" />
       <description homepage="http://github.com/szeiger/scala-query/">
@@ -27,14 +27,19 @@ def inlineXML(addInfo: Boolean, organization: String, moduleID: String, version:
   else
     <dependency org="org.scala-tools.testing" name="scalacheck_2.9.1" rev="1.9"/>
 
-def checkDownload = (dependencyClasspath in Compile) map { cp => if(cp.isEmpty) sys.error("Dependency not downloaded"); () }
-def checkInfo = (customInfo, delivered) map { (addInfo, d) =>
-  if((d \ "info").isEmpty)
-    sys.error("No info tag generated")
-  else if(addInfo) {
-    if( !deliveredWithCustom(d) ) sys.error("Expected 'license' and 'description' tags in info tag, got: \n" + (d \ "info")) else ()
-  } else
-    if( deliveredWithCustom(d) ) sys.error("Expected empty 'info' tag, got: \n" + (d \ "info")) else ()
+def checkDownload = Def task {
+  if ((dependencyClasspath in Compile).value.isEmpty) sys.error("Dependency not downloaded"); ()
 }
-def deliveredWithCustom(d: NodeSeq) = (d \ "info" \ "license").nonEmpty && (d \ "info" \ "description").nonEmpty
 
+def checkInfo = Def task {
+  val d = delivered.value
+  val addInfo = customInfo.value
+  if ((d \ "info").isEmpty)
+    sys.error("No info tag generated")
+  else if (addInfo) {
+    if (!deliveredWithCustom(d)) sys.error("Expected 'license' and 'description' tags in info tag, got: \n" + (d \ "info")) else ()
+  } else
+    if (deliveredWithCustom(d)) sys.error("Expected empty 'info' tag, got: \n" + (d \ "info")) else ()
+}
+
+def deliveredWithCustom(d: NodeSeq) = (d \ "info" \ "license").nonEmpty && (d \ "info" \ "description").nonEmpty

--- a/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -1,15 +1,14 @@
 import scala.xml._
 
-lazy val root = (project in file(".")).
-  settings(
-    readPom := (makePom map XML.loadFile).value,
-    TaskKey[Unit]("checkPom") := checkPom.value,
-    TaskKey[Unit]("checkExtra") := checkExtra.value,
-    TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-    makePomConfiguration ~= { _.copy(extra = <extra-tag/>) },
-    libraryDependencies += "com.google.code.findbugs" % "jsr305" % "1.3.+"
-  )
+lazy val root = (project in file(".")) settings (
+  readPom := (makePom map XML.loadFile).value,
+  TaskKey[Unit]("checkPom") := checkPom.value,
+  TaskKey[Unit]("checkExtra") := checkExtra.value,
+  TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
+  resolvers += Resolver.sonatypeRepo("snapshots"),
+  makePomConfiguration ~= { _.copy(extra = <extra-tag/>) },
+  libraryDependencies += "com.google.code.findbugs" % "jsr305" % "1.3.+"
+)
 
 val readPom = TaskKey[Elem]("read-pom")
 
@@ -18,18 +17,19 @@ val fakeURL = "http://example.org"
 val fakeRepo = fakeName at fakeURL
 def extraTagName = "extra-tag"
 
-def checkProject(pom: Elem) = if(pom.label != "project") sys.error("Top level element was not 'project': " + pom.label)
+def checkProject(pom: Elem) =
+  if (pom.label != "project") sys.error("Top level element was not 'project': " + pom.label)
 
-def withRepositories[T](pomXML: Elem)(f: NodeSeq => T) =
-{
+def withRepositories[T](pomXML: Elem)(f: NodeSeq => T) = {
   val repositoriesElement = pomXML \ "repositories"
-  if(repositoriesElement.size == 1) f(repositoriesElement) else sys.error("'repositories' element not found in generated pom")
+  if (repositoriesElement.size == 1) f(repositoriesElement)
+  else sys.error("'repositories' element not found in generated pom")
 }
 
 lazy val checkExtra = readPom map { pomXML =>
   checkProject(pomXML)
   val extra =  pomXML \ extraTagName
-  if(extra.isEmpty) sys.error("'" + extraTagName + "' not found in generated pom.xml.") else ()
+  if (extra.isEmpty) sys.error("'" + extraTagName + "' not found in generated pom.xml.") else ()
 }
 
 lazy val checkVersionPlusMapping = (readPom) map { (pomXml) =>
@@ -43,8 +43,10 @@ lazy val checkVersionPlusMapping = (readPom) map { (pomXml) =>
   ()
 }
 
-lazy val checkPom = (readPom, fullResolvers) map { (pomXML, ivyRepositories) =>
+lazy val checkPom = Def task {
+  val pomXML = readPom.value
   checkProject(pomXML)
+  val ivyRepositories = fullResolvers.value
   withRepositories(pomXML) { repositoriesElement =>
     val repositories =  repositoriesElement \ "repository"
     val writtenRepositories = repositories.map(read).distinct
@@ -54,7 +56,7 @@ lazy val checkPom = (readPom, fullResolvers) map { (pomXML, ivyRepositories) =>
 
     lazy val explain = (("Written:" +: writtenRepositories) ++ ("Declared:" +: mavenStyleRepositories)).mkString("\n\t")
 
-    if( writtenRepositories != mavenStyleRepositories )
+    if (writtenRepositories != mavenStyleRepositories)
       sys.error("Written repositories did not match declared repositories.\n\t" + explain)
     else
       ()
@@ -64,9 +66,9 @@ lazy val checkPom = (readPom, fullResolvers) map { (pomXML, ivyRepositories) =>
 def read(repository: xml.Node): MavenRepository =
   (repository \ "name").text at normalize((repository \ "url").text)
 
-def normalize(url: String): String =
-  {
-    val base = uri( url ).normalize.toString
-    if(base.endsWith("/")) base else (base + "/")
-  }
+def normalize(url: String): String = {
+  val base = uri(url).normalize.toString
+  if (base.endsWith("/")) base else s"$base/"
+}
+
 def normalize(repo: MavenRepository): MavenRepository = MavenRepository(repo.name, normalize(repo.root))

--- a/sbt/src/sbt-test/dependency-management/metadata-only-resolver/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/metadata-only-resolver/build.sbt
@@ -1,4 +1,4 @@
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / ".ivy2"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / ".ivy2"))
 
 // not in the default repositories
 libraryDependencies += "com.sun.jmx" % "jmxri" % "1.2.1"

--- a/sbt/src/sbt-test/dependency-management/module-name/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-name/build.sbt
@@ -4,8 +4,10 @@ moduleName := "asdf"
 
 crossPaths := false
 
-TaskKey[Unit]("checkName") := ((moduleName, name, packageBin in Compile) map { (module, n, f) =>
-  val path = f.getAbsolutePath 
-  assert(path contains module, "Path " + path + " did not contain module name " + module)
-  assert(!path.contains(n), "Path " + path + " contained " + n)
-}).value
+TaskKey[Unit]("checkName") := Def task {
+  val path = (packageBin in Compile).value.getAbsolutePath
+  val module = moduleName.value
+  val n = name.value
+  assert(path contains module, s"Path $path did not contain module name $module")
+  assert(!path.contains(n), s"Path $path contained $n")
+}

--- a/sbt/src/sbt-test/dependency-management/no-file-fails-publish/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/no-file-fails-publish/build.sbt
@@ -1,4 +1,4 @@
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 organization := "org.example"
 

--- a/sbt/src/sbt-test/dependency-management/override/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/override/build.sbt
@@ -1,10 +1,15 @@
 autoScalaLibrary := false
 
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
-ivyScala := ((scalaVersion in update, scalaBinaryVersion in update) { (fv, bv) =>
-  Some(IvyScala(fv, bv, Vector.empty, filterImplicit = false, checkExplicit = false, overrideScalaVersion = false))
-}).value
+ivyScala := Some(IvyScala(
+  (scalaVersion in update).value,
+  (scalaBinaryVersion in update).value,
+  Vector.empty,
+  filterImplicit = false,
+  checkExplicit = false,
+  overrideScalaVersion = false
+))
 
 InputKey[Unit]("check") := {
   val args = Def.spaceDelimited().parsed

--- a/sbt/src/sbt-test/dependency-management/pom-classpaths/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-classpaths/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
     externalPom(),
     scalaVersion := "2.9.0-1",
     check := checkTask.evaluated,
-    managedClasspath in Provided := ((classpathTypes, update) map { (cpts, report) => Classpaths.managedJars(Provided, cpts, report) }).value
+    managedClasspath in Provided := Classpaths.managedJars(Provided, classpathTypes.value, update.value)
   )
 
 def checkTask = Def.inputTask {

--- a/sbt/src/sbt-test/dependency-management/t468/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/t468/build.sbt
@@ -1,6 +1,6 @@
 autoScalaLibrary := false
 
-ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value
+ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 libraryDependencies ++= Seq(
 	"org.sat4j" % "org.sat4j.pb" % "2.3.1",

--- a/sbt/src/sbt-test/dependency-management/url/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/url/build.sbt
@@ -2,7 +2,7 @@ import sbt.internal.inc.classpath.ClasspathUtilities
 
 lazy val root = (project in file(".")).
   settings(
-    ivyPaths := (baseDirectory, target)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value,
+    ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
     libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1" % Test from "http://jsoup.org/packages/jsoup-1.9.1.jar",
     ivyLoggingLevel := UpdateLogging.Full,
     TaskKey[Unit]("checkInTest") := checkClasspath(Test).value,

--- a/sbt/src/sbt-test/java/argfile/build.sbt
+++ b/sbt/src/sbt-test/java/argfile/build.sbt
@@ -1,11 +1,12 @@
-scalaSource in Configurations.Compile := sourceDirectory( _ / " scala test " ).value
+scalaSource in Configurations.Compile := (sourceDirectory.value / " scala test ")
+ javaSource in Configurations.Compile := (sourceDirectory.value / " java test ")
 
-javaSource in Configurations.Compile := sourceDirectory( _ / " java test " ).value
-
-TaskKey[Unit]("init") := ((scalaSource in Configurations.Compile, javaSource in Configurations.Compile) map { (ss, js) =>
-	import IO._
-	createDirectories(ss :: js :: Nil)
-	copyFile(file("changes") / "Test.scala", ss / " Test s.scala")
-	copyFile(file("changes") / "A.java", js / "a" / "A.java")
-	delete(file("changes"))
-}).value
+TaskKey[Unit]("init") := {
+  val ss = (scalaSource in Configurations.Compile).value
+  val js = ( javaSource in Configurations.Compile).value
+  import IO._
+  createDirectories(ss :: js :: Nil)
+  copyFile(file("changes") / "Test.scala", ss / " Test s.scala")
+  copyFile(file("changes") / "A.java", js / "a" / "A.java")
+  delete(file("changes"))
+}

--- a/sbt/src/sbt-test/package/manifest/build.sbt
+++ b/sbt/src/sbt-test/package/manifest/build.sbt
@@ -1,5 +1,5 @@
-	import java.util.jar.{Attributes, Manifest}
-	import Path.makeString
+import java.util.jar.{Attributes, Manifest}
+import Path.makeString
 
 name := "Jar Manifest Test"
 
@@ -9,12 +9,11 @@ crossPaths := false
 
 mainClass := Some("jartest.Main")
 
-packageOptions in (Compile, packageBin) := ((packageOptions in (Compile, packageBin), scalaInstance) map { (opts, si) =>
-	def manifestExtra =
-	{
-		val mf = new Manifest
-		mf.getMainAttributes.put(Attributes.Name.CLASS_PATH, makeString(si.libraryJar :: Nil) )
-		mf
-	}
-	opts :+ Package.JarManifest(manifestExtra)
-}).value
+packageOptions in (Compile, packageBin) := {
+  def manifestExtra = {
+    val mf = new Manifest
+    mf.getMainAttributes.put(Attributes.Name.CLASS_PATH, makeString(scalaInstance.value.libraryJar :: Nil))
+    mf
+  }
+  (packageOptions in (Compile, packageBin)).value :+ Package.JarManifest(manifestExtra)
+}

--- a/sbt/src/sbt-test/package/resources/build.sbt
+++ b/sbt/src/sbt-test/package/resources/build.sbt
@@ -4,13 +4,12 @@ version := "0.1"
 
 crossPaths := false
 
-packageOptions := ((packageOptions, scalaInstance) map { (opts, si) =>
-	def manifestExtra =
-	{
-		import java.util.jar._
-		val mf = new Manifest
-		mf.getMainAttributes.put(Attributes.Name.CLASS_PATH, si.libraryJar.getAbsolutePath)
-		mf
-	}
-	Package.JarManifest(manifestExtra) +: opts
-}).value
+packageOptions := {
+  def manifestExtra = {
+    import java.util.jar._
+    val mf = new Manifest
+    mf.getMainAttributes.put(Attributes.Name.CLASS_PATH, scalaInstance.value.libraryJar.getAbsolutePath)
+    mf
+  }
+  Package.JarManifest(manifestExtra) +: packageOptions.value
+}

--- a/sbt/src/sbt-test/project/build-deps/changes/b.sbt
+++ b/sbt/src/sbt-test/project/build-deps/changes/b.sbt
@@ -1,3 +1,5 @@
-buildDependencies in Global := ((buildDependencies in Global, thisProjectRef, thisProjectRef in LocalProject("a")) { (deps, refB, refA) =>
-	deps.addClasspath(refA, ResolvedClasspathDependency(refB, None))
-}).value
+buildDependencies in Global :=
+  (buildDependencies in Global).value.addClasspath(
+    (thisProjectRef in LocalProject("a")).value,
+    ResolvedClasspathDependency(thisProjectRef.value, None)
+  )

--- a/sbt/src/sbt-test/project/provided/build.sbt
+++ b/sbt/src/sbt-test/project/provided/build.sbt
@@ -1,38 +1,27 @@
-import sbt.internal.inc.classpath.ClasspathUtilities
+val rootRef = LocalProject("root")
+val sub = project
+val superRoot = project in file("super") dependsOn rootRef
 
-lazy val superRoot = (project in file("super")).
-  dependsOn(rootRef)
+val root = project in file(".") dependsOn (sub % "provided->test") settings (
+  TaskKey[Unit]("check") := {
+    check0((fullClasspath in (sub, Test)).value, "sub test", true)
+    check0((fullClasspath in (superRoot, Compile)).value, "superRoot main", false)
+    check0((fullClasspath in (rootRef, Compile)).value, "root main", true)
+    check0((fullClasspath in (rootRef, Runtime)).value, "root runtime", false)
+    check0((fullClasspath in (rootRef, Test)).value, "root test", true)
+  }
+)
 
-lazy val root = (project in file(".")).
-  dependsOn(sub % "provided->test").
-  settings(
-    rootSettings
-  )
-
-lazy val sub = project
-
-lazy val rootRef = LocalProject("root")
-
-def rootSettings = (TaskKey[Unit]("check") := checkTask.value)
-def checkTask = (fullClasspath in (rootRef, Compile), fullClasspath in (rootRef, Runtime), fullClasspath in (rootRef, Test), fullClasspath in (sub, Test), fullClasspath in (superRoot, Compile)) map { (rc, rr, rt, st, pr) =>
-  check0(st, "sub test", true)
-  check0(pr, "superRoot main", false)
-  check0(rc, "root main", true)
-  check0(rr, "root runtime", false)
-  check0(rt, "root test", true)
-}
-
-def check0(cp: Seq[Attributed[File]], label: String, shouldSucceed: Boolean): Unit =
-{
+def check0(cp: Seq[Attributed[File]], label: String, shouldSucceed: Boolean): Unit = {
+  import sbt.internal.inc.classpath.ClasspathUtilities
   val loader = ClasspathUtilities.toLoader(cp.files)
   println("Checking " + label)
   val err = try { Class.forName("org.example.ProvidedTest", false, loader); None }
   catch { case e: Exception => Some(e) }
 
-  (err, shouldSucceed) match
-  {
+  (err, shouldSucceed) match {
     case (None, true) | (Some(_), false) => ()
-    case (None, false) => sys.error("Expected failure")
-    case (Some(x), true) => throw x
+    case (None, false)                   => sys.error("Expected failure")
+    case (Some(x), true)                 => throw x
   }
 }

--- a/sbt/src/sbt-test/project/transitive-plugins/a/build.sbt
+++ b/sbt/src/sbt-test/project/transitive-plugins/a/build.sbt
@@ -1,11 +1,5 @@
-publishTo := (baseDirectory in ThisBuild)(x =>
-	Some(Resolver.file("test-publish", x / "repo/"))
-).value
-
-resolvers += (baseDirectory in ThisBuild)(x =>
-	"test" at (x / "repo/").asURL.toString
-).value
-
+publishTo := Some(Resolver.file("test-publish", (baseDirectory in ThisBuild).value / "repo/"))
+resolvers += ("test" at ((baseDirectory in ThisBuild).value / "repo/").asURL.toString)
 resolvers += Resolver.mavenLocal
 
 name := "demo1"

--- a/sbt/src/sbt-test/project/transitive-plugins/b/build.sbt
+++ b/sbt/src/sbt-test/project/transitive-plugins/b/build.sbt
@@ -1,11 +1,5 @@
-publishTo := (baseDirectory in ThisBuild)(x =>
-	Some(Resolver.file("test-publish", x / "repo"))
-).value
-
-resolvers += (baseDirectory in ThisBuild)(x =>
-	"test" at (x / "repo").asURL.toString
-).value
-
+publishTo := Some(Resolver.file("test-publish", (baseDirectory in ThisBuild).value / "repo"))
+resolvers += ("test" at ((baseDirectory in ThisBuild).value / "repo").asURL.toString)
 resolvers += Resolver.mavenLocal
 
 name := "demo2"

--- a/sbt/src/sbt-test/project/transitive-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/transitive-plugins/build.sbt
@@ -7,11 +7,11 @@ lazy val c = proj(project in file("c"))
 
 def proj(p: Project): Project =
   p.settings(
-    ivyPaths := (baseDirectory in root, target in root)( (dir, t) => IvyPaths(dir, Some(t / "ivy-cache"))).value,
-    resolvers += (appConfiguration { app => // need this to resolve sbt
-      val ivyHome = Classpaths.bootIvyHome(app) getOrElse sys.error("Launcher did not provide the Ivy home directory.")
+    ivyPaths := IvyPaths((baseDirectory in root).value, Some((target in root).value / "ivy-cache")),
+    resolvers += {
+      val ivyHome = Classpaths.bootIvyHome(appConfiguration.value) getOrElse sys.error("Launcher did not provide the Ivy home directory.")
       Resolver.file("real-local",  ivyHome / "local")(Resolver.ivyStylePatterns)
-    }).value,
+    },
     resolvers += Resolver.typesafeIvyRepo("releases"), // not sure why this isn't included by default
     resolvers += Resolver.mavenLocal
   )

--- a/sbt/src/sbt-test/project/transitive-plugins/c/build.sbt
+++ b/sbt/src/sbt-test/project/transitive-plugins/c/build.sbt
@@ -1,11 +1,5 @@
-publishTo := (baseDirectory in ThisBuild)(x =>
-	Some(Resolver.file("test-publish", x / "repo"))
-).value
-
-resolvers += (baseDirectory in ThisBuild)(x =>
-	"test" at (x / "repo").asURL.toString
-).value
-
+publishTo := Some(Resolver.file("test-publish", (baseDirectory in ThisBuild).value / "repo"))
+resolvers += ("test" at ((baseDirectory in ThisBuild).value / "repo").asURL.toString)
 resolvers += Resolver.mavenLocal
 
 name := "demo3"


### PR DESCRIPTION
This undeprecates the syntax, but at the same times moves it out of
implicit scope, therefore requiring a 'import Scoped.syntax._' to opt-in to
the old syntax.

Fixes #2762