### PR TITLE
WIP: Support non-echoing console for emacs

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -90,6 +90,7 @@ private[sbt] object JLine {
   //  older Scala, since it shaded classes but not the system property
   private[sbt] def fixTerminalProperty(): Unit = {
     val newValue = System.getProperty(TerminalProperty) match {
+      case _ if isEmacsShell                                => "false"
       case "jline.UnixTerminal"                             => "unix"
       case null if System.getProperty("sbt.cygwin") != null => "unix"
       case "jline.WindowsTerminal"                          => "windows"
@@ -161,6 +162,13 @@ private[sbt] object JLine {
 
   val HandleCONT =
     !java.lang.Boolean.getBoolean("sbt.disable.cont") && Signals.supported(Signals.CONT)
+
+  val isEmacsShell = {
+    import scala.util.Properties
+
+    (Properties.propOrElse("env.emacs", "") != "") || // same as scala.tools.nsc.Properties.isEmacsShell
+    Properties.envOrNone("INSIDE_EMACS").isDefined // preferred by emacs
+  }
 }
 
 private[sbt] class InputStreamWrapper(is: InputStream, val poll: Duration)


### PR DESCRIPTION
Emacs `comint-mode` is having a hard time with sbt echoing back the commands to it. This causes sporadic freezing in emacs `sbt-mode` (of which I'm the author).

Scala 2.13 has already implemented emacs support for the REPL by way of an environment property called `env.emacs`. If the property has a non-empty value, then a "SimpleConsole" is used where there is no echo and no completions.

This PR tries to bring the same functionality to SBT.

~Special review should be placed on the `trait Implicit` changes as I do not understand the (macro?) magic there. The file used to refer to `internal.util.FullReader`, but there never was such an object (only a final class).~

I'm waiting for any feedback for changes that might be required to get this PR included into the next release of sbt.