### PR TITLE
Reinstate tests run/error and tests/fork-parallel

### DIFF
--- a/sbt/src/sbt-test/run/error/test
+++ b/sbt/src/sbt-test/run/error/test
@@ -13,7 +13,6 @@ $ copy-file changes/ThreadRunError.scala src/main/scala/Run.scala
 $ copy-file changes/RunExplicitSuccess.scala src/main/scala/Run.scala
 > run
 
-# https://github.com/sbt/sbt/issues/3543
-# # explicitly calling System.exit(1) should fail the 'run' task
-# $ copy-file changes/RunExplicitFailure.scala src/main/scala/Run.scala
-# -> run
+# explicitly calling System.exit(1) should fail the 'run' task
+$ copy-file changes/RunExplicitFailure.scala src/main/scala/Run.scala
+-> run

--- a/sbt/src/sbt-test/tests/fork-parallel/test
+++ b/sbt/src/sbt-test/tests/fork-parallel/test
@@ -1,6 +1,5 @@
-# https://github.com/sbt/sbt/issues/3545
-# > test
-# -> check
+> test
+-> check
 
 > clean
 > set testForkedParallel := true


### PR DESCRIPTION
Restore the two disabled tests, optimistically assuming that #3743 had a positive effect on the flaky tests.
See sbt/sbt#3545 and sbt/sbt#3543.
