### PR TITLE
WIP: Fix unexpected responses from the server

### DIFF
--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -64,7 +64,7 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
           else throw LangServerError(ErrorCodes.InvalidRequest, "invalid token")
         } else ()
         setInitialized(true)
-        append(Exec(s"collectAnalyses", Some(request.id), Some(CommandSource(name))))
+        append(Exec(s"collectAnalyses", None, Some(CommandSource(name))))
         langRespond(InitializeResult(serverCapabilities), Option(request.id))
       case "textDocument/definition" =>
         import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
Addresses #4091. 

85ab082 should fix the first problem. 

And I think the second one sits here:

https://github.com/sbt/sbt/blob/7ae83cc755e5b7f0aeb404163861c7966189688e/main/src/main/scala/sbt/internal/CommandExchange.scala#L250-L256

But I'm not sure how to fix it. In this case it matches any events (so we cannot check channel name here) and redirects them to the [`NetworkChannel.publishEvent`](https://github.com/sbt/sbt/blob/7ae83cc755e5b7f0aeb404163861c7966189688e/main/src/main/scala/sbt/internal/server/NetworkChannel.scala#L239) which already doesn't check if the channel name matches.

On the other hand there is also [`publishEventMessage`](https://github.com/sbt/sbt/blob/7ae83cc755e5b7f0aeb404163861c7966189688e/main/src/main/scala/sbt/internal/CommandExchange.scala#L316) method which handles `ExecStatusEvent` and checks channel name. So probably we could reuse it here. 

I'm not sure what is the general intent of this piece of code quoted above: if it's not a `StringMessage`, just broadcast is on all channels? Even if we want to do that, `publishEvent` is not a good choice, probably using `langNotify` or something similar would be better.