### PR TITLE
deliver task fixes

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1690,8 +1690,8 @@ object Classpaths {
       config.file.get
     },
     packagedArtifact in makePom := ((artifact in makePom).value -> makePom.value),
-    deliver := deliverTask(publishConfiguration).value,
-    deliverLocal := deliverTask(publishLocalConfiguration).value,
+    deliver := deliverTask(makeIvyXmlConfiguration).value,
+    deliverLocal := deliverTask(makeIvyXmlLocalConfiguration).value,
     publish := publishTask(publishConfiguration, deliver).value,
     publishLocal := publishTask(publishLocalConfiguration, deliverLocal).value,
     publishM2 := publishTask(publishM2Configuration, deliverLocal).value
@@ -1871,6 +1871,17 @@ object Classpaths {
       .withProcess(pomPostProcess.value)
       .withFilterRepositories(pomIncludeRepository.value)
       .withAllRepositories(pomAllRepositories.value),
+    makeIvyXmlConfiguration := {
+      makeIvyXmlConfig(
+        publishMavenStyle.value,
+        sbt.Classpaths.deliverPattern(crossTarget.value),
+        if (isSnapshot.value) "integration" else "release",
+        ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+        checksums.in(publish).value.toVector,
+        ivyLoggingLevel.value,
+        isSnapshot.value
+      )
+    },
     publishConfiguration := {
       publishConfig(
         publishMavenStyle.value,
@@ -1882,6 +1893,18 @@ object Classpaths {
         getPublishTo(publishTo.value).name,
         ivyLoggingLevel.value,
         isSnapshot.value
+      )
+    },
+    makeIvyXmlLocalConfiguration := {
+      makeIvyXmlConfig(
+        false, //publishMavenStyle.value,
+        sbt.Classpaths.deliverPattern(crossTarget.value),
+        if (isSnapshot.value) "integration" else "release",
+        ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+        checksums.in(publish).value.toVector,
+        ivyLoggingLevel.value,
+        isSnapshot.value,
+        optResolverName = Some("local")
       )
     },
     publishLocalConfiguration := publishConfig(
@@ -2405,6 +2428,24 @@ object Classpaths {
                          artifacts,
                          checksums,
                          logging,
+                         overwrite)
+
+  def makeIvyXmlConfig(publishMavenStyle: Boolean,
+                       deliverIvyPattern: String,
+                       status: String,
+                       configurations: Vector[ConfigRef],
+                       checksums: Vector[String],
+                       logging: sbt.librarymanagement.UpdateLogging = UpdateLogging.DownloadOnly,
+                       overwrite: Boolean = false,
+                       optResolverName: Option[String] = None) =
+    PublishConfiguration(publishMavenStyle,
+                         Some(deliverIvyPattern),
+                         Some(status),
+                         Some(configurations),
+                         optResolverName,
+                         Vector.empty,
+                         checksums,
+                         Some(logging),
                          overwrite)
 
   def deliverPattern(outputPath: File): String =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1692,6 +1692,7 @@ object Classpaths {
     packagedArtifact in makePom := ((artifact in makePom).value -> makePom.value),
     deliver := deliverTask(makeIvyXmlConfiguration).value,
     deliverLocal := deliverTask(makeIvyXmlLocalConfiguration).value,
+    makeIvyXml := deliverTask(makeIvyXmlConfiguration).value,
     publish := publishTask(publishConfiguration, deliver).value,
     publishLocal := publishTask(publishLocalConfiguration, deliverLocal).value,
     publishM2 := publishTask(publishM2Configuration, deliverLocal).value

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -372,6 +372,8 @@ object Keys {
   val makePom = taskKey[File]("Generates a pom for publishing when publishing Maven-style.").withRank(BPlusTask)
   val deliver = taskKey[File]("Generates the Ivy file for publishing to a repository.").withRank(BTask)
   val deliverLocal = taskKey[File]("Generates the Ivy file for publishing to the local repository.").withRank(BTask)
+  // makeIvyXml is currently identical to the confusingly-named "deliver", which may be deprecated in the future
+  val makeIvyXml = taskKey[File]("Generates the Ivy file for publishing to a repository.").withRank(BTask)
   val publish = taskKey[Unit]("Publishes artifacts to a repository.").withRank(APlusTask)
   val publishLocal = taskKey[Unit]("Publishes artifacts to the local Ivy repository.").withRank(APlusTask)
   val publishM2 = taskKey[Unit]("Publishes artifacts to the local Maven repository.").withRank(ATask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -363,6 +363,8 @@ object Keys {
   val publishLocalConfiguration = taskKey[PublishConfiguration]("Configuration for publishing to the local Ivy repository.").withRank(DTask)
   val publishM2Configuration = taskKey[PublishConfiguration]("Configuration for publishing to the local Maven repository.").withRank(DTask)
   val makePomConfiguration = settingKey[MakePomConfiguration]("Configuration for generating a pom.").withRank(DSetting)
+  val makeIvyXmlConfiguration = taskKey[PublishConfiguration]("Configuration for generating ivy.xml.").withRank(DSetting)
+  val makeIvyXmlLocalConfiguration = taskKey[PublishConfiguration]("Configuration for generating ivy.xml.").withRank(DSetting)
   val packagedArtifacts = taskKey[Map[Artifact, File]]("Packages all artifacts for publishing and maps the Artifact definition to the generated file.").withRank(CTask)
   val publishMavenStyle = settingKey[Boolean]("Configures whether to generate and publish a pom (true) or Ivy file (false).").withRank(BSetting)
   val credentials = taskKey[Seq[Credentials]]("The credentials to use for updating and publishing.").withRank(BMinusTask)


### PR DESCRIPTION
* prevents `deliver` from relying on `publishTo` or `packagedArtifacts` values
* add `makeIvyXml` as a more sensible name for the `deliver` task

The `deliver` and `deliverLocal` tasks (which seem to be identical in function, incidentally) may possibly be deprecated at a later time, in favor of `makeIvyXml`.

Closes #3419