### PR TITLE
Remove compiler warnings introduced with Scala 2.12

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -33,9 +33,9 @@ object ContextUtil {
       f: (c.Expr[Any], c.Position) => c.Expr[T]): c.Expr[T] = {
     import c.universe._
     c.macroApplication match {
-      case s @ Select(Apply(_, t :: Nil), tp) => f(c.Expr[Any](t), s.pos)
-      case a @ Apply(_, t :: Nil)             => f(c.Expr[Any](t), a.pos)
-      case x                                  => unexpectedTree(x)
+      case s @ Select(Apply(_, t :: Nil), _) => f(c.Expr[Any](t), s.pos)
+      case a @ Apply(_, t :: Nil)            => f(c.Expr[Any](t), a.pos)
+      case x                                 => unexpectedTree(x)
     }
   }
 

--- a/internal/util-collection/src/main/scala/sbt/internal/util/KList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/KList.scala
@@ -18,7 +18,10 @@ sealed trait KList[+M[_]] {
   def transform[N[_]](f: M ~> N): Transform[N]
 
   /** Folds this list using a function that operates on the homogeneous type of the elements of this list. */
-  def foldr[B](f: (M[_], B) => B, init: B): B = init // had trouble defining it in KNil
+  def foldr[B](f: (M[_], B) => B, init: B): B = this match {
+    case KNil              => init // had trouble defining it in KNil
+    case KCons(head, tail) => f(head, tail.foldr(f, init))
+  }
 
   /** Applies `f` to the elements of this list in the applicative functor defined by `ap`. */
   def apply[N[x] >: M[x], Z](f: Transform[Id] => Z)(implicit ap: Applicative[N]): N[Z]
@@ -51,7 +54,6 @@ final case class KCons[H, +T <: KList[M], +M[_]](head: M[H], tail: T) extends KL
   }
 
   def :^:[A, N[x] >: M[x]](h: N[A]) = KCons(h, this)
-  override def foldr[B](f: (M[_], B) => B, init: B): B = f(head, tail.foldr(f, init))
 }
 
 sealed abstract class KNil extends KList[Nothing] {

--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -85,8 +85,10 @@ object Package {
   }
   def setVersion(main: Attributes): Unit = {
     val version = Attributes.Name.MANIFEST_VERSION
-    if (main.getValue(version) eq null)
+    if (main.getValue(version) eq null) {
       main.put(version, "1.0")
+      ()
+    }
   }
   def addSpecManifestAttributes(name: String, version: String, orgName: String): PackageOption = {
     import Attributes.Name._

--- a/main-actions/src/main/scala/sbt/Sync.scala
+++ b/main-actions/src/main/scala/sbt/Sync.scala
@@ -67,6 +67,7 @@ object Sync {
       {
         IO.createDirectory(target)
         IO.copyLastModified(source, target)
+        ()
       }
 
   def noDuplicateTargets(relation: Relation[File, File]): Unit = {

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -126,6 +126,7 @@ object NetworkClient {
   def run(arguments: List[String]): Unit =
     try {
       new NetworkClient(arguments)
+      ()
     } catch {
       case NonFatal(e) => println(e.getMessage)
     }

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -48,7 +48,7 @@ object Def extends Init[Scope] with TaskMacroExtra {
         Scope.display(
           key.scope,
           withColor(key.key.label, keyNameColor),
-          ref => displayRelative(current, multi, ref)
+          ref => displayRelativeReference(current, ref)
       ))
 
   def showBuildRelativeKey(

--- a/main/src/main/scala/sbt/TemplateCommand.scala
+++ b/main/src/main/scala/sbt/TemplateCommand.scala
@@ -21,9 +21,10 @@ import BasicCommandStrings._, BasicKeys._
 
 private[sbt] object TemplateCommandUtil {
   def templateCommand: Command =
-    Command(TemplateCommand, templateBrief, templateDetailed)(templateCommandParser)(runTemplate)
+    Command(TemplateCommand, templateBrief, templateDetailed)(_ => templateCommandParser)(
+      runTemplate)
 
-  private def templateCommandParser(state: State): Parser[Seq[String]] =
+  private def templateCommandParser: Parser[Seq[String]] =
     (token(Space) ~> repsep(StringBasic, token(Space))) | (token(EOF) map (_ => Nil))
 
   private def runTemplate(s0: State, inputArg: Seq[String]): State = {

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -202,11 +202,10 @@ private[sbt] object SettingCompletions {
     val definedScopes = data.toSeq flatMap {
       case (scope, attrs) => if (attrs contains key) scope :: Nil else Nil
     }
-    scope(key, allScopes, definedScopes, context)
+    scope(allScopes, definedScopes, context)
   }
 
-  private[this] def scope(key: AttributeKey[_],
-                          allScopes: Seq[Scope],
+  private[this] def scope(allScopes: Seq[Scope],
                           definedScopes: Seq[Scope],
                           context: ResolvedProject): Parser[Scope] = {
     def axisParser[T](axis: Scope => ScopeAxis[T],

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -61,7 +61,10 @@ private[sbt] final class TaskTimings(shutdown: Boolean) extends ExecuteProgress[
     }
   }
   def ready(state: Unit, task: Task[_]) = ()
-  def workStarting(task: Task[_]) = timings.put(task, System.nanoTime)
+  def workStarting(task: Task[_]) = {
+    timings.put(task, System.nanoTime)
+    ()
+  }
   def workFinished[T](task: Task[T], result: Either[Task[T], Result[T]]) = {
     timings.put(task, System.nanoTime - timings.get(task))
     result.left.foreach { t =>

--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -277,7 +277,7 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
       modifiedContent: String,
       imports: Seq[Tree]
   ): Seq[(String, Int)] = {
-    val toLineRange = imports map convertImport(modifiedContent)
+    val toLineRange = imports map convertImport
     val groupedByLineNumber = toLineRange.groupBy { case (_, lineNumber) => lineNumber }
     val mergedImports = groupedByLineNumber.map {
       case (l, seq) => (l, extractLine(modifiedContent, seq))
@@ -287,11 +287,10 @@ private[sbt] case class SbtParser(file: File, lines: Seq[String]) extends Parsed
 
   /**
    *
-   * @param modifiedContent - modifiedContent
    * @param t - tree
    * @return ((start,end),lineNumber)
    */
-  private def convertImport(modifiedContent: String)(t: Tree): ((Int, Int), Int) = {
+  private def convertImport(t: Tree): ((Int, Int), Int) = {
     val lineNumber = t.pos.line - 1
     ((t.pos.start, t.pos.end), lineNumber)
   }

--- a/main/src/main/scala/sbt/internal/server/Definition.scala
+++ b/main/src/main/scala/sbt/internal/server/Definition.scala
@@ -36,6 +36,7 @@ private[sbt] object Definition {
     } yield {
       channel.publishEvent(params, Option(execId))
     }
+    ()
   }
 
   object textProcessor {
@@ -228,7 +229,7 @@ private[sbt] object Definition {
     updateCache(StandardMain.cache)(cacheFile, useBinary)
   }
 
-  private[sbt] def getAnalyses(log: Logger): Future[Seq[Analysis]] = {
+  private[sbt] def getAnalyses(): Future[Seq[Analysis]] = {
     import scalacache.modes.scalaFuture._
     import scala.concurrent.ExecutionContext.Implicits.global
     StandardMain.cache
@@ -261,7 +262,7 @@ private[sbt] object Definition {
     val LspDefinitionLogHead = "lsp-definition"
     import sjsonnew.support.scalajson.unsafe.CompactPrinter
     log.debug(s"$LspDefinitionLogHead json request: ${CompactPrinter(jsonDefinition)}")
-    lazy val analyses = getAnalyses(log)
+    lazy val analyses = getAnalyses()
     val definition = getDefinition(jsonDefinition)
     definition
       .flatMap { definition =>

--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -39,6 +39,7 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
     notification.method match {
       case "textDocument/didSave" =>
         append(Exec(";Test/compile; collectAnalyses", None, Some(CommandSource(name))))
+        ()
       case u => log.debug(s"Unhandled notification received: $u")
     }
   }
@@ -69,9 +70,11 @@ private[sbt] trait LanguageServerProtocol extends CommandChannel {
       case "textDocument/definition" =>
         import scala.concurrent.ExecutionContext.Implicits.global
         Definition.lspDefinition(json, request.id, CommandSource(name), log)
+        ()
       case "sbt/exec" =>
         val param = Converter.fromJson[SbtExecParams](json).get
         append(Exec(param.commandLine, Some(request.id), Some(CommandSource(name))))
+        ()
       case "sbt/setting" => {
         import sbt.protocol.codec.JsonProtocol._
         val param = Converter.fromJson[Q](json).get

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -312,7 +312,7 @@ final class NetworkChannel(val name: String,
 
   def onCommand(command: CommandMessage): Unit = command match {
     case x: InitCommand  => onInitCommand(x)
-    case x: ExecCommand  => onExecCommand(x)
+    case x: ExecCommand  => onExecCommand(x); ()
     case x: SettingQuery => onSettingQuery(None, x)
   }
 

--- a/project/StatusPlugin.scala
+++ b/project/StatusPlugin.scala
@@ -31,7 +31,7 @@ object StatusPlugin extends AutoPlugin {
     val status = extracted.get(publishStatus)
     // Set new version AND lock down the publishStatus to what it was, as
     // our release regexes no longer support ivy data format, due to other issues.
-    extracted.append((version in ThisBuild ~= stamp) ::
+    extracted.appendWithoutSession((version in ThisBuild ~= stamp) ::
                        (publishStatus in ThisBuild := status) ::
                        Nil,
                      state)

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -90,7 +90,7 @@ class Run(instance: ScalaInstance, trapExit: Boolean, nativeTmp: File) extends S
     val currentThread = Thread.currentThread
     val oldLoader = Thread.currentThread.getContextClassLoader
     currentThread.setContextClassLoader(loader)
-    try { main.invoke(null, options.toArray[String]) } finally {
+    try { main.invoke(null, options.toArray[String]); () } finally {
       currentThread.setContextClassLoader(oldLoader)
     }
   }

--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -152,7 +152,7 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
   def runManaged(f: Supplier[Unit], xlog: xsbti.Logger): Int = {
     val _ = running.incrementAndGet()
     try runManaged0(f, xlog)
-    finally running.decrementAndGet()
+    finally { running.decrementAndGet(); () }
   }
   private[this] def runManaged0(f: Supplier[Unit], xlog: xsbti.Logger): Int = {
     val log: Logger = xlog
@@ -264,6 +264,7 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
         val old = groups.putIfAbsent(groupID, new WeakReference(g))
         if (old.isEmpty) { // wasn't registered
           threadToApp.put(groupID, this)
+          ()
         }
       }
 
@@ -299,6 +300,7 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
       threadToApp.remove(id)
       threads.remove(id)
       groups.remove(id)
+      ()
     }
 
     /** Final cleanup for this application after it has terminated. */

--- a/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted/plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -142,6 +142,7 @@ object ScriptedPlugin extends AutoPlugin {
         scriptedLaunchOpts.value.toArray,
         new java.util.ArrayList()
       )
+      ()
     } catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
   }
 

--- a/scripted/sbt/src/main/scala/sbt/test/SbtHandler.scala
+++ b/scripted/sbt/src/main/scala/sbt/test/SbtHandler.scala
@@ -65,6 +65,7 @@ final class SbtHandler(directory: File,
       try {
         send("exit", server)
         process.exitValue()
+        ()
       } catch {
         case _: IOException => process.destroy()
       }

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -24,13 +24,16 @@ import java.util.concurrent.{
 object CompletionService {
   def apply[A, T](poolSize: Int): (CompletionService[A, T], () => Unit) = {
     val pool = Executors.newFixedThreadPool(poolSize)
-    (apply[A, T](pool), () => pool.shutdownNow())
+    (apply[A, T](pool), () => { pool.shutdownNow(); () })
   }
   def apply[A, T](x: Executor): CompletionService[A, T] =
     apply(new ExecutorCompletionService[T](x))
   def apply[A, T](completion: JCompletionService[T]): CompletionService[A, T] =
     new CompletionService[A, T] {
-      def submit(node: A, work: () => T) = CompletionService.submit(work, completion)
+      def submit(node: A, work: () => T) = {
+        CompletionService.submit(work, completion)
+        ()
+      }
       def take() = completion.take().get()
     }
   def submit[T](work: () => T, completion: JCompletionService[T]): () => T = {

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -128,7 +128,7 @@ object ConcurrentRestrictions {
   def completionService[A, R](tags: ConcurrentRestrictions[A],
                               warn: String => Unit): (CompletionService[A, R], () => Unit) = {
     val pool = Executors.newCachedThreadPool()
-    (completionService[A, R](pool, tags, warn), () => pool.shutdownNow())
+    (completionService[A, R](pool, tags, warn), () => { pool.shutdownNow(); () })
   }
 
   /**
@@ -167,6 +167,7 @@ object ConcurrentRestrictions {
           if (running == 0) errorAddingToIdle()
           pending.add(new Enqueue(node, work))
         }
+        ()
       }
       private[this] def submitValid(node: A, work: () => R) = {
         running += 1
@@ -192,6 +193,7 @@ object ConcurrentRestrictions {
           if (!tried.isEmpty) {
             if (running == 0) errorAddingToIdle()
             pending.addAll(tried)
+            ()
           }
         } else {
           val next = pending.remove()

--- a/testing/src/main/scala/sbt/TestStatusReporter.scala
+++ b/testing/src/main/scala/sbt/TestStatusReporter.scala
@@ -18,7 +18,7 @@ private[sbt] class TestStatusReporter(f: File) extends TestsListener {
   private lazy val succeeded = TestStatus.read(f)
 
   def doInit = ()
-  def startGroup(name: String): Unit = { succeeded remove name }
+  def startGroup(name: String): Unit = { succeeded remove name; () }
   def testEvent(event: TestEvent): Unit = ()
   def endGroup(name: String, t: Throwable): Unit = ()
   def endGroup(name: String, result: TestResult): Unit = {


### PR DESCRIPTION
- [x ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

 This PR removes some of the compiler warnings introduced with Scala 2.12. Specifically,  it removes warnings related to discarded non-unit values and unused parameters. 

Please note that it does _not_ remove _all_ such warnings, because a lot of them are coming from generated code or are part of SBT's public API. Removing those will have to be done in separate PRs and certainly not against the `1.1.x` branch.
