### PR TITLE
make sbt server extensible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -498,6 +498,7 @@ lazy val sbtProj = (project in file("sbt"))
     connectInput in run in Test := true,
     outputStrategy in run in Test := Some(StdoutOutput),
     fork in Test := true,
+    parallelExecution in Test := false,
   )
   .configure(addSbtCompilerBridge)
 

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -10,6 +10,7 @@ package sbt
 import java.io.File
 import sbt.internal.util.AttributeKey
 import sbt.internal.inc.classpath.ClassLoaderCache
+import sbt.internal.server.ServerHandler
 import sbt.librarymanagement.ModuleID
 import sbt.util.Level
 

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -39,6 +39,11 @@ object BasicKeys {
                                  "The wire protocol for the server command.",
                                  10000)
 
+  val fullServerHandlers =
+    AttributeKey[Seq[ServerHandler]]("fullServerHandlers",
+                                     "Combines default server handlers and user-defined handlers.",
+                                     10000)
+
   val autoStartServer =
     AttributeKey[Boolean](
       "autoStartServer",

--- a/main-command/src/main/scala/sbt/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/ServerHandler.scala
@@ -26,8 +26,8 @@ object ServerHandler {
 
   lazy val fallback: ServerHandler = ServerHandler({ handler =>
     ServerIntent(
-      { case x => handler.log.debug(s"Unhandled notification received: ${x.method}") },
-      { case x => handler.log.debug(s"Unhandled request received: ${x.method}") }
+      { case x => handler.log.debug(s"Unhandled notification received: ${x.method}: $x") },
+      { case x => handler.log.debug(s"Unhandled request received: ${x.method}: $x") }
     )
   })
 }

--- a/main-command/src/main/scala/sbt/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/ServerHandler.scala
@@ -1,0 +1,67 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt
+
+import sjsonnew.JsonFormat
+import sbt.internal.protocol._
+import sbt.util.Logger
+import sbt.protocol.{ SettingQuery => Q }
+
+/**
+ * ServerHandler allows plugins to extend sbt server.
+ * It's a wrapper around curried function ServerCallback => JsonRpcRequestMessage => Unit.
+ */
+final class ServerHandler(val handler: ServerCallback => ServerIntent) {
+  override def toString: String = s"Serverhandler(...)"
+}
+
+object ServerHandler {
+  def apply(handler: ServerCallback => ServerIntent): ServerHandler =
+    new ServerHandler(handler)
+
+  lazy val fallback: ServerHandler = ServerHandler({ handler =>
+    ServerIntent(
+      { case x => handler.log.debug(s"Unhandled notification received: ${x.method}") },
+      { case x => handler.log.debug(s"Unhandled request received: ${x.method}") }
+    )
+  })
+}
+
+final class ServerIntent(val onRequest: PartialFunction[JsonRpcRequestMessage, Unit],
+                         val onNotification: PartialFunction[JsonRpcNotificationMessage, Unit]) {
+  override def toString: String = s"ServerIntent(...)"
+}
+
+object ServerIntent {
+  def apply(onRequest: PartialFunction[JsonRpcRequestMessage, Unit],
+            onNotification: PartialFunction[JsonRpcNotificationMessage, Unit]): ServerIntent =
+    new ServerIntent(onRequest, onNotification)
+
+  def request(onRequest: PartialFunction[JsonRpcRequestMessage, Unit]): ServerIntent =
+    new ServerIntent(onRequest, PartialFunction.empty)
+
+  def notify(onNotification: PartialFunction[JsonRpcNotificationMessage, Unit]): ServerIntent =
+    new ServerIntent(PartialFunction.empty, onNotification)
+}
+
+/**
+ * Interface to invoke JSON-RPC response.
+ */
+trait ServerCallback {
+  def jsonRpcRespond[A: JsonFormat](event: A, execId: Option[String]): Unit
+  def jsonRpcRespondError(execId: Option[String], code: Long, message: String): Unit
+  def jsonRpcNotify[A: JsonFormat](method: String, params: A): Unit
+  def appendExec(exec: Exec): Boolean
+  def log: Logger
+  def name: String
+
+  private[sbt] def authOptions: Set[ServerAuthentication]
+  private[sbt] def authenticate(token: String): Boolean
+  private[sbt] def setInitialized(value: Boolean): Unit
+  private[sbt] def onSettingQuery(execId: Option[String], req: Q): Unit
+}

--- a/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
@@ -6,6 +6,8 @@
  */
 
 package sbt
+package internal
+package server
 
 import sjsonnew.JsonFormat
 import sbt.internal.protocol._

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -26,7 +26,7 @@ import sbt.internal.librarymanagement.mavenint.{
   PomExtraDependencyAttributes,
   SbtPomExtraProperties
 }
-import sbt.internal.server.{ LanguageServerReporter, Definition }
+import sbt.internal.server.{ LanguageServerReporter, Definition, LanguageServerProtocol }
 import sbt.internal.testing.TestLogger
 import sbt.internal.util._
 import sbt.internal.util.Attributed.data
@@ -277,6 +277,12 @@ object Defaults extends BuildCommon {
       serverAuthentication := {
         if (serverConnectionType.value == ConnectionType.Tcp) Set(ServerAuthentication.Token)
         else Set()
+      },
+      serverHandlers :== Nil,
+      fullServerHandlers := {
+        (Vector(LanguageServerProtocol.handler)
+          ++ serverHandlers.value
+          ++ Vector(ServerHandler.fallback))
       },
       insideCI :== sys.env.contains("BUILD_NUMBER") || sys.env.contains("CI"),
     ))

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -26,7 +26,12 @@ import sbt.internal.librarymanagement.mavenint.{
   PomExtraDependencyAttributes,
   SbtPomExtraProperties
 }
-import sbt.internal.server.{ LanguageServerReporter, Definition, LanguageServerProtocol }
+import sbt.internal.server.{
+  LanguageServerReporter,
+  Definition,
+  LanguageServerProtocol,
+  ServerHandler
+}
 import sbt.internal.testing.TestLogger
 import sbt.internal.util._
 import sbt.internal.util.Attributed.data

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -42,6 +42,7 @@ import sbt.internal.{
 }
 import sbt.io.{ FileFilter, WatchService }
 import sbt.internal.io.WatchState
+import sbt.internal.server.ServerHandler
 import sbt.internal.util.{ AttributeKey, SourcePosition }
 
 import sbt.librarymanagement.Configurations.CompilerPlugin

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -136,6 +136,8 @@ object Keys {
   val serverHost = SettingKey(BasicKeys.serverHost)
   val serverAuthentication = SettingKey(BasicKeys.serverAuthentication)
   val serverConnectionType = SettingKey(BasicKeys.serverConnectionType)
+  val fullServerHandlers = SettingKey(BasicKeys.fullServerHandlers)
+  val serverHandlers = settingKey[Seq[ServerHandler]]("User-defined server handlers.")
 
   val analysis = AttributeKey[CompileAnalysis]("analysis", "Analysis of compilation, including dependencies and generated outputs.", DSetting)
   val watch = SettingKey(BasicKeys.watch)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -45,6 +45,7 @@ import sbt.internal.{
 import sbt.internal.util.{ AttributeKey, AttributeMap, Dag, Relation, Settings, ~> }
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util.complete.DefaultParsers
+import sbt.internal.server.ServerHandler
 import sbt.librarymanagement.Configuration
 import sbt.util.{ Show, Level }
 import sjsonnew.JsonFormat

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -27,6 +27,7 @@ import Keys.{
   serverPort,
   serverAuthentication,
   serverConnectionType,
+  fullServerHandlers,
   logLevel,
   watch
 }
@@ -475,6 +476,7 @@ object Project extends ProjectExtra {
     val authentication: Option[Set[ServerAuthentication]] = get(serverAuthentication)
     val connectionType: Option[ConnectionType] = get(serverConnectionType)
     val srvLogLevel: Option[Level.Value] = (logLevel in (ref, serverLog)).get(structure.data)
+    val hs: Option[Seq[ServerHandler]] = get(fullServerHandlers)
     val commandDefs = allCommands.distinct.flatten[Command].map(_ tag (projectCommand, true))
     val newDefinedCommands = commandDefs ++ BasicCommands.removeTagged(s.definedCommands,
                                                                        projectCommand)
@@ -491,6 +493,7 @@ object Project extends ProjectExtra {
         .put(templateResolverInfos.key, trs)
         .setCond(shellPrompt.key, prompt)
         .setCond(serverLogLevel, srvLogLevel)
+        .setCond(fullServerHandlers.key, hs)
     s.copy(
       attributes = newAttrs,
       definedCommands = newDefinedCommands

--- a/sbt/src/server-test/handshake/build.sbt
+++ b/sbt/src/server-test/handshake/build.sbt
@@ -1,3 +1,5 @@
+import sbt.internal.ServerHandler
+
 lazy val root = (project in file("."))
   .settings(
     Global / serverLog / logLevel := Level.Debug,

--- a/sbt/src/server-test/handshake/build.sbt
+++ b/sbt/src/server-test/handshake/build.sbt
@@ -1,6 +1,21 @@
 lazy val root = (project in file("."))
   .settings(
     Global / serverLog / logLevel := Level.Debug,
+
+    // custom handler
+    Global / serverHandlers += ServerHandler({ callback =>
+      import callback._
+      import sjsonnew.BasicJsonProtocol._
+      import sbt.internal.protocol.JsonRpcRequestMessage
+      ServerIntent(
+        {
+          case r: JsonRpcRequestMessage if r.method == "lunar/helo" =>
+            jsonRpcNotify("lunar/oleh", "")
+            ()
+        },
+        PartialFunction.empty
+      )
+    }),
     name := "handshake",
     scalaVersion := "2.12.3",
   )


### PR DESCRIPTION
Fixes #3890

Here's an example:

```scala
    Global / serverHandlers += ServerHandler({ callback =>
      import callback._
      import sjsonnew.BasicJsonProtocol._
      import sbt.internal.protocol.JsonRpcRequestMessage
      ServerIntent(
        {
          case r: JsonRpcRequestMessage if r.method == "lunar/helo" =>
            jsonRpcNotify("lunar/oleh", "")
            ()
        },
        PartialFunction.empty
      )
```

