### PR TITLE
delete "buildinfo.BuildInfo" from sbt main

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -448,7 +448,6 @@ lazy val mainProj = (project in file("main"))
 //  with the sole purpose of providing certain identifiers without qualification (with a package object)
 lazy val sbtProj = (project in file("sbt"))
   .dependsOn(mainProj, scriptedSbtProj % "test->test")
-  .enablePlugins(BuildInfoPlugin)
   .settings(
     baseSettings,
     name := "sbt",
@@ -459,6 +458,7 @@ lazy val sbtProj = (project in file("sbt"))
     mimaSettings,
     mimaBinaryIssueFilters ++= sbtIgnoredProblems,
     addBuildInfoToConfig(Test),
+    BuildInfoPlugin.buildInfoDefaultSettings,
     buildInfoObject in Test := "TestBuildInfo",
     buildInfoKeys in Test := Seq[BuildInfoKey](fullClasspath in Compile),
     connectInput in run in Test := true,


### PR DESCRIPTION
sbt-buildinfo plugin have `buildInfoScopedSettings(Compile)` in default.
I think it is unnecessary. or we should set `buildinfoPackage in Compile` and `buildinfoObject in Compile`

- https://github.com/sbt/sbt-buildinfo/blob/v0.7.0/src/main/scala/sbtbuildinfo/BuildInfoPlugin.scala#L11
- https://github.com/sbt/sbt/commit/9c32c16adee85e8ae5032ebb5140c34c50664053