### PR TITLE
Introduce ScopeFilterReference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -391,6 +391,8 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.internal.KeyIndex.*"),
       // Removed unused val. internal.
       exclude[DirectMissingMethodProblem]("sbt.internal.RelayAppender.jsonFormat"),
+      // Removed unused def. internal.
+      exclude[DirectMissingMethodProblem]("sbt.internal.Load.isProjectThis"),
     )
   )
   .configure(

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -14,8 +14,10 @@ import sbt.io.IO
 
 // in all of these, the URI must be resolved and normalized before it is definitive
 
+sealed trait ScopeFilterReference
+
 /** Identifies a project or build. */
-sealed trait Reference
+sealed trait Reference extends ScopeFilterReference
 
 /** A fully resolved, unique identifier for a project or build. */
 sealed trait ResolvedReference extends Reference
@@ -29,8 +31,10 @@ final case object ThisBuild extends BuildReference
 /** Uniquely identifies a build by a URI. */
 final case class BuildRef(build: URI) extends BuildReference with ResolvedReference
 
+sealed trait ScopeFilterProjectReference extends ScopeFilterReference
+
 /** Identifies a project. */
-sealed trait ProjectReference extends Reference
+sealed trait ProjectReference extends Reference with ScopeFilterProjectReference
 
 /** Uniquely references a project by a URI and a project identifier String. */
 final case class ProjectRef(build: URI, project: String)
@@ -47,7 +51,7 @@ final case class RootProject(build: URI) extends ProjectReference
 final case object LocalRootProject extends ProjectReference
 
 /** Identifies the project for the current context. */
-final case object ThisProject extends ProjectReference
+final case object ThisProject extends ScopeFilterProjectReference
 
 object ProjectRef {
   def apply(base: File, id: String): ProjectRef = ProjectRef(IO toURI base, id)
@@ -91,7 +95,6 @@ object Reference {
     }
   def display(ref: ProjectReference): String =
     ref match {
-      case ThisProject         => "{<this>}<this>"
       case LocalRootProject    => "{<this>}<root>"
       case LocalProject(id)    => "{<this>}" + id
       case RootProject(uri)    => "{" + uri + " }<root>"

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -97,8 +97,7 @@ object Scope {
       case LocalProject(id)    => ProjectRef(current, id)
       case RootProject(uri)    => RootProject(resolveBuild(current, uri))
       case ProjectRef(uri, id) => ProjectRef(resolveBuild(current, uri), id)
-      case ThisProject =>
-        RootProject(current) // Is this right? It was an inexhaustive match before..
+      case ThisProject         => ThisProject // haven't exactly "resolved" anything..
     }
   def resolveBuild(current: URI, uri: URI): URI =
     if (!uri.isAbsolute && current.isOpaque && uri.getSchemeSpecificPart == ".")
@@ -118,13 +117,11 @@ object Scope {
                         rootProject: URI => String,
                         ref: ProjectReference): ProjectRef =
     ref match {
-      case LocalRootProject => ProjectRef(current, rootProject(current))
-      case LocalProject(id) => ProjectRef(current, id)
-      case RootProject(uri) =>
-        val res = resolveBuild(current, uri); ProjectRef(res, rootProject(res))
+      case LocalRootProject    => ProjectRef(current, rootProject(current))
+      case LocalProject(id)    => ProjectRef(current, id)
+      case RootProject(uri)    => val u = resolveBuild(current, uri); ProjectRef(u, rootProject(u))
       case ProjectRef(uri, id) => ProjectRef(resolveBuild(current, uri), id)
-      case ThisProject =>
-        ProjectRef(current, rootProject(current)) // Is this right? It was an inexhaustive match before..
+      case ThisProject         => sys.error("Cannot resolve ThisProject w/o the current project")
     }
   def resolveBuildRef(current: URI, ref: BuildReference): BuildRef =
     ref match {

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -363,12 +363,6 @@ private[sbt] object Load {
     )
   }
 
-  def isProjectThis(s: Setting[_]): Boolean =
-    s.key.scope.project match {
-      case This | Select(ThisProject) => true
-      case _                          => false
-    }
-
   def buildConfigurations(
       loaded: LoadedBuild,
       rootProject: URI => String,


### PR DESCRIPTION
This removes ThisProject as a ProjectReference, and defines an additional
sealed hierarchy of references for ScopeFilter, which includes ThisProject.

This fixes Scope's resolveProjectBuild and resolveProjectRef, that no
longer mishandle ThisProject.

Builds on #3609