### PR TITLE
Revert "Automatically choose proper compiler bridge for dotty"

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -390,14 +390,7 @@ object Defaults extends BuildCommon {
       val _ = clean.value
       IvyActions.cleanCachedResolutionCache(ivyModule.value, streams.value.log)
     },
-    scalaCompilerBridgeSource := {
-      if (ScalaInstance.isDotty(scalaVersion.value))
-        // Maintained at https://github.com/lampepfl/dotty/tree/master/sbt-bridge
-        ModuleID(scalaOrganization.value, "dotty-sbt-bridge", scalaVersion.value)
-          .withConfigurations(Some("component"))
-          .sources()
-      else ZincUtil.getDefaultBridgeModule(scalaVersion.value)
-    }
+    scalaCompilerBridgeSource := ZincUtil.getDefaultBridgeModule(scalaVersion.value)
   )
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(


### PR DESCRIPTION
This reverts commit 2283c68031732751b2488d3571f3bf68a6694178, which I forward ported in https://github.com/sbt/sbt/pull/3070

@dotta pointed out to me that:
1. sbt 1 shouldn't use `"component"` configuration for the compiler bridge.
2. The bridge for Dotty is not yet available.

Given that the module name is used for sbt 0.13, the original forward porting was a bad idea.
