### PR TITLE
Dedup DefaultCommands and allBasicCommands

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -161,9 +161,6 @@ object BuiltinCommands {
 
   def DefaultCommands: Seq[Command] =
     Seq(
-      ignore,
-      help,
-      completionsCommand,
       about,
       tasks,
       settingsCommand,
@@ -171,9 +168,6 @@ object BuiltinCommands {
       templateCommand,
       projects,
       project,
-      reboot,
-      read,
-      history,
       set,
       sessionCommand,
       inspect,
@@ -184,36 +178,21 @@ object BuiltinCommands {
       PluginCross.pluginCross,
       PluginCross.pluginSwitch,
       Cross.crossRestoreSession,
-      setOnFailure,
-      clearOnFailure,
-      stashOnFailure,
-      popOnFailure,
       setLogLevel,
       plugin,
       plugins,
       writeSbtVersion,
       notifyUsersAboutShell,
-      ifLast,
-      multi,
       shell,
-      oldshell,
       startServer,
-      BasicCommands.client,
-      continuous,
       eval,
-      alias,
-      append,
       last,
       lastGrep,
       export,
       boot,
-      nop,
-      call,
-      exit,
-      early,
       initialize,
       act
-    ) ++ compatCommands
+    ) ++ allBasicCommands
 
   def DefaultBootCommands: Seq[String] =
     WriteSbtVersion :: LoadProject :: NotifyUsersAboutShell :: s"$IfLast $Shell" :: Nil


### PR DESCRIPTION
The command component's BasicCommands.allBasicCommands is a subset of
main component's BuiltinCommands.DefaultCommands, so I deduplicated.