### PR TITLE
Sbt server could miss some messages

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/ServerConnection.scala
+++ b/main-command/src/main/scala/sbt/internal/client/ServerConnection.scala
@@ -30,8 +30,8 @@ abstract class ServerConnection(connection: Socket) {
             bytesRead = in.read(readBuffer)
             buffer = buffer ++ readBuffer.toVector.take(bytesRead)
             // handle un-framing
-            val delimPos = buffer.indexOf(delimiter)
-            if (delimPos > 0) {
+            var delimPos = buffer.indexOf(delimiter)
+            while (delimPos > -1) {
               val chunk = buffer.take(delimPos)
               buffer = buffer.drop(delimPos + 1)
 
@@ -47,6 +47,7 @@ abstract class ServerConnection(connection: Socket) {
                     case event: StringEvent  => onLogEntry(event)
                   }
                 )
+              delimPos = buffer.indexOf(delimiter)
             }
 
           } catch {

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -29,8 +29,8 @@ final class NetworkChannel(val name: String, connection: Socket, structure: Buil
             bytesRead = in.read(readBuffer)
             buffer = buffer ++ readBuffer.toVector.take(bytesRead)
             // handle un-framing
-            val delimPos = buffer.indexOf(delimiter)
-            if (delimPos > 0) {
+            var delimPos = buffer.indexOf(delimiter)
+            while (delimPos > -1) {
               val chunk = buffer.take(delimPos)
               buffer = buffer.drop(delimPos + 1)
 
@@ -40,6 +40,7 @@ final class NetworkChannel(val name: String, connection: Socket, structure: Buil
                   errorDesc => println("Got invalid chunk from client: " + errorDesc),
                   onCommand
                 )
+              delimPos = buffer.indexOf(delimiter)
             }
 
           } catch {

--- a/notes/1.0.2/server-issue.markdown
+++ b/notes/1.0.2/server-issue.markdown
@@ -1,0 +1,5 @@
+### Bug fixes
+
+- In some cases sbt server was missing some messages. By [@guillaumebort][@guillaumebort].
+
+  [@guillaumebort]: https://github.com/guillaumebort


### PR DESCRIPTION
If the read buffer contains more than 2 messages, we need to consume them all before blocking on socket read again. For that we have to loop until the buffer does not contain anymore the message delimiter character.

Same problem in the client ServerConnection code.
