### PR TITLE
Encode POSIX file path to URI using u3 (file:///)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ def buildLevelSettings: Seq[Setting[_]] =
   inThisBuild(
     Seq(
       organization := "org.scala-sbt",
-      version := "1.0.3-SNAPSHOT",
+      version := "1.1.0-SNAPSHOT",
       description := "sbt is an interactive build tool",
       bintrayOrganization := Some("sbt"),
       bintrayRepository := {

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -174,7 +174,7 @@ private[sbt] object Server {
           auth match {
             case _ if auth(ServerAuthentication.Token) =>
               writeTokenfile()
-              PortFile(uri, Option(tokenfile.toString), Option(tokenfile.toURI.toString))
+              PortFile(uri, Option(tokenfile.toString), Option(IO.toURI(tokenfile).toString))
             case _ =>
               PortFile(uri, None, None)
           }

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{ Success, Failure }
 import sbt.io.syntax._
-import sbt.io.Hash
+import sbt.io.{ Hash, IO }
 import sbt.internal.server._
 import sbt.internal.langserver.{ LogMessageParams, MessageType }
 import sbt.internal.util.{ StringEvent, ObjectEvent, MainAppender }
@@ -135,7 +135,7 @@ private[sbt] final class CommandExchange {
       case Some(_) => // do nothing
       case _ =>
         val portfile = (new File(".")).getAbsoluteFile / "project" / "target" / "active.json"
-        val h = Hash.halfHashString(portfile.toURI.toString)
+        val h = Hash.halfHashString(IO.toURI(portfile).toString)
         val tokenfile = BuildPaths.getGlobalBase(s) / "server" / h / "token.json"
         val socketfile = BuildPaths.getGlobalBase(s) / "server" / h / "sock"
         val pipeName = "sbt-server-" + h

--- a/main/src/main/scala/sbt/internal/server/Definition.scala
+++ b/main/src/main/scala/sbt/internal/server/Definition.scala
@@ -9,6 +9,7 @@ package sbt
 package internal
 package server
 
+import sbt.io.IO
 import sbt.internal.inc.MixedAnalyzingCompiler
 import sbt.internal.langserver.ErrorCodes
 import sbt.util.Logger
@@ -297,7 +298,7 @@ private[sbt] object Definition {
                   textProcessor.markPosition(classFile, sym).collect {
                     case (file, line, from, to) =>
                       import sbt.internal.langserver.{ Location, Position, Range }
-                      Location(file.toURI.toURL.toString,
+                      Location(IO.toURI(file).toString,
                                Range(Position(line, from), Position(line, to)))
                   }
                 }

--- a/main/src/main/scala/sbt/internal/server/LanguageServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerReporter.scala
@@ -24,6 +24,7 @@ import sbt.internal.langserver.{
 import sbt.internal.inc.JavaInterfaceUtil._
 import scala.collection.mutable
 import scala.collection.JavaConverters._
+import sbt.io.IO
 
 /**
  * Defines a compiler reporter that uses event logging provided by a [[ManagedLogger]].
@@ -82,7 +83,7 @@ class LanguageServerReporter(
     import sbt.internal.langserver.codec.JsonProtocol._
     val files = analysis.readSourceInfos.getAllSourceInfos.keySet.asScala
     files foreach { f =>
-      val params = PublishDiagnosticsParams(f.toURI.toString, Vector())
+      val params = PublishDiagnosticsParams(IO.toURI(f).toString, Vector())
       exchange.notifyEvent("textDocument/publishDiagnostics", params)
     }
   }
@@ -94,7 +95,7 @@ class LanguageServerReporter(
       problemsByFile.get(sourceFile) match {
         case Some(xs: List[Problem]) =>
           val ds = toDiagnostics(xs)
-          val params = PublishDiagnosticsParams(sourceFile.toURI.toString, ds)
+          val params = PublishDiagnosticsParams(IO.toURI(sourceFile).toString, ds)
           exchange.notifyEvent("textDocument/publishDiagnostics", params)
         case _ =>
       }

--- a/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
+++ b/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
@@ -1,4 +1,4 @@
-val baseSbt = "1.0"
+val baseSbt = "1."
 
 val buildCrossList = List("2.10.6", "2.11.11", "2.12.2")
 scalaVersion in ThisBuild := "2.12.2"
@@ -10,20 +10,20 @@ lazy val root = (project in file("."))
   .settings(
     sbtPlugin := true,
 
-    TaskKey[Unit]("check") := mkCheck("2.12", "1.0").value,
-    TaskKey[Unit]("check2") := mkCheck("2.10", "0.13").value
+    TaskKey[Unit]("check") := mkCheck("2.12", "1.0", "1.").value,
+    TaskKey[Unit]("check2") := mkCheck("2.10", "0.13", "0.13").value
   )
 
 lazy val app = (project in file("app"))
 
-def mkCheck(scalaBinV: String, sbtBinVer: String) = Def task {
+def mkCheck(scalaBinV: String, sbtBinVer: String, sbtVerPrefix: String) = Def task {
   val crossV = (sbtVersion in pluginCrossBuild).value
   val crossBinV = (sbtBinaryVersion in pluginCrossBuild).value
   val sv = projectID.value.extraAttributes("e:scalaVersion")
   assert(sbtVersion.value startsWith baseSbt, s"Wrong sbt version: ${sbtVersion.value}")
   assert(sv == scalaBinV, s"Wrong e:scalaVersion: $sv")
   assert(scalaBinaryVersion.value == scalaBinV, s"Wrong Scala binary version: ${scalaBinaryVersion.value}")
-  assert(crossV startsWith sbtBinVer, s"Wrong `sbtVersion in pluginCrossBuild`: $crossV")
+  assert(crossV startsWith sbtVerPrefix, s"Wrong `sbtVersion in pluginCrossBuild`: $crossV")
 
   val ur = update.value
   val cr = ur.configuration(Compile).get
@@ -31,7 +31,7 @@ def mkCheck(scalaBinV: String, sbtBinVer: String) = Def task {
   val plugSv = mr.module.extraAttributes("scalaVersion")
   val plugSbtV = mr.module.extraAttributes("sbtVersion")
   assert(plugSv == scalaBinV, s"Wrong plugin scalaVersion: $plugSv")
-  assert(plugSbtV == sbtBinVer, s"Wrong plugin scalaVersion: $sbtBinVer")
+  assert(plugSbtV == sbtBinVer, s"Wrong plugin sbtVersion: $plugSbtV")
 
   // crossScalaVersions in app should not be affected, per se or after ^^
   val appCrossScalaVersions = (crossScalaVersions in app).value.toList


### PR DESCRIPTION
Ref https://github.com/sbt/io/pull/96
Fixes https://github.com/sbt/sbt/issues/3801

Under RFC 8089, both u1 and u3 are legal, but many of the other platforms expect traditional u3.
This will increase the compatibility/usability of sbt server, for example to integrate with Vim.