### PR TITLE
Allow `.value` on SettingKey inside ifs & lambdas

### DIFF
--- a/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
@@ -150,4 +150,25 @@ class TaskPosSpec {
       avoidDCE
     }
   }
+
+  locally {
+    import sbt._
+    import sbt.Def._
+    val foo = settingKey[String]("")
+    val condition = true
+    val baz = Def.task[String] {
+      // settings can be evaluated in a condition
+      if (condition) foo.value
+      else "..."
+    }
+  }
+
+  locally {
+    import sbt._
+    import sbt.Def._
+    val foo = settingKey[String]("")
+    val baz = Def.task[Seq[String]] {
+      (1 to 10).map(_ => foo.value)
+    }
+  }
 }


### PR DESCRIPTION
Calling `.value` on a SettingKey doesn't trigger any execution and
doesn't have any side effect, so we can safely allow calls to `.value`
inside conditionals and lambdas.

Fixes #3299