### PR TITLE
Add MavenCentral to RunFromSourceMain's repos

### DIFF
--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -117,8 +117,10 @@ object RunFromSourceMain {
           def topLoader = new java.net.URLClassLoader(Array(), null)
           def globalLock = noGlobalLock
           def bootDirectory = RunFromSourceMain.bootDirectory
-          def ivyRepositories = Array()
-          def appRepositories = Array()
+          final case class PredefRepo(id: Predefined) extends PredefinedRepository
+          import Predefined._
+          def ivyRepositories = Array(PredefRepo(Local), PredefRepo(MavenCentral))
+          def appRepositories = Array(PredefRepo(Local), PredefRepo(MavenCentral))
           def isOverrideRepositories = false
           def ivyHome = file(sys.props("user.home")) / ".ivy2"
           def checksums = Array("sha1", "md5")


### PR DESCRIPTION
This is a selective backport to 1.1.x of 3d0619fa3797edfcab248ec7e06cc6d59bfd0cd3 and part of b2290658ba366203d9b2aa6e0845690e00f6d1fd, in order to add MavenCentral to the list of repositories used by RunFromSourceMain. Fixes `sbtProj:test` for 1.1.x.