### PR TITLE
Only the first session starts the server

### DIFF
--- a/main-command/src/main/java/sbt/internal/NGUnixDomainSocketLibrary.java
+++ b/main-command/src/main/java/sbt/internal/NGUnixDomainSocketLibrary.java
@@ -131,6 +131,8 @@ public class NGUnixDomainSocketLibrary {
   public static native int listen(int fd, int backlog) throws LastErrorException;
   public static native int accept(int fd, SockaddrUn address, IntByReference addressLen)
     throws LastErrorException;
+  public static native int connect(int fd, SockaddrUn address, int addressLen)
+    throws LastErrorException;
   public static native int read(int fd, ByteBuffer buffer, int count)
     throws LastErrorException;
   public static native int write(int fd, ByteBuffer buffer, int count)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -152,11 +152,13 @@ private[sbt] final class CommandExchange {
         Await.ready(x.ready, Duration("10s"))
         x.ready.value match {
           case Some(Success(_)) =>
+            // rememeber to shutdown only when the server comes up
+            server = Some(x)
           case Some(Failure(e)) =>
             s.log.error(e.toString)
+            server = None
           case None => // this won't happen because we awaited
         }
-        server = Some(x)
     }
     s
   }


### PR DESCRIPTION
Currently the server will try to start even if there are existing sbt sessions. This causes the second session to take over the server for Unix domain socket.

This adds a check before the server comes up and make sure that the socket is not taken.

Another thing that was happening was that even when the server didn't start, it was going through the shutdown sequence when sbt exists, deleting the portfile. This is fixed in 
2b2c1f0.