### PR TITLE
upgrade Scala 2.12.4 -> 2.12.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ Afterwhich start sbt with a stable launcher: `sbt -sbt-jar ~/.sbt/launchers/1.1.
 
 ### Clearing out boot and local cache
 
-When you run a locally built sbt, the JAR artifacts will be now cached under `$HOME/.sbt/boot/scala-2.12.4/org.scala-sbt/sbt/1.$MINOR.$PATCH-SNAPSHOT` directory. To clear this out run: `reboot dev` command from sbt's session of your test application.
+When you run a locally built sbt, the JAR artifacts will be now cached under `$HOME/.sbt/boot/scala-2.12.6/org.scala-sbt/sbt/1.$MINOR.$PATCH-SNAPSHOT` directory. To clear this out run: `reboot dev` command from sbt's session of your test application.
 
 One drawback of `-SNAPSHOT` version is that it's slow to resolve as it tries to hit all the resolvers. You can workaround that by using a version name like `1.$MINOR.$PATCH-LOCAL1`. A non-SNAPSHOT artifacts will now be cached under `$HOME/.ivy/cache/` directory, so you need to clear that out using [sbt-dirty-money](https://github.com/sbt/sbt-dirty-money)'s `cleanCache` task.
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -96,7 +96,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.4"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.6"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.4"
+  val scala212 = "2.12.6"
   val baseScalaVersion = scala212
 
   // sbt modules

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.2.0")

--- a/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
@@ -3,11 +3,11 @@ lazy val root = (project in file("."))
 
 lazy val core = (project in file("core"))
   .settings(
-    scalaVersion := "2.12.4",
-    crossScalaVersions := Seq("2.11.11", "2.12.4"))
+    scalaVersion := "2.12.6",
+    crossScalaVersions := Seq("2.11.11", "2.12.6"))
 
 lazy val module = (project in file("module"))
   .dependsOn(core)
   .settings(
-    scalaVersion := "2.12.4",
-    crossScalaVersions := Seq("2.12.4"))
+    scalaVersion := "2.12.6",
+    crossScalaVersions := Seq("2.12.6"))

--- a/sbt/src/sbt-test/tests/fork-async/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-async/build.sbt
@@ -2,7 +2,7 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 
 lazy val root = (project in file(".")).
   settings(
-    scalaVersion := "2.12.4",
+    scalaVersion := "2.12.6",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.4" % Test,
     fork in Test := true
   )

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -13,7 +13,7 @@ import xsbti._
 
 object RunFromSourceMain {
   private val sbtVersion = "1.1.0" // "dev"
-  private val scalaVersion = "2.12.4"
+  private val scalaVersion = "2.12.6"
 
   def main(args: Array[String]): Unit = args match {
     case Array()              => sys.error(s"Must specify working directory as the first argument")


### PR DESCRIPTION
I have no specific user-visible benefit in mind other than fewer
JARs to download for people who are on current versions of things