### PR TITLE
Add dependencyResolution scoped to updateSbtClassifiers task

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2168,6 +2168,7 @@ object Classpaths {
                 filterImplicit = false,
                 overrideScalaVersion = true).withScalaOrganization(scalaOrganization.value))
           },
+          dependencyResolution := IvyDependencyResolution(ivyConfiguration.value),
           updateSbtClassifiers in TaskGlobal := (Def.task {
             val lm = dependencyResolution.value
             val s = streams.value

--- a/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
@@ -1,1 +1,9 @@
 scalaVersion := "2.11.11"
+
+ivyConfiguration := {
+  throw new RuntimeException("updateSbtClassifiers should use updateSbtClassifiers / ivyConfiguration")
+}
+
+dependencyResolution := {
+  throw new RuntimeException("updateSbtClassifiers should use updateSbtClassifiers / dependencyResolution")
+}


### PR DESCRIPTION
Fixes #3432 

The test isn't great but it does the job. Ideally it would check that the configuration that is used when creating `IvySbt` is the same that is passed to `update` but that was a bit tricky.

The contributing guidelines say that there should be notes (https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md#adding-notes) but it doesn't seem to match up with what was there. Let me know if I need to add this.