### PR TITLE
Fixes link to documentation for deprecated 0.10/0.12 DSL syntax

### DIFF
--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -570,7 +570,7 @@ object Scoped {
 
 /** The sbt 0.10 style DSL was deprecated in 0.13.13, favouring the use of the '.value' macro.
  *
- * See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html for how to migrate.
+ * See http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style for how to migrate.
  */
 trait TupleSyntax {
   import Scoped._

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -89,12 +89,12 @@ object TaskMacro {
   final val InputTaskCreateDynName = "createDyn"
   final val InputTaskCreateFreeName = "createFree"
   final val append1Migration =
-    "`<+=` operator is removed. Try `lhs += { x.value }`\n  or see http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html."
+    "`<+=` operator is removed. Try `lhs += { x.value }`\n  or see http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style."
   final val appendNMigration =
-    "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html."
+    "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style."
   final val assignMigration =
     """`<<=` operator is removed. Use `key := { x.value }` or `key ~= (old => { newValue })`.
-      |See http://www.scala-sbt.org/1.0/docs/Migrating-from-sbt-012x.html""".stripMargin
+      |See http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style""".stripMargin
 
   import LinterDSL.{ Empty => EmptyLinter }
 

--- a/notes/1.2.0/fix-sbt012x-link.md
+++ b/notes/1.2.0/fix-sbt012x-link.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+* Fixes link to SBT upgrade migration page
+


### PR DESCRIPTION
Fixes sbt/website#558
