### PR TITLE
Fix for #4148 (SessionSettingsSpec intermittently fails)

### DIFF
--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -148,7 +148,9 @@ private[sbt] object SbtParser {
     reporter.reset()
     val wrapperFile = new BatchSourceFile(reporterId, code)
     val unit = new CompilationUnit(wrapperFile)
-    val parser = new syntaxAnalyzer.UnitParser(unit)
+    val parser = SbtParser.synchronized { // see https://github.com/sbt/sbt/issues/4148
+      new syntaxAnalyzer.UnitParser(unit)
+    }
     val parsedTrees = SbtParser.synchronized { // see https://github.com/scala/bug/issues/10605
       parser.templateStats()
     }


### PR DESCRIPTION
It turns out that `syntaxAnalyzer.UnitParser()` in global now also
needs to be synchronized. The alternative is adding `synchronizeNames = true`
in the global constructor, but that already proved unreliable in the
case of #3743 (see comment https://github.com/sbt/sbt/issues/3170#issuecomment-355218833)