### PR TITLE
[1.0.x] `Append` instance to add `File` to `Seq[Source]`

### DIFF
--- a/main-settings/src/main/scala/sbt/Append.scala
+++ b/main-settings/src/main/scala/sbt/Append.scala
@@ -6,6 +6,8 @@ import scala.annotation.implicitNotFound
 import sbt.internal.util.Attributed
 import Def.Initialize
 import reflect.internal.annotations.compileTimeOnly
+import sbt.internal.io.Source
+import sbt.io.{ AllPassFilter, NothingFilter }
 
 object Append {
   @implicitNotFound(
@@ -95,5 +97,12 @@ object Append {
     new Sequence[Seq[T], Option[T], Option[T]] {
       def appendValue(a: Seq[T], b: Option[T]): Seq[T] = b.fold(a)(a :+ _)
       def appendValues(a: Seq[T], b: Option[T]): Seq[T] = b.fold(a)(a :+ _)
+    }
+  implicit def appendSource: Sequence[Seq[Source], Seq[File], File] =
+    new Sequence[Seq[Source], Seq[File], File] {
+      def appendValue(a: Seq[Source], b: File): Seq[Source] =
+        appendValues(a, Seq(b))
+      def appendValues(a: Seq[Source], b: Seq[File]): Seq[Source] =
+        a ++ b.map(new Source(_, AllPassFilter, NothingFilter))
     }
 }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -37,7 +37,7 @@ import sbt.internal.{
   LogManager
 }
 import sbt.io.{ FileFilter, WatchService }
-import sbt.internal.io.{ Source, WatchState }
+import sbt.internal.io.WatchState
 import sbt.internal.util.{ AttributeKey, SourcePosition }
 
 import sbt.librarymanagement.Configurations.CompilerPlugin
@@ -132,8 +132,8 @@ object Keys {
   val suppressSbtShellNotification = settingKey[Boolean]("""True to suppress the "Executing in batch mode.." message.""").withRank(CSetting)
   val pollInterval = settingKey[FiniteDuration]("Interval between checks for modified sources by the continuous execution command.").withRank(BMinusSetting)
   val watchService = settingKey[() => WatchService]("Service to use to monitor file system changes.").withRank(BMinusSetting)
-  val watchSources = taskKey[Seq[Source]]("Defines the sources in this project for continuous execution to watch for changes.").withRank(BMinusSetting)
-  val watchTransitiveSources = taskKey[Seq[Source]]("Defines the sources in all projects for continuous execution to watch.").withRank(CSetting)
+  val watchSources = taskKey[Seq[Watched.WatchSource]]("Defines the sources in this project for continuous execution to watch for changes.").withRank(BMinusSetting)
+  val watchTransitiveSources = taskKey[Seq[Watched.WatchSource]]("Defines the sources in all projects for continuous execution to watch.").withRank(CSetting)
   val watchingMessage = settingKey[WatchState => String]("The message to show when triggered execution waits for sources to change.").withRank(DSetting)
   val triggeredMessage = settingKey[WatchState => String]("The message to show before triggered execution executes an action after sources change.").withRank(DSetting)
 


### PR DESCRIPTION
Let's people write, for instance:

```scala
watchSources += baseDirectory.value / "some-directory"
```

Instead of

```scala
watchSources += new sbt.internal.io.Source(baseDirectory.value / "some-directory", AllPassFilter, NothingFilter)
```

It also simplifies the life of people cross-building plugins between 0.13 and 1.0.