### PR TITLE
Make scope path syntax eligible for `.value` and `.previous`

### DIFF
--- a/main-settings/src/main/scala/sbt/ScopePathSyntax.scala
+++ b/main-settings/src/main/scala/sbt/ScopePathSyntax.scala
@@ -31,11 +31,12 @@ import Def._
 trait ScopePathSyntax {
   import ScopePathSyntax._
 
-  implicit def sbtScopeSyntaxRichReference(r: Reference): RichReference =
-    new RichReference(Scope(Select(r), This, This, This))
+  implicit def sbtSlashSyntaxRichReferenceAxis(a: ScopeAxis[Reference]): RichReference =
+    new RichReference(Scope(a, This, This, This))
 
-  implicit def sbtScopeSyntaxRichProject(p: Project): RichReference =
-    new RichReference(Scope(Select(p), This, This, This))
+  implicit def sbtSlashSyntaxRichReference(r: Reference): RichReference = Select(r)
+  implicit def sbtSlashSyntaxRichProject[A](p: A)(implicit x: A => Reference): RichReference =
+    (p: Reference)
 
   implicit def sbtScopeSyntaxRichConfiguration(c: Configuration): RichConfiguration =
     new RichConfiguration(Scope(This, Select(c), This, This))

--- a/main-settings/src/test/scala/sbt/ScopePathSyntaxExample.scala
+++ b/main-settings/src/test/scala/sbt/ScopePathSyntaxExample.scala
@@ -1,0 +1,57 @@
+package sbt.test
+
+import java.io.File
+import sbt.Def.{ Setting, settingKey, taskKey }
+import sbt.Scope.Global
+import sbt.librarymanagement.ModuleID
+import sbt.librarymanagement.syntax._
+import sbt.{ LocalProject, ProjectReference, ThisBuild, Zero }
+import sbt.Def._
+import sjsonnew._, BasicJsonProtocol._
+
+object ScopePathSyntaxExample extends sbt.ScopePathSyntax {
+  final case class Proj(id: String)
+  implicit def projToRef(p: Proj): ProjectReference = LocalProject(p.id)
+
+  val projA = Proj("a")
+
+  val cancelable = settingKey[Boolean]("")
+  val console = taskKey[Unit]("")
+  val libraryDependencies = settingKey[Seq[ModuleID]]("")
+  val name = settingKey[String]("")
+  val scalaVersion = settingKey[String]("")
+  val scalacOptions = taskKey[Seq[String]]("")
+  val run =
+    inputKey[Unit]("Runs a main class, passing along arguments provided on the command line.")
+
+  val foo = taskKey[Int]("")
+  val bar = taskKey[Int]("")
+  val baz = inputKey[Unit]("")
+  val buildInfo = taskKey[Seq[File]]("The task that generates the build info.")
+
+  val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
+
+  Seq[Setting[_]](
+    Global / cancelable := true,
+    ThisBuild / scalaVersion := "2.12.3",
+    console / scalacOptions += "-deprecation",
+    Compile / console / scalacOptions += "-Ywarn-numeric-widen",
+    projA / Compile / console / scalacOptions += "-feature",
+    Zero / Zero / name := "foo",
+    Zero / Zero / Zero / name := "foo",
+    Test / bar := 1,
+    Test / foo := (Test / bar).value + 1,
+    Compile / foo := {
+      (Compile / bar).previous.getOrElse(1)
+    },
+    Compile / bar := {
+      (Compile / foo).previous.getOrElse(2)
+    },
+    Test / buildInfo := Nil,
+    baz := {
+      val x = (Test / buildInfo).taskValue
+      (Compile / run).evaluated
+    },
+    libraryDependencies += uTest % Test,
+  )
+}

--- a/main/src/main/scala/sbt/ScopePathSyntax.scala
+++ b/main/src/main/scala/sbt/ScopePathSyntax.scala
@@ -12,7 +12,7 @@ import sbt.internal.util.AttributeKey
 import Def._
 
 /**
- * SlashSyntax implements the slash syntax to scope keys for build.sbt DSL.
+ * ScopePathSyntax implements the scope path syntax to scope keys for build.sbt DSL.
  * The implicits are set up such that the order that the scope components
  * must appear in the order of the project axis, the configuration axis, and
  * the task axis. This ordering is the same as the shell syntax.
@@ -28,8 +28,8 @@ import Def._
  *  Zero / Zero / name := "foo"
  *  }}}
  */
-trait SlashSyntax {
-  import SlashSyntax._
+trait ScopePathSyntax {
+  import ScopePathSyntax._
 
   implicit def sbtScopeSyntaxRichReference(r: Reference): RichReference =
     new RichReference(Scope(Select(r), This, This, This))
@@ -72,7 +72,7 @@ trait SlashSyntax {
     thunk.rescope
 }
 
-object SlashSyntax {
+object ScopePathSyntax {
   sealed trait RichScopeLike {
     protected def toScope: Scope
 

--- a/main/src/main/scala/sbt/SlashSyntax.scala
+++ b/main/src/main/scala/sbt/SlashSyntax.scala
@@ -7,6 +7,7 @@
 
 package sbt
 
+import java.io.File
 import sbt.librarymanagement.Configuration
 import sbt.internal.util.AttributeKey
 
@@ -30,84 +31,130 @@ import sbt.internal.util.AttributeKey
 trait SlashSyntax {
   import SlashSyntax._
 
-  implicit def sbtSlashSyntaxRichReferenceAxis(a: ScopeAxis[Reference]): RichReference =
-    new RichReference(Scope(a, This, This, This))
+  implicit def sbtScopeSyntaxRichReference(r: Reference): RichReference =
+    new RichReference(Scope(Select(r), This, This, This))
 
-  implicit def sbtSlashSyntaxRichReference(r: Reference): RichReference = Select(r)
-  implicit def sbtSlashSyntaxRichProject(p: Project): RichReference = (p: Reference)
+  implicit def sbtScopeSyntaxRichProject(p: Project): RichReference =
+    new RichReference(Scope(Select(p), This, This, This))
 
-  implicit def sbtSlashSyntaxRichConfigKey(c: ConfigKey): RichConfiguration =
+  implicit def sbtScopeSyntaxRichConfiguration(c: Configuration): RichConfiguration =
     new RichConfiguration(Scope(This, Select(c), This, This))
 
-  implicit def sbtSlashSyntaxRichConfiguration(c: Configuration): RichConfiguration = (c: ConfigKey)
+  implicit def sbtScopeSyntaxRichScope(s: Scope): RichScope =
+    new RichScope(s)
 
-  implicit def sbtSlashSyntaxRichScopeFromScoped(t: Scoped): RichScope =
+  implicit def sbtScopeSyntaxRichScopeFromScoped(t: Scoped): RichScope =
     new RichScope(Scope(This, This, Select(t.key), This))
 
-  implicit def sbtSlashSyntaxRichScope(s: Scope): RichScope = new RichScope(s)
+  implicit def sbtScopeSyntaxRichScopeAxis(a: ScopeAxis[Reference]): RichScopeAxis =
+    new RichScopeAxis(a)
 
-  implicit def sbtSlashSyntaxScopeAndKeyRescope(scopeAndKey: ScopeAndKey[_]): TerminalScope =
-    scopeAndKey.rescope
+  // Materialize the setting key thunk
+  implicit def sbtScopeSyntaxSettingKeyThunkMaterialize[A](
+      thunk: SettingKeyThunk[A]): SettingKey[A] =
+    thunk.materialize
 
-  implicit def sbtSlashSyntaxScopeAndKeyMaterialize[K <: Key[K]](scopeAndKey: ScopeAndKey[K]): K =
-    scopeAndKey.materialize
+  implicit def sbtScopeSyntaxSettingKeyThunkKeyRescope[A](thunk: SettingKeyThunk[A]): RichScope =
+    thunk.rescope
+
+  // Materialize the task key thunk
+  implicit def sbtScopeSyntaxTaskKeyThunkMaterialize[A](thunk: TaskKeyThunk[A]): TaskKey[A] =
+    thunk.materialize
+
+  implicit def sbtScopeSyntaxTaskKeyThunkRescope[A](thunk: TaskKeyThunk[A]): RichScope =
+    thunk.rescope
+
+  // Materialize the input key thunk
+  implicit def sbtScopeSyntaxInputKeyThunkMaterialize[A](thunk: InputKeyThunk[A]): InputKey[A] =
+    thunk.materialize
+
+  implicit def sbtScopeSyntaxInputKeyThunkRescope[A](thunk: InputKeyThunk[A]): RichScope =
+    thunk.rescope
 }
 
 object SlashSyntax {
 
-  /** RichReference wraps a reference to provide the `/` operator for scoping. */
-  final class RichReference(protected val scope: Scope) extends RichScopeLike {
-    def /(c: Configuration): RichConfiguration = new RichConfiguration(scope in c)
+  /** RichReference wraps a project to provide the `/` operator for scoping. */
+  final class RichReference(s: Scope) {
+    def /(c: Configuration): RichConfiguration = new RichConfiguration(s in c)
 
-    // This is for handling `Zero / Zero / name`.
-    def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
-      new RichConfiguration(scope.copy(config = configAxis))
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: SettingKey[A]): SettingKeyThunk[A] = new SettingKeyThunk(s, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: TaskKey[A]): TaskKeyThunk[A] = new TaskKeyThunk(s, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: InputKey[A]): InputKeyThunk[A] = new InputKeyThunk(s, key)
   }
 
   /** RichConfiguration wraps a configuration to provide the `/` operator for scoping. */
-  final class RichConfiguration(protected val scope: Scope) extends RichScopeLike {
+  final class RichConfiguration(s: Scope) {
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: SettingKey[A]): SettingKeyThunk[A] = new SettingKeyThunk(s, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: TaskKey[A]): TaskKeyThunk[A] = new TaskKeyThunk(s, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: InputKey[A]): InputKeyThunk[A] = new InputKeyThunk(s, key)
 
     // This is for handling `Zero / Zero / Zero / name`.
     def /(taskAxis: ScopeAxis[AttributeKey[_]]): RichScope =
-      new RichScope(scope.copy(task = taskAxis))
-  }
-
-  /** Both `Scoped.ScopingSetting` and `Scoped` are parents of `SettingKey`, `TaskKey` and
-   * `InputKey`. We'll need both, so this is a convenient type alias. */
-  type Key[K] = Scoped.ScopingSetting[K] with Scoped
-
-  sealed trait RichScopeLike {
-    protected def scope: Scope
-
-    // We don't know what the key is for yet, so just capture for now.
-    def /[K <: Key[K]](key: K): ScopeAndKey[K] = new ScopeAndKey(scope, key)
+      new RichScope(s.copy(task = taskAxis))
   }
 
   /** RichScope wraps a general scope to provide the `/` operator for scoping. */
-  final class RichScope(protected val scope: Scope) extends RichScopeLike
+  final class RichScope(scope: Scope) {
+    def /[A](key: SettingKey[A]): SettingKey[A] = key in scope
+    def /[A](key: TaskKey[A]): TaskKey[A] = key in scope
+    def /[A](key: InputKey[A]): InputKey[A] = key in scope
+  }
 
-  /** TerminalScope provides the last `/` for scoping. */
-  final class TerminalScope(scope: Scope) {
-    def /[K <: Key[K]](key: K): K = key in scope
+  /** RichScopeAxis wraps a project axis to provide the `/` operator to `Zero` for scoping. */
+  final class RichScopeAxis(a: ScopeAxis[Reference]) {
+    private[this] def toScope: Scope = Scope(a, This, This, This)
+
+    def /(c: Configuration): RichConfiguration = new RichConfiguration(toScope in c)
+
+    // This is for handling `Zero / Zero / name`.
+    def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
+      new RichConfiguration(toScope.copy(config = configAxis))
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: SettingKey[A]): SettingKeyThunk[A] = new SettingKeyThunk(toScope, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: TaskKey[A]): TaskKeyThunk[A] = new TaskKeyThunk(toScope, key)
+
+    // We don't know what the key is for yet, so just capture in a thunk.
+    def /[A](key: InputKey[A]): InputKeyThunk[A] = new InputKeyThunk(toScope, key)
   }
 
   /**
-   * ScopeAndKey is a synthetic DSL construct necessary to capture both the built-up scope with a
-   * given key, while we're not sure if the given key is terminal or task-scoping. The "materialize"
-   * method will be used if it's terminal, returning the scoped key, while "rescope" will be used
-   * if we're task-scoping.
-   *
-   * @param scope the built-up scope
-   * @param key a given key
-   * @tparam K the type of the given key, necessary to type "materialize"
+   * SettingKeyThunk is a thunk used to hold a scope and a key
+   * while we're not sure if the key is terminal or task-scoping.
    */
-  final class ScopeAndKey[K <: Key[K]](scope: Scope, key: K) {
-    private[sbt] def materialize: K = key in scope
-    private[sbt] def rescope: TerminalScope = new TerminalScope(scope in key.key)
-
-    override def toString: String = {
-      s"$scope / ${key.key}"
-    }
+  final class SettingKeyThunk[A](base: Scope, key: SettingKey[A]) {
+    private[sbt] def materialize: SettingKey[A] = key in base
+    private[sbt] def rescope: RichScope = new RichScope(base in key.key)
   }
 
+  /**
+   * TaskKeyThunk is a thunk used to hold a scope and a key
+   * while we're not sure if the key is terminal or task-scoping.
+   */
+  final class TaskKeyThunk[A](base: Scope, key: TaskKey[A]) {
+    private[sbt] def materialize: TaskKey[A] = key in base
+    private[sbt] def rescope: RichScope = new RichScope(base in key.key)
+  }
+
+  /**
+   * InputKeyThunk is a thunk used to hold a scope and a key
+   * while we're not sure if the key is terminal or task-scoping.
+   */
+  final class InputKeyThunk[A](base: Scope, key: InputKey[A]) {
+    private[sbt] def materialize: InputKey[A] = key in base
+    private[sbt] def rescope: RichScope = new RichScope(base in key.key)
+  }
 }

--- a/main/src/main/scala/sbt/internal/KeyIndex.scala
+++ b/main/src/main/scala/sbt/internal/KeyIndex.scala
@@ -35,7 +35,9 @@ object KeyIndex {
     } yield {
       val data = ids map { id =>
         val configs = configurations.getOrElse(id, Seq())
-        Option(id) -> new ConfigIndex(Map.empty, configs.map(c => (c.name, c.id)).toMap)
+        Option(id) -> new ConfigIndex(Map.empty, Map(configs map { c =>
+          (c.name, c.id)
+        }: _*))
       }
       Option(uri) -> new ProjectIndex(data.toMap)
     }

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -328,8 +328,11 @@ private[sbt] object Load {
     val attributeKeys = Index.attributeKeys(data) ++ keys.map(_.key)
     val scopedKeys = keys ++ data.allKeys((s, k) => ScopedKey(s, k)).toVector
     val projectsMap = projects.mapValues(_.defined.keySet)
-    val configsMap: Map[String, Seq[Configuration]] =
-      projects.values.flatMap(bu => bu.defined map { case (k, v) => (k, v.configurations) }).toMap
+    val configsMap: Map[String, Seq[Configuration]] = Map(projects.values.toSeq flatMap { bu =>
+      bu.defined map {
+        case (k, v) => (k, v.configurations)
+      }
+    }: _*)
     val keyIndex = KeyIndex(scopedKeys.toVector, projectsMap, configsMap)
     val aggIndex = KeyIndex.aggregate(scopedKeys.toVector, extra(keyIndex), projectsMap, configsMap)
     new StructureIndex(

--- a/main/src/test/scala/sbt/internal/TestBuild.scala
+++ b/main/src/test/scala/sbt/internal/TestBuild.scala
@@ -232,7 +232,9 @@ abstract class TestBuild {
       p <- b.projects.toVector
       c <- p.configurations.toVector
     } yield c
-    val confMap = confs.map(c => (c.name, Seq(c))).toMap
+    val confMap = Map(confs map { c =>
+      (c.name, Seq(c))
+    }: _*)
     new Structure(env, current, data, KeyIndex(keys, projectsMap, confMap), keyMap)
   }
 

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -43,16 +43,6 @@ package object sbt
   final val Global = Scope.Global
   final val GlobalScope = Scope.GlobalScope
 
-  // import sbt.{ Configurations => C }
-  // final val Compile = C.Compile
-  // final val Test = C.Test
-  // final val Runtime = C.Runtime
-  // final val IntegrationTest = C.IntegrationTest
-  // final val Default = C.Default
-  // final val Provided = C.Provided
-  // java.lang.System is more important, so don't alias this one
-  //  final val System = C.System
-  // final val Optional = C.Optional
   def config(name: String): Configuration =
     macro sbt.librarymanagement.ConfigurationMacro.configMacroImpl
 }

--- a/sbt/src/main/scala/package.scala
+++ b/sbt/src/main/scala/package.scala
@@ -20,7 +20,7 @@ package object sbt
     with sbt.ScopeFilter.Make
     with sbt.BuildSyntax
     with sbt.OptionSyntax
-    with sbt.SlashSyntax
+    with sbt.ScopePathSyntax
     with sbt.Import {
   // IO
   def uri(s: String): URI = new URI(s)

--- a/sbt/src/sbt-test/project/unified/build.sbt
+++ b/sbt/src/sbt-test/project/unified/build.sbt
@@ -1,4 +1,3 @@
-import Dependencies._
 import sbt.internal.CommandStrings.{ inspectBrief, inspectDetailed }
 import sbt.internal.Inspect
 import sjsonnew._, BasicJsonProtocol._
@@ -7,6 +6,8 @@ val foo = taskKey[Int]("")
 val bar = taskKey[Int]("")
 val baz = inputKey[Unit]("")
 val buildInfo = taskKey[Seq[File]]("The task that generates the build info.")
+
+val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/project/unified/build.sbt
+++ b/sbt/src/sbt-test/project/unified/build.sbt
@@ -1,6 +1,12 @@
 import Dependencies._
 import sbt.internal.CommandStrings.{ inspectBrief, inspectDetailed }
 import sbt.internal.Inspect
+import sjsonnew._, BasicJsonProtocol._
+
+val foo = taskKey[Int]("")
+val bar = taskKey[Int]("")
+val baz = inputKey[Unit]("")
+val buildInfo = taskKey[Seq[File]]("The task that generates the build info.")
 
 lazy val root = (project in file("."))
   .settings(
@@ -11,6 +17,19 @@ lazy val root = (project in file("."))
     projA / Compile / console / scalacOptions += "-feature",
     Zero / Zero / name := "foo",
     Zero / Zero / Zero / name := "foo",
+    Test / bar := 1,
+    Test / foo := (Test / bar).value + 1,
+    Compile / foo := {
+      (Compile / bar).previous.getOrElse(1)
+    },
+    Compile / bar := {
+      (Compile / foo).previous.getOrElse(2)
+    },
+    Test / buildInfo := Nil,
+    baz := {
+      val x = (Test / buildInfo).taskValue
+      (Compile / run).evaluated
+    },
 
     libraryDependencies += uTest % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),

--- a/sbt/src/sbt-test/project/unified/project/Dependencies.scala
+++ b/sbt/src/sbt-test/project/unified/project/Dependencies.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-object Dependencies {
-  val uTest = "com.lihaoyi" %% "utest" % "0.5.3"
-}


### PR DESCRIPTION
This is a retake of https://github.com/sbt/sbt/pull/3606

Since #3606 brings back the three key types, I first reverted "Cleanup and improve the unified slash syntax" (#3596), and then moved the thunk classes into `Def` where it should probably belong. This allowed me to implement handling for `.previous` in the macro by injecting `.materialize` at compile-time.

I've also taken the liberty to rename "slash syntax" to "scope path" for documentation purpose.

Finally I've copied over the example class created by Dale.

Fixes #3605
