### PR TITLE
Unknown LSP error code

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -212,7 +212,8 @@ object MainLoop {
   // it's handled by executing the shell again, instead of the state failing
   // so we also use that to indicate that the execution failed
   private[this] def exitCodeFromStateOnFailure(state: State, prevState: State): ExitCode =
-    if (prevState.onFailure.isDefined && state.onFailure.isEmpty) ExitCode(ErrorCodes.UnknownError)
+    if (prevState.onFailure.isDefined && state.onFailure.isEmpty)
+      ExitCode(ErrorCodes.UnknownErrorCode)
     else ExitCode.Success
 
 }

--- a/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
@@ -36,13 +36,12 @@ object ErrorCodes {
   val serverErrorStart = -32099L     // from LSP's spec code snippet
   val serverErrorEnd   = -32000L     // from LSP's spec code snippet
 
-  val UnknownServerError   = -32001L // Defined by LSP
+  val UnknownErrorCode     = -32001L // Defined by LSP
   val ServerNotInitialized = -32002L // Defined by LSP
 
 
   // The remainder of the space is available for application defined errors.
   val RequestCancelled = -32800L     // Defined by LSP
-  val UnknownError     = -33000L     // A generic error, unknown if the user or server is at fault.
 
   // format: on
 }


### PR DESCRIPTION
See https://github.com/scalameta/metals/issues/233 for the context.

#3991 added `UnknownError` error code which is actually _unknown_ to LSP. So the client fails with `-33000 is not a member of enum ErrorCode`. 

I removed that error code and renamed another one to `UnknownErrorCode` as it is specified in LSP (I guess particular name is not important, but why not preserve it for consistency?). 

LSP spec for [Response Message](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#response-message):

```typescript
export namespace ErrorCodes {
	// Defined by JSON RPC
	export const ParseError: number = -32700;
	export const InvalidRequest: number = -32600;
	export const MethodNotFound: number = -32601;
	export const InvalidParams: number = -32602;
	export const InternalError: number = -32603;
	export const serverErrorStart: number = -32099;
	export const serverErrorEnd: number = -32000;
	export const ServerNotInitialized: number = -32002;
	export const UnknownErrorCode: number = -32001;      // <-- this one

	// Defined by the protocol.
	export const RequestCancelled: number = -32800;
}
```