### PR TITLE
Port of sbt/zinc#441 to sbt/sbt 1.0.x

### DIFF
--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -108,6 +108,8 @@ object Scripted {
                  prescripted: File => Unit,
                  launchOpts: Seq[String]): Unit = {
     System.err.println(s"About to run tests: ${args.mkString("\n * ", "\n * ", "\n")}")
+    // Force Log4J to not use a thread context classloader otherwise it throws a CCE
+    sys.props(org.apache.logging.log4j.util.LoaderUtil.IGNORE_TCCL_PROPERTY) = "true"
     val noJLine = new classpath.FilteredLoader(scriptedSbtInstance.loader, "jline." :: Nil)
     val loader = classpath.ClasspathUtilities.toLoader(scriptedSbtClasspath.files, noJLine)
     val bridgeClass = Class.forName("sbt.test.ScriptedRunner", true, loader)


### PR DESCRIPTION
I was affected by the same log4j exception while testing using scripted, so porting the zinc scripted fix https://github.com/sbt/zinc/pull/441 over to sbt/sbt.
Note: copy/paste unavoidably leads to outdated code; we should strive to factor out common code in a separate library.