### PR TITLE
Optimize settings storage and delegation

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -85,7 +85,7 @@ private final class Settings0[Scope](
   }
 
   def definingScope(scope: Scope, key: AttributeKey[_]): Option[Scope] =
-    delegates(scope).toStream.find(sc => getDirect(sc, key).isDefined)
+    delegates(scope).find(sc => getDirect(sc, key).isDefined)
 
   def getDirect[T](scope: Scope, key: AttributeKey[T]): Option[T] =
     (keyDefs get key).flatMap(_.get(scope).asInstanceOf[Option[T]])

--- a/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -316,7 +316,7 @@ object Index {
       .toSet
 
   def attributeKeys(settings: Settings[Scope]): Set[AttributeKey[_]] =
-    settings.data.values.flatMap(_.keys).toSet[AttributeKey[_]]
+    settings.attributeKeys
 
   def stringToKeyMap(settings: Set[AttributeKey[_]]): Map[String, AttributeKey[_]] =
     stringToKeyMap0(settings)(_.label)


### PR DESCRIPTION
In my testing this improves minimum start up time (i.e. in steady state after sbt has cached everything from a previous run, testing with `time sbt exit && time sbt exit && time sbt exit` using the last result) for cinnamon by ~10 seconds both on 1.1.0 and 1.1.1.

Startup time 1.1.0 Vanilla: 56s
With the patch: 44s
Startup time 1.1.1 Vanilla: 63s
With the patch: 52s (together with the validId patch 45s)

This is quite a big improvement for such a self-contained change (and if you know what sbt else is doing startup...)

It also show that sbt 1.1.1 seems to have an unrelated performance regression that costs ~ 5s.

/cc @bantonsson