### PR TITLE
warn about multiple instances once

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -97,7 +97,7 @@ private[sbt] object Server {
             case Failure(e) => ()
             case Success(socket) =>
               socket.close()
-              throw new IOException("sbt server is already running.")
+              throw new AlreadyRunningException()
           }
         } else ()
       }
@@ -210,3 +210,5 @@ private[sbt] case class ServerConnection(
     }
   }
 }
+
+private[sbt] class AlreadyRunningException extends IOException("sbt server is already running.")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.4


### PR DESCRIPTION
Fixes #3823

When you launch a second instance of sbt on a build, prior to this change it was displaying `java.io.IOException: sbt server is already running` on every command. This make it a bit less aggressive, and just display a warning once.

```
[warn] Is another instance of sbt is running on this build?
[warn] Running multiple instances is unsupported
```

**updated**:

```
[warn] sbt server could not start because there's another instance of sbt running on this build.
[warn] Running multiple instances is unsupported
```
