### PR TITLE
upgrade Scala 2.12.4 -> 2.12.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ $ sbt
 
 ### Clearing out boot and local cache
 
-When you run a locally built sbt, the JAR artifacts will be now cached under `$HOME/.sbt/boot/scala-2.12.4/org.scala-sbt/sbt/1.$MINOR.$PATCH-SNAPSHOT` directory. To clear this out run: `reboot dev` command from sbt's session of your test application.
+When you run a locally built sbt, the JAR artifacts will be now cached under `$HOME/.sbt/boot/scala-2.12.6/org.scala-sbt/sbt/1.$MINOR.$PATCH-SNAPSHOT` directory. To clear this out run: `reboot dev` command from sbt's session of your test application.
 
 One drawback of `-SNAPSHOT` version is that it's slow to resolve as it tries to hit all the resolvers. You can workaround that by using a version name like `1.$MINOR.$PATCH-LOCAL1`. A non-SNAPSHOT artifacts will now be cached under `$HOME/.ivy/cache/` directory, so you need to clear that out using [sbt-dirty-money](https://github.com/sbt/sbt-dirty-money)'s `cleanCache` task.
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -93,7 +93,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.4"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.6"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.5"
+  val scala212 = "2.12.6"
   val baseScalaVersion = scala212
 
   // sbt modules

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
 addSbtPlugin("org.scala-sbt"     % "sbt-houserules" % "0.3.6")

--- a/sbt/src/sbt-test/tests/fork-async/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-async/build.sbt
@@ -2,7 +2,7 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 
 lazy val root = (project in file(".")).
   settings(
-    scalaVersion := "2.12.4",
+    scalaVersion := "2.12.6",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.4" % Test,
     fork in Test := true
   )

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -14,8 +14,8 @@ import buildinfo.TestBuildInfo
 import xsbti._
 
 object RunFromSourceMain {
-  private val sbtVersion = "1.0.3" // "dev"
-  private val scalaVersion = "2.12.4"
+  private val sbtVersion = "1.1.0" // "dev"
+  private val scalaVersion = "2.12.6"
 
   def fork(workingDirectory: File): Try[Unit] = {
     val fo = ForkOptions()

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -67,9 +67,44 @@ object RunFromSourceMain {
     def apply[T](lockFile: File, run: java.util.concurrent.Callable[T]) = run.call()
   }
 
+  private lazy val bootDirectory: File = file(sys.props("user.home")) / ".sbt" / "boot"
+  private lazy val scalaHome: File = {
+    val scalaHome0 = bootDirectory / s"scala-$scalaVersion"
+    if (scalaHome0.exists) scalaHome0
+    else {
+      val target = new File("target").getAbsoluteFile
+      val fakeboot = target / "fakeboot"
+      val scalaHome1 = fakeboot / s"scala-$scalaVersion"
+      val scalaHome1Lib = scalaHome1 / "lib"
+      val scalaHome1Temp = scalaHome1 / "temp"
+      if (scalaHome1Lib.exists) ()
+      else {
+        IO.createDirectories(List(scalaHome1Lib, scalaHome1Temp))
+        val log = sbt.util.LogExchange.logger("run-from-source")
+        val lm = {
+          import sbt.librarymanagement.ivy.IvyDependencyResolution
+          val ivyConfig = InlineIvyConfiguration().withLog(log)
+          IvyDependencyResolution(ivyConfig)
+        }
+        val Name = """(.*)(\-[\d|\.]+)\.jar""".r
+        val module = "org.scala-lang" % "scala-compiler" % scalaVersion
+        lm.retrieve(module, scalaModuleInfo = None, scalaHome1Temp, log) match {
+          case Right(_) =>
+            (scalaHome1Temp ** "*.jar").get foreach { x =>
+              val Name(head, _) = x.getName
+              IO.copyFile(x, scalaHome1Lib / (head + ".jar"))
+            }
+          case Left(w) => sys.error(w.toString)
+        }
+      }
+      scalaHome1
+    }
+  }
+
   private def getConf(baseDir: File, args: Seq[String]): AppConfiguration = new AppConfiguration {
     def baseDirectory = baseDir
     def arguments = args.toArray
+
     def provider = new AppProvider { appProvider =>
       def scalaProvider = new ScalaProvider { scalaProvider =>
         def scalaOrg = "org.scala-lang"
@@ -80,7 +115,7 @@ object RunFromSourceMain {
           def app(id: xsbti.ApplicationID, version: String) = appProvider
           def topLoader = new java.net.URLClassLoader(Array(), null)
           def globalLock = noGlobalLock
-          def bootDirectory = file(sys.props("user.home")) / ".sbt" / "boot"
+          def bootDirectory = RunFromSourceMain.bootDirectory
           def ivyRepositories = Array()
           def appRepositories = Array()
           def isOverrideRepositories = false
@@ -88,11 +123,14 @@ object RunFromSourceMain {
           def checksums = Array("sha1", "md5")
         }
         def version = scalaVersion
-        def libDir: File = launcher.bootDirectory / s"scala-$version" / "lib"
+        lazy val libDir: File = RunFromSourceMain.scalaHome / "lib"
         def jar(name: String): File = libDir / s"$name.jar"
-        def libraryJar = jar("scala-library")
-        def compilerJar = jar("scala-compiler")
-        def jars = libDir.listFiles(f => !f.isDirectory && f.getName.endsWith(".jar"))
+        lazy val libraryJar = jar("scala-library")
+        lazy val compilerJar = jar("scala-compiler")
+        lazy val jars = {
+          assert(libDir.exists)
+          libDir.listFiles(f => !f.isDirectory && f.getName.endsWith(".jar"))
+        }
         def loader = new java.net.URLClassLoader(jars map (_.toURI.toURL), null)
         def app(id: xsbti.ApplicationID) = appProvider
       }


### PR DESCRIPTION
This is a continuation of https://github.com/sbt/sbt/pull/4126

RunFromSourceMain currently assumes that Scala is already available in boot directory, which doesn't work if we tried to upgrade to another Scala version. This adds a workaround by letting Ivy resolve it like Launcher does internally.
