### PR TITLE
Drop -Ywarn-unused:-params

### DIFF
--- a/project/Util.scala
+++ b/project/Util.scala
@@ -48,7 +48,7 @@ object Util {
           "-Yno-adapted-args",
           "-Ywarn-dead-code",
           "-Ywarn-numeric-widen",
-          "-Ywarn-unused:-patvars,-params,-implicits,_",
+          "-Ywarn-unused:-patvars,-implicits,_",
           "-Ywarn-unused-import"
         )
     }),


### PR DESCRIPTION
Previously we'd get in the build logs:

    [error] params cannot be negated, it enables other arguments

and lots of wawrnings.

Now we just get lots of warnings without the non-fatal error message.