### PR TITLE
Convert lastModified() calls to the more precise getModifiedTime() + modules bump

### DIFF
--- a/main-actions/src/main/scala/sbt/Sync.scala
+++ b/main-actions/src/main/scala/sbt/Sync.scala
@@ -66,7 +66,7 @@ object Sync {
     else if (!target.exists) // we don't want to update the last modified time of an existing directory
       {
         IO.createDirectory(target)
-        IO.copyModifiedTime(source, target)
+        IO.copyLastModified(source, target)
       }
 
   def noDuplicateTargets(relation: Relation[File, File]): Unit = {

--- a/main-actions/src/main/scala/sbt/Sync.scala
+++ b/main-actions/src/main/scala/sbt/Sync.scala
@@ -66,7 +66,7 @@ object Sync {
     else if (!target.exists) // we don't want to update the last modified time of an existing directory
       {
         IO.createDirectory(target)
-        IO.copyLastModified(source, target)
+        IO.copyModifiedTime(source, target)
       }
 
   def noDuplicateTargets(relation: Relation[File, File]): Unit = {

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -487,8 +487,10 @@ private[sbt] object Eval {
   def fileModifiedBytes(f: File): Array[Byte] =
     (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter)
      else
-       bytes(try IO.getModifiedTime(f) catch { case _: java.io.FileNotFoundException => 0L })) ++
-         bytes(f.getAbsolutePath)
+       bytes(
+         try IO.getModifiedTime(f)
+         catch { case _: java.io.FileNotFoundException => 0L })) ++
+      bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++
       bytes(f.getAbsolutePath)

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -21,7 +21,6 @@ import java.net.URLClassLoader
 import Eval.{ getModule, getValue, WrapValName }
 
 import sbt.io.{ DirectoryFilter, FileFilter, GlobFilter, Hash, IO, Path }
-import sbt.io.IO.getModifiedTime
 
 // TODO: provide a way to cleanup backing directory
 
@@ -488,11 +487,8 @@ private[sbt] object Eval {
   def fileModifiedBytes(f: File): Array[Byte] =
     (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter)
      else
-       bytes(try {
-         getModifiedTime(f)
-       } catch {
-         case _: java.io.FileNotFoundException => 0L
-       })) ++ bytes(f.getAbsolutePath)
+       bytes(try IO.getModifiedTime(f) catch { case _: java.io.FileNotFoundException => 0L })) ++
+         bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++
       bytes(f.getAbsolutePath)

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -21,6 +21,7 @@ import java.net.URLClassLoader
 import Eval.{ getModule, getValue, WrapValName }
 
 import sbt.io.{ DirectoryFilter, FileFilter, GlobFilter, Hash, IO, Path }
+import sbt.io.Milli.getModifiedTime
 
 // TODO: provide a way to cleanup backing directory
 
@@ -485,7 +486,8 @@ private[sbt] object Eval {
   def filesModifiedBytes(fs: Array[File]): Array[Byte] =
     if (fs eq null) filesModifiedBytes(Array[File]()) else seqBytes(fs)(fileModifiedBytes)
   def fileModifiedBytes(f: File): Array[Byte] =
-    (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter) else bytes(f.lastModified)) ++
+    (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter)
+     else bytes(getModifiedTime(f))) ++
       bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -487,8 +487,12 @@ private[sbt] object Eval {
     if (fs eq null) filesModifiedBytes(Array[File]()) else seqBytes(fs)(fileModifiedBytes)
   def fileModifiedBytes(f: File): Array[Byte] =
     (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter)
-     else bytes(getModifiedTime(f))) ++
-      bytes(f.getAbsolutePath)
+     else
+       bytes(try {
+         getModifiedTime(f)
+       } catch {
+         case _: java.io.FileNotFoundException => 0L
+       })) ++ bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++
       bytes(f.getAbsolutePath)

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -21,7 +21,7 @@ import java.net.URLClassLoader
 import Eval.{ getModule, getValue, WrapValName }
 
 import sbt.io.{ DirectoryFilter, FileFilter, GlobFilter, Hash, IO, Path }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 // TODO: provide a way to cleanup backing directory
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -47,7 +47,6 @@ import sbt.io.{
   DirectoryFilter,
   Hash
 }, Path._
-import sbt.io.IO.getModifiedTime
 import sbt.librarymanagement.Artifact.{ DocClassifier, SourceClassifier }
 import sbt.librarymanagement.Configurations.{
   Compile,
@@ -2316,7 +2315,7 @@ object Classpaths {
         case Some(period) =>
           val fullUpdateOutput = cacheDirectory / "out"
           val now = System.currentTimeMillis
-          val diff = now - getModifiedTime(fullUpdateOutput)
+          val diff = now - IO.getModifiedTime(fullUpdateOutput)
           val elapsedDuration = new FiniteDuration(diff, TimeUnit.MILLISECONDS)
           fullUpdateOutput.exists() && elapsedDuration > period
       }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -47,6 +47,7 @@ import sbt.io.{
   DirectoryFilter,
   Hash
 }, Path._
+import sbt.io.Milli.getModifiedTime
 import sbt.librarymanagement.Artifact.{ DocClassifier, SourceClassifier }
 import sbt.librarymanagement.Configurations.{
   Compile,
@@ -2315,7 +2316,7 @@ object Classpaths {
         case Some(period) =>
           val fullUpdateOutput = cacheDirectory / "out"
           val now = System.currentTimeMillis
-          val diff = now - fullUpdateOutput.lastModified()
+          val diff = now - getModifiedTime(fullUpdateOutput)
           val elapsedDuration = new FiniteDuration(diff, TimeUnit.MILLISECONDS)
           fullUpdateOutput.exists() && elapsedDuration > period
       }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -47,7 +47,7 @@ import sbt.io.{
   DirectoryFilter,
   Hash
 }, Path._
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 import sbt.librarymanagement.Artifact.{ DocClassifier, SourceClassifier }
 import sbt.librarymanagement.Configurations.{
   Compile,

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -13,7 +13,7 @@ import sbt.internal.librarymanagement._
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._
 import sbt.util.{ CacheStore, CacheStoreFactory, Logger, Tracked }
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 private[sbt] object LibraryManagement {
 
@@ -127,7 +127,7 @@ private[sbt] object LibraryManagement {
   }
 
   private[this] def fileUptodate(file: File, stamps: Map[File, Long]): Boolean =
-    stamps.get(file).forall(_ == getModifiedTime(file))
+    stamps.get(file).forall(_ == IO.getModifiedTime(file))
 
   private[sbt] def transitiveScratch(
       lm: DependencyResolution,

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -13,6 +13,7 @@ import sbt.internal.librarymanagement._
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._
 import sbt.util.{ CacheStore, CacheStoreFactory, Logger, Tracked }
+import sbt.io.Milli.getModifiedTime
 
 private[sbt] object LibraryManagement {
 
@@ -126,7 +127,7 @@ private[sbt] object LibraryManagement {
   }
 
   private[this] def fileUptodate(file: File, stamps: Map[File, Long]): Boolean =
-    stamps.get(file).forall(_ == file.lastModified)
+    stamps.get(file).forall(_ == getModifiedTime(file))
 
   private[sbt] def transitiveScratch(
       lm: DependencyResolution,

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -13,7 +13,7 @@ import sbt.internal.librarymanagement._
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._
 import sbt.util.{ CacheStore, CacheStoreFactory, Logger, Tracked }
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 private[sbt] object LibraryManagement {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,10 +12,10 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.1.1"
-  private val utilVersion = "1.1.0"
-  private val lmVersion = "1.1.0"
-  private val zincVersion = "1.1.0-RC1"
+  private val ioVersion = "1.1.2"
+  private val utilVersion = "1.1.1"
+  private val lmVersion = "1.1.1"
+  private val zincVersion = "1.1.0-RC3"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/SiteMap.scala
+++ b/project/SiteMap.scala
@@ -68,6 +68,8 @@ object SiteMap {
   // generates a string suitable for a sitemap file representing the last modified time of the given File
   private[this] def lastModifiedString(f: File): String = {
     val formatter = new java.text.SimpleDateFormat("yyyy-MM-dd")
+    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
+    // has been upgraded to a version of sbt that includes sbt.io.Milli.
     formatter.format(new java.util.Date(f.lastModified))
   }
   // writes the provided XML node to `output` and then gzips it to `gzipped` if `gzip` is true

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -105,6 +105,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
+    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
+    // has been upgraded to a version of sbt that includes sbt.io.Milli.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,8 @@
 scalaVersion := "2.12.3"
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.17")
-// addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
-// addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.2")
-// addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")
-// addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.4")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.2")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/ClientCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/ClientCapabilities.scala
@@ -9,7 +9,7 @@ final class ClientCapabilities private () extends Serializable {
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: ClientCapabilities => true
+  case _: ClientCapabilities => true
   case _ => false
 }
 override def hashCode: Int = {

--- a/protocol/src/main/contraband-scala/sbt/protocol/CommandMessage.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/CommandMessage.scala
@@ -11,7 +11,7 @@ abstract class CommandMessage() extends Serializable {
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: CommandMessage => true
+  case _: CommandMessage => true
   case _ => false
 }
 override def hashCode: Int = {

--- a/protocol/src/main/contraband-scala/sbt/protocol/EventMessage.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/EventMessage.scala
@@ -11,7 +11,7 @@ abstract class EventMessage() extends Serializable {
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: EventMessage => true
+  case _: EventMessage => true
   case _ => false
 }
 override def hashCode: Int = {

--- a/protocol/src/main/contraband-scala/sbt/protocol/SettingQueryResponse.scala
+++ b/protocol/src/main/contraband-scala/sbt/protocol/SettingQueryResponse.scala
@@ -10,7 +10,7 @@ abstract class SettingQueryResponse() extends sbt.protocol.EventMessage() with S
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: SettingQueryResponse => true
+  case _: SettingQueryResponse => true
   case _ => false
 }
 override def hashCode: Int = {

--- a/sbt/src/sbt-test/run/error/test
+++ b/sbt/src/sbt-test/run/error/test
@@ -13,7 +13,6 @@ $ copy-file changes/ThreadRunError.scala src/main/scala/Run.scala
 $ copy-file changes/RunExplicitSuccess.scala src/main/scala/Run.scala
 > run
 
-# https://github.com/sbt/sbt/issues/3543
-# # explicitly calling System.exit(1) should fail the 'run' task
-# $ copy-file changes/RunExplicitFailure.scala src/main/scala/Run.scala
-# -> run
+# explicitly calling System.exit(1) should fail the 'run' task
+$ copy-file changes/RunExplicitFailure.scala src/main/scala/Run.scala
+-> run

--- a/testing/src/main/contraband-scala/sbt/protocol/testing/TestInitEvent.scala
+++ b/testing/src/main/contraband-scala/sbt/protocol/testing/TestInitEvent.scala
@@ -10,7 +10,7 @@ final class TestInitEvent private () extends sbt.protocol.testing.TestMessage() 
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: TestInitEvent => true
+  case _: TestInitEvent => true
   case _ => false
 }
 override def hashCode: Int = {

--- a/testing/src/main/contraband-scala/sbt/protocol/testing/TestMessage.scala
+++ b/testing/src/main/contraband-scala/sbt/protocol/testing/TestMessage.scala
@@ -11,7 +11,7 @@ abstract class TestMessage() extends Serializable {
 
 
 override def equals(o: Any): Boolean = o match {
-  case x: TestMessage => true
+  case _: TestMessage => true
   case _ => false
 }
 override def hashCode: Int = {


### PR DESCRIPTION
This is a continuation of https://github.com/sbt/sbt/pull/3789

Use the new native file modification timestamps, which return times with full millisecond precisions whenever possible. Re-enables the tests run/error and tests/fork-parallel.
Depends on https://github.com/sbt/zinc/pull/463
See: https://github.com/sbt/io/pull/92

Fixes #3543