### PR TITLE
Continuous execution fail if command name is not defined

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -124,7 +124,6 @@ object Watched {
         printIfDefined(watched triggeredMessage newWatchState)
         (ClearOnFailure :: next :: FailureWall :: repeat :: s).put(ContinuousState, newWatchState)
       } else {
-
         while (System.in.available() > 0) System.in.read()
         service.close()
         s.remove(ContinuousState)

--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -85,12 +85,12 @@ object Watched {
   def isEnter(key: Int): Boolean = key == 10 || key == 13
   def printIfDefined(msg: String) = if (!msg.isEmpty) System.out.println(msg)
 
-  def isCommandDefined(s: State, commandName: String) = s.definedCommands.exists {
-    case c: SimpleCommand => c.name == commandName
-    case _                => false
-  }
-
   def executeContinuously(watched: Watched, s: State, next: String, repeat: String): State = {
+    def isCommandDefined(s: State, commandName: String): Boolean = s.definedCommands.exists {
+      case c: SimpleCommand => c.name == commandName
+      case _                => false
+    }
+
     @tailrec def shouldTerminate: Boolean =
       (System.in.available > 0) && (watched.terminateWatch(System.in.read()) || shouldTerminate)
     val sources = watched.watchSources(s)
@@ -113,18 +113,22 @@ object Watched {
           (false, watchState)
       }
 
-    if (triggered) {
-      printIfDefined(watched triggeredMessage newWatchState)
-      if (isCommandDefined(s, next)) {
+    if (!isCommandDefined(s, next)) {
+      val allowed = s.definedCommands.collect {
+        case c: SimpleCommand => c.name
+      }
+      s.log.error(Command.invalidValue("command", allowed)(next))
+      s.fail
+    } else {
+      if (triggered) {
+        printIfDefined(watched triggeredMessage newWatchState)
         (ClearOnFailure :: next :: FailureWall :: repeat :: s).put(ContinuousState, newWatchState)
       } else {
-        throw new IllegalArgumentException(s"`$next` is not a defined command name")
-      }
-    } else {
 
-      while (System.in.available() > 0) System.in.read()
-      service.close()
-      s.remove(ContinuousState)
+        while (System.in.available() > 0) System.in.read()
+        service.close()
+        s.remove(ContinuousState)
+      }
     }
   }
   val ContinuousState =

--- a/sbt/src/sbt-test/actions/error-file-watch/build.sbt
+++ b/sbt/src/sbt-test/actions/error-file-watch/build.sbt
@@ -1,0 +1,1 @@
+lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/actions/error-file-watch/test
+++ b/sbt/src/sbt-test/actions/error-file-watch/test
@@ -1,0 +1,1 @@
+-> ~nonExistingCommand


### PR DESCRIPTION
Fixes [#3309](https://github.com/sbt/sbt/issues/3309)

This changes make continuous execution fail straight away without entering in the watch cycle.