### PR TITLE
[sbt 0.13] Override current project's scalaVersion on ^^

### DIFF
--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -15,6 +15,7 @@ import Scope.GlobalScope
 import Def.ScopedKey
 import CommandStrings._
 import Cross.{ spacedFirst, requireSession }
+import Configurations._
 
 /**
  * Module responsible for plugin cross building.
@@ -39,7 +40,10 @@ private[sbt] object PluginCross {
         val x = Project.extract(state)
         import x._
         state.log.info(s"Setting `sbtVersion in pluginCrossBuild` to $version")
-        val add = (sbtVersion in GlobalScope in pluginCrossBuild :== version) :: Nil
+        val add = List(sbtVersion in GlobalScope in pluginCrossBuild :== version) ++
+          inConfig(Compile)(List(scalaVersion := scalaVersionSetting.value)) ++
+          inConfig(Test)(List(scalaVersion := scalaVersionSetting.value))
+
         val cleared = session.mergeSettings.filterNot(crossExclude)
         val newStructure = Load.reapply(cleared ++ add, structure)
         Project.setProject(session, newStructure, command :: state)
@@ -69,4 +73,19 @@ private[sbt] object PluginCross {
         else versions.map(PluginSwitchCommand + " " + _ + " " + command) ::: current ::: state
     }
   }
+
+  def scalaVersionSetting: Def.Initialize[String] = Def.setting {
+    val scalaV = scalaVersion.value
+    val sv = (sbtBinaryVersion in pluginCrossBuild).value
+    if (sbtPlugin.value) scalaVersionFromSbtBinaryVersion(sv)
+    else scalaV
+  }
+
+  def scalaVersionFromSbtBinaryVersion(sv: String): String =
+    VersionNumber(sv) match {
+      case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
+      case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.6"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.2"
+      case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
+    }
 }


### PR DESCRIPTION
Both the default settings and ^^ together set the correct scalaVersion based on `sbtVersion in pluginCrossBuild`, but frequently people set up `scalaVersion` on sbt plugin's subproject, which disables the feature.

This change appends the scalaVersionSetting on ^^ so scalaVersion gets switched to 2.12.2 on ^^ 1.0.0-RC2 etc.

Fixes #3205 and #3330 

