### PR TITLE
Make CaffeineCache a lazy val

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -103,7 +103,7 @@ object StandardMain {
   private[sbt] lazy val exchange = new CommandExchange()
   import scalacache._
   import scalacache.caffeine._
-  private[sbt] val cache: Cache[Any] = CaffeineCache[Any]
+  private[sbt] lazy val cache: Cache[Any] = CaffeineCache[Any]
 
   def runManaged(s: State): xsbti.MainResult = {
     val previous = TrapExit.installManager()
@@ -135,9 +135,6 @@ object StandardMain {
       Exec(x, None)
     }
     val initAttrs = BuiltinCommands.initialAttributes
-    import scalacache.modes.scalaFuture._
-    import scala.concurrent.ExecutionContext.Implicits.global
-    cache.removeAll()
     val s = State(
       configuration,
       initialDefinitions,


### PR DESCRIPTION
This is to avoid it initialising Log4J2 (via SLF4J), which we initialise
ourselves programmatically in LogExchange. Also there's no need to
removeAll in initialState.

Fixes #3787

My proposed alternative to #3808.