### PR TITLE
[1.0.x] Track sources in base directory non-recursively

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -315,11 +315,13 @@ object Defaults extends BuildCommon {
                                      excludeFilter in unmanagedSources).value,
     watchSources in ConfigGlobal ++= {
       val baseDir = baseDirectory.value
-      val bases = unmanagedSourceDirectories.value ++ (if (sourcesInBase.value) Seq(baseDir)
-                                                       else Seq.empty)
+      val bases = unmanagedSourceDirectories.value
       val include = (includeFilter in unmanagedSources).value
       val exclude = (excludeFilter in unmanagedSources).value
-      bases.map(b => new Source(b, include, exclude))
+      val baseSources =
+        if (sourcesInBase.value) Seq(new Source(baseDir, include, exclude, recursive = false))
+        else Nil
+      bases.map(b => new Source(b, include, exclude)) ++ baseSources
     },
     managedSourceDirectories := Seq(sourceManaged.value),
     managedSources := generate(sourceGenerators).value,

--- a/notes/1.0.3/watch2.md
+++ b/notes/1.0.3/watch2.md
@@ -1,0 +1,12 @@
+[@dwijnand]: https://github.com/dwijnand
+
+[#3501]: https://github.com/sbt/sbt/issues/3501
+[#3634]: https://github.com/sbt/sbt/pull/3634
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Fixes `~` to recompile on loop (when a source generator or sbt-buildinfo is present). [#3501][]/[#3634][] by [@dwijnand][]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.0.1"
+  private val ioVersion = "1.0.2"
   private val utilVersion = "1.0.1"
   private val lmVersion = "1.0.2"
   private val zincVersion = "1.0.1"


### PR DESCRIPTION
Using a recursive Source meant that ~ looked into target. If you have
any source generators and use ~ with anything the invokes them, like
~compile, that means that the act of generating sources triggers ~ to
re-execute compile (perhaps only on macOS where the NIO WatchService
just polls, after an initial delay).

Requires sbt/io#78

Fixes #3501