### PR TITLE
[WIP] Adapt to new library management API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,12 +212,12 @@ lazy val actionsProj = (project in file("main-actions"))
     addSbtUtilCompletion,
     addSbtCompilerApiInfo,
     addSbtZinc,
-    addSbtCompilerIvyIntegration,
+    addSbtCompilerLmIntegration,
     addSbtCompilerInterface,
     addSbtIO,
     addSbtUtilLogging,
     addSbtUtilRelation,
-    addSbtLm,
+    addSbtLmCore,
     addSbtUtilTracking
   )
 
@@ -252,7 +252,7 @@ lazy val commandProj = (project in file("main-command"))
              addSbtUtilLogging,
              addSbtUtilCompletion,
              addSbtCompilerClasspath,
-             addSbtLm)
+             addSbtLmCore)
 
 // The core macro project defines the main logic of the DSL, abstracted
 // away from several sbt implementators (tasks, settings, et cetera).
@@ -300,7 +300,7 @@ lazy val mainSettingsProj = (project in file("main-settings"))
     addSbtIO,
     addSbtUtilCompletion,
     addSbtCompilerClasspath,
-    addSbtLm
+    addSbtLmCore
   )
 
 // The main integration project for sbt.  It brings all of the projects together, configures them, and provides for overriding conventions.
@@ -319,7 +319,8 @@ lazy val mainProj = (project in file("main"))
              addSbtIO,
              addSbtUtilLogging,
              addSbtUtilLogic,
-             addSbtLm,
+             addSbtLmCore,
+             addSbtLmIvy,
              addSbtZincCompile)
 
 // Strictly for bringing implicits and aliases from subsystems into the top-level sbt namespace through a single package object

--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -16,6 +16,7 @@ import sbt.util.Logger
 
 import sbt.util.{ CacheStoreFactory, FilesInfo, ModifiedFileInfo, PlainFileInfo }
 import sbt.internal.util.HNil
+import sbt.internal.util.HListFormats._
 import sbt.util.FileInfo.{ exists, lastModified }
 import sbt.util.CacheImplicits._
 import sbt.util.Tracked.inputChanged

--- a/main-actions/src/main/scala/sbt/RawCompileLike.scala
+++ b/main-actions/src/main/scala/sbt/RawCompileLike.scala
@@ -15,6 +15,7 @@ import sbt.util.CacheImplicits._
 import sbt.util.Tracked.inputChanged
 import sbt.util.{ CacheStoreFactory, FilesInfo, HashFileInfo, ModifiedFileInfo, PlainFileInfo }
 import sbt.internal.util.HNil
+import sbt.internal.util.HListFormats._
 import sbt.util.FileInfo.{ exists, hash, lastModified }
 import xsbti.compile.ClasspathOptions
 

--- a/main-actions/src/test/scala/sbt/CacheIvyTest.scala
+++ b/main-actions/src/test/scala/sbt/CacheIvyTest.scala
@@ -46,14 +46,20 @@ class CacheIvyTest extends Properties("CacheIvy") {
       eq(out, m) :| s"Expected: ${str(m)}" :| s"Got: ${str(out)}"
   }
 
-  implicit val arbExclusionRule: Arbitrary[ExclusionRule] = Arbitrary(
+  implicit val arbConfigRef: Arbitrary[ConfigRef] = Arbitrary(
+    for {
+      n <- Gen.alphaStr
+    } yield ConfigRef(n)
+  )
+
+  implicit val arbExclusionRule: Arbitrary[InclExclRule] = Arbitrary(
     for {
       o <- Gen.alphaStr
       n <- Gen.alphaStr
       a <- Gen.alphaStr
       v <- arbCrossVersion.arbitrary
-      cs <- arbitrary[List[String]]
-    } yield ExclusionRule(o, n, a, cs.toVector, v)
+      cs <- arbitrary[List[ConfigRef]]
+    } yield InclExclRule(o, n, a, cs.toVector, v)
   )
 
   implicit val arbCrossVersion: Arbitrary[CrossVersion] = Arbitrary {
@@ -78,8 +84,8 @@ class CacheIvyTest extends Properties("CacheIvy") {
       isTransitive <- arbitrary[Boolean]
       isForce <- arbitrary[Boolean]
       explicitArtifacts <- Gen.listOf(arbitrary[Artifact])
-      exclusions <- Gen.listOf(arbitrary[ExclusionRule])
-      inclusions <- Gen.listOf(arbitrary[InclusionRule])
+      exclusions <- Gen.listOf(arbitrary[InclExclRule])
+      inclusions <- Gen.listOf(arbitrary[InclExclRule])
       extraAttributes <- Gen.mapOf(arbitrary[(String, String)])
       crossVersion <- arbitrary[CrossVersion]
     } yield

--- a/main-settings/src/main/scala/sbt/Append.scala
+++ b/main-settings/src/main/scala/sbt/Append.scala
@@ -56,6 +56,14 @@ object Append {
         })
       def appendValue(a: List[T], b: V): List[T] = a :+ (b: T)
     }
+  implicit def appendVectorImplicit[T, V](implicit ev: V => T): Sequence[Vector[T], Seq[V], V] =
+    new Sequence[Vector[T], Seq[V], V] {
+      def appendValues(a: Vector[T], b: Seq[V]): Vector[T] =
+        a ++ (b map { x =>
+          (x: T)
+        })
+      def appendValue(a: Vector[T], b: V): Vector[T] = a :+ (b: T)
+    }
   implicit def appendString: Value[String, String] = new Value[String, String] {
     def appendValue(a: String, b: String) = a + b
   }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -48,8 +48,7 @@ import sbt.io.{
   PathFinder,
   SimpleFileFilter,
   DirectoryFilter,
-  Hash,
-  WatchService
+  Hash
 }, Path._
 import sbt.librarymanagement.Artifact.{ DocClassifier, SourceClassifier }
 import sbt.librarymanagement.Configurations.{
@@ -62,7 +61,8 @@ import sbt.librarymanagement.Configurations.{
   Test
 }
 import sbt.librarymanagement.CrossVersion.{ binarySbtVersion, binaryScalaVersion, partialVersion }
-import sbt.librarymanagement.{ `package` => _, _ }
+import sbt.librarymanagement._
+import sbt.librarymanagement.ivy._
 import sbt.librarymanagement.syntax._
 import sbt.util.InterfaceUtil.f1
 import sbt.util._
@@ -471,7 +471,7 @@ object Defaults extends BuildCommon {
         globalLock = launcher.globalLock,
         componentProvider = app.provider.components,
         secondaryCacheDir = Option(zincDir),
-        ivyConfiguration = bootIvyConfiguration.value,
+        dependencyResolution = dependencyResolution.value,
         compilerBridgeSource = scalaCompilerBridgeSource.value,
         scalaJarsTarget = zincDir,
         log = streams.value.log
@@ -623,7 +623,7 @@ object Defaults extends BuildCommon {
   }
 
   def scalaInstanceFromUpdate: Initialize[Task[ScalaInstance]] = Def.task {
-    val toolReport = update.value.configuration(Configurations.ScalaTool.name) getOrElse
+    val toolReport = update.value.configuration(Configurations.ScalaTool) getOrElse
       sys.error(noToolConfiguration(managedScalaInstance.value))
     def files(id: String) =
       for {
@@ -1063,12 +1063,13 @@ object Defaults extends BuildCommon {
         case c       => Some(c.name)
       }
       val combined = cPart.toList ++ classifier.toList
-      if (combined.isEmpty) a.withClassifier(None).withConfigurations(cOpt.toVector)
+      val configurations = cOpt.map(c => ConfigRef(c.name)).toVector
+      if (combined.isEmpty) a.withClassifier(None).withConfigurations(configurations)
       else {
         val classifierString = combined mkString "-"
         a.withClassifier(Some(classifierString))
           .withType(Artifact.classifierType(classifierString))
-          .withConfigurations(cOpt.toVector)
+          .withConfigurations(configurations)
       }
     }
 
@@ -1658,7 +1659,9 @@ object Classpaths {
     def notFound =
       sys.error(
         "Configuration to use for managed classpath must be explicitly defined when default configurations are not present.")
-    search find { defined contains _.name } getOrElse notFound
+    search find { c =>
+      defined contains ConfigRef(c.name)
+    } getOrElse notFound
   }
 
   def packaged(pkgTasks: Seq[TaskKey[File]]): Initialize[Task[Map[Artifact, File]]] =
@@ -1694,12 +1697,14 @@ object Classpaths {
     packagedArtifacts :== Map.empty,
     crossTarget := target.value,
     makePom := {
-      val config = makePomConfiguration.value;
-      IvyActions.makePom(ivyModule.value, config, streams.value.log); config.file
+      val config = makePomConfiguration.value
+      val publisher = Keys.publisher.value
+      publisher.makePomFile(ivyModule.value, config, streams.value.log)
+      config.file
     },
     packagedArtifact in makePom := ((artifact in makePom).value -> makePom.value),
-    deliver := deliverTask(deliverConfiguration).value,
-    deliverLocal := deliverTask(deliverLocalConfiguration).value,
+    deliver := deliverTask(publishConfiguration).value,
+    deliverLocal := deliverTask(publishLocalConfiguration).value,
     publish := publishTask(publishConfiguration, deliver).value,
     publishLocal := publishTask(publishLocalConfiguration, deliverLocal).value,
     publishM2 := publishTask(publishM2Configuration, deliverLocal).value
@@ -1717,7 +1722,7 @@ object Classpaths {
         scmInfo :== None,
         offline :== false,
         defaultConfiguration :== Some(Configurations.Compile),
-        dependencyOverrides :== Set.empty,
+        dependencyOverrides :== Vector.empty,
         libraryDependencies :== Nil,
         excludeDependencies :== Nil,
         ivyLoggingLevel :== {
@@ -1730,12 +1735,12 @@ object Classpaths {
         ivyValidate :== false,
         moduleConfigurations :== Nil,
         publishTo :== None,
-        resolvers :== Nil,
+        resolvers :== Vector.empty,
         useJCenter :== false,
         retrievePattern :== Resolver.defaultRetrievePattern,
         transitiveClassifiers :== Seq(SourceClassifier, DocClassifier),
-        sourceArtifactTypes :== Artifact.DefaultSourceTypes,
-        docArtifactTypes :== Artifact.DefaultDocTypes,
+        sourceArtifactTypes :== Artifact.DefaultSourceTypes.toVector,
+        docArtifactTypes :== Artifact.DefaultDocTypes.toVector,
         sbtDependency := {
           val app = appConfiguration.value
           val id = app.provider.id
@@ -1778,13 +1783,13 @@ object Classpaths {
                            useJCenter.value) match {
       case (Some(delegated), Seq(), _, _) => delegated
       case (_, rs, Some(ars), uj)         => ars ++ rs
-      case (_, rs, _, uj)                 => Resolver.withDefaultResolvers(rs, uj, mavenCentral = true)
+      case (_, rs, _, uj)                 => Resolver.combineDefaultResolvers(rs, uj, mavenCentral = true)
     }),
     appResolvers := {
       val ac = appConfiguration.value
       val uj = useJCenter.value
       appRepositories(ac) map { ars =>
-        val useMavenCentral = ars contains DefaultMavenRepository
+        val useMavenCentral = ars contains Resolver.DefaultMavenRepository
         Resolver.reorganizeAppResolvers(ars, uj, useMavenCentral)
       }
     },
@@ -1807,7 +1812,7 @@ object Classpaths {
       val st = state.value
       BuildPaths.getDependencyDirectory(st, BuildPaths.getGlobalBase(st))
     },
-    otherResolvers := Resolver.publishMavenLocal :: publishTo.value.toList,
+    otherResolvers := Resolver.publishMavenLocal +: publishTo.value.toVector,
     projectResolver := projectResolverTask.value,
     projectDependencies := projectDependenciesTask.value,
     // TODO - Is this the appropriate split?  Ivy defines this simply as
@@ -1816,10 +1821,10 @@ object Classpaths {
     allDependencies := {
       projectDependencies.value ++ libraryDependencies.value
     },
-    ivyScala := (ivyScala or (
+    scalaModuleInfo := (scalaModuleInfo or (
       Def.setting {
         Option(
-          IvyScala(
+          ScalaModuleInfo(
             (scalaVersion in update).value,
             (scalaBinaryVersion in update).value,
             Vector.empty,
@@ -1838,26 +1843,27 @@ object Classpaths {
     projectDescriptors := depMap.value,
     updateConfiguration := {
       // Tell the UpdateConfiguration which artifact types are special (for sources and javadocs)
-      val specialArtifactTypes = sourceArtifactTypes.value union docArtifactTypes.value
+      val specialArtifactTypes = sourceArtifactTypes.value.toSet union docArtifactTypes.value.toSet
       // By default, to retrieve all types *but* these (it's assumed that everything else is binary/resource)
-      UpdateConfiguration(
-        retrieve = retrieveConfiguration.value,
-        missingOk = false,
-        logging = ivyLoggingLevel.value,
-        artifactFilter = ArtifactTypeFilter.forbid(specialArtifactTypes),
-        offline = offline.value,
-        frozen = false
-      )
+      UpdateConfiguration()
+        .withRetrieveManaged(retrieveConfiguration.value)
+        .withLogging(ivyLoggingLevel.value)
+        .withArtifactFilter(ArtifactTypeFilter.forbid(specialArtifactTypes))
+        .withOffline(offline.value)
     },
     retrieveConfiguration := {
       if (retrieveManaged.value)
         Some(
-          RetrieveConfiguration(managedDirectory.value,
-                                retrievePattern.value,
-                                retrieveManagedSync.value,
-                                configurationsToRetrieve.value))
+          RetrieveConfiguration(
+            managedDirectory.value,
+            retrievePattern.value,
+            retrieveManagedSync.value,
+            configurationsToRetrieve.value.getOrElse(Vector.empty).map(c => ConfigRef(c.name))
+          ))
       else None
     },
+    dependencyResolution := IvyDependencyResolution(ivyConfiguration.value),
+    publisher := IvyPublisher(ivyConfiguration.value),
     ivyConfiguration := mkIvyConfiguration.value,
     ivyConfigurations := {
       val confs = thisProject.value.configurations
@@ -1878,36 +1884,37 @@ object Classpaths {
                                                      pomPostProcess.value,
                                                      pomIncludeRepository.value,
                                                      pomAllRepositories.value),
-    deliverLocalConfiguration := deliverConfig(crossTarget.value,
-                                               status =
-                                                 if (isSnapshot.value) "integration"
-                                                 else "release",
-                                               logging = ivyLoggingLevel.value),
-    deliverConfiguration := deliverLocalConfiguration.value,
     publishConfiguration := {
-      // TODO(jvican): I think this is a bug.
-      val delivered = deliver.value
       publishConfig(
-        packagedArtifacts.in(publish).value,
-        if (publishMavenStyle.value) None else Some(delivered),
-        resolverName = getPublishTo(publishTo.value).name,
-        checksums = checksums.in(publish).value,
-        logging = ivyLoggingLevel.value,
-        overwrite = isSnapshot.value
+        publishMavenStyle.value,
+        deliverPattern(crossTarget.value),
+        if (isSnapshot.value) "integration" else "release",
+        ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+        packagedArtifacts.in(publish).value.toVector,
+        checksums.in(publish).value,
+        getPublishTo(publishTo.value).name,
+        ivyLoggingLevel.value,
+        isSnapshot.value
       )
     },
     publishLocalConfiguration := publishConfig(
-      packagedArtifacts.in(publishLocal).value,
-      Some(deliverLocal.value),
+      publishMavenStyle.value,
+      deliverPattern(crossTarget.value),
+      if (isSnapshot.value) "integration" else "release",
+      ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+      packagedArtifacts.in(publishLocal).value.toVector,
       checksums.in(publishLocal).value,
       logging = ivyLoggingLevel.value,
       overwrite = isSnapshot.value
     ),
     publishM2Configuration := publishConfig(
-      packagedArtifacts.in(publishM2).value,
-      None,
-      resolverName = Resolver.publishMavenLocal.name,
+      true,
+      deliverPattern(crossTarget.value),
+      if (isSnapshot.value) "integration" else "release",
+      ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+      packagedArtifacts.in(publishM2).value.toVector,
       checksums = checksums.in(publishM2).value,
+      resolverName = Resolver.publishMavenLocal.name,
       logging = ivyLoggingLevel.value,
       overwrite = isSnapshot.value
     ),
@@ -1945,14 +1952,18 @@ object Classpaths {
       implicit val key = (m: ModuleID) => (m.organization, m.name, m.revision)
       val projectDeps = projectDependencies.value.iterator.map(key).toSet
       val externalModules = update.value.allModules.filterNot(m => projectDeps contains key(m))
-      GetClassifiersModule(projectID.value,
-                           externalModules,
-                           ivyConfigurations.in(updateClassifiers).value.toVector,
-                           transitiveClassifiers.in(updateClassifiers).value.toVector)
+      GetClassifiersModule(
+        projectID.value,
+        None,
+        externalModules,
+        ivyConfigurations.in(updateClassifiers).value.toVector,
+        transitiveClassifiers.in(updateClassifiers).value.toVector
+      )
     },
     updateClassifiers := (Def.task {
       val s = streams.value
       val is = ivySbt.value
+      val lm = new DependencyResolution(new IvyDependencyResolution(is))
       val mod = (classifiersModule in updateClassifiers).value
       val c = updateConfiguration.value
       val app = appConfiguration.value
@@ -1960,24 +1971,23 @@ object Classpaths {
       val docTypes = docArtifactTypes.value
       val out = is.withIvy(s.log)(_.getSettings.getDefaultIvyUserDir)
       val uwConfig = (unresolvedWarningConfiguration in update).value
-      val depDir = dependencyCacheDirectory.value
-      val ivy = ivyScala.value
-      val st = state.value
+      val scalaModule = scalaModuleInfo.value
       withExcludes(out, mod.classifiers, lock(app)) { excludes =>
-        IvyActions.updateClassifiers(
-          is,
-          GetClassifiersConfiguration(mod,
-                                      excludes,
-                                      c.withArtifactFilter(c.artifactFilter.invert),
-                                      ivy,
-                                      srcTypes,
-                                      docTypes),
+        lm.updateClassifiers(
+          GetClassifiersConfiguration(
+            mod,
+            excludes.toVector,
+            c.withArtifactFilter(c.artifactFilter.map(af => af.withInverted(!af.inverted))),
+            // scalaModule,
+            srcTypes,
+            docTypes),
           uwConfig,
-          LogicalClock(st.hashCode),
-          Some(depDir),
           Vector.empty,
           s.log
-        )
+        ) match {
+          case Left(_)   => ???
+          case Right(ur) => ur
+        }
       }
     } tag (Tags.Update, Tags.Network)).value
   )
@@ -2000,7 +2010,7 @@ object Classpaths {
         else base
       val sbtOrg = scalaOrganization.value
       val version = scalaVersion.value
-      if (scalaHome.value.isDefined || ivyScala.value.isEmpty || !managedScalaInstance.value)
+      if (scalaHome.value.isDefined || scalaModuleInfo.value.isEmpty || !managedScalaInstance.value)
         pluginAdjust
       else {
         val isDotty = ScalaInstance.isDotty(version)
@@ -2040,9 +2050,9 @@ object Classpaths {
       new IvySbt(ivyConfiguration.value)
     }
   def moduleSettings0: Initialize[Task[ModuleSettings]] = Def.task {
-    InlineConfiguration(
+    ModuleDescriptorConfiguration(
       ivyValidate.value,
-      ivyScala.value,
+      scalaModuleInfo.value,
       projectID.value,
       projectInfo.value,
       allDependencies.value.toVector,
@@ -2073,7 +2083,7 @@ object Classpaths {
               .resolvers
             explicit orElse bootRepositories(appConfiguration.value) getOrElse externalResolvers.value
           },
-          ivyConfiguration := new InlineIvyConfiguration(
+          ivyConfiguration := InlineIvyConfiguration(
             paths = ivyPaths.value,
             resolvers = externalResolvers.value.toVector,
             otherResolvers = Vector.empty,
@@ -2091,16 +2101,18 @@ object Classpaths {
           // to fix https://github.com/sbt/sbt/issues/2686
           scalaVersion := appConfiguration.value.provider.scalaProvider.version,
           scalaBinaryVersion := binaryScalaVersion(scalaVersion.value),
-          ivyScala := {
+          scalaModuleInfo := {
             Some(
-              IvyScala(scalaVersion.value,
-                       scalaBinaryVersion.value,
-                       Vector(),
-                       checkExplicit = false,
-                       filterImplicit = false,
-                       overrideScalaVersion = true).withScalaOrganization(scalaOrganization.value))
+              ScalaModuleInfo(
+                scalaVersion.value,
+                scalaBinaryVersion.value,
+                Vector(),
+                checkExplicit = false,
+                filterImplicit = false,
+                overrideScalaVersion = true).withScalaOrganization(scalaOrganization.value))
           },
           updateSbtClassifiers in TaskGlobal := (Def.task {
+            val lm = dependencyResolution.value
             val s = streams.value
             val is = ivySbt.value
             val mod = classifiersModule.value
@@ -2112,24 +2124,24 @@ object Classpaths {
             val out = is.withIvy(log)(_.getSettings.getDefaultIvyUserDir)
             val uwConfig = (unresolvedWarningConfiguration in update).value
             val depDir = dependencyCacheDirectory.value
-            val ivy = ivyScala.value
+            val ivy = scalaModuleInfo.value
             val st = state.value
             withExcludes(out, mod.classifiers, lock(app)) { excludes =>
-              val noExplicitCheck = ivy.map(_.withCheckExplicit(false))
-              IvyActions.transitiveScratch(
-                is,
+              // val noExplicitCheck = ivy.map(_.withCheckExplicit(false))
+              lm.transitiveScratch(
                 "sbt",
-                GetClassifiersConfiguration(mod,
-                                            excludes,
-                                            c.withArtifactFilter(c.artifactFilter.invert),
-                                            noExplicitCheck,
-                                            srcTypes,
-                                            docTypes),
+                GetClassifiersConfiguration(
+                  mod,
+                  excludes.toVector,
+                  c.withArtifactFilter(c.artifactFilter.map(af => af.withInverted(!af.inverted))),
+                  srcTypes,
+                  docTypes),
                 uwConfig,
-                LogicalClock(st.hashCode),
-                Some(depDir),
                 log
-              )
+              ) match {
+                case Left(uw)  => ???
+                case Right(ur) => ur
+              }
             }
           } tag (Tags.Update, Tags.Network)).value
         )) ++ Seq(bootIvyConfiguration := (ivyConfiguration in updateSbtClassifiers).value)
@@ -2141,12 +2153,16 @@ object Classpaths {
       val pluginClasspath = loadedBuild.value.units(ref.build).unit.plugins.fullClasspath.toVector
       val pluginJars = pluginClasspath.filter(_.data.isFile) // exclude directories: an approximation to whether they've been published
       val pluginIDs: Vector[ModuleID] = pluginJars.flatMap(_ get moduleID.key)
-      GetClassifiersModule(projectID.value,
-                           sbtDependency.value +: pluginIDs,
-                           Vector(Configurations.Default),
-                           classifiers.toVector)
+      GetClassifiersModule(
+        projectID.value,
+        // TODO: Should it be sbt's scalaModuleInfo?
+        scalaModuleInfo.value,
+        sbtDependency.value +: pluginIDs,
+        Vector(Configurations.Default),
+        classifiers.toVector
+      )
     }
-  def deliverTask(config: TaskKey[DeliverConfiguration]): Initialize[Task[File]] =
+  def deliverTask(config: TaskKey[PublishConfiguration]): Initialize[Task[File]] =
     Def.task {
       val _ = update.value
       IvyActions.deliver(ivyModule.value, config.value, streams.value.log)
@@ -2168,7 +2184,7 @@ object Classpaths {
     }
 
   def withExcludes(out: File, classifiers: Seq[String], lock: xsbti.GlobalLock)(
-      f: Map[ModuleID, Set[String]] => UpdateReport): UpdateReport = {
+      f: Map[ModuleID, Vector[ConfigRef]] => UpdateReport): UpdateReport = {
     import sbt.librarymanagement.LibraryManagementCodec._
     import sbt.util.FileBasedStore
     implicit val isoString: sjsonnew.IsoString[scalajson.ast.unsafe.JValue] =
@@ -2185,11 +2201,17 @@ object Classpaths {
         def call = {
           implicit val midJsonKeyFmt: sjsonnew.JsonKeyFormat[ModuleID] = moduleIdJsonKeyFormat
           val excludes =
-            store.read[Map[ModuleID, Set[String]]](default = Map.empty[ModuleID, Set[String]])
+            store
+              .read[Map[ModuleID, Vector[ConfigRef]]](
+                default = Map.empty[ModuleID, Vector[ConfigRef]])
           val report = f(excludes)
-          val allExcludes = excludes ++ IvyActions.extractExcludes(report)
+          val allExcludes: Map[ModuleID, Vector[ConfigRef]] = excludes ++ IvyActions
+            .extractExcludes(report)
+            .mapValues(cs => cs.map(c => ConfigRef(c)).toVector)
           store.write(allExcludes)
-          IvyActions.addExcluded(report, classifiers.toVector, allExcludes)
+          IvyActions.addExcluded(report,
+                                 classifiers.toVector,
+                                 allExcludes.mapValues(_.map(_.name).toSet))
         }
       }
     )
@@ -2363,25 +2385,24 @@ object Classpaths {
   def getPublishTo(repo: Option[Resolver]): Resolver =
     repo getOrElse sys.error("Repository for publishing is not specified.")
 
-  def deliverConfig(outputDirectory: File,
-                    status: String = "release",
-                    logging: UpdateLogging = UpdateLogging.DownloadOnly) =
-    new DeliverConfiguration(deliverPattern(outputDirectory), status, None, logging)
-
-  def publishConfig(
-      artifacts: Map[Artifact, File],
-      ivyFile: Option[File],
-      checksums: Seq[String],
-      resolverName: String = "local",
-      logging: UpdateLogging = UpdateLogging.DownloadOnly,
-      overwrite: Boolean = false
-  ) =
-    new PublishConfiguration(ivyFile,
-                             resolverName,
-                             artifacts,
-                             checksums.toVector,
-                             logging,
-                             overwrite)
+  def publishConfig(publishMavenStyle: Boolean,
+                    deliverIvyPattern: String,
+                    status: String,
+                    configurations: Vector[ConfigRef],
+                    artifacts: Vector[(Artifact, File)],
+                    checksums: Vector[String],
+                    resolverName: String = "local",
+                    logging: UpdateLogging = UpdateLogging.DownloadOnly,
+                    overwrite: Boolean = false) =
+    PublishConfiguration(publishMavenStyle,
+                         deliverIvyPattern,
+                         status,
+                         configurations,
+                         resolverName,
+                         artifacts,
+                         checksums,
+                         logging,
+                         overwrite)
 
   def deliverPattern(outputPath: File): String =
     (outputPath / "[artifact]-[revision](-[classifier]).[ext]").absolutePath
@@ -2416,7 +2437,8 @@ object Classpaths {
 
   def projectResolverTask: Initialize[Task[Resolver]] =
     projectDescriptors map { m =>
-      new RawRepository(new ProjectResolver(ProjectResolver.InterProject, m))
+      val resolver = new ProjectResolver(ProjectResolver.InterProject, m)
+      new RawRepository(resolver, resolver.getName)
     }
 
   def analyzed[T](data: T, analysis: CompileAnalysis) =
@@ -2545,19 +2567,16 @@ object Classpaths {
       val (rs, other) = (fullResolvers.value.toVector, otherResolvers.value.toVector)
       val s = streams.value
       warnResolversConflict(rs ++: other, s.log)
-      new InlineIvyConfiguration(
-        paths = ivyPaths.value,
-        resolvers = rs,
-        otherResolvers = other,
-        moduleConfigurations = moduleConfigurations.value.toVector,
-        // offline.value,
-        lock = Option(lock(appConfiguration.value)),
-        checksums = (checksums in update).value.toVector,
-        managedChecksums = false,
-        resolutionCacheDir = Some(crossTarget.value / "resolution-cache"),
-        updateOptions = updateOptions.value,
-        log = s.log
-      )
+      InlineIvyConfiguration()
+        .withPaths(ivyPaths.value)
+        .withResolvers(rs)
+        .withOtherResolvers(other)
+        .withModuleConfigurations(moduleConfigurations.value.toVector)
+        .withLock(lock(appConfiguration.value))
+        .withChecksums((checksums in update).value)
+        .withResolutionCacheDir(crossTarget.value / "resolution-cache")
+        .withUpdateOptions(updateOptions.value)
+        .withLog(s.log)
     }
 
   import java.util.LinkedHashSet
@@ -2571,12 +2590,12 @@ object Classpaths {
       val applicableConfigs = allConfigs(c)
       for (ac <- applicableConfigs) // add all configurations in this project
         visited add (p -> ac.name)
-      val masterConfs = names(getConfigurations(projectRef, data))
+      val masterConfs = names(getConfigurations(projectRef, data).toVector)
 
       for (ResolvedClasspathDependency(dep, confMapping) <- deps.classpath(p)) {
         val configurations = getConfigurations(dep, data)
         val mapping =
-          mapped(confMapping, masterConfs, names(configurations), "compile", "*->compile")
+          mapped(confMapping, masterConfs, names(configurations.toVector), "compile", "*->compile")
         // map master configuration 'c' and all extended configurations to the appropriate dependency configuration
         for (ac <- applicableConfigs; depConfName <- mapping(ac.name)) {
           for (depConf <- confOpt(configurations, depConfName))
@@ -2814,8 +2833,8 @@ object Classpaths {
       case _: NoSuchMethodError => None
     }
 
-  def bootChecksums(app: xsbti.AppConfiguration): Seq[String] =
-    try { app.provider.scalaProvider.launcher.checksums.toSeq } catch {
+  def bootChecksums(app: xsbti.AppConfiguration): Vector[String] =
+    try { app.provider.scalaProvider.launcher.checksums.toVector } catch {
       case _: NoSuchMethodError => IvySbt.DefaultChecksums
     }
 
@@ -2824,13 +2843,13 @@ object Classpaths {
     catch { case _: NoSuchMethodError => false }
 
   /** Loads the `appRepositories` configured for this launcher, if supported. */
-  def appRepositories(app: xsbti.AppConfiguration): Option[Seq[Resolver]] =
-    try { Some(app.provider.scalaProvider.launcher.appRepositories.toSeq map bootRepository) } catch {
+  def appRepositories(app: xsbti.AppConfiguration): Option[Vector[Resolver]] =
+    try { Some(app.provider.scalaProvider.launcher.appRepositories.toVector map bootRepository) } catch {
       case _: NoSuchMethodError => None
     }
 
-  def bootRepositories(app: xsbti.AppConfiguration): Option[Seq[Resolver]] =
-    try { Some(app.provider.scalaProvider.launcher.ivyRepositories.toSeq map bootRepository) } catch {
+  def bootRepositories(app: xsbti.AppConfiguration): Option[Vector[Resolver]] =
+    try { Some(app.provider.scalaProvider.launcher.ivyRepositories.toVector map bootRepository) } catch {
       case _: NoSuchMethodError => None
     }
 
@@ -2864,7 +2883,7 @@ object Classpaths {
         p.id match {
           case Predefined.Local                => Resolver.defaultLocal
           case Predefined.MavenLocal           => Resolver.mavenLocal
-          case Predefined.MavenCentral         => DefaultMavenRepository
+          case Predefined.MavenCentral         => Resolver.DefaultMavenRepository
           case Predefined.ScalaToolsReleases   => Resolver.ScalaToolsReleases
           case Predefined.ScalaToolsSnapshots  => Resolver.ScalaToolsSnapshots
           case Predefined.SonatypeOSSReleases  => Resolver.sonatypeRepo("releases")
@@ -2980,7 +2999,13 @@ trait BuildExtra extends BuildCommon with DefExtra {
         otherTask map {
           case (base, app, pr, uo, s) =>
             val extraResolvers = if (addMultiResolver) Vector(pr) else Vector.empty
-            ExternalIvyConfiguration(Option(lock(app)), base, s.log, uo, u, extraResolvers)
+            ExternalIvyConfiguration()
+              .withLock(lock(app))
+              .withBaseDirectory(base)
+              .withLog(s.log)
+              .withUpdateOptions(uo)
+              .withUri(u)
+              .withExtraResolvers(extraResolvers)
         }
     }).value
   }
@@ -2989,18 +3014,19 @@ trait BuildExtra extends BuildCommon with DefExtra {
     baseDirectory.value / name
   }
 
-  def externalIvyFile(
-      file: Initialize[File] = inBase("ivy.xml"),
-      iScala: Initialize[Option[IvyScala]] = ivyScala): Setting[Task[ModuleSettings]] =
+  def externalIvyFile(file: Initialize[File] = inBase("ivy.xml"),
+                      iScala: Initialize[Option[ScalaModuleInfo]] = scalaModuleInfo)
+    : Setting[Task[ModuleSettings]] =
     moduleSettings := IvyFileConfiguration(ivyValidate.value,
                                            iScala.value,
                                            file.value,
                                            managedScalaInstance.value)
 
   def externalPom(file: Initialize[File] = inBase("pom.xml"),
-                  iScala: Initialize[Option[IvyScala]] = ivyScala): Setting[Task[ModuleSettings]] =
+                  iScala: Initialize[Option[ScalaModuleInfo]] = scalaModuleInfo)
+    : Setting[Task[ModuleSettings]] =
     moduleSettings := PomConfiguration(ivyValidate.value,
-                                       ivyScala.value,
+                                       scalaModuleInfo.value,
                                        file.value,
                                        managedScalaInstance.value)
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1898,7 +1898,7 @@ object Classpaths {
       )
     },
     publishLocalConfiguration := publishConfig(
-      publishMavenStyle.value,
+      false, //publishMavenStyle.value,
       deliverPattern(crossTarget.value),
       if (isSnapshot.value) "integration" else "release",
       ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -140,7 +140,7 @@ object EvaluateTaskConfig {
 final case class PluginData(
     dependencyClasspath: Seq[Attributed[File]],
     definitionClasspath: Seq[Attributed[File]],
-    resolvers: Option[Seq[Resolver]],
+    resolvers: Option[Vector[Resolver]],
     report: Option[UpdateReport],
     scalacOptions: Seq[String]
 ) {

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -42,44 +42,40 @@ import sbt.internal.util.{ AttributeKey, SourcePosition }
 
 import sbt.librarymanagement.Configurations.CompilerPlugin
 import sbt.librarymanagement.LibraryManagementCodec._
+import sbt.librarymanagement.ivy.{ Credentials, UpdateOptions }
 import sbt.librarymanagement.{
   Artifact,
   Configuration,
   ConflictManager,
   ConflictWarning,
-  Credentials,
   CrossVersion,
   Developer,
+  DependencyResolution,
   EvictionWarning,
   EvictionWarningOptions,
-  IvyScala,
+  GetClassifiersModule,
+  MakePomConfiguration,
   MavenRepository,
   ModuleConfiguration,
   ModuleID,
   ModuleInfo,
   ModuleSettings,
+  PublishConfiguration,
+  Publisher,
   Resolver,
+  RetrieveConfiguration,
+  ScalaModuleInfo,
   ScalaVersion,
   ScmInfo,
   TrackLevel,
+  UnresolvedWarningConfiguration,
   UpdateConfiguration,
-  UpdateOptions,
   UpdateLogging,
   UpdateReport
 }
-import sbt.librarymanagement.ExclusionRule
-import sbt.internal.librarymanagement.{
-  CompatibilityWarningOptions,
-  DeliverConfiguration,
-  GetClassifiersModule,
-  IvyConfiguration,
-  IvyPaths,
-  IvySbt,
-  MakePomConfiguration,
-  PublishConfiguration,
-  RetrieveConfiguration,
-  UnresolvedWarningConfiguration
-}
+import sbt.librarymanagement.InclExclRule
+import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
+import sbt.librarymanagement.ivy.{ IvyConfiguration, IvyPaths }
 import sbt.util.{ Level, Logger }
 import org.apache.logging.log4j.core.Appender
 import sbt.BuildSyntax._
@@ -343,6 +339,8 @@ object Keys {
   val updateOptions = SettingKey[UpdateOptions]("update-options", "Options for resolving managed dependencies.", DSetting)
   val unresolvedWarningConfiguration = TaskKey[UnresolvedWarningConfiguration]("unresolved-warning-configuration", "Configuration for unresolved dependency warning.", DTask)
   val dependencyPositions = TaskKey[Map[ModuleID, SourcePosition]]("dependency-positions", "Source positions where the dependencies are defined.", DTask)
+  val dependencyResolution = TaskKey[DependencyResolution]("dependency-resolution", "Provides the sbt interface to dependency resolution.", CTask)
+  val publisher = TaskKey[Publisher]("publisher", "Provides the sbt interface to publisher")
   val ivySbt = TaskKey[IvySbt]("ivy-sbt", "Provides the sbt interface to Ivy.", CTask)
   val ivyModule = TaskKey[IvySbt#Module]("ivy-module", "Provides the sbt interface to a configured Ivy module.", CTask)
   val updateCacheName = TaskKey[String]("updateCacheName", "Defines the directory name used to store the update cache files (inside the streams cacheDirectory).", DTask)
@@ -353,14 +351,12 @@ object Keys {
   val updateClassifiers = TaskKey[UpdateReport]("update-classifiers", "Resolves and optionally retrieves classified artifacts, such as javadocs and sources, for dependency definitions, transitively.", BPlusTask, update)
   val transitiveClassifiers = SettingKey[Seq[String]]("transitive-classifiers", "List of classifiers used for transitively obtaining extra artifacts for sbt or declared dependencies.", BSetting)
   val updateSbtClassifiers = TaskKey[UpdateReport]("update-sbt-classifiers", "Resolves and optionally retrieves classifiers, such as javadocs and sources, for sbt, transitively.", BPlusTask, updateClassifiers)
-  val sourceArtifactTypes = SettingKey[Set[String]]("source-artifact-types", "Ivy artifact types that correspond to source artifacts. Used by IDEs to resolve these resources.", BSetting)
-  val docArtifactTypes = SettingKey[Set[String]]("doc-artifact-types", "Ivy artifact types that correspond to javadoc artifacts. Used by IDEs to resolve these resources.", BSetting)
+  val sourceArtifactTypes = SettingKey[Vector[String]]("source-artifact-types", "Ivy artifact types that correspond to source artifacts. Used by IDEs to resolve these resources.", BSetting)
+  val docArtifactTypes = SettingKey[Vector[String]]("doc-artifact-types", "Ivy artifact types that correspond to javadoc artifacts. Used by IDEs to resolve these resources.", BSetting)
 
   val publishConfiguration = TaskKey[PublishConfiguration]("publish-configuration", "Configuration for publishing to a repository.", DTask)
   val publishLocalConfiguration = TaskKey[PublishConfiguration]("publish-local-configuration", "Configuration for publishing to the local Ivy repository.", DTask)
   val publishM2Configuration = TaskKey[PublishConfiguration]("publish-m2-configuration", "Configuration for publishing to the local Maven repository.", DTask)
-  val deliverConfiguration = TaskKey[DeliverConfiguration]("deliver-configuration", "Configuration for generating the finished Ivy file for publishing.", DTask)
-  val deliverLocalConfiguration = TaskKey[DeliverConfiguration]("deliver-local-configuration", "Configuration for generating the finished Ivy file for local publishing.", DTask)
   val makePomConfiguration = SettingKey[MakePomConfiguration]("make-pom-configuration", "Configuration for generating a pom.", DSetting)
   val packagedArtifacts = TaskKey[Map[Artifact, File]]("packaged-artifacts", "Packages all artifacts for publishing and maps the Artifact definition to the generated file.", CTask)
   val publishMavenStyle = SettingKey[Boolean]("publish-maven-style", "Configures whether to generate and publish a pom (true) or Ivy file (false).", BSetting)
@@ -384,13 +380,13 @@ object Keys {
   val moduleID = SettingKey[ModuleID]("module-id", "A dependency management descriptor.  This is currently used for associating a ModuleID with a classpath entry.", BPlusSetting)
   val projectID = SettingKey[ModuleID]("project-id", "The dependency management descriptor for the current module.", BMinusSetting)
   val overrideBuildResolvers = SettingKey[Boolean]("override-build-resolvers", "Whether or not all the build resolvers should be overridden with what's defined from the launcher.", BMinusSetting)
-  val bootResolvers = TaskKey[Option[Seq[Resolver]]]("boot-resolvers", "The resolvers used by the sbt launcher.", BMinusSetting)
-  val appResolvers = SettingKey[Option[Seq[Resolver]]]("app-resolvers", "The resolvers configured for this application by the sbt launcher.", BMinusSetting)
-  val externalResolvers = TaskKey[Seq[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.", BMinusSetting)
-  val resolvers = SettingKey[Seq[Resolver]]("resolvers", "The user-defined additional resolvers for automatically managed dependencies.", BMinusTask)
+  val bootResolvers = TaskKey[Option[Vector[Resolver]]]("boot-resolvers", "The resolvers used by the sbt launcher.", BMinusSetting)
+  val appResolvers = SettingKey[Option[Vector[Resolver]]]("app-resolvers", "The resolvers configured for this application by the sbt launcher.", BMinusSetting)
+  val externalResolvers = TaskKey[Vector[Resolver]]("external-resolvers", "The external resolvers for automatically managed dependencies.", BMinusSetting)
+  val resolvers = SettingKey[Vector[Resolver]]("resolvers", "The user-defined additional resolvers for automatically managed dependencies.", BMinusTask)
   val projectResolver = TaskKey[Resolver]("project-resolver", "Resolver that handles inter-project dependencies.", DTask)
-  val fullResolvers = TaskKey[Seq[Resolver]]("full-resolvers", "Combines the project resolver, default resolvers, and user-defined resolvers.", CTask)
-  val otherResolvers = TaskKey[Seq[Resolver]]("other-resolvers", "Resolvers not included in the main resolver chain, such as those in module configurations.", CSetting)
+  val fullResolvers = TaskKey[Vector[Resolver]]("full-resolvers", "Combines the project resolver, default resolvers, and user-defined resolvers.", CTask)
+  val otherResolvers = TaskKey[Vector[Resolver]]("other-resolvers", "Resolvers not included in the main resolver chain, such as those in module configurations.", CSetting)
   val useJCenter = SettingKey[Boolean]("use-jcenter", "Use JCenter as the default repository.", BSetting)
   val moduleConfigurations = SettingKey[Seq[ModuleConfiguration]]("module-configurations", "Defines module configurations, which override resolvers on a per-module basis.", BMinusSetting)
   val retrievePattern = SettingKey[String]("retrieve-pattern", "Pattern used to retrieve managed dependencies to the current build.", DSetting)
@@ -399,12 +395,12 @@ object Keys {
   val ivyPaths = SettingKey[IvyPaths]("ivy-paths", "Configures paths used by Ivy for dependency management.", DSetting)
   val dependencyCacheDirectory = TaskKey[File]("dependency-cache-directory", "The base directory for cached dependencies.", DTask)
   val libraryDependencies = SettingKey[Seq[ModuleID]]("library-dependencies", "Declares managed dependencies.", APlusSetting)
-  val dependencyOverrides = SettingKey[Set[ModuleID]]("dependency-overrides", "Declares managed dependency overrides.", BSetting)
-  val excludeDependencies = SettingKey[Seq[ExclusionRule]]("exclude-dependencies", "Declares managed dependency exclusions.", BSetting)
+  val dependencyOverrides = SettingKey[Vector[ModuleID]]("dependency-overrides", "Declares managed dependency overrides.", BSetting)
+  val excludeDependencies = SettingKey[Seq[InclExclRule]]("exclude-dependencies", "Declares managed dependency exclusions.", BSetting)
   val allDependencies = TaskKey[Seq[ModuleID]]("all-dependencies", "Inter-project and library dependencies.", CTask)
   val projectDependencies = TaskKey[Seq[ModuleID]]("project-dependencies", "Inter-project dependencies.", DTask)
   val ivyXML = SettingKey[NodeSeq]("ivy-xml", "Defines inline Ivy XML for configuring dependency management.", BSetting)
-  val ivyScala = SettingKey[Option[IvyScala]]("ivy-scala", "Configures how Scala dependencies are checked, filtered, and injected.", CSetting)
+  val scalaModuleInfo = SettingKey[Option[ScalaModuleInfo]]("scala-module-info", "Configures how Scala dependencies are checked, filtered, and injected.", CSetting)
   val ivyValidate = SettingKey[Boolean]("ivy-validate", "Enables/disables Ivy validation of module metadata.", BSetting)
   val ivyLoggingLevel = SettingKey[UpdateLogging]("ivy-logging-level", "The logging level for updating.", BSetting)
   val publishTo = TaskKey[Option[Resolver]]("publish-to", "The resolver to publish to.", ASetting)
@@ -413,12 +409,12 @@ object Keys {
   val autoUpdate = SettingKey[Boolean]("auto-update", "<unimplemented>", Invisible)
   val retrieveManaged = SettingKey[Boolean]("retrieve-managed", "If true, enables retrieving dependencies to the current build.  Otherwise, dependencies are used directly from the cache.", BSetting)
   val retrieveManagedSync = SettingKey[Boolean]("retrieve-managed-sync", "If true, enables synchronizing the dependencies retrieved to the current build by removed unneeded files.", BSetting)
-  val configurationsToRetrieve = SettingKey[Option[Set[Configuration]]]("configurations-to-retrieve", "An optional set of configurations from which to retrieve dependencies if retrieveManaged is set to true", BSetting)
+  val configurationsToRetrieve = SettingKey[Option[Vector[Configuration]]]("configurations-to-retrieve", "An optional set of configurations from which to retrieve dependencies if retrieveManaged is set to true", BSetting)
   val managedDirectory = SettingKey[File]("managed-directory", "Directory to which managed dependencies are retrieved.", BSetting)
   val classpathTypes = SettingKey[Set[String]]("classpath-types", "Artifact types that are included on the classpath.", BSetting)
   val publishArtifact = SettingKey[Boolean]("publish-artifact", "Enables (true) or disables (false) publishing an artifact.", AMinusSetting)
   val packagedArtifact = TaskKey[(Artifact, File)]("packaged-artifact", "Generates a packaged artifact, returning the Artifact and the produced File.", CTask)
-  val checksums = SettingKey[Seq[String]]("checksums", "The list of checksums to generate and to verify for dependencies.", BSetting)
+  val checksums = SettingKey[Vector[String]]("checksums", "The list of checksums to generate and to verify for dependencies.", BSetting)
   val forceUpdatePeriod = SettingKey[Option[FiniteDuration]]("force-update-period", "Duration after which to force a full update to occur", CSetting)
 
   val classifiersModule = TaskKey[GetClassifiersModule]("classifiers-module", rank = CTask)

--- a/main/src/main/scala/sbt/Opts.scala
+++ b/main/src/main/scala/sbt/Opts.scala
@@ -3,7 +3,8 @@
  */
 package sbt
 
-import sbt.librarymanagement.{ Credentials, MavenRepository, Resolver }
+import sbt.librarymanagement.{ MavenRepository, Resolver }
+import sbt.librarymanagement.ivy.Credentials
 
 import java.io.File
 import java.net.URL
@@ -62,11 +63,12 @@ object DefaultOptions {
   def scaladoc(name: String, version: String): Seq[String] =
     doc.title(name) ++ doc.version(version)
 
-  def resolvers(snapshot: Boolean): Seq[Resolver] = {
-    if (snapshot) Seq(resolver.sbtSnapshots) else Nil
+  def resolvers(snapshot: Boolean): Vector[Resolver] = {
+    if (snapshot) Vector(resolver.sbtSnapshots) else Vector.empty
   }
-  def pluginResolvers(plugin: Boolean, snapshot: Boolean): Seq[Resolver] = {
-    if (plugin && snapshot) Seq(resolver.sbtSnapshots, resolver.sbtIvySnapshots) else Nil
+  def pluginResolvers(plugin: Boolean, snapshot: Boolean): Vector[Resolver] = {
+    if (plugin && snapshot) Vector(resolver.sbtSnapshots, resolver.sbtIvySnapshots)
+    else Vector.empty
   }
   def addResolvers: Setting[_] = Keys.resolvers ++= { resolvers(Keys.isSnapshot.value) }
   def addPluginResolvers: Setting[_] =

--- a/main/src/main/scala/sbt/internal/AltLibraryManagementCodec.scala
+++ b/main/src/main/scala/sbt/internal/AltLibraryManagementCodec.scala
@@ -3,13 +3,14 @@ package sbt.internal
 import sbt.internal.librarymanagement._
 import sbt.internal.util.Types._
 import sbt.internal.util.{ HList, HNil }
-import sbt.io.{ Hash, IO }
+import sbt.io.Hash
 import sbt.librarymanagement._
-import sbt.util.CacheImplicits._
+import sbt.librarymanagement.ivy._
 import sbt.util._
+import sbt.internal.util.HListFormats._
 import sjsonnew.JsonFormat
 
-object AltLibraryManagementCodec extends LibraryManagementCodec {
+object AltLibraryManagementCodec extends IvyLibraryManagementCodec {
   type In0 = ModuleSettings :+: UpdateConfiguration :+: HNil
   type In = IvyConfiguration :+: In0
 
@@ -36,33 +37,31 @@ object AltLibraryManagementCodec extends LibraryManagementCodec {
                  SftpRepository,
                  RawRepository]
 
-  type InlineIvyHL = (IvyPaths :+: Vector[Resolver] :+: Vector[Resolver] :+: Vector[
+  type InlineIvyHL = (Option[IvyPaths] :+: Vector[Resolver] :+: Vector[Resolver] :+: Vector[
     ModuleConfiguration] :+: Vector[String] :+: Boolean :+: HNil)
   def inlineIvyToHL(i: InlineIvyConfiguration): InlineIvyHL = (
     i.paths :+: i.resolvers :+: i.otherResolvers :+: i.moduleConfigurations :+:
       i.checksums :+: i.managedChecksums :+: HNil
   )
 
-  type ExternalIvyHL = PlainFileInfo :+: Array[Byte] :+: HNil
+  type ExternalIvyHL = Option[PlainFileInfo] :+: Array[Byte] :+: HNil
   def externalIvyToHL(e: ExternalIvyConfiguration): ExternalIvyHL =
-    FileInfo.exists(e.baseDirectory) :+: Hash.contentsIfLocal(e.uri) :+: HNil
+    e.baseDirectory.map(FileInfo.exists.apply) :+: e.uri
+      .map(Hash.contentsIfLocal)
+      .getOrElse(Array.empty) :+: HNil
 
   // Redefine to use a subset of properties, that are serialisable
   override lazy implicit val InlineIvyConfigurationFormat: JsonFormat[InlineIvyConfiguration] = {
     def hlToInlineIvy(i: InlineIvyHL): InlineIvyConfiguration = {
-      val (paths :+: resolvers :+: otherResolvers :+: moduleConfigurations :+: localOnly
-        :+: checksums :+: HNil) = i
-      InlineIvyConfiguration(None,
-                             IO.createTemporaryDirectory,
-                             NullLogger,
-                             UpdateOptions(),
-                             paths,
-                             resolvers,
-                             otherResolvers,
-                             moduleConfigurations,
-                             localOnly,
-                             checksums,
-                             None)
+      val (paths :+: resolvers :+: otherResolvers :+: moduleConfigurations :+: checksums
+        :+: managedChecksums :+: HNil) = i
+      InlineIvyConfiguration()
+        .withPaths(paths)
+        .withResolvers(resolvers)
+        .withOtherResolvers(otherResolvers)
+        .withModuleConfigurations(moduleConfigurations)
+        .withManagedChecksums(managedChecksums)
+        .withChecksums(checksums)
     }
 
     projectFormat[InlineIvyConfiguration, InlineIvyHL](inlineIvyToHL, hlToInlineIvy)
@@ -75,11 +74,12 @@ object AltLibraryManagementCodec extends LibraryManagementCodec {
       val baseDirectory :+: _ /* uri */ :+: HNil = e
       ExternalIvyConfiguration(
         None,
-        baseDirectory.file,
-        NullLogger,
+        Some(NullLogger),
         UpdateOptions(),
-        IO.createTemporaryDirectory.toURI /* the original uri is destroyed.. */,
-        Vector.empty)
+        baseDirectory.map(_.file),
+        None /* the original uri is destroyed.. */,
+        Vector.empty
+      )
     }
 
     projectFormat[ExternalIvyConfiguration, ExternalIvyHL](externalIvyToHL, hlToExternalIvy)

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -15,7 +15,7 @@ object ConsoleProject {
     val cpImports = new Imports(extracted, state)
     val bindings = ("currentState" -> state) :: ("extracted" -> extracted) :: ("cpHelpers" -> cpImports) :: Nil
     val unit = extracted.currentUnit
-    val (_, ivyConf) = extracted.runTask(Keys.ivyConfiguration, state)
+    val (_, dependencyResolution) = extracted.runTask(Keys.dependencyResolution, state)
     val scalaInstance = {
       val scalaProvider = state.configuration.provider.scalaProvider
       ScalaInstance(scalaProvider.version, scalaProvider.launcher)
@@ -30,7 +30,7 @@ object ConsoleProject {
       globalLock = launcher.globalLock,
       componentProvider = app.provider.components,
       secondaryCacheDir = Option(zincDir),
-      ivyConfiguration = ivyConf,
+      dependencyResolution = dependencyResolution,
       compilerBridgeSource = extracted.get(Keys.scalaCompilerBridgeSource),
       scalaJarsTarget = zincDir,
       log = log

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -102,7 +102,7 @@ object GlobalPlugin {
 final case class GlobalPluginData(projectID: ModuleID,
                                   dependencies: Seq[ModuleID],
                                   descriptors: Map[ModuleRevisionId, ModuleDescriptor],
-                                  resolvers: Seq[Resolver],
+                                  resolvers: Vector[Resolver],
                                   fullClasspath: Classpath,
                                   internalClasspath: Classpath)(val updateReport: UpdateReport)
 final case class GlobalPlugin(data: GlobalPluginData,

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -41,7 +41,7 @@ object IvyConsole {
 
       val depSettings: Seq[Setting[_]] = Seq(
         libraryDependencies ++= managed.reverse,
-        resolvers ++= repos.reverse,
+        resolvers ++= repos.reverse.toVector,
         unmanagedJars in Compile ++= Attributed blankSeq unmanaged.reverse,
         logLevel in Global := Level.Warn,
         showSuccess in Global := false

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -6,8 +6,9 @@ import sbt.internal.librarymanagement._
 import sbt.internal.util.HNil
 import sbt.internal.util.Types._
 import sbt.librarymanagement._
+import sbt.librarymanagement.ivy._
 import sbt.librarymanagement.syntax._
-import sbt.util.CacheImplicits._
+import sbt.internal.util.HListFormats._
 import sbt.util.{ CacheStore, CacheStoreFactory, Logger, Tracked }
 
 object LibraryManagement {
@@ -39,7 +40,7 @@ object LibraryManagement {
       log.info(s"Updating $label...")
       val reportOrUnresolved: Either[UnresolvedWarning, UpdateReport] =
         //try {
-        IvyActions.updateEither(module, updateConfig, uwConfig, logicalClock, depDir, log)
+        IvyActions.updateEither(module, updateConfig, uwConfig, /*logicalClock, depDir,*/ log)
       // } catch {
       //   case e: Throwable =>
       //     e.printStackTrace

--- a/main/src/main/scala/sbt/internal/PluginManagement.scala
+++ b/main/src/main/scala/sbt/internal/PluginManagement.scala
@@ -27,7 +27,7 @@ final case class PluginManagement(overrides: Set[ModuleID],
     addOverrides(extractOverrides(cp))
 
   def inject: Seq[Setting[_]] = Seq(
-    Keys.dependencyOverrides ++= overrides
+    Keys.dependencyOverrides ++= overrides.toVector
   )
 
   def resetDepth: PluginManagement =

--- a/main/src/main/scala/sbt/internal/librarymanagement/FakeRawRepository.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/FakeRawRepository.scala
@@ -7,5 +7,5 @@ import sbt.librarymanagement.RawRepository
 
 object FakeRawRepository {
   def create(name: String): RawRepository =
-    new RawRepository(new FakeResolver(name, IO.createTemporaryDirectory, Map.empty))
+    new RawRepository(new FakeResolver(name, IO.createTemporaryDirectory, Map.empty), name)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,9 +13,9 @@ object Dependencies {
 
   // sbt modules
   private val ioVersion = "1.0.0-M12"
-  private val utilVersion = "1.0.0-M25"
-  private val lmVersion = "1.0.0-X16"
-  private val zincVersion = "1.0.0-X17"
+  private val utilVersion = "1.0.0-M26"
+  private val lmVersion = "1.0.0-SNAPSHOT"
+  private val zincVersion = "1.0.0-X19-SNAPSHOT"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 
@@ -31,7 +31,8 @@ object Dependencies {
   private val utilTesting = "org.scala-sbt" %% "util-testing" % utilVersion
   private val utilTracking = "org.scala-sbt" %% "util-tracking" % utilVersion
 
-  private val libraryManagement = "org.scala-sbt" %% "librarymanagement" % lmVersion
+  private val libraryManagementCore = "org.scala-sbt" %% "librarymanagement-core" % lmVersion
+  private val libraryManagementIvy = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion
 
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
   val rawLauncher = "org.scala-sbt" % "launcher" % "1.0.0"
@@ -41,7 +42,7 @@ object Dependencies {
   private val compilerBridge = "org.scala-sbt" %% "compiler-bridge" % zincVersion
   private val compilerClasspath = "org.scala-sbt" %% "zinc-classpath" % zincVersion
   private val compilerInterface = "org.scala-sbt" % "compiler-interface" % zincVersion
-  private val compilerIvyIntegration = "org.scala-sbt" %% "zinc-ivy-integration" % zincVersion
+  private val compilerLmIntegration = "org.scala-sbt" %% "zinc-library-management-integration" % zincVersion
   private val zinc = "org.scala-sbt" %% "zinc" % zincVersion
   private val zincCompile = "org.scala-sbt" %% "zinc-compile" % zincVersion
 
@@ -93,7 +94,8 @@ object Dependencies {
   def addSbtUtilTracking(p: Project): Project =
     addSbtModule(p, sbtUtilPath, "utilTracking", utilTracking)
 
-  def addSbtLm(p: Project): Project = addSbtModule(p, sbtLmPath, "lm", libraryManagement)
+  def addSbtLmCore(p: Project): Project = addSbtModule(p, sbtLmPath, "lmCore", libraryManagementCore)
+  def addSbtLmIvy(p: Project): Project = addSbtModule(p, sbtLmPath, "lmIvy", libraryManagementIvy)
 
   def addSbtCompilerApiInfo(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincApiInfo", compilerApiInfo)
@@ -103,8 +105,8 @@ object Dependencies {
     addSbtModule(p, sbtZincPath, "zincClasspath", compilerClasspath)
   def addSbtCompilerInterface(p: Project): Project =
     addSbtModule(p, sbtZincPath, "compilerInterface", compilerInterface)
-  def addSbtCompilerIvyIntegration(p: Project): Project =
-    addSbtModule(p, sbtZincPath, "zincIvyIntegration", compilerIvyIntegration)
+  def addSbtCompilerLmIntegration(p: Project): Project =
+    addSbtModule(p, sbtZincPath, "zincLmIntegration", compilerLmIntegration)
   def addSbtZinc(p: Project): Project = addSbtModule(p, sbtZincPath, "zinc", zinc)
   def addSbtZincCompile(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincCompile", zincCompile)

--- a/sbt/src/main/scala/Import.scala
+++ b/sbt/src/main/scala/Import.scala
@@ -225,8 +225,8 @@ trait Import {
   type Caller = sbt.librarymanagement.Caller
   val ChainedResolver = sbt.librarymanagement.ChainedResolver
   type ChainedResolver = sbt.librarymanagement.ChainedResolver
-  val CircularDependencyLevel = sbt.librarymanagement.CircularDependencyLevel
-  type CircularDependencyLevel = sbt.librarymanagement.CircularDependencyLevel
+  val CircularDependencyLevel = sbt.librarymanagement.ivy.CircularDependencyLevel
+  type CircularDependencyLevel = sbt.librarymanagement.ivy.CircularDependencyLevel
   val Configuration = sbt.librarymanagement.Configuration
   type Configuration = sbt.librarymanagement.Configuration
   val ConfigurationReport = sbt.librarymanagement.ConfigurationReport
@@ -236,33 +236,33 @@ trait Import {
   type ConflictManager = sbt.librarymanagement.ConflictManager
   val ConflictWarning = sbt.librarymanagement.ConflictWarning
   type ConflictWarning = sbt.librarymanagement.ConflictWarning
-  val Credentials = sbt.librarymanagement.Credentials
-  type Credentials = sbt.librarymanagement.Credentials
+  val Credentials = sbt.librarymanagement.ivy.Credentials
+  type Credentials = sbt.librarymanagement.ivy.Credentials
   val CrossVersion = sbt.librarymanagement.CrossVersion
   type CrossVersion = sbt.librarymanagement.CrossVersion
-  val DefaultMavenRepository = sbt.librarymanagement.DefaultMavenRepository
+  val DefaultMavenRepository = sbt.librarymanagement.Resolver.DefaultMavenRepository
   val Developer = sbt.librarymanagement.Developer
   type Developer = sbt.librarymanagement.Developer
   val Disabled = sbt.librarymanagement.Disabled
   type Disabled = sbt.librarymanagement.Disabled
-  type DirectCredentials = sbt.librarymanagement.DirectCredentials
+  type DirectCredentials = sbt.librarymanagement.ivy.DirectCredentials
   val EvictionPair = sbt.librarymanagement.EvictionPair
   type EvictionPair = sbt.librarymanagement.EvictionPair
   val EvictionWarning = sbt.librarymanagement.EvictionWarning
   type EvictionWarning = sbt.librarymanagement.EvictionWarning
   val EvictionWarningOptions = sbt.librarymanagement.EvictionWarningOptions
   type EvictionWarningOptions = sbt.librarymanagement.EvictionWarningOptions
-  val ExclusionRule = sbt.librarymanagement.ExclusionRule
-  type ExclusionRule = sbt.librarymanagement.ExclusionRule
-  type FileCredentials = sbt.librarymanagement.FileCredentials
+  // val ExclusionRule = sbt.librarymanagement.InclExclRule
+  // type ExclusionRule = sbt.librarymanagement.InclExclRule
+  type FileCredentials = sbt.librarymanagement.ivy.FileCredentials
   val FileRepository = sbt.librarymanagement.FileRepository
   type FileRepository = sbt.librarymanagement.FileRepository
   val Full = sbt.librarymanagement.Full
   type Full = sbt.librarymanagement.Full
-  val IvyScala = sbt.librarymanagement.IvyScala
-  type IvyScala = sbt.librarymanagement.IvyScala
-  val JCenterRepository = sbt.librarymanagement.JCenterRepository
-  val JavaNet2Repository = sbt.librarymanagement.JavaNet2Repository
+  val IvyScala = sbt.librarymanagement.ScalaModuleInfo
+  type IvyScala = sbt.librarymanagement.ScalaModuleInfo
+  val JCenterRepository = sbt.librarymanagement.Resolver.JCenterRepository
+  val JavaNet2Repository = sbt.librarymanagement.Resolver.JavaNet2Repository
   val MavenCache = sbt.librarymanagement.MavenCache
   type MavenCache = sbt.librarymanagement.MavenCache
   val MavenRepo = sbt.librarymanagement.MavenRepo
@@ -301,8 +301,8 @@ trait Import {
   val URLRepository = sbt.librarymanagement.URLRepository
   type URLRepository = sbt.librarymanagement.URLRepository
   val UpdateLogging = sbt.librarymanagement.UpdateLogging
-  val UpdateOptions = sbt.librarymanagement.UpdateOptions
-  type UpdateOptions = sbt.librarymanagement.UpdateOptions
+  val UpdateOptions = sbt.librarymanagement.ivy.UpdateOptions
+  type UpdateOptions = sbt.librarymanagement.ivy.UpdateOptions
   val UpdateReport = sbt.librarymanagement.UpdateReport
   type UpdateReport = sbt.librarymanagement.UpdateReport
   val UpdateStats = sbt.librarymanagement.UpdateStats
@@ -312,8 +312,8 @@ trait Import {
   type VersionNumberCompatibility = sbt.librarymanagement.VersionNumberCompatibility
 
   // sbt.internal.librarymanagement
-  type IvyPaths = sbt.internal.librarymanagement.IvyPaths
-  val IvyPaths = sbt.internal.librarymanagement.IvyPaths
+  // type IvyPaths = sbt.internal.librarymanagement.ivy.IvyPaths
+  // val IvyPaths = sbt.internal.librarymanagement.ivy.IvyPaths
 
   type IncOptions = xsbti.compile.IncOptions
 }

--- a/sbt/src/main/scala/Import.scala
+++ b/sbt/src/main/scala/Import.scala
@@ -8,6 +8,8 @@ trait Import {
   type URI = java.net.URI
   type URL = java.net.URL
 
+  implicit def Seq2Vector[T](s: Seq[T]): Vector[T] = s.toVector
+
   // sbt
   val StdoutOutput = sbt.OutputStrategy.StdoutOutput
   type BufferedOutput = sbt.OutputStrategy.BufferedOutput
@@ -263,6 +265,7 @@ trait Import {
   type IvyScala = sbt.librarymanagement.ScalaModuleInfo
   val JCenterRepository = sbt.librarymanagement.Resolver.JCenterRepository
   val JavaNet2Repository = sbt.librarymanagement.Resolver.JavaNet2Repository
+  type MakePomConfiguration = sbt.librarymanagement.MakePomConfiguration
   val MavenCache = sbt.librarymanagement.MavenCache
   type MavenCache = sbt.librarymanagement.MavenCache
   val MavenRepo = sbt.librarymanagement.MavenRepo
@@ -312,8 +315,8 @@ trait Import {
   type VersionNumberCompatibility = sbt.librarymanagement.VersionNumberCompatibility
 
   // sbt.internal.librarymanagement
-  // type IvyPaths = sbt.internal.librarymanagement.ivy.IvyPaths
-  // val IvyPaths = sbt.internal.librarymanagement.ivy.IvyPaths
+  type IvyPaths = sbt.librarymanagement.ivy.IvyPaths
+  val IvyPaths = sbt.librarymanagement.ivy.IvyPaths
 
   type IncOptions = xsbti.compile.IncOptions
 }

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -5,8 +5,8 @@ package object sbt
     extends sbt.IOSyntax0
     with sbt.std.TaskExtra
     with sbt.internal.util.Types
-    with sbt.internal.librarymanagement.impl.DependencyBuilders
     with sbt.ProjectExtra
+    with sbt.librarymanagement.DependencyBuilders
     with sbt.librarymanagement.DependencyFilterExtra
     with sbt.librarymanagement.LibraryManagementSyntax
     with sbt.BuildExtra
@@ -36,15 +36,15 @@ package object sbt
   final val Global = Scope.Global
   final val GlobalScope = Scope.GlobalScope
 
-  import sbt.{ Configurations => C }
-  final val Compile = C.Compile
-  final val Test = C.Test
-  final val Runtime = C.Runtime
-  final val IntegrationTest = C.IntegrationTest
-  final val Default = C.Default
-  final val Provided = C.Provided
+  // import sbt.{ Configurations => C }
+  // final val Compile = C.Compile
+  // final val Test = C.Test
+  // final val Runtime = C.Runtime
+  // final val IntegrationTest = C.IntegrationTest
+  // final val Default = C.Default
+  // final val Provided = C.Provided
   // java.lang.System is more important, so don't alias this one
   //  final val System = C.System
-  final val Optional = C.Optional
-  def config(s: String): Configuration = C.config(s)
+  // final val Optional = C.Optional
+  // def config(s: String): Configuration = C.config(s)
 }

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -1,3 +1,5 @@
+import scala.language.experimental.macros
+
 /* sbt -- Simple Build Tool
  * Copyright 2010, 2011 Mark Harrah
  */
@@ -46,5 +48,6 @@ package object sbt
   // java.lang.System is more important, so don't alias this one
   //  final val System = C.System
   // final val Optional = C.Optional
-  // def config(s: String): Configuration = C.config(s)
+  def config(name: String): Configuration =
+    macro sbt.librarymanagement.ConfigurationMacro.configMacroImpl
 }

--- a/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
@@ -6,7 +6,7 @@ val b = project
     localCache,
     scalaVersion := "2.11.8",
     libraryDependencies += "org.example" %% "artifacta" % "1.0.0-SNAPSHOT" withSources() classifier("tests"),
-    externalResolvers := Seq(
+    externalResolvers := Vector(
       MavenCache("demo", ((baseDirectory in ThisBuild).value / "demo-repo")),
       DefaultMavenRepository
     )

--- a/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
@@ -18,8 +18,9 @@ lazy val root = (project in file("."))
       val module = ivyModule.value
       val config = updateConfiguration.value
 
-      import sbt.internal.librarymanagement.IvyConfiguration
+      import sbt.librarymanagement.ivy.IvyConfiguration
       import sbt.librarymanagement.{ ModuleSettings, UpdateConfiguration }
+      import sbt.internal.util.HListFormats._
 
       type In = IvyConfiguration :+: ModuleSettings :+: UpdateConfiguration :+: HNil
 

--- a/sbt/src/sbt-test/dependency-management/configurations-to-retrieve/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/configurations-to-retrieve/build.sbt
@@ -1,4 +1,4 @@
-configurationsToRetrieve := Some(Set(Compile))
+configurationsToRetrieve := Some(Vector(Compile))
 
 retrieveManaged := true
 

--- a/sbt/src/sbt-test/dependency-management/exclude-dependencies/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-dependencies/build.sbt
@@ -1,6 +1,7 @@
 import scala.xml.{ Node, _ }
 import scala.xml.Utility.trim
-import sbt.internal.librarymanagement.{ IvySbt, MakePomConfiguration, MakePom }
+import sbt.librarymanagement.MakePomConfiguration
+import sbt.internal.librarymanagement.{ IvySbt, MakePom }
 
 lazy val check = taskKey[Unit]("check")
 

--- a/sbt/src/sbt-test/dependency-management/exclude-scala/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-scala/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
   settings(
     libraryDependencies ++= baseDirectory(dependencies).value,
     scalaVersion := "2.9.2",
-    ivyScala := ivyScala.value map (_.withOverrideScalaVersion(sbtPlugin.value)),
+    scalaModuleInfo := scalaModuleInfo.value map (_.withOverrideScalaVersion(sbtPlugin.value)),
     autoScalaLibrary := baseDirectory(base => !(base / "noscala").exists ).value,
     scalaOverride := check("scala.App").value
   )

--- a/sbt/src/sbt-test/dependency-management/gh-1484-npe/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/gh-1484-npe/build.sbt
@@ -1,7 +1,7 @@
 lazy val check = taskKey[Unit]("tests update")
 
 def commonSettings: Seq[Def.Setting[_]] = Seq(
-    resolvers ++= Resolver.typesafeIvyRepo("releases") :: Resolver.typesafeRepo("releases") :: Resolver.sbtPluginRepo("releases") :: Nil,
+    resolvers ++= Vector(Resolver.typesafeIvyRepo("releases"), Resolver.typesafeRepo("releases"), Resolver.sbtPluginRepo("releases")),
     check := {
       val ur = update.value
       import sbinary._, Operations._, DefaultProtocol._

--- a/sbt/src/sbt-test/dependency-management/ivy-settings-c/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/ivy-settings-c/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   autoScalaLibrary := false,
-  ivyScala := None,
+  scalaModuleInfo := None,
   unmanagedJars in Compile ++= (scalaInstance map (_.allJars.toSeq)).value,
   publishArtifact in packageSrc := false,
   publishArtifact in packageDoc := false,

--- a/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -6,7 +6,10 @@ lazy val root = (project in file(".")) settings (
   TaskKey[Unit]("checkExtra") := checkExtra.value,
   TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
   resolvers += Resolver.sonatypeRepo("snapshots"),
-  makePomConfiguration ~= { _.copy(extra = <extra-tag/>) },
+  makePomConfiguration := {
+    val p = makePomConfiguration.value
+    new MakePomConfiguration(p.file, p.moduleInfo, p.configurations, <extra-tag/>, p.process, p.filterRepositories, p.allRepositories, p.includeTypes)
+  },
   libraryDependencies += "com.google.code.findbugs" % "jsr305" % "1.3.+"
 )
 

--- a/sbt/src/sbt-test/dependency-management/override/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/override/build.sbt
@@ -2,12 +2,12 @@ autoScalaLibrary := false
 
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
-ivyScala := Some(IvyScala(
+scalaModuleInfo := Some(sbt.librarymanagement.ScalaModuleInfo(
   (scalaVersion in update).value,
   (scalaBinaryVersion in update).value,
   Vector.empty,
-  filterImplicit = false,
   checkExplicit = false,
+  filterImplicit = false,
   overrideScalaVersion = false
 ))
 

--- a/sbt/src/sbt-test/dependency-management/override/test
+++ b/sbt/src/sbt-test/dependency-management/override/test
@@ -1,19 +1,19 @@
 > 'set libraryDependencies := Seq("junit" % "junit" % "3.8.1" % "test")'
 > check 3.8.1
-> 'set dependencyOverrides := Set("junit" % "junit" % "4.5")'
+> 'set dependencyOverrides := Vector("junit" % "junit" % "4.5")'
 > check 4.5
 
 > 'set libraryDependencies := Seq("junit" % "junit" % "4.5" % "test")'
 > check 4.5
-> 'set dependencyOverrides := Set("junit" % "junit" % "3.8.1")'
+> 'set dependencyOverrides := Vector("junit" % "junit" % "3.8.1")'
 > check 3.8.1
 
 > 'set libraryDependencies := Seq("net.databinder" %% "dispatch-http" % "0.8.7")'
 > check 0.8.7
-> 'set dependencyOverrides := Set("net.databinder" %% "dispatch-http" % "0.8.6")'
+> 'set dependencyOverrides := Vector("net.databinder" %% "dispatch-http" % "0.8.6")'
 > check 0.8.6
 
 > 'set libraryDependencies := Seq("net.databinder" %% "dispatch-http" % "0.8.6")'
 > check 0.8.6
-> 'set dependencyOverrides := Set("net.databinder" %% "dispatch-http" % "0.8.7")'
+> 'set dependencyOverrides := Vector("net.databinder" %% "dispatch-http" % "0.8.7")'
 > check 0.8.7

--- a/sbt/src/sbt-test/dependency-management/override2/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/override2/build.sbt
@@ -6,6 +6,6 @@ scalaBinaryVersion := "2.9.1"
 
 resolvers += Classpaths.typesafeReleases
 
-dependencyOverrides := Set("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.3.1")
+dependencyOverrides := Vector("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.3.1")
 
 autoScalaLibrary := false

--- a/sbt/src/sbt-test/dependency-management/pom-scope/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-scope/build.sbt
@@ -1,4 +1,4 @@
-lazy val custom = config("custom")
+lazy val custom = config("custom") //Configurations.config("custom")
 
 lazy val root = (project in file(".")).
   configs(custom).

--- a/sbt/src/sbt-test/dependency-management/provided-multi/changes/p.sbt
+++ b/sbt/src/sbt-test/dependency-management/provided-multi/changes/p.sbt
@@ -1,5 +1,5 @@
 def configIvyScala =
-  ivyScala ~= (_ map (_ withCheckExplicit false))
+  scalaModuleInfo ~= (_ map (_ withCheckExplicit false))
 
 val declared = SettingKey[Boolean]("declared")
 lazy val a = project.

--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -15,8 +15,8 @@ object ScriptedPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
   override def trigger = allRequirements
   object autoImport {
-    def scriptedConf = config("scripted-sbt") hide
-    def scriptedLaunchConf = config("scripted-sbt-launch") hide
+    val scriptedConf = Configurations.config("scripted-sbt") hide
+    val scriptedLaunchConf = Configurations.config("scripted-sbt-launch") hide
     val scriptedSbt = SettingKey[String]("scripted-sbt")
     val sbtLauncher = TaskKey[File]("sbt-launcher")
     val sbtTestDirectory = SettingKey[File]("sbt-test-directory")

--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -15,8 +15,8 @@ object ScriptedPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
   override def trigger = allRequirements
   object autoImport {
-    val scriptedConf = Configurations.config("scripted-sbt") hide
-    val scriptedLaunchConf = Configurations.config("scripted-sbt-launch") hide
+    val ScriptedConf = Configurations.config("scripted-sbt") hide
+    val ScriptedLaunchConf = Configurations.config("scripted-sbt-launch") hide
     val scriptedSbt = SettingKey[String]("scripted-sbt")
     val sbtLauncher = TaskKey[File]("sbt-launcher")
     val sbtTestDirectory = SettingKey[File]("sbt-test-directory")
@@ -32,26 +32,26 @@ object ScriptedPlugin extends AutoPlugin {
   }
   import autoImport._
   override lazy val projectSettings = Seq(
-    ivyConfigurations ++= Seq(scriptedConf, scriptedLaunchConf),
+    ivyConfigurations ++= Seq(ScriptedConf, ScriptedLaunchConf),
     scriptedSbt := (sbtVersion in pluginCrossBuild).value,
-    sbtLauncher := getJars(scriptedLaunchConf).map(_.get.head).value,
+    sbtLauncher := getJars(ScriptedLaunchConf).map(_.get.head).value,
     sbtTestDirectory := sourceDirectory.value / "sbt-test",
     libraryDependencies ++= {
       binarySbtVersion(scriptedSbt.value) match {
         case "0.13" =>
           Seq(
-            "org.scala-sbt" % "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
-            "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
+            "org.scala-sbt" % "scripted-sbt" % scriptedSbt.value % ScriptedConf.toString,
+            "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % ScriptedLaunchConf.toString
           )
         case sv if sv startsWith "1.0." =>
           Seq(
-            "org.scala-sbt" %% "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
-            "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
+            "org.scala-sbt" %% "scripted-sbt" % scriptedSbt.value % ScriptedConf.toString,
+            "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % ScriptedLaunchConf.toString
           )
       }
     },
     scriptedBufferLog := true,
-    scriptedClasspath := getJars(scriptedConf).value,
+    scriptedClasspath := getJars(ScriptedConf).value,
     scriptedTests := scriptedTestsTask.value,
     scriptedRun := scriptedRunTask.value,
     scriptedDependencies := {


### PR DESCRIPTION
Unit tests pass, but there are failures in `dependency-management` scripted tests (I havent tried to run the others yet):

 - dependency-management/cache-update (but ok manually)
 - dependency-management/cached-resolution-classifier
 - dependency-management/pom-scope (issue with Configuration constructor)
 - dependency-management/update-sbt-classifiers