### PR TITLE
 Escape imports from sbt files

### DIFF
--- a/main/src/main/scala/sbt/internal/LoadedSbtFile.scala
+++ b/main/src/main/scala/sbt/internal/LoadedSbtFile.scala
@@ -61,7 +61,7 @@ private[sbt] final class DefinedSbtValues(val sbtFiles: Seq[compiler.EvalDefinit
       file <- sbtFiles
       m = file.enclosingModule
       v <- file.valNames
-    } yield s"import ${m}.${v}"
+    } yield s"import ${m}.`${v}`"
   }
   def generated: Seq[File] =
     sbtFiles flatMap (_.generated)

--- a/notes/1.0.3/escape-imports-from-sbt-file.md
+++ b/notes/1.0.3/escape-imports-from-sbt-file.md
@@ -1,0 +1,9 @@
+[@panaeon]: https://github.com/panaeon
+
+[#3464]: https://github.com/sbt/sbt/issues/3464
+[#3566]: https://github.com/sbt/sbt/pull/3566
+
+### Bug fixes
+
+- Escape imports from sbt files, so if user creates a backquoted definition then task evalution will not fail.
+

--- a/sbt/src/sbt-test/project/literal-defs/build.sbt
+++ b/sbt/src/sbt-test/project/literal-defs/build.sbt
@@ -1,0 +1,19 @@
+lazy val `import` = (project in file("."))
+  .settings(
+    name := "Hello"
+  )
+
+val `return` = inputKey[Unit]("Check that commands can be defined as back-ticked variables")
+
+
+`return` := {
+	()
+}
+
+
+val `ї` = inputKey[Unit]("Check that we can defined unicode commands")
+
+`ї` := {
+	()
+}
+

--- a/sbt/src/sbt-test/project/literal-defs/test
+++ b/sbt/src/sbt-test/project/literal-defs/test
@@ -1,0 +1,12 @@
+# This test verifies that top-level literal identifiers, like `return`, are loaded correctly
+
+# Initial load should succeed
+
+# Check that we can modify project properties
+> 'set version := "1.0.0"'
+
+# Check that we can run command defined in back-quotes
+> return
+
+# Check that we can define unicode commands
+> ї


### PR DESCRIPTION
Escape imports from sbt files, so if user creates a backquoted definition then task evalution will not fail.
Fixes #3464 