### PR TITLE
Forward `run` task to `bgRun`

### DIFF
--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -5,6 +5,7 @@ import sbt.util.Logger
 import Def.{ ScopedKey, Classpath }
 import sbt.internal.util.complete._
 import java.io.File
+import scala.util.Try
 
 abstract class BackgroundJobService extends Closeable {
 
@@ -24,6 +25,12 @@ abstract class BackgroundJobService extends Closeable {
   def shutdown(): Unit
   def jobs: Vector[JobHandle]
   def stop(job: JobHandle): Unit
+
+  def waitForTry(job: JobHandle): Try[Unit] = {
+    // This implementation is provided only for backward compatibility.
+    Try(waitFor(job))
+  }
+
   def waitFor(job: JobHandle): Unit
 
   /** Copies classpath to temporary directories. */

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -503,8 +503,8 @@ object Defaults extends BuildCommon {
     selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
     mainClass in run := (selectMainClass in run).value,
     mainClass := pickMainClassOrWarn(discoveredMainClasses.value, streams.value.log),
-    runMain := runMainTask(fullClasspath, runner in run).evaluated,
-    run := runTask(fullClasspath, mainClass in run, runner in run).evaluated,
+    runMain := foregroundRunMainTask.evaluated,
+    run := foregroundRunTask.evaluated,
     copyResources := copyResourcesTask.value,
     // note that we use the same runner and mainClass as plain run
     bgRunMain := bgRunMainTask(exportedProductJars,
@@ -1540,8 +1540,11 @@ object Defaults extends BuildCommon {
   lazy val configSettings
     : Seq[Setting[_]] = Classpaths.configSettings ++ configTasks ++ configPaths ++ packageConfig ++ Classpaths.compilerPluginConfig ++ deprecationSettings
 
-  lazy val compileSettings
-    : Seq[Setting[_]] = configSettings ++ (mainBgRunMainTask +: mainBgRunTask +: addBaseSources) ++ Classpaths.addUnmanagedLibrary
+  lazy val compileSettings: Seq[Setting[_]] =
+    configSettings ++
+      (mainBgRunMainTask +: mainBgRunTask +: addBaseSources) ++
+      Classpaths.addUnmanagedLibrary
+
   lazy val testSettings: Seq[Setting[_]] = configSettings ++ testTasks
 
   lazy val itSettings: Seq[Setting[_]] = inConfig(IntegrationTest)(testSettings)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1168,14 +1168,14 @@ object Defaults extends BuildCommon {
     Def.inputTask {
       val handle = bgRunMain.evaluated
       val service = bgJobService.value
-      service.waitFor(handle)
+      service.waitForTry(handle).get
     }
   // run calls bgRun in the background and waits for the result.
   def foregroundRunTask: Initialize[InputTask[Unit]] =
     Def.inputTask {
       val handle = bgRun.evaluated
       val service = bgJobService.value
-      service.waitFor(handle)
+      service.waitForTry(handle).get
     }
   def runMainTask(classpath: Initialize[Task[Classpath]],
                   scalaRun: Initialize[Task[ScalaRun]]): Initialize[InputTask[Unit]] = {

--- a/sbt/src/sbt-test/compiler-project/run-test/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/run-test/build.sbt
@@ -1,6 +1,9 @@
+scalaVersion in ThisBuild := "2.12.3"
+
 libraryDependencies ++= Seq(
-	"com.novocode" % "junit-interface" % "0.5" % "test",
-	"junit" % "junit" % "4.8" % "test"
+	"com.novocode" % "junit-interface" % "0.5" % Test,
+	"junit" % "junit" % "4.8" % Test,
+  "commons-io" % "commons-io" % "2.5" % Runtime,
 )
 
 libraryDependencies += scalaVersion("org.scala-lang" % "scala-compiler" % _ ).value

--- a/sbt/src/sbt-test/compiler-project/run-test/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/compiler-project/run-test/src/main/scala/Foo.scala
@@ -28,10 +28,11 @@ class Foo {
 		catch { case _: URISyntaxException => new File(url.getPath) }
 }
 
-object Test
-{
-	def main(args: Array[String])
-	{
+object Test {
+	def main(args: Array[String]): Unit = {
+		// test that Runtime configuration is included
+		Class.forName("org.apache.commons.io.ByteOrderMark")
+		
 		val foo = new Foo
 		args.foreach { arg =>  foo.eval(arg) == arg.toInt }
 	}

--- a/sbt/src/sbt-test/project/flatten/build.sbt
+++ b/sbt/src/sbt-test/project/flatten/build.sbt
@@ -17,7 +17,10 @@ def unpackageSettings(name: String) = Seq(
   unmanagedSourceDirectories := (baseDirectory.value / name) :: Nil,
   excludeFilter in unmanagedResources := (includeFilter in unmanagedSources).value,
   unmanagedResourceDirectories := unmanagedSourceDirectories.value,
-  unpackage := IO.unzip(artifactPath in packageSrc value, baseDirectory.value / name)
+  unpackage := {
+    IO.unzip(artifactPath in packageSrc value, baseDirectory.value / name)
+    IO.delete(baseDirectory.value / name / "META-INF")
+  }
 )
 
 val unpackage = TaskKey[Unit]("unpackage")


### PR DESCRIPTION
Fixes #3425

The `Compile`-specific `run` task was removed in #2936 in favor of `bgRun` but it stop short of delegating the `run` to `bgRun`.

