### PR TITLE
Enrich Scope only to TerminalScope

### DIFF
--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -45,7 +45,7 @@ trait SlashSyntax {
   implicit def sbtSlashSyntaxRichScopeFromScoped(t: Scoped): RichScope =
     new RichScope(Scope(This, This, Select(t.key), This))
 
-  implicit def sbtSlashSyntaxRichScope(s: Scope): RichScope = new RichScope(s)
+  implicit def sbtSlashSyntaxRichScope(s: Scope): TerminalScope = new TerminalScope(s)
 
   implicit def sbtSlashSyntaxScopeAndKeyRescope(scopeAndKey: ScopeAndKey[_]): TerminalScope =
     scopeAndKey.rescope


### PR DESCRIPTION
This makes `Global / console / scalacOptions` illegal.