### PR TITLE
Fixes Zero / Zero / Zero / name handling

### DIFF
--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -24,6 +24,11 @@ final case class Scope(project: ScopeAxis[Reference],
   def in(project: Reference): Scope = copy(project = Select(project))
   def in(config: ConfigKey): Scope = copy(config = Select(config))
   def in(task: AttributeKey[_]): Scope = copy(task = Select(task))
+
+  override def toString: String = {
+    if (extra == This) s"$project / $config / $task"
+    else s"Scope($project, $config, $task, $extra)"
+  }
 }
 object Scope {
   val ThisScope: Scope = Scope(This, This, This, This)

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -34,6 +34,8 @@ sealed abstract class SettingKey[T]
 
   val key: AttributeKey[T]
 
+  override def toString: String = s"SettingKey($scope / $key)"
+
   final def toTask: Initialize[Task[T]] = this apply inlineTask
 
   final def scopedKey: ScopedKey[T] = ScopedKey(scope, key)
@@ -105,6 +107,8 @@ sealed abstract class TaskKey[T]
 
   val key: AttributeKey[Task[T]]
 
+  override def toString: String = s"TaskKey($scope / $key)"
+
   def toTask: Initialize[Task[T]] = this
 
   def scopedKey: ScopedKey[Task[T]] = ScopedKey(scope, key)
@@ -171,6 +175,8 @@ sealed trait InputKey[T]
     with Scoped.DefinableSetting[InputTask[T]] {
 
   val key: AttributeKey[InputTask[T]]
+
+  override def toString: String = s"InputKey($scope / $key)"
 
   def scopedKey: ScopedKey[InputTask[T]] = ScopedKey(scope, key)
 

--- a/main/src/main/scala/sbt/SlashSyntax.scala
+++ b/main/src/main/scala/sbt/SlashSyntax.scala
@@ -1,6 +1,7 @@
 package sbt
 
 import sbt.librarymanagement.Configuration
+import sbt.internal.util.AttributeKey
 
 /**
  * SlashSyntax implements the slash syntax to scope keys for build.sbt DSL.
@@ -57,7 +58,12 @@ object SlashSyntax {
   }
 
   /** RichConfiguration wraps a configuration to provide the `/` operator for scoping. */
-  final class RichConfiguration(protected val scope: Scope) extends RichScopeLike
+  final class RichConfiguration(protected val scope: Scope) extends RichScopeLike {
+
+    // This is for handling `Zero / Zero / Zero / name`.
+    def /(taskAxis: ScopeAxis[AttributeKey[_]]): RichScope =
+      new RichScope(scope.copy(task = taskAxis))
+  }
 
   /** Both `Scoped.ScopingSetting` and `Scoped` are parents of `SettingKey`, `TaskKey` and
    * `InputKey`. We'll need both, so this is a convenient type alias. */

--- a/main/src/main/scala/sbt/SlashSyntax.scala
+++ b/main/src/main/scala/sbt/SlashSyntax.scala
@@ -97,6 +97,10 @@ object SlashSyntax {
   final class ScopeAndKey[K <: Key[K]](scope: Scope, key: K) {
     private[sbt] def materialize: K = key in scope
     private[sbt] def rescope: TerminalScope = new TerminalScope(scope in key.key)
+
+    override def toString: String = {
+      s"$scope / ${key.key}"
+    }
   }
 
 }

--- a/sbt/src/sbt-test/project/unified/build.sbt
+++ b/sbt/src/sbt-test/project/unified/build.sbt
@@ -10,6 +10,7 @@ lazy val root = (project in file("."))
     Compile / console / scalacOptions += "-Ywarn-numeric-widen",
     projA / Compile / console / scalacOptions += "-feature",
     Zero / Zero / name := "foo",
+    Zero / Zero / Zero / name := "foo",
 
     libraryDependencies += uTest % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),


### PR DESCRIPTION
Prior to this change `Zero / Zero / Zero / name` broke as follows:

```scala
scala> Zero / Zero / Zero / name
Zero / Zero / Zero / name
<console>:18: error: inferred type arguments [sbt.Zero.type] do not conform to method /'s type parameter bounds [K <: sbt.SlashSyntax.Key[K]]
       Zero / Zero / Zero / name
                   ^
```

This fixes the bug, and also adds `toString` so I can test it from REPL:

```scala
scala> import sbt._
scala> import Keys._

scala> Zero / Zero / Zero / name
res0: sbt.SlashSyntax.ScopeAndKey[sbt.SettingKey[String]] = Zero / Zero / Zero / name
```
