### PR TITLE
optimize scope delegation

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -35,10 +35,10 @@ private final class Settings0[Scope](
     data.flatMap { case (scope, map) => map.keys.map(k => f(scope, k)) }.toSeq
 
   def get[T](scope: Scope, key: AttributeKey[T]): Option[T] =
-    delegates(scope).toStream.flatMap(sc => getDirect(sc, key)).headOption
+    delegates(scope).flatMap(sc => getDirect(sc, key)).headOption
 
   def definingScope(scope: Scope, key: AttributeKey[_]): Option[Scope] =
-    delegates(scope).toStream.find(sc => getDirect(sc, key).isDefined)
+    delegates(scope).find(sc => getDirect(sc, key).isDefined)
 
   def getDirect[T](scope: Scope, key: AttributeKey[T]): Option[T] =
     (data get scope).flatMap(_ get key)

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -267,7 +267,7 @@ object Scope {
     val scope = Scope.replaceThis(GlobalScope)(rawScope)
 
     // This is a hot method that gets called many times
-    def exandDelegateScopes(resolvedProj: ResolvedReference)(
+    def expandDelegateScopes(resolvedProj: ResolvedReference)(
         pLin: Seq[ScopeAxis[ResolvedReference]]): Vector[Scope] = {
       val tLin = scope.task match {
         case t @ Select(_) => linearize(t)(taskInherit)
@@ -316,7 +316,7 @@ object Scope {
             case pr: ProjectRef => index.project(pr)
             case br: BuildRef   => List(Select(br), Zero)
           }
-        exandDelegateScopes(resolvedProj)(projAxes)
+        expandDelegateScopes(resolvedProj)(projAxes)
     }
   }
 


### PR DESCRIPTION
This is a refactoring of  @jrudolph's https://github.com/sbt/sbt/pull/3979 on top of test PR https://github.com/sbt/sbt/pull/4002

For every setting, we need to calculate the delegates, so `indexedDelegates` is one of hot methods.

| build                      |  sbt 1.1.1     |  1.1.2 | this patch    |
| -------------------------- | -------------- | --------------  | ------------- |
| Cinnamon (125070 settings) | 35.539 ± 0.474s  |  35.469 ± 0.318s    | 32.242 ± 0.990s  |
| Akka      (30398 settings) | 17.908 ± 0.101s  | 17.780 ± 1.494s   | 17.166 ± 0.726s  |

Given that 1.1.x branch doesn't have optimization changes merged in we can ignore the difference between sbt 1.1.1 and 1.1.x. Basically it's around 35.5s within a second of waffling.
With this patch, I am getting around 32.2, which is 3s speedup.

As you can see, with Akka's build with much fewer settings there's roughly 0.6s speedup, so this patch likely won't help you much until you have _a lot_ of subprojects.

<s>In any case, 7s would be the lion's share of Johannes's ~10s speedup.</s> (In earlier version, I had user CPU time confused with the total) I focused on just the delegation expansion, so this change is a lot more contained.