### PR TITLE
Resolve various warnings

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
@@ -229,7 +229,9 @@ private class BasicAttributeMap(private val backing: Map[AttributeKey[_], Any])
     }
 
   def entries: Iterable[AttributeEntry[_]] =
-    for ((k: AttributeKey[kt], v) <- backing) yield AttributeEntry(k, v.asInstanceOf[kt])
+    backing.collect {
+      case (k: AttributeKey[kt], v) => AttributeEntry(k, v.asInstanceOf[kt])
+    }
 
   private[sbt] def setCond[T](k: AttributeKey[T], opt: Option[T]): AttributeMap =
     opt match {

--- a/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
@@ -41,7 +41,7 @@ object IDSet {
     def +=(t: T) = { backing.put(t, Dummy); () }
     def ++=(t: Iterable[T]) = t foreach +=
     def -=(t: T) = if (backing.remove(t) eq null) false else true
-    def all = collection.JavaConversions.collectionAsScalaIterable(backing.keySet)
+    def all = collection.JavaConverters.collectionAsScalaIterable(backing.keySet)
     def toList = all.toList
     def isEmpty = backing.isEmpty
 

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -793,7 +793,7 @@ trait Init[Scope] {
     // proper solution is for evaluate to be deprecated or for external use only and a new internal method returning Either be used
     private[this] def trapBadRef[A](run: => A): Option[A] =
       try Some(run)
-      catch { case e: InvalidReference => None }
+      catch { case _: InvalidReference => None }
 
     private[sbt] def processAttributes[B](init: B)(f: (B, AttributeMap) => B): B = a match {
       case None    => init

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Signal.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Signal.scala
@@ -16,7 +16,7 @@ object Signals {
       try {
         val signals = new Signals0
         signals.withHandler(signal, handler, action)
-      } catch { case e: LinkageError => Right(action()) }
+      } catch { case _: LinkageError => Right(action()) }
 
     result match {
       case Left(e)  => throw e
@@ -61,7 +61,7 @@ object Signals {
     try {
       val signals = new Signals0
       signals.supported(signal)
-    } catch { case e: LinkageError => false }
+    } catch { case _: LinkageError => false }
 }
 
 // Must only be referenced using a
@@ -70,7 +70,7 @@ object Signals {
 private final class Signals0 {
   def supported(signal: String): Boolean = {
     import sun.misc.Signal
-    try { new Signal(signal); true } catch { case e: IllegalArgumentException => false }
+    try { new Signal(signal); true } catch { case _: IllegalArgumentException => false }
   }
 
   // returns a LinkageError in `action` as Left(t) in order to avoid it being

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/History.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/History.scala
@@ -56,5 +56,5 @@ object History {
     new History(lines.toIndexedSeq, path, sys.error)
 
   def number(s: String): Option[Int] =
-    try { Some(s.toInt) } catch { case e: NumberFormatException => None }
+    try { Some(s.toInt) } catch { case _: NumberFormatException => None }
 }

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -11,7 +11,7 @@ package complete
 import jline.console.ConsoleReader
 import jline.console.completer.{ Completer, CompletionHandler }
 import scala.annotation.tailrec
-import collection.JavaConversions
+import scala.collection.JavaConverters
 
 object JLineCompletion {
   def installCustomCompletor(reader: ConsoleReader, parser: Parser[_]): Unit =
@@ -154,7 +154,7 @@ object JLineCompletion {
       if (line.charAt(line.length - 1) != '\n')
         reader.println()
     }
-    reader.printColumns(JavaConversions.seqAsJavaList(columns.map(_.trim)))
+    reader.printColumns(JavaConverters.seqAsJavaList(columns.map(_.trim)))
   }
 
   def hasNewline(s: String): Boolean = s.indexOf('\n') >= 0

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -280,7 +280,7 @@ object Parser extends ParserMain {
 
     def checkRepeated(invalidButOptional: => Parser[Seq[T]]): Parser[Seq[T]] =
       repeated match {
-        case i: Invalid if min == 0 => invalidButOptional
+        case _: Invalid if min == 0 => invalidButOptional
         case i: Invalid             => i
         case _ =>
           repeated.result match {
@@ -327,9 +327,7 @@ trait ParserMain {
     def !!!(msg: String): Parser[A] = onFailure(a, msg)
     def failOnException: Parser[A] = trapAndFail(a)
 
-    def unary_- = not(a, "Unexpected: " + a)
     def &(o: Parser[_]) = and(a, o)
-    def -(o: Parser[_]) = and(a, not(o, "Unexpected: " + o))
     def examples(s: String*): Parser[A] = examples(s.toSet)
 
     def examples(s: Set[String], check: Boolean = false): Parser[A] =
@@ -578,7 +576,7 @@ trait ParserMain {
     case (Invalid(af), Invalid(bf)) => Invalid(af ++ bf)
     case (Invalid(_), bv)           => bv
     case (av, Invalid(_))           => av
-    case (av, bv)                   => new HomParser(a, b)
+    case (_, _)                     => new HomParser(a, b)
   }
 
   def not(p: Parser[_], failMessage: String): Parser[Unit] = p.result match {
@@ -631,7 +629,7 @@ private final case class SoftInvalid(fail: Failure) extends ValidParser[Nothing]
 }
 
 private final class TrapAndFail[A](a: Parser[A]) extends ValidParser[A] {
-  def result = try { a.result } catch { case e: Exception           => None }
+  def result = try { a.result } catch { case _: Exception           => None }
   def resultEmpty = try { a.resultEmpty } catch { case e: Exception => fail(e) }
 
   def derive(c: Char) = try { trapAndFail(a derive c) } catch {
@@ -639,7 +637,7 @@ private final class TrapAndFail[A](a: Parser[A]) extends ValidParser[A] {
   }
 
   def completions(level: Int) = try { a.completions(level) } catch {
-    case e: Exception => Completions.nil
+    case _: Exception => Completions.nil
   }
 
   override def toString = "trap(" + a + ")"
@@ -651,7 +649,7 @@ private final class OnFailure[A](a: Parser[A], message: String) extends ValidPar
   def result = a.result
 
   def resultEmpty = a.resultEmpty match {
-    case f: Failure => mkFailure(message); case v: Value[A] => v
+    case _: Failure => mkFailure(message); case v: Value[A] => v
   }
 
   def derive(c: Char) = onFailure(a derive c, message)
@@ -685,7 +683,7 @@ private final class HomParser[A](a: Parser[A], b: Parser[A]) extends ValidParser
 }
 
 private final class HetParser[A, B](a: Parser[A], b: Parser[B]) extends ValidParser[Either[A, B]] {
-  lazy val result = tuple(a.result, b.result) map { case (a, b) => Left(a) }
+  lazy val result = tuple(a.result, b.result) map { case (a, _) => Left(a) }
   def derive(c: Char) = (a derive c) || (b derive c)
   lazy val resultEmpty = a.resultEmpty either b.resultEmpty
   def completions(level: Int) = a.completions(level) ++ b.completions(level)
@@ -699,7 +697,7 @@ private final class ParserSeq[T](a: Seq[Parser[T]], errors: => Seq[String])
   lazy val resultEmpty: Result[Seq[T]] = {
     val res = a.map(_.resultEmpty)
     val (failures, values) = separate(res)(_.toEither)
-    //		if(failures.isEmpty) Value(values) else mkFailures(failures.flatMap(_()) ++ errors)
+    //    if(failures.isEmpty) Value(values) else mkFailures(failures.flatMap(_()) ++ errors)
     if (values.nonEmpty) Value(values) else mkFailures(failures.flatMap(_()) ++ errors)
   }
 
@@ -808,8 +806,8 @@ private final class Not(delegate: Parser[_], failMessage: String) extends ValidP
   def result = None
 
   lazy val resultEmpty = delegate.resultEmpty match {
-    case f: Failure  => Value(())
-    case v: Value[_] => mkFailure(failMessage)
+    case _: Failure  => Value(())
+    case _: Value[_] => mkFailure(failMessage)
   }
 
   override def toString = " -(%s)".format(delegate)

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/TypeString.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/TypeString.scala
@@ -32,7 +32,7 @@ private[sbt] object TypeString {
   def cleanup(typeString: String): String =
     parse(typeString, typeStringParser) match {
       case Right(ts) => ts.toString
-      case Left(err) => typeString
+      case Left(_)   => typeString
     }
 
   /**

--- a/main-actions/src/main/scala/sbt/Sync.scala
+++ b/main-actions/src/main/scala/sbt/Sync.scala
@@ -71,7 +71,7 @@ object Sync {
 
   def noDuplicateTargets(relation: Relation[File, File]): Unit = {
     val dups = relation.reverseMap.filter {
-      case (target, srcs) =>
+      case (_, srcs) =>
         srcs.size >= 2 && srcs.exists(!_.isDirectory)
     } map {
       case (target, srcs) =>

--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -136,7 +136,7 @@ object TestResultLogger {
            pendingCount) =
         results.events.foldLeft((0, 0, 0, 0, 0, 0, 0)) {
           case ((skippedAcc, errorAcc, passedAcc, failureAcc, ignoredAcc, canceledAcc, pendingAcc),
-                (name, testEvent)) =>
+                (name @ _, testEvent)) =>
             (skippedAcc + testEvent.skippedCount,
              errorAcc + testEvent.errorCount,
              passedAcc + testEvent.passedCount,

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -157,7 +157,7 @@ object Tests {
         case Listeners(listeners)     => testListeners ++= listeners
         case Setup(setupFunction)     => setup += setupFunction
         case Cleanup(cleanupFunction) => cleanup += cleanupFunction
-        case a: Argument              => // now handled by whatever constructs `runners`
+        case _: Argument              => // now handled by whatever constructs `runners`
       }
     }
 

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -46,7 +46,7 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
     event match {
       case e: ConsolePromptEvent =>
         askUserThread match {
-          case Some(x) => //
+          case Some(_) =>
           case _ =>
             val x = makeAskUserThread(e.state)
             askUserThread = Some(x)
@@ -56,7 +56,7 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
         e.lastSource match {
           case Some(src) if src.channelName != name =>
             askUserThread match {
-              case Some(x) =>
+              case Some(_) =>
               // keep listening while network-origin command is running
               // make sure to test Windows and Cygwin, if you uncomment
               // shutdown()

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -111,7 +111,7 @@ class NetworkClient(arguments: List[String]) { self =>
     try {
       connection.publish(bytes)
     } catch {
-      case e: SocketException =>
+      case _: SocketException =>
       // log.debug(e.getMessage)
       // toDel += client
     }

--- a/main-command/src/main/scala/xsbt/IPC.scala
+++ b/main-command/src/main/scala/xsbt/IPC.scala
@@ -31,7 +31,7 @@ object IPC {
     def createServer(attempts: Int): ServerSocket =
       if (attempts > 0)
         try { new ServerSocket(nextPort, 1, loopback) } catch {
-          case NonFatal(e) => createServer(attempts - 1)
+          case NonFatal(_) => createServer(attempts - 1)
         } else
         sys.error("Could not connect to socket: maximum attempts exceeded")
     createServer(10)

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -275,7 +275,7 @@ object Scope {
         case Select(conf) => index.config(configProj, conf); case _ => withZeroAxis(scope.config)
       }
       val tLin = scope.task match {
-        case t @ Select(task) => linearize(t)(taskInherit); case _ => withZeroAxis(scope.task)
+        case t @ Select(_) => linearize(t)(taskInherit); case _ => withZeroAxis(scope.task)
       }
       val eLin = withZeroAxis(scope.extra)
       for (c <- cLin; t <- tLin; e <- eLin) yield Scope(px, c, t, e)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -48,7 +48,7 @@ object Util {
           "-Yno-adapted-args",
           "-Ywarn-dead-code",
           "-Ywarn-numeric-widen",
-          "-Ywarn-unused",
+          "-Ywarn-unused:-params,-implicits,_",
           "-Ywarn-unused-import"
         )
     }),

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -48,7 +48,7 @@ object Util {
           "-Yno-adapted-args",
           "-Ywarn-dead-code",
           "-Ywarn-numeric-widen",
-          "-Ywarn-unused:-params,-implicits,_",
+          "-Ywarn-unused:-patvars,-params,-implicits,_",
           "-Ywarn-unused-import"
         )
     }),

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
@@ -24,7 +24,7 @@ trait JsonRpcRequestMessageFormats {
             val id = try {
               unbuilder.readField[String]("id")
             } catch {
-              case _ => unbuilder.readField[Long]("id").toString
+              case _: Throwable => unbuilder.readField[Long]("id").toString
             }
             val method = unbuilder.readField[String]("method")
             val params = unbuilder.lookupField("params") map {

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseMessageFormats.scala
@@ -27,7 +27,7 @@ trait JsonRpcResponseMessageFormats {
             val id = try {
               unbuilder.readField[Option[String]]("id")
             } catch {
-              case _ => unbuilder.readField[Option[Long]]("id") map { _.toString }
+              case _: Throwable => unbuilder.readField[Option[Long]]("id") map { _.toString }
             }
 
             val result = unbuilder.lookupField("result") map {

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -38,7 +38,7 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
       1
     }
     val exitCode = try process.exitValue()
-    catch { case e: InterruptedException => cancel() }
+    catch { case _: InterruptedException => cancel() }
     processExitCode(exitCode, "runner")
   }
 

--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -162,7 +162,7 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
       executionThread.start() // thread actually evaluating `f`
       finish(app, log)
     } catch {
-      case e: InterruptedException => // here, the thread that started the run has been interrupted, not the main thread of the executing code
+      case _: InterruptedException => // here, the thread that started the run has been interrupted, not the main thread of the executing code
         cancel(executionThread, app, log)
     } finally app.cleanup()
   }

--- a/scripted/sbt/src/main/scala/sbt/test/SbtHandler.scala
+++ b/scripted/sbt/src/main/scala/sbt/test/SbtHandler.scala
@@ -36,7 +36,7 @@ final class SbtHandler(directory: File,
 
   def onSbtInstance(i: Option[SbtInstance])(f: (Process, IPC.Server) => Unit): Option[SbtInstance] =
     i match {
-      case Some(ai @ SbtInstance(process, server)) if server.isClosed =>
+      case Some(SbtInstance(_, server)) if server.isClosed =>
         finish(i)
         onNewSbtInstance(f)
       case Some(SbtInstance(process, server)) =>
@@ -66,7 +66,7 @@ final class SbtHandler(directory: File,
         send("exit", server)
         process.exitValue()
       } catch {
-        case e: IOException => process.destroy()
+        case _: IOException => process.destroy()
       }
     case None =>
   }
@@ -85,7 +85,7 @@ final class SbtHandler(directory: File,
     val thread = new Thread() { override def run() = { p.exitValue(); server.close() } }
     thread.start()
     try { receive("Remote sbt initialization failed", server) } catch {
-      case e: java.net.SocketException => throw new TestFailed("Remote sbt initialization failed")
+      case _: java.net.SocketException => throw new TestFailed("Remote sbt initialization failed")
     }
     p
   }

--- a/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
+++ b/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
@@ -165,7 +165,7 @@ trait TaskExtra {
           Result.tryValues[S](tx :: Nil, x)
       })
     def ||[T >: S](alt: Task[T]): Task[T] = flatMapR {
-      case Value(v) => task(v); case Inc(i) => alt
+      case Value(v) => task(v); case Inc(_) => alt
     }
     def &&[T](alt: Task[T]): Task[T] = flatMap(_ => alt)
   }
@@ -242,7 +242,7 @@ object TaskExtra extends TaskExtra {
       case Seq()     => sys.error("Cannot reduce empty sequence")
       case Seq(x)    => x
       case Seq(x, y) => reducePair(x, y, f)
-      case z =>
+      case _ =>
         val (a, b) = i.splitAt(i.size / 2)
         reducePair(reduced(a, f), reduced(b, f), f)
     }
@@ -254,7 +254,7 @@ object TaskExtra extends TaskExtra {
     val incs = failuresM(a)(in)
     if (incs.isEmpty) expectedFailure else incs
   }
-  def failM[T]: Result[T] => Incomplete = { case Inc(i) => i; case x => expectedFailure }
+  def failM[T]: Result[T] => Incomplete = { case Inc(i) => i; case _ => expectedFailure }
 
   def expectedFailure = throw Incomplete(None, message = Some("Expected dependency to fail."))
 

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -34,7 +34,7 @@ class JUnitXmlTestsListener(val outputDir: String) extends TestsListener {
   val hostname =
     try InetAddress.getLocalHost.getHostName
     catch {
-      case x: IOException => "localhost"
+      case _: IOException => "localhost"
     }
 
   /**The dir in which we put all result files. Is equal to the given dir + "/test-reports"*/


### PR DESCRIPTION
This is a continuation of https://github.com/sbt/sbt/pull/3648 by @sschaef without the problematic commit 0747c1f.

This resolves various warnings that occur during compilation. Included:

- Some warnings about unused code have been disabled because the warnings can't be resolved (warnings in contraband generated code, warnings in unused parameter in abstract definitions etc.)
- Not all warnings about unused pattern vars are resolved because there are simply too many of them and I lost interest in resolving the remaining ones. In order to get rid of the warnings I disabled them completely because unused pattern vars are not a problem anyway.
- No semantic changes should be introduced by this PR, otherwise it is an oversight.

