### PR TITLE
Adds sbt.boot.lock sysprop to opt-out

### DIFF
--- a/launch/src/main/input_resources/sbt/sbt.boot.properties
+++ b/launch/src/main/input_resources/sbt/sbt.boot.properties
@@ -22,6 +22,7 @@
 
 [boot]
   directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}
+  lock: ${sbt.boot.lock-true}
 
 [ivy]
   ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}


### PR DESCRIPTION
Adds sbt.boot.lock as a system property to opt-out of locking.

This might be useful when running on filesystems on which the locking code path would throw an exception.

Upstream issue: https://bugs.openjdk.java.net/browse/JDK-8193594
Provides a workaround for #2222, thus...
Closes #2222.
