### PR TITLE
Improve testQuick performance, restoring caching of stamps

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -766,21 +766,24 @@ object Defaults extends BuildCommon {
       }
       def intlStamp(c: String, analysis: Analysis, s: Set[String]): Long = {
         if (s contains c) Long.MinValue
-        else {
-          val x = {
-            import analysis.{ relations => rel, apis }
-            rel.internalClassDeps(c).map(intlStamp(_, analysis, s + c)) ++
-              rel.externalDeps(c).map(stamp) +
-              (apis.internal.get(c) match {
-                case Some(x) => x.compilationTimestamp
-                case _       => Long.MinValue
-              })
-          }.max
-          if (x != Long.MinValue) {
-            stamps(c) = x
-          }
-          x
-        }
+        else
+          stamps.getOrElse(
+            c, {
+              val x = {
+                import analysis.{ relations => rel, apis }
+                rel.internalClassDeps(c).map(intlStamp(_, analysis, s + c)) ++
+                  rel.externalDeps(c).map(stamp) +
+                  (apis.internal.get(c) match {
+                    case Some(x) => x.compilationTimestamp
+                    case _       => Long.MinValue
+                  })
+              }.max
+              if (x != Long.MinValue) {
+                stamps(c) = x
+              }
+              x
+            }
+          )
       }
       def noSuccessYet(test: String) = succeeded.get(test) match {
         case None     => true


### PR DESCRIPTION
This is a rebase of https://github.com/sbt/sbt/pull/3683 against 1.0.x branch.

Fixes #3680