### PR TITLE
Use MacOSXWatchService instead of PollingWatchService

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -141,7 +141,7 @@ object Watched {
         FileSystems.getDefault.newWatchService()
       case _ if Properties.isMac =>
         // WatchService is slow on macOS - use old polling mode
-        new PollingWatchService(PollDelay)
+        new MacOSXWatchService()
       case _ =>
         FileSystems.getDefault.newWatchService()
     }


### PR DESCRIPTION
This watch service should be more responsive and significantly reduce
the disk overhead of the polling based service for large repos.

(See the guidelines for contributing, linked above)
