### PR TITLE
Handle managedSources writing into unmanaged source directories

### DIFF
--- a/sbt/src/sbt-test/tests/watch-loop/build.sbt
+++ b/sbt/src/sbt-test/tests/watch-loop/build.sbt
@@ -1,0 +1,17 @@
+import java.nio.file.Files
+
+lazy val watchLoopTest = taskKey[Unit]("Check that managed sources are filtered")
+
+sourceGenerators in Compile += Def.task {
+  val path = baseDirectory.value.toPath.resolve("src/main/scala/Foo.scala")
+  Files.write(path, "object Foo".getBytes).toFile :: Nil
+}
+
+watchLoopTest := {
+  val watched = watchSources.value
+  val managedSource = (managedSources in Compile).value.head
+  assert(!SourceWrapper.accept(watched, managedSource))
+  assert((sources in Compile).value.foldLeft((true, Set.empty[File])) {
+    case ((res, set), f) => (res && !set.contains(f), set + f)
+  }._1)
+}

--- a/sbt/src/sbt-test/tests/watch-loop/project/SourceWrapper.scala
+++ b/sbt/src/sbt-test/tests/watch-loop/project/SourceWrapper.scala
@@ -1,0 +1,6 @@
+package sbt
+
+object SourceWrapper {
+  def accept(sources: Seq[sbt.internal.io.Source], file: File): Boolean =
+    sources.exists(_.accept(file.toPath))
+}

--- a/sbt/src/sbt-test/tests/watch-loop/src/main/scala/Bar.scala
+++ b/sbt/src/sbt-test/tests/watch-loop/src/main/scala/Bar.scala
@@ -1,0 +1,1 @@
+object Bar

--- a/sbt/src/sbt-test/tests/watch-loop/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/tests/watch-loop/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+object Foo

--- a/sbt/src/sbt-test/tests/watch-loop/test
+++ b/sbt/src/sbt-test/tests/watch-loop/test
@@ -1,0 +1,1 @@
+> watchLoopTest


### PR DESCRIPTION
When source generators write into the unmanaged source directory, bad
things can happen. Continuous builds will loop indefinitely and
compiling will fail because the generated sources get added to the
source list twice, causing the incremental compiler to complain about
compiling classes it has already seen. My two-pronged solution is to
de-duplicate the sources task and to filter out managed source files in
watch sources. The drawback to the latter is that it causes the source
generation task to be executed twice per compile.

(See the guidelines for contributing, linked above)
