### PR TITLE
Avoid printing RejectedExectionExeption stack trace after cancellation

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -11,7 +11,6 @@ import sbt.internal.{ Load, BuildStructure, TaskTimings, TaskName, GCUtil }
 import sbt.internal.util.{ Attributed, ErrorHandling, HList, RMap, Signals, Types }
 import sbt.util.{ Logger, Show }
 import sbt.librarymanagement.{ Resolver, UpdateReport }
-import java.util.concurrent.RejectedExecutionException
 
 import scala.concurrent.duration.Duration
 import java.io.File
@@ -388,11 +387,7 @@ object EvaluateTask {
           val results = x.runKeep(root)(service)
           storeValuesForPrevious(results, state, streams)
           applyResults(results, state, root)
-        } catch {
-          case _: RejectedExecutionException =>
-            (state, Inc(Incomplete(None, message = Some("cancelled"))))
-          case inc: Incomplete => (state, Inc(inc))
-        } finally shutdown()
+        } catch { case inc: Incomplete => (state, Inc(inc)) } finally shutdown()
       val replaced = transformInc(result)
       logIncResult(replaced, state, streams)
       (newState, replaced)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.4"
+  val scala212 = "2.12.5"
   val baseScalaVersion = scala212
 
   // sbt modules

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -7,8 +7,10 @@
 
 package sbt
 
+import java.util.concurrent.RejectedExecutionException
+
 import sbt.internal.util.ErrorHandling.wideConvert
-import sbt.internal.util.{ DelegatingPMap, PMap, RMap, IDSet, ~> }
+import sbt.internal.util.{ DelegatingPMap, IDSet, PMap, RMap, ~> }
 import sbt.internal.util.Types._
 import Execute._
 
@@ -76,7 +78,12 @@ private[sbt] final class Execute[A[_] <: AnyRef](
     "State: " + state.toString + "\n\nResults: " + results + "\n\nCalls: " + callers + "\n\n"
 
   def run[T](root: A[T])(implicit strategy: Strategy): Result[T] =
-    try { runKeep(root)(strategy)(root) } catch { case i: Incomplete => Inc(i) }
+    try {
+      runKeep(root)(strategy)(root)
+    } catch {
+      case i: Incomplete                 => Inc(i)
+      case _: RejectedExecutionException => Inc(Incomplete(None, message = Some("cancelled")))
+    }
   def runKeep[T](root: A[T])(implicit strategy: Strategy): RMap[A, Result] = {
     assert(state.isEmpty, "Execute already running/ran.")
 


### PR DESCRIPTION
Before:

```
[warn] /Users/jz/code/zinc/internal/zinc-apiinfo/src/main/scala/xsbt/api/Visit.scala:187:19: parameter value s in method visitString is never used
[warn]   def visitString(s: String): Unit = ()
[warn]                   ^
^C
[warn] Canceling execution...
[warn] 10 warnings found
[info] Compilation has been cancelled
[error] java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ExecutorCompletionService$QueueingFuture@33ec70dd rejected from java.util.concurrent.ThreadPoolExecutor@4b832de6[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1410]
[error]     at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
[error]     at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
[error]     at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
[error]     at java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:181)
[error]     at sbt.CompletionService$.submit(CompletionService.scala:36)
[error]     at sbt.ConcurrentRestrictions$$anon$4.submitValid(ConcurrentRestrictions.scala:176)
[error]     at sbt.ConcurrentRestrictions$$anon$4.submit(ConcurrentRestrictions.scala:165)
[error]     at sbt.Execute.submit(Execute.scala:262)
[error]     at sbt.Execute.ready(Execute.scala:242)
[error]     at sbt.Execute.notifyDone(Execute.scala:181)
[error]     at sbt.Execute.$anonfun$retire$2(Execute.scala:152)
[error]     at sbt.Execute.$anonfun$retire$2$adapted(Execute.scala:151)
[error]     at scala.collection.immutable.List.foreach(List.scala:389)
[error]     at sbt.Execute.retire(Execute.scala:151)
[error]     at sbt.Execute.$anonfun$work$2(Execute.scala:279)
[error]     at sbt.Execute$$anon$1.process(Execute.scala:24)
[error]     at sbt.Execute.next$1(Execute.scala:104)
[error]     at sbt.Execute.processAll(Execute.scala:107)
[error]     at sbt.Execute.runKeep(Execute.scala:84)
[error]     at sbt.EvaluateTask$.liftedTree1$1(EvaluateTask.scala:387)
[error]     at sbt.EvaluateTask$.run$1(EvaluateTask.scala:386)
[error]     at sbt.EvaluateTask$.runTask(EvaluateTask.scala:405)
[error]     at sbt.internal.Aggregation$.$anonfun$timedRun$4(Aggregation.scala:100)
[error]     at sbt.EvaluateTask$.withStreams(EvaluateTask.scala:331)
[error]     at sbt.internal.Aggregation$.timedRun(Aggregation.scala:98)
[error]     at sbt.internal.Aggregation$.runTasks(Aggregation.scala:111)
[error]     at sbt.internal.Aggregation$.$anonfun$applyTasks$1(Aggregation.scala:68)
[error]     at sbt.Command$.$anonfun$applyEffect$2(Command.scala:130)
[error]     at sbt.internal.Aggregation$.$anonfun$evaluatingParser$11(Aggregation.scala:220)
[error]     at sbt.internal.Act$.$anonfun$actParser0$3(Act.scala:387)
[error]     at sbt.MainLoop$.processCommand(MainLoop.scala:154)
[error]     at sbt.MainLoop$.$anonfun$next$2(MainLoop.scala:137)
[error]     at sbt.State$$anon$1.runCmd$1(State.scala:242)
[error]     at sbt.State$$anon$1.process(State.scala:248)
[error]     at sbt.MainLoop$.$anonfun$next$1(MainLoop.scala:137)
[error]     at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error]     at sbt.MainLoop$.next(MainLoop.scala:137)
[error]     at sbt.MainLoop$.run(MainLoop.scala:130)
[error]     at sbt.MainLoop$.$anonfun$runWithNewLog$1(MainLoop.scala:108)
[error]     at sbt.io.Using.apply(Using.scala:22)
[error]     at sbt.MainLoop$.runWithNewLog(MainLoop.scala:102)
[error]     at sbt.MainLoop$.runAndClearLast(MainLoop.scala:58)
[error]     at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:43)
[error]     at sbt.MainLoop$.runLogged(MainLoop.scala:35)
[error]     at sbt.StandardMain$.runManaged(Main.scala:113)
[error]     at sbt.xMain.run(Main.scala:76)
[error]     at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
[error]     at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
[error]     at xsbt.boot.Launch$.run(Launch.scala:109)
[error]     at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
[error]     at xsbt.boot.Launch$.launch(Launch.scala:117)
[error]     at xsbt.boot.Launch$.apply(Launch.scala:18)
[error]     at xsbt.boot.Boot$.runImpl(Boot.scala:41)
[error]     at xsbt.boot.Boot$.main(Boot.scala:17)
[error]     at xsbt.boot.Boot.main(Boot.scala)
[error] java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ExecutorCompletionService$QueueingFuture@33ec70dd rejected from java.util.concurrent.ThreadPoolExecutor@4b832de6[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1410]
[error] Use 'last' for the full log.
```

After:

```
sbt:zinc Root> ;zincIvyIntegration/cleanClasses;zincIvyIntegration/compile
[success] Total time: 0 s, completed 03/04/2018 2:24:33 PM
[info] Compiling 5 Scala sources and 1 Java source to /Users/jz/code/zinc/internal/zinc-ivy-integration/target/scala-2.12/classes ...
[warn] /Users/jz/code/zinc/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ResourceLoader.scala:14:42: parameter value classLoader in method getPropertiesFor is never used
[warn]   def getPropertiesFor(resource: String, classLoader: ClassLoader): Properties = {
[warn]                                          ^
[warn] /Users/jz/code/zinc/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala:13:17: Unused import
[warn] import java.net.URLClassLoader
[warn]                 ^
[warn] /Users/jz/code/zinc/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala:137:26: Unused import
[warn]       import sbt.io.Path.toURLs
[warn]                          ^
[warn] /Users/jz/code/zinc/internal/zinc-ivy-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala:94:30: The outer reference in this type test cannot be checked at run time.
[warn]     private final case class ScalaArtifacts(compiler: File, library: File, others: Vector[File])
[warn]                              ^
^C
[warn] Canceling execution...
[warn] four warnings found
[info] Compilation has been cancelled
[error] Total time: 1 s, completed 03/04/2018 2:24:35 PM
```

Best served with https://github.com/scala/scala/pull/6479

The Scala version upgrade was to avoid a bug in `-Xlint:unused` in 2.12.4 (fixed in 2.12.5) that I ran into.

Fixes #3958