### PR TITLE
[fport] Fix ^^ and don't inject scalaVersion by default

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -383,7 +383,6 @@ object Defaults extends BuildCommon {
       ),
     scalaInstance := scalaInstanceTask.value,
     crossVersion := (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled),
-    scalaVersion := PluginCross.scalaVersionSetting.value,
     sbtBinaryVersion in pluginCrossBuild := binarySbtVersion(
       (sbtVersion in pluginCrossBuild).value),
     crossSbtVersions := Vector((sbtVersion in pluginCrossBuild).value),

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -17,7 +17,7 @@ import sbt.internal.CommandStrings._
 import Cross.{ spacedFirst, requireSession }
 import sbt.librarymanagement.Configurations._
 import sbt.librarymanagement.VersionNumber
-import Project.inConfig
+import Project.{ inConfig, inScope }
 
 /**
  * Module responsible for plugin cross building.
@@ -46,9 +46,10 @@ private[sbt] object PluginCross {
         import x._
         state.log.info(s"Setting `sbtVersion in pluginCrossBuild` to $version")
         val add = List(sbtVersion in GlobalScope in pluginCrossBuild :== version) ++
-          inConfig(Compile)(List(scalaVersion := scalaVersionSetting.value)) ++
-          inConfig(Test)(List(scalaVersion := scalaVersionSetting.value))
-
+          List(scalaVersion := scalaVersionSetting.value) ++
+          inScope(GlobalScope.copy(project = Select(currentRef)))(Seq(
+            scalaVersion := scalaVersionSetting.value
+          ))
         val cleared = session.mergeSettings.filterNot(crossExclude)
         val newStructure = Load.reapply(cleared ++ add, structure)
         Project.setProject(session, newStructure, command :: state)

--- a/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
+++ b/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
@@ -1,5 +1,9 @@
 val baseSbt = "1.0"
 
+val buildCrossList = List("2.10.6", "2.11.11", "2.12.2")
+scalaVersion in ThisBuild := "2.12.2"
+crossScalaVersions in ThisBuild := buildCrossList
+
 lazy val root = (project in file("."))
   .settings(
     sbtPlugin := true,
@@ -11,6 +15,12 @@ lazy val root = (project in file("."))
       assert(sv == "2.12", s"Wrong e:scalaVersion: $sv")
       assert(scalaBinaryVersion.value == "2.12", s"Wrong Scala binary version: ${scalaBinaryVersion.value}")
       assert(crossV startsWith "1.0.", s"Wrong `sbtVersion in pluginCrossBuild`: $crossV")
+
+      // crossScalaVersions in app should not be affected
+      val appCrossScalaVersions = (crossScalaVersions in app).value.toList
+      val appScalaVersion = (scalaVersion in app).value
+      assert(appCrossScalaVersions == buildCrossList, s"Wrong `crossScalaVersions in app`: $appCrossScalaVersions")
+      assert(appScalaVersion startsWith "2.12", s"Wrong `scalaVersion in app`: $appScalaVersion")
     },
 
     TaskKey[Unit]("check2") := {
@@ -20,5 +30,13 @@ lazy val root = (project in file("."))
       assert(sv == "2.10", s"Wrong e:scalaVersion: $sv")
       assert(scalaBinaryVersion.value == "2.10", s"Wrong Scala binary version: ${scalaBinaryVersion.value}")
       assert(crossV startsWith "0.13", s"Wrong `sbtVersion in pluginCrossBuild`: $crossV")
+
+      // ^^ should not affect app's crossScalaVersions
+      val appCrossScalaVersions = (crossScalaVersions in app).value.toList
+      val appScalaVersion = (scalaVersion in app).value
+      assert(appCrossScalaVersions == buildCrossList, s"Wrong `crossScalaVersions in app`: $appCrossScalaVersions")
+      assert(appScalaVersion startsWith "2.12", s"Wrong `scalaVersion in app`: $appScalaVersion")
     }
   )
+
+lazy val app = (project in file("app"))


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/3370/

This no longer injects scalaVersion at the project level, which was interfering with crossScalaVersions delegation to ThisBuild scope.

Ref sbt/sbt#3353

