### PR TITLE
Exclude contraband generated files from diff by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 # to native line endings on checkout.
 *.scala text
 *.java text
+
+# Exclude contraband generated files from diff (by default - you can see it if you want)
+**/contraband-scala/**/* -diff merge=ours
+**/contraband-scala/**/* linguist-generated=true


### PR DESCRIPTION
In both local git diff and GitHub diff you can still see the diff if you
want. This is just to remove the noise by default.