### PR TITLE
Speedup Parsers.validID

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -12,14 +12,16 @@ import Parser._
 import java.io.File
 import java.net.URI
 import java.lang.Character.{
-  getType,
-  MATH_SYMBOL,
-  OTHER_SYMBOL,
+  CURRENCY_SYMBOL,
   DASH_PUNCTUATION,
-  OTHER_PUNCTUATION,
+  MATH_SYMBOL,
   MODIFIER_SYMBOL,
-  CURRENCY_SYMBOL
+  OTHER_PUNCTUATION,
+  OTHER_SYMBOL,
+  getType
 }
+
+import scala.annotation.tailrec
 
 /** Provides standard implementations of commonly useful [[Parser]]s. */
 trait Parsers {
@@ -313,6 +315,16 @@ object DefaultParsers extends Parsers with ParserMain {
     apply(p)(s).resultEmpty.isValid
 
   /** Returns `true` if `s` parses successfully according to [[ID]].*/
-  def validID(s: String): Boolean = matches(ID, s)
+  def validID(s: String): Boolean = {
+    // Handwritten version of `matches(ID, s)` because validID turned up in profiling.
+    def isIdChar(c: Char): Boolean = Character.isLetterOrDigit(c) || (c == '_')
+    @tailrec def isRestIdChar(cur: Int, s: String, length: Int): Boolean =
+      if (cur < length)
+        isIdChar(s.charAt(cur)) && isRestIdChar(cur + 1, s, length)
+      else
+        true
+
+    !s.isEmpty && Character.isLetter(s.charAt(0)) && isRestIdChar(1, s, s.length)
+  }
 
 }

--- a/internal/util-complete/src/test/scala/DefaultParsersSpec.scala
+++ b/internal/util-complete/src/test/scala/DefaultParsersSpec.scala
@@ -1,0 +1,17 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt.internal.util
+package complete
+
+import org.scalacheck._, Prop._
+
+object DefaultParsersSpec extends Properties("DefaultParsers") {
+  import DefaultParsers._
+
+  property("validID == matches(ID, s)") = forAll((s: String) => validID(s) == matches(ID, s))
+}


### PR DESCRIPTION
It turned up in profiling sessions. Previously, it used parser combinators
which are somewhat slow especially when the JVM is still cold.

The grammar for ID is simple enough to afford this handwritten parser.