### PR TITLE
Add Library interface

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,4 +20,4 @@ install:
   - SET PATH=C:\sbt\sbt\bin;%PATH%
   - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8
 test_script:
-  - sbt "scripted actions/*"
+  - sbt "scripted actions/* server/*"

--- a/main-command/src/main/java/sbt/internal/NGWin32NamedPipeLibrary.java
+++ b/main-command/src/main/java/sbt/internal/NGWin32NamedPipeLibrary.java
@@ -29,7 +29,7 @@ import com.sun.jna.ptr.IntByReference;
 
 import com.sun.jna.win32.W32APIOptions;
 
-public interface NGWin32NamedPipeLibrary extends WinNT {
+public interface NGWin32NamedPipeLibrary extends Library, WinNT {
     int PIPE_ACCESS_DUPLEX = 3;
     int PIPE_UNLIMITED_INSTANCES = 255;
     int FILE_FLAG_FIRST_PIPE_INSTANCE = 524288;


### PR DESCRIPTION
Fixes #3821

Initially I missed why #3821 was failing.

Looking at it again, the error message reads:

```
Caused by: java.lang.IllegalArgumentException: Interface (NGWin32NamedPipeLibrary) of library=kernel32 does not extend Library
        at com.sun.jna.Native.loadLibrary(Native.java:566)
        at sbt.internal.NGWin32NamedPipeLibrary.<clinit>(NGWin32NamedPipeLibrary.java:38)
        ... 7 more
```

Inside `Native.loadLibrary`, it requires the "library" interface to extend `com.sun.jna.Library`, which this adds.
