### PR TITLE
update mimaPreviousArtifacts (in the 1.1.x branch)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,10 +75,9 @@ def testedBaseSettings: Seq[Setting[_]] =
   baseSettings ++ testDependencies
 
 val mimaSettings = Def settings (
-  mimaPreviousArtifacts := Set(
-    organization.value % moduleName.value % "1.0.0"
-      cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
-  )
+  mimaPreviousArtifacts := (0 to 4).map { v =>
+    organization.value % moduleName.value % s"1.0.$v" cross (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled)
+  }.toSet
 )
 
 lazy val sbtRoot: Project = (project in file("."))


### PR DESCRIPTION
This is https://github.com/sbt/sbt/pull/3794, but targetting the 1.1.x branch, so we don't cause any binary regressions between sbt 1.0.{2,3,4} and sbt 1.1.0.