### PR TITLE
non-triggered scripted plugin: SbtPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,11 +272,18 @@ lazy val scriptedSbtProj = (project in scriptedPath / "sbt")
   .configure(addSbtIO, addSbtUtilLogging, addSbtCompilerInterface, addSbtUtilScripted, addSbtLmCore)
 
 lazy val scriptedPluginProj = (project in scriptedPath / "plugin")
-  .dependsOn(sbtProj)
+  .dependsOn(mainProj)
   .settings(
     baseSettings,
     name := "Scripted Plugin",
     mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      // scripted plugin has moved into sbt mothership as sbt.plugins.ScriptedPlugin.
+      // sbt.ScriptedPlugin is still here for bincomat.
+      exclude[DirectMissingMethodProblem]("sbt.ScriptedPlugin#autoImport*"),
+      exclude[IncompatibleResultTypeProblem]("sbt.ScriptedPlugin.requires"),
+      exclude[DirectMissingMethodProblem]("sbt.ScriptedPlugin.scriptedParser"),
+    ),
   )
   .configure(addSbtCompilerClasspath)
 
@@ -417,7 +424,7 @@ lazy val mainSettingsProj = (project in file("main-settings"))
 // The main integration project for sbt.  It brings all of the projects together, configures them, and provides for overriding conventions.
 lazy val mainProj = (project in file("main"))
   .enablePlugins(ContrabandPlugin)
-  .dependsOn(logicProj, actionsProj, mainSettingsProj, runProj, commandProj, collectionProj)
+  .dependsOn(logicProj, actionsProj, mainSettingsProj, runProj, commandProj, collectionProj, scriptedSbtProj)
   .settings(
     testedBaseSettings,
     name := "Main",

--- a/build.sbt
+++ b/build.sbt
@@ -268,6 +268,10 @@ lazy val scriptedSbtProj = (project in scriptedPath / "sbt")
     name := "Scripted sbt",
     libraryDependencies ++= Seq(launcherInterface % "provided"),
     mimaSettings,
+    mimaBinaryIssueFilters ++= Seq(
+      // sbt.test package is renamed to sbt.scriptedtest.
+      exclude[MissingClassProblem]("sbt.test.*"),
+    ),
   )
   .configure(addSbtIO, addSbtUtilLogging, addSbtCompilerInterface, addSbtUtilScripted, addSbtLmCore)
 
@@ -278,11 +282,8 @@ lazy val scriptedPluginProj = (project in scriptedPath / "plugin")
     name := "Scripted Plugin",
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
-      // scripted plugin has moved into sbt mothership as sbt.plugins.ScriptedPlugin.
-      // sbt.ScriptedPlugin is still here for bincomat.
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedPlugin#autoImport*"),
-      exclude[IncompatibleResultTypeProblem]("sbt.ScriptedPlugin.requires"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedPlugin.scriptedParser"),
+      // scripted plugin has moved into sbt mothership.
+      exclude[MissingClassProblem]("sbt.ScriptedPlugin*")
     ),
   )
   .configure(addSbtCompilerClasspath)

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -6,7 +6,6 @@
  */
 
 package sbt
-package plugins
 
 import java.io.File
 import Def.Initialize
@@ -90,7 +89,12 @@ object ScriptedPlugin extends AutoPlugin {
   private[sbt] def scriptedTestsTask: Initialize[Task[AnyRef]] =
     Def.task {
       val loader = ClasspathUtilities.toLoader(scriptedClasspath.value, scalaInstance.value.loader)
-      ModuleUtilities.getObject("sbt.test.ScriptedTests", loader)
+      try {
+        ModuleUtilities.getObject("sbt.scriptedtest.ScriptedTests", loader)
+      } catch {
+        case _: ClassNotFoundException =>
+          ModuleUtilities.getObject("sbt.test.ScriptedTests", loader)
+      }
     }
 
   private[sbt] def scriptedRunTask: Initialize[Task[Method]] = Def.taskDyn {

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -47,6 +47,8 @@ object PluginDiscovery {
       "sbt.plugins.IvyPlugin" -> sbt.plugins.IvyPlugin,
       "sbt.plugins.JvmPlugin" -> sbt.plugins.JvmPlugin,
       "sbt.plugins.CorePlugin" -> sbt.plugins.CorePlugin,
+      "sbt.plugins.ScriptedPlugin" -> sbt.plugins.ScriptedPlugin,
+      "sbt.plugins.SbtPlugin" -> sbt.plugins.SbtPlugin,
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
       "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin
     )

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -47,7 +47,7 @@ object PluginDiscovery {
       "sbt.plugins.IvyPlugin" -> sbt.plugins.IvyPlugin,
       "sbt.plugins.JvmPlugin" -> sbt.plugins.JvmPlugin,
       "sbt.plugins.CorePlugin" -> sbt.plugins.CorePlugin,
-      "sbt.plugins.ScriptedPlugin" -> sbt.plugins.ScriptedPlugin,
+      "sbt.ScriptedPlugin" -> sbt.ScriptedPlugin,
       "sbt.plugins.SbtPlugin" -> sbt.plugins.SbtPlugin,
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
       "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin

--- a/main/src/main/scala/sbt/plugins/SbtPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SbtPlugin.scala
@@ -1,0 +1,19 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+import Keys._
+
+object SbtPlugin extends AutoPlugin {
+  override def requires = ScriptedPlugin
+
+  override lazy val projectSettings = Seq(
+    sbtPlugin := true
+  )
+}

--- a/notes/1.2.0/scripted-change.md
+++ b/notes/1.2.0/scripted-change.md
@@ -1,0 +1,27 @@
+
+### Fixes with compatibility implications
+
+- In sbt 1.2, `ScriptedPlugin` is no longer triggered automatically. This allows easier use of the plugin in a multi-project build. We recommend migration to `SbtPlugin`.  [#3514][3514]/[#3875][3875] by [@eed3si9n][@eed3si9n]
+- `scriptedBufferLog` and `scriptedLaunchOpts` settings are changed so they are scoped globally.
+
+### Features
+
+- Adds `SbtPlugin`. See below.
+
+### Bug fixes
+
+
+### SbtPlugin
+
+`SbtPlugin` is a new plugin that represents sbt plugin projects.
+
+    lazy val fooPlugin = (project in file("plugin"))
+      .enablePlugins(SbtPlugin)
+
+This sets `sbtPlugin` setting to `true`, and brings in the new non-triggered `ScriptedPlugin`.
+
+[#3875][3875] by [@eed3si9n][@eed3si9n]
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [3514]: https://github.com/sbt/sbt/issues/3514
+  [3875]: https://github.com/sbt/sbt/pull/3875

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -115,7 +115,7 @@ object Scripted {
     sys.props(org.apache.logging.log4j.util.LoaderUtil.IGNORE_TCCL_PROPERTY) = "true"
     val noJLine = new classpath.FilteredLoader(scriptedSbtInstance.loader, "jline." :: Nil)
     val loader = classpath.ClasspathUtilities.toLoader(scriptedSbtClasspath.files, noJLine)
-    val bridgeClass = Class.forName("sbt.test.ScriptedRunner", true, loader)
+    val bridgeClass = Class.forName("sbt.scriptedtest.ScriptedRunner", true, loader)
     val bridge = bridgeClass.getDeclaredConstructor().newInstance().asInstanceOf[SbtScriptedRunner]
     try {
       // Using java.util.List to encode File => Unit.

--- a/sbt/src/sbt-test/project/scripted-plugin/build.sbt
+++ b/sbt/src/sbt-test/project/scripted-plugin/build.sbt
@@ -1,0 +1,2 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SbtPlugin)

--- a/sbt/src/sbt-test/project/scripted-skip-incompatible/build.sbt
+++ b/sbt/src/sbt-test/project/scripted-skip-incompatible/build.sbt
@@ -1,0 +1,2 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SbtPlugin)

--- a/sbt/src/sbt-test/project/scripted-skip-incompatible/project/plugins.sbt
+++ b/sbt/src/sbt-test/project/scripted-skip-incompatible/project/plugins.sbt
@@ -1,3 +1,0 @@
-libraryDependencies += {
-  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-}

--- a/scripted/plugin/src/main/resources/sbt/sbt.autoplugins
+++ b/scripted/plugin/src/main/resources/sbt/sbt.autoplugins
@@ -1,1 +1,0 @@
-sbt.ScriptedPlugin

--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -1,0 +1,10 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+
+// ScriptedPlugin has moved to main.

--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -16,7 +16,7 @@ import java.lang.reflect.Method
 
 object ScriptedPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
-  override def trigger = allRequirements
+
   object autoImport {
     val ScriptedConf = Configurations.config("scripted-sbt") hide
     val ScriptedLaunchConf = Configurations.config("scripted-sbt-launch") hide

--- a/scripted/plugin/src/main/scala/sbt/test/ScriptedTests.scala
+++ b/scripted/plugin/src/main/scala/sbt/test/ScriptedTests.scala
@@ -1,0 +1,32 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt.test
+
+import java.io.File
+
+/**
+ * This is a bincompat place holder sbt.test package that we are now trying to hide
+ * because of the name conflict with Keys.test.
+ */
+@deprecated("Use sbt.scriptedtest.ScriptedRunner.", "1.2.0")
+private[sbt] class ScriptedRunner extends sbt.scriptedtest.ScriptedRunner
+
+/**
+ * This is a bincompat place holder for sbt.test package that we are now trying to hide
+ * because of the name conflict with Keys.test.
+ */
+@deprecated("Use sbt.scriptedtest.ScriptedTests.", "1.2.0")
+private[sbt] object ScriptedTests extends ScriptedRunner {
+
+  /** Represents the function that runs the scripted tests, both in single or batch mode. */
+  type TestRunner = () => Seq[Option[String]]
+
+  val emptyCallback: File => Unit = _ => ()
+  def main(args: Array[String]): Unit =
+    sbt.scriptedtest.ScriptedTests.main(args)
+}

--- a/scripted/sbt/src/main/scala/sbt/scriptedtest/BatchScriptRunner.scala
+++ b/scripted/sbt/src/main/scala/sbt/scriptedtest/BatchScriptRunner.scala
@@ -6,10 +6,10 @@
  */
 
 package sbt
-package test
+package scriptedtest
 
 import sbt.internal.scripted._
-import sbt.test.BatchScriptRunner.States
+import sbt.scriptedtest.BatchScriptRunner.States
 
 /** Defines an alternative script runner that allows batch execution. */
 private[sbt] class BatchScriptRunner extends ScriptRunner {

--- a/scripted/sbt/src/main/scala/sbt/scriptedtest/SbtHandler.scala
+++ b/scripted/sbt/src/main/scala/sbt/scriptedtest/SbtHandler.scala
@@ -6,7 +6,7 @@
  */
 
 package sbt
-package test
+package scriptedtest
 
 import java.io.{ File, IOException }
 import xsbt.IPC

--- a/scripted/sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted/sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -6,7 +6,7 @@
  */
 
 package sbt
-package test
+package scriptedtest
 
 import java.io.File
 import java.util.Properties
@@ -466,13 +466,13 @@ class ScriptedRunner {
 final case class ScriptedTest(group: String, name: String) {
   override def toString = group + "/" + name
 }
-private[test] object ListTests {
+private[sbt] object ListTests {
   def list(directory: File, filter: java.io.FileFilter) = wrapNull(directory.listFiles(filter))
 }
 import ListTests._
-private[test] final class ListTests(baseDirectory: File,
-                                    accept: ScriptedTest => Boolean,
-                                    log: Logger) {
+private[sbt] final class ListTests(baseDirectory: File,
+                                   accept: ScriptedTest => Boolean,
+                                   log: Logger) {
   def filter = DirectoryFilter -- HiddenFileFilter
   def listTests: Seq[ScriptedTest] = {
     list(baseDirectory, filter) flatMap { group =>


### PR DESCRIPTION
This PR takes care of a few scripted plugin related issues at one fell swoop.

1. Scripted plugin is no longer triggered. (#3514 suggested by @alexarchambault)
2. New `SbtPlugin` is added to the sbt mothership that depends on `sbt.ScriptedPlugin`. (#3538 suggested by @jvican) 
3. Some scripted default settings are now scoped globally. (#3656 suggested by @jvican)

The net effect is that a plugin author will be able to use `scripted` with

```scala
lazy val fooPlugin = (project in file("plugin"))
  .enablePlugins(SbtPlugin)

lazy val app = project
```

and it no longer requires disabling in other subprojects (like `app` above).

### notes about name conflict and bincompat

There is a name conflict between `sbt.test` package and `sbt.Keys.test`.

```scala
[error] /tmp/sbt_ea607a5c/build.sbt:5: error: reference to test is ambiguous;
[error] it is imported twice in the same scope by
[error] import _root_.sbt.Keys._
[error] and import _root_.sbt._
[error]     parallelExecution in test := false
[error]                          ^
```

Here are the workaround steps that I took.

1. sbt.test package is renamed to sbt.scriptedtest. This allows 1.0 plugins and builds to use `test` to mean `Keys.test`.
2. To keep binary compatibility for sbt 0.13 scripted, I am adding `sbt.test.ScriptedRunner` and `sbt.test.ScriptedTests` in `scripted-plugin` artifact.
3. Another affected user is Giter8 plugin that uses ScriptedPlugin. Since the intereactions are limited to `sbt.ScriptedPlugin.*`, we should be fine here. - https://github.com/foundweekends/giter8/blob/v0.11.0-M2/plugin/src/main/scala-sbt-1.0/giter8/SBTCompat.scala