### PR TITLE
Re-fix console and JLine bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ def buildLevelSettings: Seq[Setting[_]] =
   inThisBuild(
     Seq(
       organization := "org.scala-sbt",
-      version := "1.1.4-SNAPSHOT",
+      version := "1.1.5-SNAPSHOT",
       description := "sbt is an interactive build tool",
       bintrayOrganization := Some("sbt"),
       bintrayRepository := {

--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -41,7 +41,8 @@ final class Console(compiler: AnalyzingCompiler) {
       implicit log: Logger): Try[Unit] = {
     def console0() =
       compiler.console(classpath, options, initialCommands, cleanupCommands, log)(loader, bindings)
-    JLine.usingTerminal { _ =>
+    JLine.usingTerminal { t =>
+      t.init
       Run.executeTrapExit(console0, log)
     }
   }


### PR DESCRIPTION
Fixes #3482 take 3

There are two bugs related REPL and JLine.
1. JLine getting disabled (up arrow not working) on the second run of `console` task.
2. Typed characters not showing up even on the `console` task.

The first issue was fixed by #4054 which added `t.init`. When I noticed the second problem, I fixed it in #4082 (adds `t.restore`) but undid the first fix. This attempts to fix both the issues.

### notes

I confirmed using Scala 2.12.3, 2.12.4, and 2.12.5.
