### PR TITLE
Fix #3413: Include base directory to watched sources

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -316,7 +316,9 @@ object Defaults extends BuildCommon {
                                      includeFilter in unmanagedSources,
                                      excludeFilter in unmanagedSources).value,
     watchSources in ConfigGlobal ++= {
-      val bases = unmanagedSourceDirectories.value
+      val baseDir = baseDirectory.value
+      val bases = unmanagedSourceDirectories.value ++ (if (sourcesInBase.value) Seq(baseDir)
+                                                       else Seq.empty)
       val include = (includeFilter in unmanagedSources).value
       val exclude = (excludeFilter in unmanagedSources).value
       bases.map(b => new Source(b, include, exclude))


### PR DESCRIPTION
If `sourcesInBase` is true, we must also watch sources in the base
directory.

This doesn't completely fix #3413, as the same problem would happen if `sourcesInBase` is `false` and no source directories exist. The new watch service expects to watch existing directories. If no such directories are given, it throws an exception because it will never detect anything.

I think that the second part of the fix should be to make `WatchState` throw a less scary-looking exception if it cannot find anything to watch. That'd be different from 0.13. @dwijnand @eed3si9n WDYT?