### PR TITLE
Fix VS Code extension startup

### DIFF
--- a/vscode-sbt-scala/client/package.json
+++ b/vscode-sbt-scala/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-sbt-scala",
   "displayName": "Scala (sbt)",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Lightbend, Inc.",
   "license": "BSD-3-Clause",
   "publisher": "lightbend",

--- a/vscode-sbt-scala/server/src/server.ts
+++ b/vscode-sbt-scala/server/src/server.ts
@@ -2,32 +2,20 @@
 
 import * as path from 'path';
 import * as url from 'url';
-let net = require('net'),
-  fs = require('fs'),
+import * as net from 'net';
+let fs = require('fs'),
   os = require('os'),
   stdin = process.stdin,
   stdout = process.stdout;
 
-let u = discoverUrl();
-
-let socket = net.Socket();
+let socket = new net.Socket();
 socket.on('data', (chunk: any) => {
   // send it back to stdout
   stdout.write(chunk);
 }).on('end', () => {
   stdin.pause();
 });
-
-if (u.protocol == 'tcp:') {
-  socket.connect(u.port, '127.0.0.1');
-} else if (u.protocol == 'local:' && os.platform() == 'win32') {
-  let pipePath = '\\\\.\\pipe\\' + u.hostname;
-  socket.connect(pipePath);
-} else if (u.protocol == 'local:') {
-  socket.connect(u.path);
-} else {
-  throw 'Unknown protocol ' + u.protocol;
-}
+connectSocket(socket);
 
 stdin.resume();
 stdin.on('data', (chunk: any) => {
@@ -35,6 +23,22 @@ stdin.on('data', (chunk: any) => {
 }).on('end', () => {
   socket.end();
 });
+
+function connectSocket(socket: net.Socket):　net.Socket {
+  let u = discoverUrl();
+  // let socket = net.Socket();
+  if (u.protocol == 'tcp:') {
+    socket.connect(+u.port, '127.0.0.1');
+  } else if (u.protocol == 'local:' && os.platform() == 'win32') {
+    let pipePath = '\\\\.\\pipe\\' + u.hostname;
+    socket.connect(pipePath);
+  } else if (u.protocol == 'local:') {
+    socket.connect(u.path);
+  } else {
+    throw 'Unknown protocol ' + u.protocol;
+  }
+  return socket;
+}
 
 // the port file is hardcoded to a particular location relative to the build.
 function discoverUrl(): url.Url {


### PR DESCRIPTION
The change contributed in https://github.com/sbt/sbt/pull/4130 to start sbt within VS Code looked ok at first, but when I published the extension and started using it, I realized that it's a bit broken.
Basically there's no cleanup logic (that I could find), so simply closing VS Code would leave `project/target/active.json` behind, which lets VS Code extension to attempt connection, and it fails because there's no server running. To workaround this, I'll attempt to connect to the socket to confirm sbt server is up.

/cc @olofwalker