### PR TITLE
Add warning for slow hostname lookups on OS X

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1039,7 +1039,9 @@ private[sbt] object Load {
         // Grab all the settings we already loaded from sbt files
         def settings(files: Seq[File]): Seq[Setting[_]] = {
           if (files.nonEmpty)
-            log.info(s"${files.map(_.getName).mkString(s"Loading settings for project ${p.id} from ", ",", " ...")}")
+            log.info(
+              s"${files.map(_.getName).mkString(s"Loading settings for project ${p.id} from ", ",", " ...")}"
+            )
           for {
             file <- files
             config <- (memoSettings get file).toSeq

--- a/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
@@ -30,6 +30,6 @@ object JUnitXmlReportPlugin extends AutoPlugin {
   // It might be a good idea to derive this setting into specific test scopes.
   override lazy val projectSettings: Seq[Setting[_]] =
     Seq(
-      testListeners += new JUnitXmlTestsListener(target.value.getAbsolutePath)
+      testListeners += new JUnitXmlTestsListener(target.value.getAbsolutePath, streams.value.log)
     )
 }


### PR DESCRIPTION
I spent a lot of time debugging why it took 5 seconds to run tests each
time. It turns out that if the hostname is not set explicitly on os x,
then getaddrinfo takes 5 seconds to try (and fail) to resolve the dns
entry for the localhostname. This is easily fixed by setting the
hostname, but it is not at all easy to figure out that a slow hostname
lookup is the reason why tests are slow to start.

I don't know if this is a common issue on other platforms, so only issue
the warning on OS X.

Related to #1506

(See the guidelines for contributing, linked above)
