### PR TITLE
Re-fixing console and JLine

### DIFF
--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -41,7 +41,9 @@ final class Console(compiler: AnalyzingCompiler) {
       implicit log: Logger): Try[Unit] = {
     def console0() =
       compiler.console(classpath, options, initialCommands, cleanupCommands, log)(loader, bindings)
-    JLine.withJLine(Run.executeTrapExit(console0, log))
+    JLine.usingTerminal { _ =>
+      Run.executeTrapExit(console0, log)
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #3482 take 2

I thought I tested #4054 using a local build, but when I ran 1.1.3, `console` did not display anything that I typed.
Switching to `usingTerminal` which calls `terminal.restore` similar to what I had in 1.1.1 fixes `console`.

Here's a session using a locally built 1.1.4-LOCAL-M1:


```
sbt:Hello> console
[info] Starting scala interpreter...
Welcome to Scala 2.12.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_151).
Type in expressions for evaluation. Or try :help.

scala> 1 + 1
res0: Int = 2

scala> :q

[success] Total time: 6 s, completed Apr 9, 2018 12:08:19 AM
sbt:Hello> console
[info] Starting scala interpreter...
Welcome to Scala 2.12.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_151).
Type in expressions for evaluation. Or try :help.

// made sure up arrow still works second time
scala> :q

[success] Total time: 5 s, completed Apr 9, 2018 12:08:25 AM
sbt:Hello> :q
[info] shutting down server
```
