### PR TITLE
Fix handling id in jsonrpc model

### DIFF
--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
@@ -24,7 +24,10 @@ trait JsonRpcRequestMessageFormats {
             val id = try {
               unbuilder.readField[String]("id")
             } catch {
-              case _: Throwable => unbuilder.readField[Long]("id").toString
+              case _: Throwable => {
+                val prefix = "\u2668" // Append prefix to show the original type was Number
+                prefix + unbuilder.readField[Long]("id").toString
+              }
             }
             val method = unbuilder.readField[String]("method")
             val params = unbuilder.lookupField("params") map {

--- a/sbt/src/test/scala/sbt/ServerSpec.scala
+++ b/sbt/src/test/scala/sbt/ServerSpec.scala
@@ -9,6 +9,7 @@ package sbt
 
 import org.scalatest._
 import scala.concurrent._
+import scala.annotation.tailrec
 import java.io.{ InputStream, OutputStream }
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ ThreadFactory, ThreadPoolExecutor }
@@ -23,14 +24,21 @@ class ServerSpec extends AsyncFlatSpec with Matchers {
         """{ "jsonrpc": "2.0", "id": 3, "method": "sbt/setting", "params": { "setting": "root/name" } }""",
         out)
       Thread.sleep(100)
-      val l2 = contentLength(in)
-      println(l2)
-      readLine(in)
-      readLine(in)
-      val x2 = readContentLength(in, l2)
-      println(x2)
-      assert(1 == 1)
+      assert(waitFor(in, 10) { s =>
+        s contains """"id":3"""
+      })
     }
+  }
+
+  @tailrec
+  private[this] def waitFor(in: InputStream, num: Int)(f: String => Boolean): Boolean = {
+    if (num < 0) false
+    else
+      readFrame(in) match {
+        case Some(x) if f(x) => true
+        case _ =>
+          waitFor(in, num - 1)(f)
+      }
   }
 }
 
@@ -88,6 +96,13 @@ object ServerSpec {
     writeLine(s"""Content-Length: ${message.size + 2}""", out)
     writeLine("", out)
     writeLine(message, out)
+  }
+
+  def readFrame(in: InputStream): Option[String] = {
+    val l = contentLength(in)
+    readLine(in)
+    readLine(in)
+    readContentLength(in, l)
   }
 
   def contentLength(in: InputStream): Int = {


### PR DESCRIPTION
Workaround for #3861.

This pull request fixes the behavior of sbt server to respond with number or string id judging by the type of id in requests. As suggested by @eed3si9n in ScalaMatsuri hackason, I append a prefix if id in requests is number and use it later to serialize responses.
