### PR TITLE
Bump to Scala 2.12.4

### DIFF
--- a/notes/1.0.3/scala2124.markdown
+++ b/notes/1.0.3/scala2124.markdown
@@ -1,0 +1,5 @@
+
+- Uses Scala 2.12.4 for the build definition. This includes fix for runtime reflection of empty package members under Java 9. [#3587][3587] by [@eed3si9n][@eed3si9n]
+
+  [3587]: https://github.com/sbt/sbt/issues/3587
+  [@eed3si9n]: https://github.com/eed3si9n

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scala293 = "2.9.3"
   val scala210 = "2.10.6"
   val scala211 = "2.11.8"
-  val scala212 = "2.12.3"
+  val scala212 = "2.12.4"
   val baseScalaVersion = scala212
 
   // sbt modules


### PR DESCRIPTION
Uses Scala 2.12.4 for the build definition. This includes fix for runtime reflection of empty package members under Java 9.

Fixes sbt/sbt#3587

