### PR TITLE
cleanKeepFiles is ignored if cleanFiles is overriden

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -517,9 +517,9 @@ object Defaults extends BuildCommon {
     ))
 
   lazy val projectTasks: Seq[Setting[_]] = Seq(
-    cleanFiles := cleanFilesTask.value,
+    cleanFiles := Seq(managedDirectory.value, target.value),
     cleanKeepFiles := historyPath.value.toVector,
-    clean := (Def.task { IO.delete(cleanFiles.value) } tag (Tags.Clean)).value,
+    clean := (Def.task { IO.delete(cleanFilesTask.value) } tag (Tags.Clean)).value,
     consoleProject := consoleProjectTask.value,
     watchTransitiveSources := watchTransitiveSourcesTask.value,
     watch := watchSetting.value
@@ -1097,23 +1097,20 @@ object Defaults extends BuildCommon {
     pickMainClass(classes)
   }
 
-  /** Implements `cleanFiles` task. */
-  def cleanFilesTask: Initialize[Task[Vector[File]]] =
+  /** Files that will be deleted by the `clean` task */
+  def cleanFilesTask: Initialize[Task[Seq[File]]] =
     Def.task {
-      val filesAndDirs = Vector(managedDirectory.value, target.value)
-      val preserve = cleanKeepFiles.value
-      val (dirs, fs) = filesAndDirs.filter(_.exists).partition(_.isDirectory)
-      val preserveSet = preserve.filter(_.exists).toSet
-      // performance reasons, only the direct items under `filesAndDirs` are allowed to be preserved.
+      val (dirs, files) = cleanFiles.value.filter(_.exists).partition(_.isDirectory)
+      val preserveSet = cleanKeepFiles.value.filter(_.exists).toSet
       val dirItems = dirs flatMap { _.glob("*").get }
-      (preserveSet diff dirItems.toSet) match {
-        case xs if xs.isEmpty => ()
-        case xs =>
-          sys.error(
-            s"cleanKeepFiles contains directory/file that are not directly under cleanFiles: $xs")
+      // for performance reasons, only the direct items under `cleanFiles` are allowed to be preserved
+      val wrongKeepFiles = preserveSet diff dirItems.toSet
+      if (wrongKeepFiles.nonEmpty) {
+        sys.error(
+          s"""cleanKeepFiles contains directory/file that are not directly under cleanFiles: ${wrongKeepFiles
+            .mkString(", ")}""")
       }
-      val toClean = (dirItems filterNot { preserveSet(_) }) ++ fs
-      toClean
+      (dirItems filterNot { preserveSet(_) }) ++ files
     }
 
   def bgRunMainTask(

--- a/sbt/src/sbt-test/actions/clean-keep-files-override/build.sbt
+++ b/sbt/src/sbt-test/actions/clean-keep-files-override/build.sbt
@@ -1,0 +1,8 @@
+cleanFiles := Seq(
+  target.value,
+  target.value / "deletefile"
+)
+
+cleanKeepFiles := Seq(
+  target.value / "keep"
+)

--- a/sbt/src/sbt-test/actions/clean-keep-files-override/test
+++ b/sbt/src/sbt-test/actions/clean-keep-files-override/test
@@ -1,0 +1,8 @@
+$ touch target/keep/a target/deletefile target/deletedir/b
+$ exists target/keep/a target/deletefile target/deletedir/b
+
+> show cleanFiles
+> show cleanKeepFiles
+> clean
+$ absent target/deletefile target/deletedir/b
+$ exists target/keep/a 

--- a/sbt/src/sbt-test/actions/clean-keep/build.sbt
+++ b/sbt/src/sbt-test/actions/clean-keep/build.sbt
@@ -1,7 +1,5 @@
-cleanFiles := Seq(target.value)
-
 cleanKeepFiles ++= Seq(
-  target.value / "keep",
-  target.value / "keepfile",
-  target.value / "keepdir"
+	target.value / "keep",
+	target.value / "keepfile",
+	target.value / "keepdir"
 )

--- a/sbt/src/sbt-test/actions/clean-keep/build.sbt
+++ b/sbt/src/sbt-test/actions/clean-keep/build.sbt
@@ -1,6 +1,7 @@
-cleanKeepFiles ++= Seq(
-	target.value / "keep",
-	target.value / "keepfile",
-	target.value / "keepdir"
-)
+cleanFiles := Seq(target.value)
 
+cleanKeepFiles ++= Seq(
+  target.value / "keep",
+  target.value / "keepfile",
+  target.value / "keepdir"
+)


### PR DESCRIPTION
### Steps
1. `touch target/keep`
1. `build.sbt`:
    ```scala
    cleanFiles := Seq(target.value)
    cleanKeepFiles := Seq(target.value / "keep")
    ```
2. Run `sbt clean`.

### Problems

File `target/keep` had to be preserved, but it's deleted.

### Expectations

Key descriptions say:
* `cleanFiles`: The files to recursively delete during a clean.
* `cleanKeepFiles`: Files or directories to keep during a clean. Must be direct children of target.

So I would expect that running `clean` will delete everything under `cleanFiles` _except_ those in `cleanKeepFiles`. 

### Notes

The reason is that `cleanFiles` is defined through `cleanFilesTask`, which uses `cleanKeepFiles` directly, so if you override `cleanFiles`, it doesn't depend on `cleanKeepFiles` anymore. 

So I changed `cleanFilesTask` to define it in terms of the `cleanFiles` and `cleanKeepFiles` settings (their diff with the limitation that keep-files have to be direct children of the directories in `cleanFiles`). 