### PR TITLE
Alt scala parser sync workaround

### DIFF
--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -109,7 +109,9 @@ private[sbt] object SbtParser {
     scalacGlobalInitReporter = Some(new ConsoleReporter(settings))
 
     // Mix Positions, otherwise global ignores -Yrangepos
-    val global = new Global(settings, globalReporter) with Positions
+    val global = new Global(settings, globalReporter) with Positions {
+      override protected def synchronizeNames = true // https://github.com/scala/bug/issues/10605
+    }
     val run = new global.Run
     // Add required dummy unit for initialization...
     val initFile = new BatchSourceFile("<wrapper-init>", "")
@@ -142,9 +144,7 @@ private[sbt] object SbtParser {
     val wrapperFile = new BatchSourceFile(reporterId, code)
     val unit = new CompilationUnit(wrapperFile)
     val parser = new syntaxAnalyzer.UnitParser(unit)
-    val parsedTrees = SbtParser.synchronized { // see https://github.com/scala/bug/issues/10605
-      parser.templateStats()
-    }
+    val parsedTrees = parser.templateStats()
     parser.accept(scala.tools.nsc.ast.parser.Tokens.EOF)
     globalReporter.throwParserErrorsIfAny(reporter, filePath)
     parsedTrees -> reporterId


### PR DESCRIPTION
Apply retronym's suggestion at https://github.com/scala/bug/issues/10605
instead of the workaround merged in https://github.com/sbt/sbt/pull/3743.