### PR TITLE
LSP: improve logging

### DIFF
--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -138,6 +138,20 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
     publishBytes(bytes)
   }
 
+  def logMessage(level: String, message: String): Unit = {
+    val messageType = level.toLowerCase match {
+      case "error" => MessageType.Error
+      case "warn"  => MessageType.Warning
+      case "info"  => MessageType.Info
+      case _       => MessageType.Log
+    }
+    import sbt.internal.langserver.codec.JsonProtocol._
+    langNotify(
+      "window/logMessage",
+      LogMessageParams(messageType, message)
+    )
+  }
+
   private[sbt] lazy val serverCapabilities: ServerCapabilities = {
     ServerCapabilities(textDocumentSync =
                          TextDocumentSyncOptions(true, 0, false, false, SaveOptions(false)),

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/LogMessageParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/LogMessageParams.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.langserver
+final class LogMessageParams private (
+  /** The message type. See MessageType. */
+  val `type`: Option[Long],
+  /** The actual message. */
+  val message: Option[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: LogMessageParams => (this.`type` == x.`type`) && (this.message == x.message)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.langserver.LogMessageParams".##) + `type`.##) + message.##)
+  }
+  override def toString: String = {
+    "LogMessageParams(" + `type` + ", " + message + ")"
+  }
+  protected[this] def copy(`type`: Option[Long] = `type`, message: Option[String] = message): LogMessageParams = {
+    new LogMessageParams(`type`, message)
+  }
+  def withType(`type`: Option[Long]): LogMessageParams = {
+    copy(`type` = `type`)
+  }
+  def withType(`type`: Long): LogMessageParams = {
+    copy(`type` = Option(`type`))
+  }
+  def withMessage(message: Option[String]): LogMessageParams = {
+    copy(message = message)
+  }
+  def withMessage(message: String): LogMessageParams = {
+    copy(message = Option(message))
+  }
+}
+object LogMessageParams {
+  
+  def apply(`type`: Option[Long], message: Option[String]): LogMessageParams = new LogMessageParams(`type`, message)
+  def apply(`type`: Long, message: String): LogMessageParams = new LogMessageParams(Option(`type`), Option(message))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/JsonProtocol.scala
@@ -18,4 +18,5 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.langserver.codec.InitializeResultFormats
   with sbt.internal.langserver.codec.PublishDiagnosticsParamsFormats
   with sbt.internal.langserver.codec.SbtExecParamsFormats
+  with sbt.internal.langserver.codec.LogMessageParamsFormats
 object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/LogMessageParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/LogMessageParamsFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.langserver.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait LogMessageParamsFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val LogMessageParamsFormat: JsonFormat[sbt.internal.langserver.LogMessageParams] = new JsonFormat[sbt.internal.langserver.LogMessageParams] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.langserver.LogMessageParams = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val `type` = unbuilder.readField[Option[Long]]("type")
+      val message = unbuilder.readField[Option[String]]("message")
+      unbuilder.endObject()
+      sbt.internal.langserver.LogMessageParams(`type`, message)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.langserver.LogMessageParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("type", obj.`type`)
+    builder.addField("message", obj.message)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/lsp.contra
+++ b/protocol/src/main/contraband/lsp.contra
@@ -117,3 +117,13 @@ type PublishDiagnosticsParams {
 type SbtExecParams {
   commandLine: String!
 }
+
+# Notifications
+
+type LogMessageParams {
+  ## The message type. See MessageType.
+  type: Long
+
+  ## The actual message.
+  message: String
+}

--- a/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
@@ -1,0 +1,34 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+package internal
+package langserver
+
+object MessageType {
+
+  /**
+   * An error message.
+   */
+  val Error = 1L
+
+  /**
+   * A warning message.
+   */
+  val Warning = 2L
+
+  /**
+   * An information message.
+   */
+  val Info = 3L
+
+  /**
+   * A log message.
+   */
+  val Log = 4L
+
+}


### PR DESCRIPTION
Fixes #3644. See also #3712: although these PRs are related, I split them for easier review, because the changes are independent. 

In the current implementation any event is sent back to the client as [`ResponseMessage`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#response-message) (in this sense this PR is dual to #3712). This is wrong because `ResponseMessage`s should be sent only in response to a `RequestMessage` and **have the same ID**. 

This PR introduces LSP logging for several types of sbt log events. It adds `LogMessage` type and uses notifications with the [`window/logMessage`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#window_logMessage) method.

There are many different log events, event messages, object messages, etc. in sbt and I don't completely understand what are they for and where do they come from. So I tried to determine those that could be relevant for a client of the sbt server:
- `StringEvent` which is what we usually see in the sbt shell while something is running
- `ExecStatusEvent` which indicates that something is in the process of execution or is done
- `LogEvent` (didn't see it, but added anyway, because it has `level` and `message` parameters)

(these comments are my simplified understanding of what they are, correct me if it's wrong)

<details><summary>An example debug output for one didSave-compile cycle</summary>

```
[debug] onNotification: JsonRpcNotificationMessage(2.0, textDocument/didSave, {"textDocument":{"uri":"file:///test.scala"}})
[debug] langNotify: JsonRpcNotificationMessage(2.0, window/logMessage, {"type":4,"message":"Processing"})
[debug] langNotify: JsonRpcNotificationMessage(2.0, textDocument/publishDiagnostics, {"uri":"file:/test.scala","diagnostics":[]})
[debug] langNotify: JsonRpcNotificationMessage(2.0, window/logMessage, {"type":3,"message":"Compiling 1 Scala source to /Users/laughedelic/dev/laughedelic/scala-adder/target/scala-2.12/classes ..."})
[debug] langNotify: JsonRpcNotificationMessage(2.0, textDocument/publishDiagnostics, {"uri":"file:/test.scala","diagnostics":[{"range":{"start":{"line":3,"character":21},"end":{"line":3,"character":22}},"severity":1,"source":"sbt","message":"type mismatch;\n found   : Int\n required: Boolean"}]})
[debug] langNotify: JsonRpcNotificationMessage(2.0, textDocument/publishDiagnostics, {"uri":"file:/test.scala","diagnostics":[{"range":{"start":{"line":5,"character":23},"end":{"line":5,"character":24}},"severity":1,"source":"sbt","message":"type mismatch;\n found   : Boolean\n required: Int"},{"range":{"start":{"line":3,"character":21},"end":{"line":3,"character":22}},"severity":1,"source":"sbt","message":"type mismatch;\n found   : Int\n required: Boolean"}]})
[debug] langNotify: JsonRpcNotificationMessage(2.0, window/logMessage, {"type":1,"message":"two errors found"})
[debug] langNotify: JsonRpcNotificationMessage(2.0, window/logMessage, {"type":1,"message":"(Compile / compileIncremental) Compilation failed"})
[error] Total time: 4 s, completed Nov 4, 2017 8:18:07 PM
[debug] langNotify: JsonRpcNotificationMessage(2.0, window/logMessage, {"type":4,"message":"Done"})
```

</details>

----

I used `ExecStatusEvent`s on the client side to start/stop the UI progress indicator, but probably there is a better way (some other type of event) to get same type of information. I also attached `StringEvent`s to the progress indicator, so that if something takes a long time user will know what's happening. This, of course, depends on the client how to interpret these logging notifications, I'm just showing an example of what could be done.

![screen shot 2017-11-04 at 21 33 14](https://user-images.githubusercontent.com/766656/32409255-8b71e844-c1a8-11e7-9b2d-896124181c79.png)
![screen shot 2017-11-04 at 21 33 38](https://user-images.githubusercontent.com/766656/32409257-8fe212e6-c1a8-11e7-9e84-71fe18a874ee.png)

