### PR TITLE
don't require publishTo specified if publishArtifact is `false`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1935,8 +1935,10 @@ object Classpaths {
         if (isSnapshot.value) "integration" else "release",
         ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
         packagedArtifacts.in(publish).value.toVector,
-        checksums.in(publish).value.toVector,
-        getPublishTo(publishTo.value).name,
+        checksums.in(publish).value.toVector, { //resolvername: not required if publishTo is false
+          val publishToOption = publishTo.value
+          if (publishArtifact.value) getPublishTo(publishToOption).name else "local"
+        },
         ivyLoggingLevel.value,
         isSnapshot.value
       )

--- a/notes/1.2.0/publishTo-not-required-if-not-publishing.md
+++ b/notes/1.2.0/publishTo-not-required-if-not-publishing.md
@@ -1,0 +1,12 @@
+
+[@mpollmeier]: https://github.com/mpollmeier
+
+[#3760]: https://github.com/sbt/sbt/pull/3760
+
+### Fixes with compatibility implications
+
+### Improvements
+
+### Bug fixes
+
+- Remove requirement on `publishTo` if `publishArtifact` is false. [#3760][] by [@mpollmeier][]

--- a/sbt/src/sbt-test/project/no-publish/build.sbt
+++ b/sbt/src/sbt-test/project/no-publish/build.sbt
@@ -1,0 +1,3 @@
+// this is supposed to do nothing, and more importantly: not fail
+// https://github.com/sbt/sbt/pull/3760
+publishArtifact := false

--- a/sbt/src/sbt-test/project/no-publish/test
+++ b/sbt/src/sbt-test/project/no-publish/test
@@ -1,0 +1,1 @@
+> publish


### PR DESCRIPTION
Even with `publishArtifact := false` the user is still forced to define a (dummy) resolver that's never used, e.g. `publishTo := { Some("publishMeNot" at "https://publish/me/not") }`

Otherwise the following error is thrown:
```
publish
[error] java.lang.RuntimeException: Repository for publishing is not specified.
[error]         at scala.sys.package$.error(package.scala:27)
[error]         at sbt.Classpaths$.$anonfun$getPublishTo$1(Defaults.scala:2436)
[error]         at scala.Option.getOrElse(Option.scala:121)
[error]         at sbt.Classpaths$.getPublishTo(Defaults.scala:2436)
[error]         at sbt.Classpaths$.$anonfun$ivyBaseSettings$48(Defaults.scala:1917)
```

Is 1.0.x the right target branch, or should it rather be 1.x?