### PR TITLE
Move fakeboot to home

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.4

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -69,18 +69,19 @@ object RunFromSourceMain {
 
   private lazy val bootDirectory: File = file(sys.props("user.home")) / ".sbt" / "boot"
   private lazy val scalaHome: File = {
+    val log = sbt.util.LogExchange.logger("run-from-source")
     val scalaHome0 = bootDirectory / s"scala-$scalaVersion"
-    if (scalaHome0.exists) scalaHome0
+    if ((scalaHome0 / "lib").exists) scalaHome0
     else {
-      val target = new File("target").getAbsoluteFile
-      val fakeboot = target / "fakeboot"
+      log.info(s"""scalaHome ($scalaHome0) wasn't found""")
+      val fakeboot = file(sys.props("user.home")) / ".sbt" / "fakeboot"
       val scalaHome1 = fakeboot / s"scala-$scalaVersion"
       val scalaHome1Lib = scalaHome1 / "lib"
       val scalaHome1Temp = scalaHome1 / "temp"
-      if (scalaHome1Lib.exists) ()
+      if (scalaHome1Lib.exists) log.info(s"""using $scalaHome1 that was found""")
       else {
+        log.info(s"""creating $scalaHome1 by downloading scala-compiler $scalaVersion""")
         IO.createDirectories(List(scalaHome1Lib, scalaHome1Temp))
-        val log = sbt.util.LogExchange.logger("run-from-source")
         val lm = {
           import sbt.librarymanagement.ivy.IvyDependencyResolution
           val ivyConfig = InlineIvyConfiguration().withLog(log)


### PR DESCRIPTION
https://github.com/sbt/sbt/pull/4143 kept failing, and while I was debugging,
I noticed that the target that it was downloading scala-compiler was in
/tmp/... for the remote instance.
This moves the fakeboot to a full path, which should make the build
less susceptible to failure due to random network issues.
