### PR TITLE
Deprecate addMavenResolverPlugin, see #3486

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2981,7 +2981,7 @@ object Classpaths {
           case Predefined.SonatypeOSSSnapshots => Resolver.sonatypeRepo("snapshots")
           case unknown =>
             sys.error(
-              "Unknown predefined resolver '" + unknown + "'.  This resolver may only be supported in newer sbt versions.")
+              "Unknown predefined resolver '" + unknown + "'. This resolver may only be supported in newer sbt versions.")
         }
     }
   }
@@ -3016,11 +3016,16 @@ trait BuildExtra extends BuildCommon with DefExtra {
   /**
    * Adds Maven resolver plugin.
    */
+  @deprecated(
+    "Noop. sbt-maven-resolver is not currently maintained and hasn't been released for sbt 1.0.",
+    "1.0.5")
   def addMavenResolverPlugin: Setting[Seq[ModuleID]] =
-    libraryDependencies += sbtPluginExtra(
-      ModuleID("org.scala-sbt", "sbt-maven-resolver", sbtVersion.value),
-      sbtBinaryVersion.value,
-      scalaBinaryVersion.value)
+    libraryDependencies ++= {
+      sLog.value.warn(
+        "addMavenResolverPlugin is a noop. " +
+          "sbt-maven-resolver is not currently maintained and hasn't been released for sbt 1.0.")
+      Seq.empty[ModuleID]
+    }
 
   /**
    * Adds `dependency` as an sbt plugin for the specific sbt version `sbtVersion` and Scala version `scalaVersion`.


### PR DESCRIPTION
Motivation:

sbt-maven-resolver hasn’t been maintained lately and hasn’t been
released for sbt 1.0. Without this fix, adding addMavenResolverPlugin
will make build fail on unresolved dependency.

Modification:

Deprecate and make `addMavenResolverPlugin` a noop.

Result:

Build no longer crashes on sbt 1.0 when using `addMavenResolverPlugin`.
User will get a warning though.

(See the guidelines for contributing, linked above)
