### PR TITLE
Use MacOSXWatchService instead of PollingWatchService

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -141,7 +141,7 @@ object Watched {
         FileSystems.getDefault.newWatchService()
       case _ if Properties.isMac =>
         // WatchService is slow on macOS - use old polling mode
-        new PollingWatchService(PollDelay)
+        new MacOSXWatchService(PollDelay)
       case _ =>
         FileSystems.getDefault.newWatchService()
     }

--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -134,14 +134,14 @@ object Watched {
     AttributeKey[Watched]("watched-configuration", "Configures continuous execution.")
 
   def createWatchService(): WatchService = {
+    def closeWatch = new MacOSXWatchService()
     sys.props.get("sbt.watch.mode") match {
       case Some("polling") =>
         new PollingWatchService(PollDelay)
       case Some("nio") =>
         FileSystems.getDefault.newWatchService()
-      case _ if Properties.isMac =>
-        // WatchService is slow on macOS - use old polling mode
-        new MacOSXWatchService(PollDelay)
+      case Some("closewatch")    => closeWatch
+      case _ if Properties.isMac => closeWatch
       case _ =>
         FileSystems.getDefault.newWatchService()
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.1.4"
+  private val ioVersion = "1.1.5"
   private val utilVersion = "1.1.3"
   private val lmVersion = "1.1.4"
   private val zincVersion = "1.1.3"


### PR DESCRIPTION
This is a resend of https://github.com/sbt/sbt/pull/4052.

It bumps up IO to 1.1.5, and also adds new `closewatch` mode.

/cc @eatkins
