### PR TITLE
Correct handling of resolving ThisProject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -391,6 +391,8 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.internal.KeyIndex.*"),
       // Removed unused val. internal.
       exclude[DirectMissingMethodProblem]("sbt.internal.RelayAppender.jsonFormat"),
+      // Removed unused def. internal.
+      exclude[DirectMissingMethodProblem]("sbt.internal.Load.isProjectThis"),
     )
   )
   .configure(

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -97,8 +97,7 @@ object Scope {
       case LocalProject(id)    => ProjectRef(current, id)
       case RootProject(uri)    => RootProject(resolveBuild(current, uri))
       case ProjectRef(uri, id) => ProjectRef(resolveBuild(current, uri), id)
-      case ThisProject =>
-        RootProject(current) // Is this right? It was an inexhaustive match before..
+      case ThisProject         => ThisProject // haven't exactly "resolved" anything..
     }
   def resolveBuild(current: URI, uri: URI): URI =
     if (!uri.isAbsolute && current.isOpaque && uri.getSchemeSpecificPart == ".")
@@ -118,13 +117,11 @@ object Scope {
                         rootProject: URI => String,
                         ref: ProjectReference): ProjectRef =
     ref match {
-      case LocalRootProject => ProjectRef(current, rootProject(current))
-      case LocalProject(id) => ProjectRef(current, id)
-      case RootProject(uri) =>
-        val res = resolveBuild(current, uri); ProjectRef(res, rootProject(res))
+      case LocalRootProject    => ProjectRef(current, rootProject(current))
+      case LocalProject(id)    => ProjectRef(current, id)
+      case RootProject(uri)    => val u = resolveBuild(current, uri); ProjectRef(u, rootProject(u))
       case ProjectRef(uri, id) => ProjectRef(resolveBuild(current, uri), id)
-      case ThisProject =>
-        ProjectRef(current, rootProject(current)) // Is this right? It was an inexhaustive match before..
+      case ThisProject         => sys.error("Cannot resolve ThisProject w/o the current project")
     }
   def resolveBuildRef(current: URI, ref: BuildReference): BuildRef =
     ref match {

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -363,12 +363,6 @@ private[sbt] object Load {
     )
   }
 
-  def isProjectThis(s: Setting[_]): Boolean =
-    s.key.scope.project match {
-      case This | Select(ThisProject) => true
-      case _                          => false
-    }
-
   def buildConfigurations(
       loaded: LoadedBuild,
       rootProject: URI => String,


### PR DESCRIPTION
In ca71b4b9026d973b9fd2b55032144e6c7d5cd57a I went about fixing the
inexhaustive matching in Scope's resolveProjectBuild and
resolveProjectRef. Looking back the change was wrong.

For resolveProjectBuild the new implementation is less wrong, but still
not great, seeing as it doesn't actually do any build resolving.

For resolveProjectRef the new implementation now blows up instead of
lies. Which means it's less leneant, more "fail-fast".

isProjectThis is unused; remnant of the pre-AutoPlugin days when build
settings where defined in Plugin.settings.