### PR TITLE
Make slash syntax constructs eligible for .value enrichments

### DIFF
--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -178,6 +178,7 @@ object Def extends Init[Scope] with TaskMacroExtra {
   implicit def macroValueIInT[T](in: Initialize[InputTask[T]]): InputEvaluated[T] = ???
   implicit def taskMacroValueIT[T](in: Initialize[Task[T]]): MacroTaskValue[T] = ???
   implicit def macroPrevious[T](in: TaskKey[T]): MacroPrevious[T] = ???
+  implicit def taskKeyThunkPrevious[T](in: SlashSyntax.ScopeAndTaskKey[T]): MacroPrevious[T] = ???
 
   // The following conversions enable the types Parser[T], Initialize[Parser[T]], and Initialize[State => Parser[T]] to
   //  be used in the inputTask macro as an input with an ultimate result of type T

--- a/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
@@ -11,7 +11,7 @@ import org.scalacheck.{ Test => _, _ }, Arbitrary.arbitrary, Gen._, Prop._
 
 import java.io.File
 import sbt.io.IO
-import sbt.SlashSyntax, SlashSyntax.Key
+import sbt.SlashSyntax
 import sbt.{ Scope, ScopeAxis, Scoped, Select, This, Zero }, Scope.{ Global, ThisScope }
 import sbt.{ BuildRef, LocalProject, LocalRootProject, ProjectRef, Reference, RootProject, ThisBuild, ThisProject }
 import sbt.ConfigKey
@@ -72,14 +72,6 @@ object BuildDSLInstances {
   implicit def arbTaskKey[A: Manifest]: Arbitrary[TaskKey[A]] =
     withScope(Gen.identifier map (TaskKey[A](_)))
 
-  implicit def arbKey[A: Manifest]: Arbitrary[Key[_]] = Arbitrary {
-    Gen.frequency[Key[_]](
-      15 -> arbitrary[InputKey[A]],   // 15,431
-      20 -> arbitrary[SettingKey[A]], // 19,645
-      23 -> arbitrary[TaskKey[A]],    // 22,867
-    )
-  }
-
   implicit def arbScopeAxis[A: Arbitrary]: Arbitrary[ScopeAxis[A]] =
     Arbitrary(Gen.oneOf[ScopeAxis[A]](This, Zero, arbitrary[A] map (Select(_))))
 
@@ -134,111 +126,136 @@ import CustomEquality._
 
 object SlashSyntaxSpec extends Properties("SlashSyntax") with SlashSyntax {
   property("Global / key == key in Global") = {
-    def check[K <: Key[K]: Arbitrary] = forAll((k: K) => expectValue(k in Global)(Global / k))
-    check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((k: InputKey[String])   => expectValue(k in Global)(Global / k))
+        && forAll((k: SettingKey[String]) => expectValue(k in Global)(Global / k))
+        && forAll((k: TaskKey[String])    => expectValue(k in Global)(Global / k))
+    )
   }
   property("Reference / key == key in Reference") = {
-    def check[K <: Key[K]: Arbitrary] = forAll((r: Reference, k: K) => expectValue(k in r)(r / k))
-    check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((r: Reference, k: InputKey[String]) => expectValue(k in r)(r / k))
+        && forAll((r: Reference, k: SettingKey[String]) => expectValue(k in r)(r / k))
+        && forAll((r: Reference, k: TaskKey[String]) => expectValue(k in r)(r / k))
+    )
   }
   property("Reference / Config / key == key in Reference in Config") = {
-    def check[K <: Key[K]: Arbitrary] =
-      forAll((r: Reference, c: ConfigKey, k: K) => expectValue(k in r in c)(r / c / k))
-    check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((r: Reference, c: ConfigKey, k: InputKey[String]) => expectValue(k in r in c)(r / c / k))
+        && forAll((r: Reference, c: ConfigKey, k: SettingKey[String]) => expectValue(k in r in c)(r / c / k))
+        && forAll((r: Reference, c: ConfigKey, k: TaskKey[String]) => expectValue(k in r in c)(r / c / k))
+    )
   }
   property("Reference / task / key == key in Reference in task") = {
-    def check[T <: Key[T]: Arbitrary, K <: Key[K]: Arbitrary] =
-      forAll((r: Reference, t: K, k: K) => expectValue(k in (r, t))(r / t / k))
     (true
-        && check[InputKey[String], InputKey[String]]
-        && check[InputKey[String], SettingKey[String]]
-        && check[InputKey[String], TaskKey[String]]
-        && check[SettingKey[String], InputKey[String]]
-        && check[SettingKey[String], SettingKey[String]]
-        && check[SettingKey[String], TaskKey[String]]
-        && check[TaskKey[String], InputKey[String]]
-        && check[TaskKey[String], SettingKey[String]]
-        && check[TaskKey[String], TaskKey[String]]
+        && forAll((r: Reference, t: InputKey[String], k: InputKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: InputKey[String], k: SettingKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: InputKey[String], k: TaskKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: SettingKey[String], k: InputKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: SettingKey[String], k: SettingKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: SettingKey[String], k: TaskKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: TaskKey[String], k: InputKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: TaskKey[String], k: SettingKey[String]) => expectValue(k in (r, t))(r / t / k))
+        && forAll((r: Reference, t: TaskKey[String], k: TaskKey[String]) => expectValue(k in (r, t))(r / t / k))
     )
   }
   property("Reference / Config / task / key == key in Reference in Config in task") = {
-    def check[T <: Key[T]: Arbitrary, K <: Key[K]: Arbitrary] =
-      forAll((r: Reference, c: ConfigKey, t: K, k: K) => expectValue(k in (r, c, t))(r / c / t / k))
     (true
-        && check[InputKey[String], InputKey[String]]
-        && check[InputKey[String], SettingKey[String]]
-        && check[InputKey[String], TaskKey[String]]
-        && check[SettingKey[String], InputKey[String]]
-        && check[SettingKey[String], SettingKey[String]]
-        && check[SettingKey[String], TaskKey[String]]
-        && check[TaskKey[String], InputKey[String]]
-        && check[TaskKey[String], SettingKey[String]]
-        && check[TaskKey[String], TaskKey[String]]
+        && forAll((r: Reference, c: ConfigKey, t: InputKey[String], k: InputKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: InputKey[String], k: SettingKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: InputKey[String], k: TaskKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: SettingKey[String], k: InputKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: SettingKey[String], k: SettingKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: SettingKey[String], k: TaskKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: TaskKey[String], k: InputKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: TaskKey[String], k: SettingKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
+        && forAll((r: Reference, c: ConfigKey, t: TaskKey[String], k: TaskKey[String]) => expectValue(k in (r, c, t))(r / c / t / k))
     )
   }
   property("Config / key == key in Config") = {
-    def check[K <: Key[K]: Arbitrary] =
-      forAll((c: ConfigKey, k: K) => expectValue(k in c)(c / k))
-    check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((c: ConfigKey, k: InputKey[String]) => expectValue(k in c)(c / k))
+        && forAll((c: ConfigKey, k: SettingKey[String]) => expectValue(k in c)(c / k))
+        && forAll((c: ConfigKey, k: TaskKey[String]) => expectValue(k in c)(c / k))
+    )
   }
   property("Config / task / key == key in Config in task") = {
-    def check[T <: Key[T]: Arbitrary, K <: Key[K]: Arbitrary] =
-      forAll((c: ConfigKey, t: K, k: K) => expectValue(k in c in t)(c / t / k))
     (true
-        && check[InputKey[String], InputKey[String]]
-        && check[InputKey[String], SettingKey[String]]
-        && check[InputKey[String], TaskKey[String]]
-        && check[SettingKey[String], InputKey[String]]
-        && check[SettingKey[String], SettingKey[String]]
-        && check[SettingKey[String], TaskKey[String]]
-        && check[TaskKey[String], InputKey[String]]
-        && check[TaskKey[String], SettingKey[String]]
-        && check[TaskKey[String], TaskKey[String]]
+        && forAll((c: ConfigKey, t: InputKey[String], k: InputKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: InputKey[String], k: SettingKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: InputKey[String], k: TaskKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: SettingKey[String], k: InputKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: SettingKey[String], k: SettingKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: SettingKey[String], k: TaskKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: TaskKey[String], k: InputKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: TaskKey[String], k: SettingKey[String]) => expectValue(k in c in t)(c / t / k))
+        && forAll((c: ConfigKey, t: TaskKey[String], k: TaskKey[String]) => expectValue(k in c in t)(c / t / k))
     )
   }
   property("task / key == key in task") = {
-    def check[T <: Key[T]: Arbitrary, K <: Key[K]: Arbitrary] =
-      forAll((t: K, k: K) => expectValue(k in t)(t / k))
     (true
-        && check[InputKey[String], InputKey[String]]
-        && check[InputKey[String], SettingKey[String]]
-        && check[InputKey[String], TaskKey[String]]
-        && check[SettingKey[String], InputKey[String]]
-        && check[SettingKey[String], SettingKey[String]]
-        && check[SettingKey[String], TaskKey[String]]
-        && check[TaskKey[String], InputKey[String]]
-        && check[TaskKey[String], SettingKey[String]]
-        && check[TaskKey[String], TaskKey[String]]
-        )
+        && forAll((t: InputKey[String], k: InputKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: InputKey[String], k: SettingKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: InputKey[String], k: TaskKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: SettingKey[String], k: InputKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: SettingKey[String], k: SettingKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: SettingKey[String], k: TaskKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: TaskKey[String], k: InputKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: TaskKey[String], k: SettingKey[String]) => expectValue(k in t)(t / k))
+        && forAll((t: TaskKey[String], k: TaskKey[String]) => expectValue(k in t)(t / k))
+    )
   }
   property("Scope / key == key in Scope") = {
-    def check[K <: Key[K]: Arbitrary] = forAll((s: Scope, k: K) => expectValue(k in s)(s / k))
-    check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((s: Scope, k: InputKey[String]) => expectValue(k in s)(s / k))
+        && forAll((s: Scope, k: SettingKey[String]) => expectValue(k in s)(s / k))
+        && forAll((s: Scope, k: TaskKey[String]) => expectValue(k in s)(s / k))
+    )
   }
   property("Reference? / key == key in ThisScope.copy(..)") = {
-    def check[K <: Key[K]: Arbitrary] =
-      forAll((r: ScopeAxis[Reference], k: K) =>
-        expectValue(k in ThisScope.copy(project = r))(r / k))
-      check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((r: ScopeAxis[Reference], k: InputKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r))(r / k))
+        && forAll((r: ScopeAxis[Reference], k: SettingKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r))(r / k))
+        && forAll((r: ScopeAxis[Reference], k: TaskKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r))(r / k))
+    )
   }
   property("Reference? / ConfigKey? / key == key in ThisScope.copy(..)") = {
-    def check[K <: Key[K]: Arbitrary] =
-      forAll((r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], k: K) =>
-        expectValue(k in ThisScope.copy(project = r, config = c))(r / c / k))
-      check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll((r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], k: InputKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r, config = c))(r / c / k))
+        && forAll((r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], k: SettingKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r, config = c))(r / c / k))
+        && forAll((r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], k: TaskKey[String]) =>
+          expectValue(k in ThisScope.copy(project = r, config = c))(r / c / k))
+    )
   }
 //  property("Reference? / AttributeKey? / key == key in ThisScope.copy(..)") = {
-//    def check[K <: Key[K]: Arbitrary] =
-//      forAll(
-//        (r: ScopeAxis[Reference], t: ScopeAxis[AttributeKey[_]], k: K) =>
-//          expectValue(k in ThisScope.copy(project = r, task = t))(r / t / k))
-//      check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+//    (true
+//        && forAll(
+//          (r: ScopeAxis[Reference], t: ScopeAxis[AttributeKey[_]], k: InputKey[String]) =>
+//            expectValue(k in ThisScope.copy(project = r, task = t))(r / t / k))
+//        && forAll(
+//          (r: ScopeAxis[Reference], t: ScopeAxis[AttributeKey[_]], k: SettingKey[String]) =>
+//            expectValue(k in ThisScope.copy(project = r, task = t))(r / t / k))
+//        && forAll(
+//          (r: ScopeAxis[Reference], t: ScopeAxis[AttributeKey[_]], k: TaskKey[String]) =>
+//            expectValue(k in ThisScope.copy(project = r, task = t))(r / t / k))
+//    )
 //  }
   property("Reference? / ConfigKey? / AttributeKey? / key == key in ThisScope.copy(..)") = {
-    def check[K <: Key[K]: Arbitrary] =
-      forAll(
-        (r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], t: ScopeAxis[AttributeKey[_]], k: K) =>
-          expectValue(k in ThisScope.copy(project = r, config = c, task = t))(r / c / t / k))
-      check[InputKey[String]] && check[SettingKey[String]] && check[TaskKey[String]]
+    (true
+        && forAll(
+          (r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], t: ScopeAxis[AttributeKey[_]], k: InputKey[String]) =>
+            expectValue(k in ThisScope.copy(project = r, config = c, task = t))(r / c / t / k))
+        && forAll(
+          (r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], t: ScopeAxis[AttributeKey[_]], k: SettingKey[String]) =>
+            expectValue(k in ThisScope.copy(project = r, config = c, task = t))(r / c / t / k))
+        && forAll(
+          (r: ScopeAxis[Reference], c: ScopeAxis[ConfigKey], t: ScopeAxis[AttributeKey[_]], k: TaskKey[String]) =>
+            expectValue(k in ThisScope.copy(project = r, config = c, task = t))(r / c / t / k))
+    )
   }
 }

--- a/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
@@ -26,6 +26,9 @@ object SlashSyntaxTest extends sbt.SlashSyntax {
   val scalaVersion = settingKey[String]("")
   val scalacOptions = taskKey[Seq[String]]("")
 
+  val foo = settingKey[Int]("")
+  val bar = settingKey[Int]("")
+
   val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
 
   Seq[Setting[_]](
@@ -36,6 +39,7 @@ object SlashSyntaxTest extends sbt.SlashSyntax {
     projA / Compile / console / scalacOptions += "-feature",
     Zero / Zero / name := "foo",
     Zero / Zero / Zero / name := "foo",
+    foo := (Test / bar).value + 1,
     libraryDependencies += uTest % Test,
   )
 }

--- a/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
@@ -7,7 +7,9 @@
 
 package sbt.test
 
-import sbt.Def.{ Setting, settingKey, taskKey }
+import java.io.File
+import sjsonnew._, BasicJsonProtocol._
+import sbt.Def.{ Setting, inputKey, settingKey, taskKey }
 import sbt.Scope.Global
 import sbt.librarymanagement.ModuleID
 import sbt.librarymanagement.syntax._
@@ -23,11 +25,14 @@ object SlashSyntaxTest extends sbt.SlashSyntax {
   val console = taskKey[Unit]("")
   val libraryDependencies = settingKey[Seq[ModuleID]]("")
   val name = settingKey[String]("")
+  val run = inputKey[Unit]("")
   val scalaVersion = settingKey[String]("")
   val scalacOptions = taskKey[Seq[String]]("")
 
-  val foo = settingKey[Int]("")
-  val bar = settingKey[Int]("")
+  val foo = taskKey[Int]("")
+  val bar = taskKey[Int]("")
+  val baz = inputKey[Unit]("")
+  val buildInfo = taskKey[Seq[File]]("")
 
   val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
 
@@ -39,6 +44,19 @@ object SlashSyntaxTest extends sbt.SlashSyntax {
     projA / Compile / console / scalacOptions += "-feature",
     Zero / Zero / name := "foo",
     Zero / Zero / Zero / name := "foo",
+    Test / bar := 1,
+    Test / foo := (Test / bar).value + 1,
+    Compile / foo := {
+      (Compile / bar).previous.getOrElse(1)
+    },
+    Compile / bar := {
+      (Compile / foo).previous.getOrElse(2)
+    },
+    Test / buildInfo := Nil,
+    baz := {
+      val _ = (Test / buildInfo).taskValue
+      (Compile / run).evaluated
+    },
     foo := (Test / bar).value + 1,
     libraryDependencies += uTest % Test,
   )

--- a/sbt/src/sbt-test/project/unified/build.sbt
+++ b/sbt/src/sbt-test/project/unified/build.sbt
@@ -1,5 +1,11 @@
 import sbt.internal.CommandStrings.{ inspectBrief, inspectDetailed }
 import sbt.internal.Inspect
+import sjsonnew._, BasicJsonProtocol._
+
+val foo = taskKey[Int]("")
+val bar = taskKey[Int]("")
+val baz = inputKey[Unit]("")
+val buildInfo = taskKey[Seq[File]]("The task that generates the build info.")
 
 val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
 
@@ -12,6 +18,19 @@ lazy val root = (project in file("."))
     projA / Compile / console / scalacOptions += "-feature",
     Zero / Zero / name := "foo",
     Zero / Zero / Zero / name := "foo",
+    Test / bar := 1,
+    Test / foo := (Test / bar).value + 1,
+    Compile / foo := {
+      (Compile / bar).previous.getOrElse(1)
+    },
+    Compile / bar := {
+      (Compile / foo).previous.getOrElse(2)
+    },
+    Test / buildInfo := Nil,
+    baz := {
+      val x = (Test / buildInfo).taskValue
+      (Compile / run).evaluated
+    },
 
     libraryDependencies += uTest % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),


### PR DESCRIPTION
The implicit conversions in Def that add the .value, .evaluated,
.taskValue, .inputTaskValue and .parsed methods enrich Initialize, which
ScopeAndKey wasn't a subtype of.

Because of the lack of, what I believe is called, "kind polymorphism" the
fix requires an implementation for each of the 3 key type kinds.

Notably missing is the .previous enrichment, which is only on TaskKeys, so
I'm deferring the fix for .previous on slash syntax to a later date.

Fixes #3605