### PR TITLE
try to set jna.nosys to true programmatically

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,4 +20,4 @@ install:
   - SET PATH=C:\sbt\sbt\bin;%PATH%
   - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8
 test_script:
-  - sbt "-Djna.nosys=true" "scripted actions/*"
+  - sbt "scripted actions/*"

--- a/build.sbt
+++ b/build.sbt
@@ -572,7 +572,7 @@ def otherRootSettings =
     scriptedUnpublished := scriptedUnpublishedTask.evaluated,
     scriptedSource := (sourceDirectory in sbtProj).value / "sbt-test",
     // scriptedPrescripted := { addSbtAlternateResolver _ },
-    scriptedLaunchOpts := List("-Xmx1500M", "-Xms512M", "-server", "-Djna.nosys=true"),
+    scriptedLaunchOpts := List("-Xmx1500M", "-Xms512M", "-server"),
     publishAll := { val _ = (publishLocal).all(ScopeFilter(inAnyProject)).value },
     publishLocalBinAll := { val _ = (publishLocalBin).all(ScopeFilter(inAnyProject)).value },
     aggregate in bintrayRelease := false

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -128,6 +128,9 @@ object StandardMain {
   def initialState(configuration: xsbti.AppConfiguration,
                    initialDefinitions: Seq[Command],
                    preCommands: Seq[String]): State = {
+    // This is to workaround https://github.com/sbt/io/issues/110
+    sys.props.put("jna.nosys", "true")
+
     import BasicCommandStrings.isEarlyCommand
     val userCommands = configuration.arguments.map(_.trim)
     val (earlyCommands, normalCommands) = (preCommands ++ userCommands).partition(isEarlyCommand)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -156,7 +156,8 @@ private[sbt] final class CommandExchange {
             // rememeber to shutdown only when the server comes up
             server = Some(x)
           case Some(Failure(e: AlreadyRunningException)) =>
-            s.log.warn("sbt server could not start because there's another instance of sbt running on this build.")
+            s.log.warn(
+              "sbt server could not start because there's another instance of sbt running on this build.")
             s.log.warn("Running multiple instances is unsupported")
             server = None
             firstInstance.set(false)

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -37,6 +37,9 @@ trait ScriptedKeys {
 }
 
 object Scripted {
+  // This is to workaround https://github.com/sbt/io/issues/110
+  sys.props.put("jna.nosys", "true")
+
   lazy val MavenResolverPluginTest = config("mavenResolverPluginTest") extend Compile
   lazy val RepoOverrideTest = config("repoOverrideTest") extend Compile
 


### PR DESCRIPTION
Previously I was seeing the error upon the first scripted test. I thought it was because Main was somehow not early enough. It might just be because scripted technically runs as part of the build.

Ref https://github.com/java-native-access/jna/issues/384
Fixes sbt/io#110

### notes

https://java-native-access.github.io/jna/4.2.1/com/sun/jna/Native.html

> When JNA classes are loaded, the native shared library (`jnidispatch`) is loaded as well. An attempt is made to load it from the any paths defined in `jna.boot.library.path` (if defined), then the system library path using `System.loadLibrary(java.lang.String)`, unless `jna.nosys=true`. If not found, the appropriate library will be extracted from the class path (into a temporary directory if found within a jar file) and loaded from there, unless `jna.noclasspath=true`. If your system has additional security constraints regarding execution or load of files (SELinux, for example), you should probably install the native library in an accessible location and configure your system accordingly, rather than relying on JNA to extract the library from its own jar file.
>
> To avoid the automatic unpacking (in situations where you want to force a failure if the JNA native library is not properly installed on the system), set the system property `jna.nounpack=true`.


