### PR TITLE
Allow the full tests/fork-parallel to pass on less than four cores

### DIFF
--- a/sbt/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-parallel/build.sbt
@@ -13,6 +13,8 @@ lazy val root = (project in file(".")).
       val log = streams.value.log
       if( nbProc < 4 ) {
         log.warn("With fewer than 4 processors this test is meaningless")
+        // mimic behavior expected by scripted
+        if (!testForkedParallel.value) sys.error("Exiting with error (note: test not performed)")
       } else {
         // we've got at least 4 processors, we'll check the upper end but also 3 and 4 as the upper might not
         // be reached if the system is under heavy load.

--- a/sbt/src/sbt-test/tests/fork-parallel/test
+++ b/sbt/src/sbt-test/tests/fork-parallel/test
@@ -1,18 +1,7 @@
-# The tests/fork-parallel test will currently always 
-# report success when run on less than four cores,
-# rather than  failing in one of the two cases as expected.
-# TODO: Adjust this scripted test so that it works as
-# intended on less than four cores as well.
+# Note: this test is meaningless on less than four cores
 
-# To debug, it is possible to limit the number of cores
-# reported to sbt, and run the test, by using:
-#   taskset 0x00000003 sbt 'scripted tests/fork-parallel'
-# See: https://github.com/sbt/sbt/issues/3545
-
-# This bit won't currently work when using less than four cores.
-# > test
-# -> check
-
+> test
+-> check
 > clean
 > set testForkedParallel := true
 > test


### PR DESCRIPTION
The test will be meaningless on less than four cores, but the
scripted test will pass. On four or more cores, the test will
test testForkedParallel as expected.

Closes #3545
