### PR TITLE
Use IO.getModifiedTimeOrZero(file) calls

### DIFF
--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -488,8 +488,7 @@ private[sbt] object Eval {
     (if (f.isDirectory)
        filesModifiedBytes(f listFiles classDirFilter)
      else
-       bytes(IO.lastModified(f))
-    ) ++ bytes(f.getAbsolutePath)
+       bytes(IO.getModifiedTimeOrZero(f))) ++ bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++
       bytes(f.getAbsolutePath)

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -485,12 +485,11 @@ private[sbt] object Eval {
   def filesModifiedBytes(fs: Array[File]): Array[Byte] =
     if (fs eq null) filesModifiedBytes(Array[File]()) else seqBytes(fs)(fileModifiedBytes)
   def fileModifiedBytes(f: File): Array[Byte] =
-    (if (f.isDirectory) filesModifiedBytes(f listFiles classDirFilter)
+    (if (f.isDirectory)
+       filesModifiedBytes(f listFiles classDirFilter)
      else
-       bytes(
-         try IO.getModifiedTime(f)
-         catch { case _: java.io.FileNotFoundException => 0L })) ++
-      bytes(f.getAbsolutePath)
+       bytes(IO.lastModified(f))
+    ) ++ bytes(f.getAbsolutePath)
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++
       bytes(f.getAbsolutePath)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2315,7 +2315,7 @@ object Classpaths {
         case Some(period) =>
           val fullUpdateOutput = cacheDirectory / "out"
           val now = System.currentTimeMillis
-          val diff = now - IO.lastModified(fullUpdateOutput)
+          val diff = now - IO.getModifiedTimeOrZero(fullUpdateOutput)
           val elapsedDuration = new FiniteDuration(diff, TimeUnit.MILLISECONDS)
           fullUpdateOutput.exists() && elapsedDuration > period
       }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2315,7 +2315,7 @@ object Classpaths {
         case Some(period) =>
           val fullUpdateOutput = cacheDirectory / "out"
           val now = System.currentTimeMillis
-          val diff = now - IO.getModifiedTime(fullUpdateOutput)
+          val diff = now - IO.lastModified(fullUpdateOutput)
           val elapsedDuration = new FiniteDuration(diff, TimeUnit.MILLISECONDS)
           fullUpdateOutput.exists() && elapsedDuration > period
       }

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -127,7 +127,7 @@ private[sbt] object LibraryManagement {
   }
 
   private[this] def fileUptodate(file: File, stamps: Map[File, Long]): Boolean =
-    stamps.get(file).forall(_ == IO.lastModified(file))
+    stamps.get(file).forall(_ == IO.getModifiedTimeOrZero(file))
 
   private[sbt] def transitiveScratch(
       lm: DependencyResolution,

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -127,7 +127,7 @@ private[sbt] object LibraryManagement {
   }
 
   private[this] def fileUptodate(file: File, stamps: Map[File, Long]): Boolean =
-    stamps.get(file).forall(_ == IO.getModifiedTime(file))
+    stamps.get(file).forall(_ == IO.lastModified(file))
 
   private[sbt] def transitiveScratch(
       lm: DependencyResolution,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,10 +12,10 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.1.2"
-  private val utilVersion = "1.1.1"
-  private val lmVersion = "1.1.1"
-  private val zincVersion = "1.1.0-RC3"
+  private val ioVersion = "1.1.3"
+  private val utilVersion = "1.1.2"
+  private val lmVersion = "1.1.2"
+  private val zincVersion = "1.1.0-RC4"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/SiteMap.scala
+++ b/project/SiteMap.scala
@@ -68,8 +68,8 @@ object SiteMap {
   // generates a string suitable for a sitemap file representing the last modified time of the given File
   private[this] def lastModifiedString(f: File): String = {
     val formatter = new java.text.SimpleDateFormat("yyyy-MM-dd")
-    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
-    // has been upgraded to a version of sbt that includes sbt.io.Milli.
+    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // has been upgraded to a version of sbt that includes that call.
     formatter.format(new java.util.Date(f.lastModified))
   }
   // writes the provided XML node to `output` and then gzips it to `gzipped` if `gzip` is true

--- a/project/SiteMap.scala
+++ b/project/SiteMap.scala
@@ -68,7 +68,7 @@ object SiteMap {
   // generates a string suitable for a sitemap file representing the last modified time of the given File
   private[this] def lastModifiedString(f: File): String = {
     val formatter = new java.text.SimpleDateFormat("yyyy-MM-dd")
-    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // TODO: replace lastModified() with sbt.io.IO.getModifiedTimeOrZero(), once the build
     // has been upgraded to a version of sbt that includes that call.
     formatter.format(new java.util.Date(f.lastModified))
   }

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -105,7 +105,7 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
-    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // TODO: replace lastModified() with sbt.io.IO.getModifiedTimeOrZero(), once the build
     // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -105,8 +105,8 @@ object Util {
     val timestamp = formatter.format(new Date)
     val content = versionLine(version) + "\ntimestamp=" + timestamp
     val f = dir / "xsbt.version.properties"
-    // TODO: replace lastModified() with sbt.io.Milli.getModifiedTime(), once the build
-    // has been upgraded to a version of sbt that includes sbt.io.Milli.
+    // TODO: replace lastModified() with sbt.io.IO.lastModified(), once the build
+    // has been upgraded to a version of sbt that includes that call.
     if (!f.exists || f.lastModified < lastCompilationTime(analysis) || !containsVersion(f, version)) {
       s.log.info("Writing version information to " + f + " :\n" + content)
       IO.write(f, content)


### PR DESCRIPTION
There are just too many instances in which sbt's code relies on
the `lastModified`/`setLastModified` semantics, so instead of moving
to `get`/`setModifiedTime`, we use new IO calls that offer the new
timestamp precision, but retain the old semantics.