### PR TITLE
Workaround for scala/bug#10605

### DIFF
--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -142,7 +142,9 @@ private[sbt] object SbtParser {
     val wrapperFile = new BatchSourceFile(reporterId, code)
     val unit = new CompilationUnit(wrapperFile)
     val parser = new syntaxAnalyzer.UnitParser(unit)
-    val parsedTrees = parser.templateStats()
+    val parsedTrees = SbtParser.synchronized { // see https://github.com/scala/bug/issues/10605
+      parser.templateStats()
+    }
     parser.accept(scala.tools.nsc.ast.parser.Tokens.EOF)
     globalReporter.throwParserErrorsIfAny(reporter, filePath)
     parsedTrees -> reporterId


### PR DESCRIPTION
`templateStats()` is not thread-safe in 2.12.x (at least up to 2.12.4).
See scala/bug#10605
