### PR TITLE
[0.13] Use precise machines for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
-# Use Docker-based container (instead of OpenVZ)
 sudo: false
+
+# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+# Travis now defaults to Trusty, which is missing openjdk6.
+dist: precise
 
 cache:
   directories:


### PR DESCRIPTION
PR validation to 0.13 branch is failing because Travis now defaults to Trusty, which does not seem to support openjdk6.

Ref travis-ci/travis-ci#8199

