### PR TITLE
LSP: added handler for notification messages

### DIFF
--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -39,7 +39,7 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
     notification.method match {
       case "textDocument/didSave" =>
         append(Exec(";compile; collectAnalyses", None, Some(CommandSource(name))))
-      case _ => ()
+      case u => log.debug(s"Unhandled notification received: $u")
     }
   }
 


### PR DESCRIPTION
This is a continuation/rebase of https://github.com/sbt/sbt/pull/3712

----

See https://github.com/sbt/sbt/issues/3644#issuecomment-341299860.

Currently all incoming messages are treated as [`RequestMessage`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#requestmessage)s. It's is wrong, because this way [`NotificationMessage`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#notification-message)s are treated as requests with an _empty_ request ID. Notifications don't have an ID and don't need a response (while `RequestMessage`s do require response).

This implementation is far from perfect, so I'm ready to change it according to the feedback.
