### PR TITLE
Revert back to non-blocking watch termination condition

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -100,7 +100,7 @@ object Watched {
 
   def executeContinuously(watched: Watched, s: State, next: String, repeat: String): State = {
     @tailrec def shouldTerminate: Boolean =
-      watched.terminateWatch(System.in.read()) || shouldTerminate
+      (System.in.available > 0) && (watched.terminateWatch(System.in.read()) || shouldTerminate)
     val log = s.log
     val logger = new EventMonitor.Logger {
       override def debug(msg: => Any): Unit = log.debug(msg.toString)


### PR DESCRIPTION
A thread blocking on System.in.read() cannot be interrupted, so check
System.in.available before blocking. This is how it used to work. It
requires https://github.com/sbt/io/pull/149 or else a cpu will be
pegged by the EventMonitor user input thread spinning on
System.in.available.

- [ ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
