### PR TITLE
[sbt 1.0] Better prompt out of the box

### DIFF
--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -1,7 +1,7 @@
 package sbt
 
 import sbt.internal.util.Types.const
-import sbt.internal.util.{ Attributed, AttributeKey, Init }
+import sbt.internal.util.{ Attributed, AttributeKey, Init, ConsoleAppender }
 import sbt.util.Show
 import sbt.internal.util.complete.Parser
 import java.io.File
@@ -36,7 +36,7 @@ object Def extends Init[Scope] with TaskMacroExtra {
     Show[ScopedKey[_]](
       (key: ScopedKey[_]) =>
         Scope.display(key.scope,
-                      colored(key.key.label, keyNameColor),
+                      withColor(key.key.label, keyNameColor),
                       ref => displayRelative(current, multi, ref)))
 
   def showBuildRelativeKey(currentBuild: URI,
@@ -45,7 +45,7 @@ object Def extends Init[Scope] with TaskMacroExtra {
     Show[ScopedKey[_]](
       (key: ScopedKey[_]) =>
         Scope.display(key.scope,
-                      colored(key.key.label, keyNameColor),
+                      withColor(key.key.label, keyNameColor),
                       ref => displayBuildRelative(currentBuild, multi, ref)))
 
   def displayRelative(current: ProjectRef, multi: Boolean, project: Reference): String =
@@ -63,13 +63,16 @@ object Def extends Init[Scope] with TaskMacroExtra {
     }
   def displayFull(scoped: ScopedKey[_]): String = displayFull(scoped, None)
   def displayFull(scoped: ScopedKey[_], keyNameColor: Option[String]): String =
-    Scope.display(scoped.scope, colored(scoped.key.label, keyNameColor))
+    Scope.display(scoped.scope, withColor(scoped.key.label, keyNameColor))
   def displayMasked(scoped: ScopedKey[_], mask: ScopeMask): String =
     Scope.displayMasked(scoped.scope, scoped.key.label, mask)
 
-  def colored(s: String, color: Option[String]): String = color match {
-    case Some(c) => c + s + scala.Console.RESET
-    case None    => s
+  def withColor(s: String, color: Option[String]): String = {
+    val useColor = ConsoleAppender.formatEnabled
+    color match {
+      case Some(c) if useColor => c + s + scala.Console.RESET
+      case _                   => s
+    }
   }
 
   override def deriveAllowed[T](s: Setting[T], allowDynamic: Boolean): Option[String] =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1746,7 +1746,8 @@ object Classpaths {
           }
           val base = ModuleID(id.groupID, id.name, sbtVersion.value).withCrossVersion(cross)
           CrossVersion(scalaVersion, binVersion)(base).withCrossVersion(Disabled())
-        }
+        },
+        shellPrompt := shellPromptFromState
       ))
 
   val ivyBaseSettings: Seq[Setting[_]] = baseGlobalDefaults ++ sbtClassifiersTasks ++ Seq(
@@ -2871,6 +2872,14 @@ object Classpaths {
             sys.error(
               "Unknown predefined resolver '" + unknown + "'.  This resolver may only be supported in newer sbt versions.")
         }
+    }
+  }
+
+  def shellPromptFromState: State => String = { s: State =>
+    val extracted = Project.extract(s)
+    (name in extracted.currentRef).get(extracted.structure.data) match {
+      case Some(name) => s"sbt:$name" + Def.withColor("> ", Option(scala.Console.CYAN))
+      case _          => "> "
     }
   }
 }


### PR DESCRIPTION
Fixes #3313

This changes the default prompt to include "sbt:" + current project name.
See https://twitter.com/eed3si9n/status/884914670351659009

![dark](https://user-images.githubusercontent.com/184683/28182989-d38643d6-67db-11e7-922c-1208fec907cc.png)

![light](https://user-images.githubusercontent.com/184683/28182997-db292ebe-67db-11e7-840d-f4ed43a8b6b0.png)

The prompt style was created by @jvican and @japgolly in https://twitter.com/japgolly/status/884945037125013504
