### PR TITLE
Update to Jline 2.14.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,7 @@ object Dependencies {
     "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value
   }
 
-  val jline = "jline" % "jline" % "2.14.4"
+  val jline = "jline" % "jline" % "2.14.6"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.4"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
   val specs2 = "org.specs2" %% "specs2-junit" % "4.0.1"


### PR DESCRIPTION
This version of Jline fixes three things for Emacs users:
- ANSI colors are now enabled for Emacs.
- Terminal echo is now disabled for Emacs.
- History is enabled for all dump terminals.

(See the guidelines for contributing, linked above)
