### PR TITLE
Don't warn on by-name keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ def buildLevelSettings: Seq[Setting[_]] =
   inThisBuild(
     Seq(
       organization := "org.scala-sbt",
-      version := "1.0.1-SNAPSHOT",
+      version := "1.0.2-SNAPSHOT",
       description := "sbt is an interactive build tool",
       bintrayOrganization := Some("sbt"),
       bintrayRepository := {

--- a/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
@@ -65,7 +65,7 @@ abstract class BaseTaskLinterDSL extends LinterDSL {
             val wrapperName = nme.decodedName.toString
             val (qualName, isSettingKey) =
               Option(qual.symbol)
-                .map(sym => (sym.name.decodedName.toString, sym.info <:< typeOf[SettingKey[_]]))
+                .map(sym => (sym.name.decodedName.toString, qual.tpe <:< typeOf[SettingKey[_]]))
                 .getOrElse((ap.pos.lineContent, false))
 
             if (!isSettingKey && !shouldIgnore && isTask(wrapperName, tpe.tpe, qual)) {

--- a/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
@@ -2,7 +2,7 @@ package sbt.std
 
 import sbt.SettingKey
 import sbt.internal.util.ConsoleAppender
-import sbt.internal.util.appmacro.{ Convert, Converted, LinterDSL }
+import sbt.internal.util.appmacro.{ Convert, LinterDSL }
 
 import scala.collection.mutable.{ HashSet => MutableSet }
 import scala.io.AnsiColor
@@ -27,7 +27,7 @@ abstract class BaseTaskLinterDSL extends LinterDSL {
 
       def handleUncheckedAnnotation(exprAtUseSite: Tree, tt: TypeTree): Unit = {
         tt.original match {
-          case Annotated(annot, arg) =>
+          case Annotated(annot, _) =>
             Option(annot.tpe) match {
               case Some(AnnotatedType(annotations, _)) =>
                 val tpeAnnotations = annotations.flatMap(ann => Option(ann.tree.tpe).toList)

--- a/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
@@ -152,6 +152,15 @@ class TaskPosSpec {
   }
 
   locally {
+    import sbt._, Def._
+    def withKey(foo: => SettingKey[String]) = {
+      Def.task { if (true) foo.value }
+    }
+    val foo = settingKey[String]("")
+    withKey(foo)
+  }
+
+  locally {
     import sbt._
     import sbt.Def._
     val foo = settingKey[String]("")
@@ -170,5 +179,18 @@ class TaskPosSpec {
     val baz = Def.task[Seq[String]] {
       (1 to 10).map(_ => foo.value)
     }
+  }
+
+  locally {
+    import sbt._, Def._
+    def withKey(bar: => SettingKey[Int]) = {
+      Def.task {
+        List(42).map { _ =>
+          if (true) bar.value
+        }
+      }
+    }
+    val bar = settingKey[Int]("bar")
+    withKey(bar)
   }
 }


### PR DESCRIPTION
.. which is apparently what the type of bare vals in *.sbt files are.

Fixes #3299, again.

Also set version to 1.0.2-SNAPSHOT and fix file warnings.