### PR TITLE
Show `actual` as potential option of `inspect`

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -98,7 +98,7 @@ $LastCommand <key>
 
   val InspectCommand = "inspect"
   val inspectBrief =
-    (s"$InspectCommand [uses|tree|definitions] <key>",
+    (s"$InspectCommand [tree|uses|definitions|actual] <key>",
      "Prints the value for 'key', the defining scope, delegates, related definitions, and dependencies.")
   val inspectDetailed = s"""
     |$InspectCommand <key>


### PR DESCRIPTION
It is described in the extended help but not mentioned in the short version.