### PR TITLE
WatchSource = sbt.internal.io.Source

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import Util._
 import Dependencies._
 import Sxr.sxr
+import com.typesafe.tools.mima.core._, ProblemFilters._
 
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
@@ -382,8 +383,17 @@ lazy val sbtProj = (project in file("sbt"))
     crossScalaVersions := Seq(baseScalaVersion),
     crossPaths := false,
     mimaSettings,
+    mimaBinaryIssueFilters ++= sbtIgnoredProblems,
   )
   .configure(addSbtCompilerBridge)
+
+lazy val sbtIgnoredProblems = {
+  Seq(
+    // Added more items to Import trait.
+    exclude[ReversedMissingMethodProblem]("sbt.Import.sbt$Import$_setter_$WatchSource_="),
+    exclude[ReversedMissingMethodProblem]("sbt.Import.WatchSource")
+  )
+}
 
 def scriptedTask: Def.Initialize[InputTask[Unit]] = Def.inputTask {
   val result = scriptedSource(dir => (s: State) => Scripted.scriptedParser(dir)).parsed

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.0.0"
+  private val ioVersion = "1.0.1"
   private val utilVersion = "1.0.1"
   private val lmVersion = "1.0.0"
   private val zincVersion = "1.0.0"

--- a/sbt/src/main/scala/Import.scala
+++ b/sbt/src/main/scala/Import.scala
@@ -50,6 +50,8 @@ trait Import {
   type RichFile = sbt.io.RichFile
   type SimpleFileFilter = sbt.io.SimpleFileFilter
   type SimpleFilter = sbt.io.SimpleFilter
+  type WatchSource = sbt.internal.io.Source
+  val WatchSource = sbt.internal.io.Source
 
   // sbt.util
   type AbstractLogger = sbt.util.AbstractLogger


### PR DESCRIPTION
Together with https://github.com/sbt/io/pull/74, this change implements

```scala
watchSources += WatchSource(sourceDirectory.value) // or WatchSource(sourceDirectory.value, filter, filter) 
```

that I mentioned in #3438 as the new Watch API.
