### PR TITLE
Fix sbtOn's prompt & echo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -468,6 +468,7 @@ lazy val sbtProj = (project in file("sbt"))
     buildInfoObject in Test := "TestBuildInfo",
     buildInfoKeys in Test := Seq[BuildInfoKey](fullClasspath in Compile),
     connectInput in run in Test := true,
+    outputStrategy in run in Test := Some(StdoutOutput),
   )
   .configure(addSbtCompilerBridge)
 


### PR DESCRIPTION
This is what it looks like now! 🎉

    > sbtOn /s/t-sbtOn
    [...]
    [info] Running (fork) sbt.RunFromSourceMain /s/t-sbtOn
    Listening for transport dt_socket at address: 5005
    [warn] sbt version mismatch, current: 1.0.3, in build.properties: "1.1.0", use 'reboot' to use the new value.
    [info] Loading settings from idea.sbt,global-plugins.sbt ...
    [info] Loading global plugins from /Users/dnw/.dotfiles/.sbt/1.0/plugins
    [info] Updating ProjectRef(uri("file:/Users/dnw/.sbt/1.0/plugins/"), "global-plugins")...
    [info] Done updating.
    [info] Loading settings from plugins.sbt ...
    [info] Loading project definition from /s/t-sbtOn/project
    [info] Updating ProjectRef(uri("file:/s/t-sbtOn/project/"), "t-sbton-build")...
    [info] Done updating.
    [info] Loading settings from build.sbt ...
    [info] Set current project to t (in build file:/s/t-sbtOn/)
    [info] sbt server started at local:///Users/dnw/.sbt/1.0/server/2c27eaf4c750902a3a41/sock
    > show baseDirectory
    [info] /s/t-sbtOn
    > exit
    [info] shutting down server
    [success] Total time: 34 s, completed 16-Jan-2018 14:37:32
    > Exception in thread "Thread-17" java.io.IOException: Stream closed
    	at java.lang.ProcessBuilder$NullOutputStream.write(ProcessBuilder.java:433)
    	at java.io.OutputStream.write(OutputStream.java:116)
    	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
    	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
    	at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
    	at scala.sys.process.BasicIO$.$anonfun$input$1(BasicIO.scala:200)
    	at scala.sys.process.BasicIO$.$anonfun$input$1$adapted(BasicIO.scala:198)
    	at scala.sys.process.ProcessBuilderImpl$Simple.$anonfun$run$2(ProcessBuilderImpl.scala:75)
    	at scala.sys.process.ProcessImpl$Spawn$$anon$1.run(ProcessImpl.scala:23)

    > show {.}/baseDirectory
    [...]
    [info] ThisBuild / baseDirectory
    [info] 	/d/sbt