### PR TITLE
InteractionService#terminalWidth

### DIFF
--- a/main/src/main/scala/sbt/CommandLineUIService.scala
+++ b/main/src/main/scala/sbt/CommandLineUIService.scala
@@ -1,6 +1,6 @@
 package sbt
 
-import sbt.internal.util.SimpleReader
+import sbt.internal.util.{ JLine, SimpleReader }
 
 trait CommandLineUIService extends InteractionService {
   override def readLine(prompt: String, mask: Boolean): Option[String] = {
@@ -19,6 +19,10 @@ trait CommandLineUIService extends InteractionService {
       case _              => false
     }
   }
+
+  override def terminalWidth: Int = JLine.usingTerminal(_.getWidth)
+
+  override def terminalHeight: Int = JLine.usingTerminal(_.getHeight)
 }
 
 object CommandLineUIService extends CommandLineUIService

--- a/main/src/main/scala/sbt/InteractionService.scala
+++ b/main/src/main/scala/sbt/InteractionService.scala
@@ -13,5 +13,9 @@ abstract class InteractionService {
   /** Ask the user to confirm something (yes or no) before continuing. */
   def confirm(msg: String): Boolean
 
+  def terminalWidth: Int
+
+  def terminalHeight: Int
+
   // TODO - Ask for input with autocomplete?
 }


### PR DESCRIPTION
Adds `def terminalWidth: Int` to InteractionService to wrap JLine 2 (or 3 in the future).

Fixes #3352

