### PR TITLE
quick fix for the broken used name

### DIFF
--- a/compile/inc/src/main/scala/sbt/inc/Relations.scala
+++ b/compile/inc/src/main/scala/sbt/inc/Relations.scala
@@ -687,7 +687,7 @@ private class MRelationsNameHashing(srcProd: Relation[File, File], binaryDep: Re
 
   def addUsedName(src: File, name: String): Relations =
     new MRelationsNameHashing(srcProd, binaryDep, internalDependencies = internalDependencies,
-      externalDependencies = externalDependencies, classes, names = names + (src, name))
+      externalDependencies = externalDependencies, classes, names = names + (src, name.replaceAllLiterally("\n", "")))
 
   override def inheritance: SourceDependencies =
     new SourceDependencies(internalDependencies.dependencies.getOrElse(DependencyByInheritance, Relation.empty), externalDependencies.dependencies.getOrElse(DependencyByInheritance, Relation.empty))


### PR DESCRIPTION
Quick fix #3666 . 

Simply get ride of the `\n`, this solution works currently, but seems very tricky

I wonder whether it should be merged.

If this pr is merged, I will send pr to zinc