### PR TITLE
implement window/logMessage

### DIFF
--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/LogMessageParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/LogMessageParams.scala
@@ -1,0 +1,38 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.langserver
+final class LogMessageParams private (
+  /** The message type. */
+  val `type`: Long,
+  /** The actual message */
+  val message: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: LogMessageParams => (this.`type` == x.`type`) && (this.message == x.message)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.langserver.LogMessageParams".##) + `type`.##) + message.##)
+  }
+  override def toString: String = {
+    "LogMessageParams(" + `type` + ", " + message + ")"
+  }
+  protected[this] def copy(`type`: Long = `type`, message: String = message): LogMessageParams = {
+    new LogMessageParams(`type`, message)
+  }
+  def withType(`type`: Long): LogMessageParams = {
+    copy(`type` = `type`)
+  }
+  def withMessage(message: String): LogMessageParams = {
+    copy(message = message)
+  }
+}
+object LogMessageParams {
+  
+  def apply(`type`: Long, message: String): LogMessageParams = new LogMessageParams(`type`, message)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/JsonProtocol.scala
@@ -16,6 +16,7 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.langserver.codec.TextDocumentSyncOptionsFormats
   with sbt.internal.langserver.codec.ServerCapabilitiesFormats
   with sbt.internal.langserver.codec.InitializeResultFormats
+  with sbt.internal.langserver.codec.LogMessageParamsFormats
   with sbt.internal.langserver.codec.PublishDiagnosticsParamsFormats
   with sbt.internal.langserver.codec.SbtExecParamsFormats
 object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/LogMessageParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/LogMessageParamsFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.langserver.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait LogMessageParamsFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val LogMessageParamsFormat: JsonFormat[sbt.internal.langserver.LogMessageParams] = new JsonFormat[sbt.internal.langserver.LogMessageParams] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.langserver.LogMessageParams = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val `type` = unbuilder.readField[Long]("type")
+      val message = unbuilder.readField[String]("message")
+      unbuilder.endObject()
+      sbt.internal.langserver.LogMessageParams(`type`, message)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.langserver.LogMessageParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("type", obj.`type`)
+    builder.addField("message", obj.message)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/lsp.contra
+++ b/protocol/src/main/contraband/lsp.contra
@@ -98,6 +98,16 @@ type SaveOptions {
   includeText: Boolean
 }
 
+# LogMessage Notification
+
+type LogMessageParams {
+  ## The message type.
+  type: Long!
+
+  ## The actual message
+  message: String!
+}
+
 # Document
 
 # PublishDiagnostics Notification https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_publishDiagnostics

--- a/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
@@ -1,0 +1,34 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+package internal
+package langserver
+
+object MessageType {
+
+  /** An error message. */
+  val Error = 1L
+
+  /** A warning message. */
+  val Warning = 2L
+
+  /** An information message. */
+  val Info = 3L
+
+  /** A log message. */
+  val Log = 4L
+
+  def fromLevelString(level: String): Long = {
+    level.toLowerCase match {
+      case "debug" => Log
+      case "info"  => Info
+      case "warn"  => Warning
+      case "error" => Error
+    }
+  }
+}


### PR DESCRIPTION
This sends sbt's log message as [window/logMessage](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#window_logMessage) event to Language Server client.
