### PR TITLE
Remove collectAnalyses step in sbt server initialize.

### DIFF
--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -64,7 +64,6 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
           else throw LangServerError(ErrorCodes.InvalidRequest, "invalid token")
         } else ()
         setInitialized(true)
-        append(Exec(s"collectAnalyses", Some(request.id), Some(CommandSource(name))))
         langRespond(InitializeResult(serverCapabilities), Option(request.id))
       case "textDocument/definition" =>
         import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
A client should trigger this command manually instead. Currently,
this automatic step triggers compilation in all root-aggregated
projects, which for large projects may take a long time to run.
It is better left to the client to decide what exact command to run on
startup, for example it might be desirable to scope the command by
custom project/config.
