### PR TITLE
Run scripted without sbt/launcher

### DIFF
--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -64,8 +64,10 @@ object RunFromSourceMain {
           def globalLock = noGlobalLock
           def bootDirectory = appProvider.bootDirectory
           def ivyHome = file(sys.props("user.home")) / ".ivy2"
-          def ivyRepositories = Array(new PredefinedRepository { def id() = Predefined.Local })
-          def appRepositories = Array(new PredefinedRepository { def id() = Predefined.Local })
+          final case class PredefRepo(id: Predefined) extends PredefinedRepository
+          import Predefined._
+          def ivyRepositories = Array(PredefRepo(Local), PredefRepo(MavenCentral))
+          def appRepositories = Array(PredefRepo(Local), PredefRepo(MavenCentral))
           def isOverrideRepositories = false
           def checksums = Array("sha1", "md5")
         }

--- a/scripted/sbt/src/main/scala/sbt/scriptedtest/RemoteSbtCreator.scala
+++ b/scripted/sbt/src/main/scala/sbt/scriptedtest/RemoteSbtCreator.scala
@@ -1,0 +1,67 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+package scriptedtest
+
+import java.io.File
+
+import scala.sys.process.{ BasicIO, Process }
+
+import sbt.io.IO
+import sbt.util.Logger
+
+import xsbt.IPC
+
+private[sbt] sealed trait RemoteSbtCreatorKind
+private[sbt] object RemoteSbtCreatorKind {
+  case object LauncherBased extends RemoteSbtCreatorKind
+  case object RunFromSourceBased extends RemoteSbtCreatorKind
+}
+
+abstract class RemoteSbtCreator private[sbt] {
+  def newRemote(server: IPC.Server): Process
+}
+
+final class LauncherBasedRemoteSbtCreator(
+    directory: File,
+    launcher: File,
+    log: Logger,
+    launchOpts: Seq[String] = Nil,
+) extends RemoteSbtCreator {
+  def newRemote(server: IPC.Server) = {
+    val launcherJar = launcher.getAbsolutePath
+    val globalBase = "-Dsbt.global.base=" + (new File(directory, "global")).getAbsolutePath
+    val args = List("<" + server.port)
+    val cmd = "java" :: launchOpts.toList ::: globalBase :: "-jar" :: launcherJar :: args ::: Nil
+    val io = BasicIO(false, log).withInput(_.close())
+    val p = Process(cmd, directory) run (io)
+    val thread = new Thread() { override def run() = { p.exitValue(); server.close() } }
+    thread.start()
+    p
+  }
+}
+
+final class RunFromSourceBasedRemoteSbtCreator(
+    directory: File,
+    log: Logger,
+    launchOpts: Seq[String] = Nil,
+) extends RemoteSbtCreator {
+  def newRemote(server: IPC.Server) = {
+    val globalBase = "-Dsbt.global.base=" + (new File(directory, "global")).getAbsolutePath
+    val cp = IO readLinesURL (getClass getResource "/RunFromSource.classpath")
+    val cpString = cp mkString File.pathSeparator
+    val mainClassName = "sbt.RunFromSourceMain"
+    val args = List(mainClassName, directory.toString, "<" + server.port)
+    val cmd = "java" :: launchOpts.toList ::: globalBase :: "-cp" :: cpString :: args ::: Nil
+    val io = BasicIO(false, log).withInput(_.close())
+    val p = Process(cmd, directory) run (io)
+    val thread = new Thread() { override def run() = { p.exitValue(); server.close() } }
+    thread.start()
+    p
+  }
+}


### PR DESCRIPTION
This runs the majority of sbt/sbt scripted tests without using sbt/launcher.

Still TODO:
* investigate the effects of changing the dependency between sbt and the scripted plugin