### PR TITLE
sbt client-server port discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - SBT_CMD="scripted dependency-management/*4of4"
     - SBT_CMD="scripted java/* package/* reporter/* run/* project-load/*"
     - SBT_CMD="scripted project/*1of2"
-    - SBT_CMD="scripted project/*2of2"
+    - SBT_CMD="scripted project/*2of2 server/*"
     - SBT_CMD="scripted source-dependencies/*1of3"
     - SBT_CMD="scripted source-dependencies/*2of3"
     - SBT_CMD="scripted source-dependencies/*3of3"

--- a/build.sbt
+++ b/build.sbt
@@ -290,6 +290,10 @@ lazy val commandProj = (project in file("main-command"))
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     contrabandFormatsForType in generateContrabands in Compile := ContrabandConfig.getFormats,
     mimaSettings,
+    mimaBinaryIssueFilters ++= Vector(
+      // Changed the signature of Server method. nacho cheese.
+      exclude[DirectMissingMethodProblem]("sbt.internal.server.Server.*")
+    )
   )
   .configure(
     addSbtIO,

--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,10 @@ val collectionProj = (project in file("internal") / "util-collection")
     name := "Collections",
     libraryDependencies ++= Seq(sjsonNewScalaJson.value),
     mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      // Added private[sbt] method to capture State attributes.
+      exclude[ReversedMissingMethodProblem]("sbt.internal.util.AttributeMap.setCond"),
+    ),
   )
   .configure(addSbtUtilPosition)
 
@@ -292,7 +296,9 @@ lazy val commandProj = (project in file("main-command"))
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
       // Changed the signature of Server method. nacho cheese.
-      exclude[DirectMissingMethodProblem]("sbt.internal.server.Server.*")
+      exclude[DirectMissingMethodProblem]("sbt.internal.server.Server.*"),
+      // Added method to ServerInstance. This is also internal.
+      exclude[ReversedMissingMethodProblem]("sbt.internal.server.ServerInstance.*"),
     )
   )
   .configure(
@@ -365,6 +371,10 @@ lazy val mainProj = (project in file("main"))
       baseDirectory.value / "src" / "main" / "contraband-scala",
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     mimaSettings,
+    mimaBinaryIssueFilters ++= Vector(
+      // Changed the signature of NetworkChannel ctor. internal.
+      exclude[DirectMissingMethodProblem]("sbt.internal.server.NetworkChannel.*"),
+    )
   )
   .configure(
     addSbtIO,

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
@@ -168,6 +168,11 @@ trait AttributeMap {
   /** `true` if there are no mappings in this map, `false` if there are. */
   def isEmpty: Boolean
 
+  /**
+   * Adds the mapping `k -> opt.get` if opt is Some.
+   * Otherwise, it returns this map without the mapping for `k`.
+   */
+  private[sbt] def setCond[T](k: AttributeKey[T], opt: Option[T]): AttributeMap
 }
 
 object AttributeMap {
@@ -216,6 +221,12 @@ private class BasicAttributeMap(private val backing: Map[AttributeKey[_], Any])
 
   def entries: Iterable[AttributeEntry[_]] =
     for ((k: AttributeKey[kt], v) <- backing) yield AttributeEntry(k, v.asInstanceOf[kt])
+
+  private[sbt] def setCond[T](k: AttributeKey[T], opt: Option[T]): AttributeMap =
+    opt match {
+      case Some(v) => put(k, v)
+      case None    => remove(k)
+    }
 
   override def toString = entries.mkString("(", ", ", ")")
 }

--- a/main-command/src/main/contraband-scala/ServerAuthenticationFormats.scala
+++ b/main-command/src/main/contraband-scala/ServerAuthenticationFormats.scala
@@ -1,0 +1,26 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ServerAuthenticationFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val ServerAuthenticationFormat: JsonFormat[sbt.ServerAuthentication] = new JsonFormat[sbt.ServerAuthentication] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.ServerAuthentication = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.readString(js) match {
+        case "Token" => sbt.ServerAuthentication.Token
+      }
+      case None =>
+      deserializationError("Expected JsString but found None")
+    }
+  }
+  override def write[J](obj: sbt.ServerAuthentication, builder: Builder[J]): Unit = {
+    val str = obj match {
+      case sbt.ServerAuthentication.Token => "Token"
+    }
+    builder.writeString(str)
+  }
+}
+}

--- a/main-command/src/main/contraband-scala/sbt/ServerAuthentication.scala
+++ b/main-command/src/main/contraband-scala/sbt/ServerAuthentication.scala
@@ -1,0 +1,12 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt
+sealed abstract class ServerAuthentication extends Serializable
+object ServerAuthentication {
+  
+  
+  case object Token extends ServerAuthentication
+}

--- a/main-command/src/main/contraband/state.contra
+++ b/main-command/src/main/contraband/state.contra
@@ -12,3 +12,7 @@ type Exec {
 type CommandSource {
   channelName: String!
 }
+
+enum ServerAuthentication {
+  Token
+}

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -17,6 +17,15 @@ object BasicKeys {
   val watch = AttributeKey[Watched]("watch", "Continuous execution configuration.", 1000)
   val serverPort =
     AttributeKey[Int]("server-port", "The port number used by server command.", 10000)
+
+  val serverHost =
+    AttributeKey[String]("serverHost", "The host used by server command.", 10000)
+
+  val serverAuthentication =
+    AttributeKey[Set[ServerAuthentication]]("serverAuthentication",
+                                            "Method of authenticating server command.",
+                                            10000)
+
   private[sbt] val interactive = AttributeKey[Boolean](
     "interactive",
     "True if commands are currently being entered from an interactive environment.",

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -138,12 +138,14 @@ private[sbt] object Server {
         import JsonProtocol._
 
         val uri = s"tcp://$host:$port"
-        val tokenRef =
-          if (auth(ServerAuthentication.Token)) {
-            writeTokenfile()
-            Some(tokenfile.toURI.toString)
-          } else None
-        val p = PortFile(uri, tokenRef)
+        val p =
+          auth match {
+            case _ if auth(ServerAuthentication.Token) =>
+              writeTokenfile()
+              PortFile(uri, Option(tokenfile.toString), Option(tokenfile.toURI.toString))
+            case _ =>
+              PortFile(uri, None, None)
+          }
         val json = Converter.toJson(p).get
         IO.write(portfile, CompactPrinter(json))
       }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -264,9 +264,11 @@ object Defaults extends BuildCommon {
         .getOrElse(GCUtil.defaultForceGarbageCollection),
       minForcegcInterval :== GCUtil.defaultMinForcegcInterval,
       interactionService :== CommandLineUIService,
+      serverHost := "127.0.0.1",
       serverPort := 5000 + (Hash
         .toHex(Hash(appConfiguration.value.baseDirectory.toString))
-        .## % 1000)
+        .## % 1000),
+      serverAuthentication := Set(ServerAuthentication.Token),
     ))
 
   def defaultTestTasks(key: Scoped): Seq[Setting[_]] =

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -127,6 +127,8 @@ object Keys {
   val historyPath = SettingKey(BasicKeys.historyPath)
   val shellPrompt = SettingKey(BasicKeys.shellPrompt)
   val serverPort = SettingKey(BasicKeys.serverPort)
+  val serverHost = SettingKey(BasicKeys.serverHost)
+  val serverAuthentication = SettingKey(BasicKeys.serverAuthentication)
   val analysis = AttributeKey[CompileAnalysis]("analysis", "Analysis of compilation, including dependencies and generated outputs.", DSetting)
   val watch = SettingKey(BasicKeys.watch)
   val suppressSbtShellNotification = settingKey[Boolean]("""True to suppress the "Executing in batch mode.." message.""").withRank(CSetting)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -101,7 +101,9 @@ object StandardMain {
     val previous = TrapExit.installManager()
     try {
       try {
-        MainLoop.runLogged(s)
+        try {
+          MainLoop.runLogged(s)
+        } finally exchange.shutdown
       } finally DefaultBackgroundJobService.backgroundJobService.shutdown()
     } finally TrapExit.uninstallManager(previous)
   }

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -15,6 +15,8 @@ import sjsonnew.JsonFormat
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{ Success, Failure }
+import sbt.io.syntax._
+import sbt.io.Hash
 
 /**
  * The command exchange merges multiple command channels (e.g. network and console),
@@ -87,7 +89,10 @@ private[sbt] final class CommandExchange {
     server match {
       case Some(x) => // do nothing
       case _ =>
-        val x = Server.start("127.0.0.1", port, onIncomingSocket, s.log)
+        val portfile = (new File(".")).getAbsoluteFile / "project" / "target" / "active.json"
+        val h = Hash.halfHashString(portfile.toURL.toString)
+        val tokenfile = BuildPaths.getGlobalBase(s) / "server" / h / "token.json"
+        val x = Server.start("127.0.0.1", port, onIncomingSocket, portfile, tokenfile, s.log)
         Await.ready(x.ready, Duration("10s"))
         x.ready.value match {
           case Some(Success(_)) =>

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -90,7 +90,7 @@ private[sbt] final class CommandExchange {
       case Some(x) => // do nothing
       case _ =>
         val portfile = (new File(".")).getAbsoluteFile / "project" / "target" / "active.json"
-        val h = Hash.halfHashString(portfile.toURL.toString)
+        val h = Hash.halfHashString(portfile.toURI.toString)
         val tokenfile = BuildPaths.getGlobalBase(s) / "server" / h / "token.json"
         val x = Server.start("127.0.0.1", port, onIncomingSocket, portfile, tokenfile, s.log)
         Await.ready(x.ready, Duration("10s"))

--- a/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
+++ b/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
@@ -172,7 +172,7 @@ object SettingQueryTest extends org.specs2.mutable.Specification {
 
   def query(setting: String): String = {
     import sbt.protocol._
-    val req: SettingQuery = protocol.SettingQuery(setting)
+    val req: SettingQuery = sbt.protocol.SettingQuery(setting)
     val rsp: SettingQueryResponse = server.SettingQuery.handleSettingQuery(req, structure)
     val bytes: Array[Byte] = Serialization serializeEventMessage rsp
     val payload: String = new String(bytes, java.nio.charset.StandardCharsets.UTF_8)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.0.1"
+  private val ioVersion = "1.1.0"
   private val utilVersion = "1.0.1"
   private val lmVersion = "1.0.2"
   private val zincVersion = "1.0.1"

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
@@ -11,35 +11,42 @@ package sbt.internal.protocol
 final class PortFile private (
   /** URI of the sbt server. */
   val uri: String,
-  val tokenfile: Option[String]) extends Serializable {
+  val tokenfilePath: Option[String],
+  val tokenfileUri: Option[String]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = o match {
-    case x: PortFile => (this.uri == x.uri) && (this.tokenfile == x.tokenfile)
+    case x: PortFile => (this.uri == x.uri) && (this.tokenfilePath == x.tokenfilePath) && (this.tokenfileUri == x.tokenfileUri)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "sbt.internal.protocol.PortFile".##) + uri.##) + tokenfile.##)
+    37 * (37 * (37 * (37 * (17 + "sbt.internal.protocol.PortFile".##) + uri.##) + tokenfilePath.##) + tokenfileUri.##)
   }
   override def toString: String = {
-    "PortFile(" + uri + ", " + tokenfile + ")"
+    "PortFile(" + uri + ", " + tokenfilePath + ", " + tokenfileUri + ")"
   }
-  protected[this] def copy(uri: String = uri, tokenfile: Option[String] = tokenfile): PortFile = {
-    new PortFile(uri, tokenfile)
+  protected[this] def copy(uri: String = uri, tokenfilePath: Option[String] = tokenfilePath, tokenfileUri: Option[String] = tokenfileUri): PortFile = {
+    new PortFile(uri, tokenfilePath, tokenfileUri)
   }
   def withUri(uri: String): PortFile = {
     copy(uri = uri)
   }
-  def withTokenfile(tokenfile: Option[String]): PortFile = {
-    copy(tokenfile = tokenfile)
+  def withTokenfilePath(tokenfilePath: Option[String]): PortFile = {
+    copy(tokenfilePath = tokenfilePath)
   }
-  def withTokenfile(tokenfile: String): PortFile = {
-    copy(tokenfile = Option(tokenfile))
+  def withTokenfilePath(tokenfilePath: String): PortFile = {
+    copy(tokenfilePath = Option(tokenfilePath))
+  }
+  def withTokenfileUri(tokenfileUri: Option[String]): PortFile = {
+    copy(tokenfileUri = tokenfileUri)
+  }
+  def withTokenfileUri(tokenfileUri: String): PortFile = {
+    copy(tokenfileUri = Option(tokenfileUri))
   }
 }
 object PortFile {
   
-  def apply(uri: String, tokenfile: Option[String]): PortFile = new PortFile(uri, tokenfile)
-  def apply(uri: String, tokenfile: String): PortFile = new PortFile(uri, Option(tokenfile))
+  def apply(uri: String, tokenfilePath: Option[String], tokenfileUri: Option[String]): PortFile = new PortFile(uri, tokenfilePath, tokenfileUri)
+  def apply(uri: String, tokenfilePath: String, tokenfileUri: String): PortFile = new PortFile(uri, Option(tokenfilePath), Option(tokenfileUri))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.protocol
+/**
+ * This file should exist throughout the lifetime of the server.
+ * It can be used to find out the transport protocol (port number etc).
+ */
+final class PortFile private (
+  /** URL of the sbt server. */
+  val url: String,
+  val tokenfile: Option[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: PortFile => (this.url == x.url) && (this.tokenfile == x.tokenfile)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.protocol.PortFile".##) + url.##) + tokenfile.##)
+  }
+  override def toString: String = {
+    "PortFile(" + url + ", " + tokenfile + ")"
+  }
+  protected[this] def copy(url: String = url, tokenfile: Option[String] = tokenfile): PortFile = {
+    new PortFile(url, tokenfile)
+  }
+  def withUrl(url: String): PortFile = {
+    copy(url = url)
+  }
+  def withTokenfile(tokenfile: Option[String]): PortFile = {
+    copy(tokenfile = tokenfile)
+  }
+  def withTokenfile(tokenfile: String): PortFile = {
+    copy(tokenfile = Option(tokenfile))
+  }
+}
+object PortFile {
+  
+  def apply(url: String, tokenfile: Option[String]): PortFile = new PortFile(url, tokenfile)
+  def apply(url: String, tokenfile: String): PortFile = new PortFile(url, Option(tokenfile))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/PortFile.scala
@@ -9,27 +9,27 @@ package sbt.internal.protocol
  * It can be used to find out the transport protocol (port number etc).
  */
 final class PortFile private (
-  /** URL of the sbt server. */
-  val url: String,
+  /** URI of the sbt server. */
+  val uri: String,
   val tokenfile: Option[String]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = o match {
-    case x: PortFile => (this.url == x.url) && (this.tokenfile == x.tokenfile)
+    case x: PortFile => (this.uri == x.uri) && (this.tokenfile == x.tokenfile)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "sbt.internal.protocol.PortFile".##) + url.##) + tokenfile.##)
+    37 * (37 * (37 * (17 + "sbt.internal.protocol.PortFile".##) + uri.##) + tokenfile.##)
   }
   override def toString: String = {
-    "PortFile(" + url + ", " + tokenfile + ")"
+    "PortFile(" + uri + ", " + tokenfile + ")"
   }
-  protected[this] def copy(url: String = url, tokenfile: Option[String] = tokenfile): PortFile = {
-    new PortFile(url, tokenfile)
+  protected[this] def copy(uri: String = uri, tokenfile: Option[String] = tokenfile): PortFile = {
+    new PortFile(uri, tokenfile)
   }
-  def withUrl(url: String): PortFile = {
-    copy(url = url)
+  def withUri(uri: String): PortFile = {
+    copy(uri = uri)
   }
   def withTokenfile(tokenfile: Option[String]): PortFile = {
     copy(tokenfile = tokenfile)
@@ -40,6 +40,6 @@ final class PortFile private (
 }
 object PortFile {
   
-  def apply(url: String, tokenfile: Option[String]): PortFile = new PortFile(url, tokenfile)
-  def apply(url: String, tokenfile: String): PortFile = new PortFile(url, Option(tokenfile))
+  def apply(uri: String, tokenfile: Option[String]): PortFile = new PortFile(uri, tokenfile)
+  def apply(uri: String, tokenfile: String): PortFile = new PortFile(uri, Option(tokenfile))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/TokenFile.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/TokenFile.scala
@@ -5,26 +5,26 @@
 // DO NOT EDIT MANUALLY
 package sbt.internal.protocol
 final class TokenFile private (
-  val url: String,
+  val uri: String,
   val token: String) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = o match {
-    case x: TokenFile => (this.url == x.url) && (this.token == x.token)
+    case x: TokenFile => (this.uri == x.uri) && (this.token == x.token)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "sbt.internal.protocol.TokenFile".##) + url.##) + token.##)
+    37 * (37 * (37 * (17 + "sbt.internal.protocol.TokenFile".##) + uri.##) + token.##)
   }
   override def toString: String = {
-    "TokenFile(" + url + ", " + token + ")"
+    "TokenFile(" + uri + ", " + token + ")"
   }
-  protected[this] def copy(url: String = url, token: String = token): TokenFile = {
-    new TokenFile(url, token)
+  protected[this] def copy(uri: String = uri, token: String = token): TokenFile = {
+    new TokenFile(uri, token)
   }
-  def withUrl(url: String): TokenFile = {
-    copy(url = url)
+  def withUri(uri: String): TokenFile = {
+    copy(uri = uri)
   }
   def withToken(token: String): TokenFile = {
     copy(token = token)
@@ -32,5 +32,5 @@ final class TokenFile private (
 }
 object TokenFile {
   
-  def apply(url: String, token: String): TokenFile = new TokenFile(url, token)
+  def apply(uri: String, token: String): TokenFile = new TokenFile(uri, token)
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/TokenFile.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/TokenFile.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.protocol
+final class TokenFile private (
+  val url: String,
+  val token: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: TokenFile => (this.url == x.url) && (this.token == x.token)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.protocol.TokenFile".##) + url.##) + token.##)
+  }
+  override def toString: String = {
+    "TokenFile(" + url + ", " + token + ")"
+  }
+  protected[this] def copy(url: String = url, token: String = token): TokenFile = {
+    new TokenFile(url, token)
+  }
+  def withUrl(url: String): TokenFile = {
+    copy(url = url)
+  }
+  def withToken(token: String): TokenFile = {
+    copy(token = token)
+  }
+}
+object TokenFile {
+  
+  def apply(url: String, token: String): TokenFile = new TokenFile(url, token)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.protocol.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait PortFileFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val PortFileFormat: JsonFormat[sbt.internal.protocol.PortFile] = new JsonFormat[sbt.internal.protocol.PortFile] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.protocol.PortFile = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val url = unbuilder.readField[String]("url")
+      val tokenfile = unbuilder.readField[Option[String]]("tokenfile")
+      unbuilder.endObject()
+      sbt.internal.protocol.PortFile(url, tokenfile)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.protocol.PortFile, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("url", obj.url)
+    builder.addField("tokenfile", obj.tokenfile)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
@@ -11,17 +11,17 @@ implicit lazy val PortFileFormat: JsonFormat[sbt.internal.protocol.PortFile] = n
     jsOpt match {
       case Some(js) =>
       unbuilder.beginObject(js)
-      val url = unbuilder.readField[String]("url")
+      val uri = unbuilder.readField[String]("uri")
       val tokenfile = unbuilder.readField[Option[String]]("tokenfile")
       unbuilder.endObject()
-      sbt.internal.protocol.PortFile(url, tokenfile)
+      sbt.internal.protocol.PortFile(uri, tokenfile)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
   }
   override def write[J](obj: sbt.internal.protocol.PortFile, builder: Builder[J]): Unit = {
     builder.beginObject()
-    builder.addField("url", obj.url)
+    builder.addField("uri", obj.uri)
     builder.addField("tokenfile", obj.tokenfile)
     builder.endObject()
   }

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/PortFileFormats.scala
@@ -12,9 +12,10 @@ implicit lazy val PortFileFormat: JsonFormat[sbt.internal.protocol.PortFile] = n
       case Some(js) =>
       unbuilder.beginObject(js)
       val uri = unbuilder.readField[String]("uri")
-      val tokenfile = unbuilder.readField[Option[String]]("tokenfile")
+      val tokenfilePath = unbuilder.readField[Option[String]]("tokenfilePath")
+      val tokenfileUri = unbuilder.readField[Option[String]]("tokenfileUri")
       unbuilder.endObject()
-      sbt.internal.protocol.PortFile(uri, tokenfile)
+      sbt.internal.protocol.PortFile(uri, tokenfilePath, tokenfileUri)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -22,7 +23,8 @@ implicit lazy val PortFileFormat: JsonFormat[sbt.internal.protocol.PortFile] = n
   override def write[J](obj: sbt.internal.protocol.PortFile, builder: Builder[J]): Unit = {
     builder.beginObject()
     builder.addField("uri", obj.uri)
-    builder.addField("tokenfile", obj.tokenfile)
+    builder.addField("tokenfilePath", obj.tokenfilePath)
+    builder.addField("tokenfileUri", obj.tokenfileUri)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/TokenFileFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/TokenFileFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.protocol.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait TokenFileFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val TokenFileFormat: JsonFormat[sbt.internal.protocol.TokenFile] = new JsonFormat[sbt.internal.protocol.TokenFile] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.protocol.TokenFile = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val url = unbuilder.readField[String]("url")
+      val token = unbuilder.readField[String]("token")
+      unbuilder.endObject()
+      sbt.internal.protocol.TokenFile(url, token)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.protocol.TokenFile, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("url", obj.url)
+    builder.addField("token", obj.token)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/TokenFileFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/protocol/codec/TokenFileFormats.scala
@@ -11,17 +11,17 @@ implicit lazy val TokenFileFormat: JsonFormat[sbt.internal.protocol.TokenFile] =
     jsOpt match {
       case Some(js) =>
       unbuilder.beginObject(js)
-      val url = unbuilder.readField[String]("url")
+      val uri = unbuilder.readField[String]("uri")
       val token = unbuilder.readField[String]("token")
       unbuilder.endObject()
-      sbt.internal.protocol.TokenFile(url, token)
+      sbt.internal.protocol.TokenFile(uri, token)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
   }
   override def write[J](obj: sbt.internal.protocol.TokenFile, builder: Builder[J]): Unit = {
     builder.beginObject()
-    builder.addField("url", obj.url)
+    builder.addField("uri", obj.uri)
     builder.addField("token", obj.token)
     builder.endObject()
   }

--- a/protocol/src/main/contraband-scala/sbt/protocol/InitCommand.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/InitCommand.scala
@@ -1,0 +1,43 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.protocol
+final class InitCommand private (
+  val token: Option[String],
+  val execId: Option[String]) extends sbt.protocol.CommandMessage() with Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: InitCommand => (this.token == x.token) && (this.execId == x.execId)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.protocol.InitCommand".##) + token.##) + execId.##)
+  }
+  override def toString: String = {
+    "InitCommand(" + token + ", " + execId + ")"
+  }
+  protected[this] def copy(token: Option[String] = token, execId: Option[String] = execId): InitCommand = {
+    new InitCommand(token, execId)
+  }
+  def withToken(token: Option[String]): InitCommand = {
+    copy(token = token)
+  }
+  def withToken(token: String): InitCommand = {
+    copy(token = Option(token))
+  }
+  def withExecId(execId: Option[String]): InitCommand = {
+    copy(execId = execId)
+  }
+  def withExecId(execId: String): InitCommand = {
+    copy(execId = Option(execId))
+  }
+}
+object InitCommand {
+  
+  def apply(token: Option[String], execId: Option[String]): InitCommand = new InitCommand(token, execId)
+  def apply(token: String, execId: String): InitCommand = new InitCommand(Option(token), Option(execId))
+}

--- a/protocol/src/main/contraband-scala/sbt/protocol/codec/CommandMessageFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/codec/CommandMessageFormats.scala
@@ -6,6 +6,6 @@
 package sbt.protocol.codec
 
 import _root_.sjsonnew.JsonFormat
-trait CommandMessageFormats { self: sjsonnew.BasicJsonProtocol with sbt.protocol.codec.ExecCommandFormats with sbt.protocol.codec.SettingQueryFormats =>
-implicit lazy val CommandMessageFormat: JsonFormat[sbt.protocol.CommandMessage] = flatUnionFormat2[sbt.protocol.CommandMessage, sbt.protocol.ExecCommand, sbt.protocol.SettingQuery]("type")
+trait CommandMessageFormats { self: sjsonnew.BasicJsonProtocol with sbt.protocol.codec.InitCommandFormats with sbt.protocol.codec.ExecCommandFormats with sbt.protocol.codec.SettingQueryFormats =>
+implicit lazy val CommandMessageFormat: JsonFormat[sbt.protocol.CommandMessage] = flatUnionFormat3[sbt.protocol.CommandMessage, sbt.protocol.InitCommand, sbt.protocol.ExecCommand, sbt.protocol.SettingQuery]("type")
 }

--- a/protocol/src/main/contraband-scala/sbt/protocol/codec/InitCommandFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/codec/InitCommandFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.protocol.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait InitCommandFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val InitCommandFormat: JsonFormat[sbt.protocol.InitCommand] = new JsonFormat[sbt.protocol.InitCommand] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.protocol.InitCommand = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val token = unbuilder.readField[Option[String]]("token")
+      val execId = unbuilder.readField[Option[String]]("execId")
+      unbuilder.endObject()
+      sbt.protocol.InitCommand(token, execId)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.protocol.InitCommand, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("token", obj.token)
+    builder.addField("execId", obj.execId)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/protocol/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/codec/JsonProtocol.scala
@@ -5,6 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.protocol.codec
 trait JsonProtocol extends sjsonnew.BasicJsonProtocol
+  with sbt.protocol.codec.InitCommandFormats
   with sbt.protocol.codec.ExecCommandFormats
   with sbt.protocol.codec.SettingQueryFormats
   with sbt.protocol.codec.CommandMessageFormats

--- a/protocol/src/main/contraband/portfile.contra
+++ b/protocol/src/main/contraband/portfile.contra
@@ -7,7 +7,8 @@ package sbt.internal.protocol
 type PortFile {
   ## URI of the sbt server.
   uri: String!
-  tokenfile: String
+  tokenfilePath: String
+  tokenfileUri: String
 }
 
 type TokenFile {

--- a/protocol/src/main/contraband/portfile.contra
+++ b/protocol/src/main/contraband/portfile.contra
@@ -5,12 +5,12 @@ package sbt.internal.protocol
 ## This file should exist throughout the lifetime of the server.
 ## It can be used to find out the transport protocol (port number etc).
 type PortFile {
-  ## URL of the sbt server.
-  url: String!
+  ## URI of the sbt server.
+  uri: String!
   tokenfile: String
 }
 
 type TokenFile {
-  url: String!
+  uri: String!
   token: String!
 }

--- a/protocol/src/main/contraband/portfile.contra
+++ b/protocol/src/main/contraband/portfile.contra
@@ -1,0 +1,16 @@
+package sbt.internal.protocol
+@target(Scala)
+@codecPackage("sbt.internal.protocol.codec")
+
+## This file should exist throughout the lifetime of the server.
+## It can be used to find out the transport protocol (port number etc).
+type PortFile {
+  ## URL of the sbt server.
+  url: String!
+  tokenfile: String
+}
+
+type TokenFile {
+  url: String!
+  token: String!
+}

--- a/protocol/src/main/contraband/server.contra
+++ b/protocol/src/main/contraband/server.contra
@@ -7,6 +7,11 @@ package sbt.protocol
 interface CommandMessage {
 }
 
+type InitCommand implements CommandMessage {
+  token: String
+  execId: String
+}
+
 ## Command to execute sbt command.
 type ExecCommand implements CommandMessage {
   commandLine: String!

--- a/sbt/src/sbt-test/server/handshake/Client.scala
+++ b/sbt/src/sbt-test/server/handshake/Client.scala
@@ -30,7 +30,7 @@ object Client extends App {
   IO.write(baseDirectory / "ok.txt", "ok")
 
   def getToken: String = {
-    val tokenfile = new File(getTokenFile)
+    val tokenfile = new File(getTokenFileUri)
     val json: JValue = Parser.parseFromFile(tokenfile).get
     json match {
       case JObject(fields) =>
@@ -43,12 +43,12 @@ object Client extends App {
     }
   }
 
-  def getTokenFile: URI = {
+  def getTokenFileUri: URI = {
     val portfile = baseDirectory / "project" / "target" / "active.json"
     val json: JValue = Parser.parseFromFile(portfile).get
     json match {
       case JObject(fields) =>
-        (fields find { _.field == "tokenfile" } map { _.value }) match {
+        (fields find { _.field == "tokenfileUri" } map { _.value }) match {
           case Some(JString(value)) => new URI(value)
           case _                    =>
             sys.error("json doesn't tokenfile field that is JString")

--- a/sbt/src/sbt-test/server/handshake/Client.scala
+++ b/sbt/src/sbt-test/server/handshake/Client.scala
@@ -1,0 +1,35 @@
+package example
+
+import java.net.{ URI, Socket, InetAddress, SocketException }
+import sbt.io._
+import sbt.io.syntax._
+import java.io.File
+
+object Client extends App {
+  val host = "127.0.0.1"
+  val port = 5123
+  val delimiter: Byte = '\n'.toByte
+
+  println("hello")
+  Thread.sleep(1000)
+
+  val connection = getConnection
+  val out = connection.getOutputStream
+  val in = connection.getInputStream
+
+  out.write("""{ "type": "ExecCommand", "commandLine": "exit" }""".getBytes("utf-8"))
+  out.write(delimiter.toInt)
+  out.flush
+
+  val baseDirectory = new File(args(0))
+  IO.write(baseDirectory / "ok.txt", "ok")
+
+  def getConnection: Socket =
+    try {
+      new Socket(InetAddress.getByName(host), port)
+    } catch {
+      case _ =>
+        Thread.sleep(1000)
+        getConnection
+    }
+}

--- a/sbt/src/sbt-test/server/handshake/Client.scala
+++ b/sbt/src/sbt-test/server/handshake/Client.scala
@@ -30,14 +30,14 @@ object Client extends App {
     val json: JValue = Parser.parseFromFile(portfile).get
     json match {
       case JObject(fields) =>
-        (fields find { _.field == "url" } map { _.value }) match {
+        (fields find { _.field == "uri" } map { _.value }) match {
           case Some(JString(value)) => 
             val u = new URI(value)
             u.getPort
           case _                    =>
-            sys.error("json doesn't url field that is JString")
+            sys.error("json doesn't uri field that is JString")
         }
-      case _ => sys.error("json doesn't have url field")
+      case _ => sys.error("json doesn't have uri field")
     }
   }
 

--- a/sbt/src/sbt-test/server/handshake/build.sbt
+++ b/sbt/src/sbt-test/server/handshake/build.sbt
@@ -5,6 +5,7 @@ lazy val root = (project in file("."))
     scalaVersion := "2.12.3",
     serverPort in Global := 5123,
     libraryDependencies += "org.scala-sbt" %% "io" % "1.0.1",
+    libraryDependencies += "com.eed3si9n" %%  "sjson-new-scalajson" % "0.8.0",
     runClient := (Def.taskDyn {
       val b = baseDirectory.value
       (bgRun in Compile).toTask(s""" $b""")

--- a/sbt/src/sbt-test/server/handshake/build.sbt
+++ b/sbt/src/sbt-test/server/handshake/build.sbt
@@ -1,0 +1,13 @@
+lazy val runClient = taskKey[Unit]("")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.12.3",
+    serverPort in Global := 5123,
+    libraryDependencies += "org.scala-sbt" %% "io" % "1.0.1",
+    runClient := (Def.taskDyn {
+      val b = baseDirectory.value
+      (bgRun in Compile).toTask(s""" $b""")
+    }).value
+  )
+ 

--- a/sbt/src/sbt-test/server/handshake/test
+++ b/sbt/src/sbt-test/server/handshake/test
@@ -1,0 +1,6 @@
+> show serverPort
+> runClient
+-> shell
+
+$ sleep 1000
+$ exists ok.txt


### PR DESCRIPTION
This implements JSON-based port file. Throughout the lifetime of the sbt server, there will be `cwd / "project" / "target" / "active.json"`, which contains `uri` field.

```json
{"uri":"tcp://127.0.0.1:5010"}
```

Using this a potential client, such as IDEs, can find out which port number to hit.

Ref #3508
