### PR TITLE
Drop deprecated write-sbt-version & notify-users-about-shell

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -197,9 +197,7 @@ object BuiltinCommands {
       plugin,
       plugins,
       writeSbtVersion,
-      oldWriteSbtVersion,
       notifyUsersAboutShell,
-      oldNotifyUsersAboutShell,
       shell,
       startServer,
       eval,
@@ -856,16 +854,9 @@ object BuiltinCommands {
       writeSbtVersionUnconditionally(state)
 
   private def WriteSbtVersion = "writeSbtVersion"
-  private def OldWriteSbtVersion = "write-sbt-version"
 
   private def writeSbtVersion: Command =
     Command.command(WriteSbtVersion) { state =>
-      writeSbtVersion(state); state
-    }
-  @deprecated("Use `writeSbtVersion` instead", "1.2.0")
-  private def oldWriteSbtVersion: Command =
-    Command.command(OldWriteSbtVersion) { state =>
-      state.log.warn(deprecationWarningText(OldWriteSbtVersion, WriteSbtVersion))
       writeSbtVersion(state); state
     }
 
@@ -879,16 +870,9 @@ object BuiltinCommands {
   }
 
   private def NotifyUsersAboutShell = "notifyUsersAboutShell"
-  private def OldNotifyUsersAboutShell = "notify-users-about-shell"
 
   private def notifyUsersAboutShell: Command =
     Command.command(NotifyUsersAboutShell) { state =>
-      notifyUsersAboutShell(state); state
-    }
-  @deprecated("Use `notifyUsersAboutShell` instead", "1.2.0")
-  private def oldNotifyUsersAboutShell: Command =
-    Command.command(OldNotifyUsersAboutShell) { state =>
-      state.log.warn(deprecationWarningText(OldNotifyUsersAboutShell, NotifyUsersAboutShell))
       notifyUsersAboutShell(state); state
     }
 }


### PR DESCRIPTION
Introduced in https://github.com/sbt/sbt/pull/4169, these commands
aren't "user-facing" and are quite new. So no need to keep the old kebab
syntax.