### PR TITLE
Add the eviction warnings options to global

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1999,7 +1999,7 @@ object Classpaths {
       ConflictWarning(conflictWarning.value, report, log)
       report
     },
-    evictionWarningOptions in update := (evictionWarningOptions in GlobalScope).value,
+    evictionWarningOptions in update := evictionWarningOptions.value,
     evictionWarningOptions in evicted := EvictionWarningOptions.full,
     evicted := {
       import ShowLines._

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1753,6 +1753,7 @@ object Classpaths {
     Defaults.globalDefaults(
       Seq(
         conflictWarning :== ConflictWarning.default("global"),
+        evictionWarningOptions := EvictionWarningOptions.default,
         compatibilityWarningOptions :== CompatibilityWarningOptions.default,
         homepage :== None,
         startYear :== None,
@@ -1988,7 +1989,6 @@ object Classpaths {
       val suffix = if (crossPaths.value) s"_$binVersion" else ""
       s"update_cache$suffix"
     },
-    evictionWarningOptions in update := EvictionWarningOptions.default,
     dependencyPositions := dependencyPositionsTask.value,
     unresolvedWarningConfiguration in update := UnresolvedWarningConfiguration(
       dependencyPositions.value),
@@ -1999,6 +1999,7 @@ object Classpaths {
       ConflictWarning(conflictWarning.value, report, log)
       report
     },
+    evictionWarningOptions in update := (evictionWarningOptions in GlobalScope).value,
     evictionWarningOptions in evicted := EvictionWarningOptions.full,
     evicted := {
       import ShowLines._

--- a/notes/1.2.0/global-eviction-warnin-options.md
+++ b/notes/1.2.0/global-eviction-warnin-options.md
@@ -1,0 +1,3 @@
+### Improvements
+
+- Add the eviction warning options to global, so that one can change the options for all sub projects at a time.


### PR DESCRIPTION
Partially adresses https://github.com/sbt/sbt/issues/3773

It adds the eviction warning options to global, so that one can change the options for all sub projects at a time. 

Another PR (adding `EvictionWarningsOptions.summary`) for the issue in librarymanagement is https://github.com/sbt/librarymanagement/pull/211