### PR TITLE
Adds "reboot dev"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -309,6 +309,8 @@ lazy val commandProj = (project in file("main-command"))
       exclude[ReversedMissingMethodProblem]("sbt.internal.server.ServerInstance.*"),
       // Added method to CommandChannel. internal.
       exclude[ReversedMissingMethodProblem]("sbt.internal.CommandChannel.*"),
+      // Added an overload to reboot. The overload is private[sbt].
+      exclude[ReversedMissingMethodProblem]("sbt.StateOps.reboot"),
     )
   )
   .configure(

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -117,14 +117,17 @@ $HelpCommand <regular expression>
 
   def RebootCommand = "reboot"
   def RebootDetailed =
-    RebootCommand + """ [full]
+    RebootCommand + """ [dev | full]
 
 	This command is equivalent to exiting sbt, restarting, and running the
 	  remaining commands with the exception that the JVM is not shut down.
 
-	If 'full' is specified, the boot directory (`~/.sbt/boot` by default)
-	  is deleted before restarting.  This forces an update of sbt and Scala
-	  and is useful when working with development versions of sbt or Scala."""
+	If 'dev' is specified, the current sbt artifacts from the boot directory
+	  (`~/.sbt/boot` by default) are deleted before restarting.
+	This forces an update of sbt and Scala, which is useful when working with development
+	  versions of sbt.
+	If 'full' is specified, the boot directory is wiped out before restarting.
+"""
 
   def Multi = ";"
   def MultiBrief =

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -175,10 +175,19 @@ object BasicCommands {
   }
 
   def reboot: Command =
-    Command(RebootCommand, Help.more(RebootCommand, RebootDetailed))(rebootParser)((s, full) =>
-      s reboot full)
+    Command(RebootCommand, Help.more(RebootCommand, RebootDetailed))(rebootOptionParser) {
+      case (s, (full, currentOnly)) =>
+        s.reboot(full, currentOnly)
+    }
 
-  def rebootParser(s: State): Parser[Boolean] = token(Space ~> "full" ^^^ true) ?? false
+  @deprecated("Use rebootOptionParser", "1.1.0")
+  def rebootParser(s: State): Parser[Boolean] =
+    rebootOptionParser(s) map { case (full, currentOnly) => full }
+
+  private[sbt] def rebootOptionParser(s: State): Parser[(Boolean, Boolean)] =
+    token(
+      Space ~> (("full" ^^^ ((true, false))) |
+        ("dev" ^^^ ((false, true))))) ?? ((false, false))
 
   def call: Command =
     Command(ApplyCommand, Help.more(ApplyCommand, ApplyDetailed))(_ => callParser) {

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -7,11 +7,12 @@
 
 package sbt
 
+import java.util.Properties
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import jline.TerminalFactory
 
-import sbt.io.Using
+import sbt.io.{ IO, Using }
 import sbt.internal.util.{ ErrorHandling, GlobalLogBacking }
 import sbt.internal.util.complete.DefaultParsers
 import sbt.util.Logger
@@ -58,6 +59,10 @@ object MainLoop {
       case e: xsbti.FullReload =>
         deleteLastLog(logBacking)
         throw e // pass along a reboot request
+      case e: RebootCurrent =>
+        deleteLastLog(logBacking)
+        deleteCurrentArtifacts(state)
+        throw new xsbti.FullReload(e.arguments.toArray, false)
       case NonFatal(e) =>
         System.err.println(
           "sbt appears to be exiting abnormally.\n  The log file for this session is at " + logBacking.file)
@@ -68,6 +73,28 @@ object MainLoop {
   /** Deletes the previous global log file. */
   def deleteLastLog(logBacking: GlobalLogBacking): Unit =
     logBacking.last.foreach(_.delete())
+
+  /** Deletes the current sbt artifacts from boot. */
+  private[sbt] def deleteCurrentArtifacts(state: State): Unit = {
+    import sbt.io.syntax._
+    val provider = state.configuration.provider
+    val appId = provider.id
+    // If we can obtain boot directory more accurately it'd be better.
+    val defaultBoot = BuildPaths.defaultGlobalBase / "boot"
+    val buildProps = state.baseDir / "project" / "build.properties"
+    // First try reading the sbt version from build.properties file.
+    val sbtVersionOpt = if (buildProps.exists) {
+      val buildProperties = new Properties()
+      IO.load(buildProperties, buildProps)
+      Option(buildProperties.getProperty("sbt.version"))
+    } else None
+    val sbtVersion = sbtVersionOpt.getOrElse(appId.version)
+    val currentArtDirs = defaultBoot * "*" / appId.groupID / appId.name / sbtVersion
+    currentArtDirs.get foreach { dir =>
+      state.log.info(s"Deleting $dir")
+      IO.delete(dir)
+    }
+  }
 
   /** Runs the next sequence of commands with global logging in place. */
   def runWithNewLog(state: State, logBacking: GlobalLogBacking): RunNext =
@@ -109,6 +136,7 @@ object MainLoop {
     ErrorHandling.wideConvert { state.process(processCommand) } match {
       case Right(s)                  => s
       case Left(t: xsbti.FullReload) => throw t
+      case Left(t: RebootCurrent)    => throw t
       case Left(t)                   => state.handleError(t)
     }
 

--- a/notes/1.1.0/reboot.md
+++ b/notes/1.1.0/reboot.md
@@ -1,0 +1,3 @@
+### Improvements
+
+- Adds `reboot dev` command, which deletes the current artifact from the boot directory. This is useful when working with development versions of sbt.


### PR DESCRIPTION
This adds a new option `dev` to the `reboot` command, which deletes the only the current sbt artifacts from the boot directory. `reboot dev` reads actively from `build.properties` instead of using the current state since `reboot` can restart into another sbt version.

In general, `reboot dev` is intended for the local development of sbt.

Fixes #3590
