### PR TITLE
[DON'T MERGE, TO BE CLOSED] Fixed issues from #4094, performance research  

### DIFF
--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -15,8 +15,16 @@ import ast.parser.Tokens
 import reporters.{ ConsoleReporter, Reporter }
 import scala.reflect.internal.util.{ AbstractFileClassLoader, BatchSourceFile }
 import Tokens.{ EOF, NEWLINE, NEWLINES, SEMI }
-import java.io.{ File, FileNotFoundException }
+import java.io.{ File, IOException }
 import java.nio.ByteBuffer
+import java.nio.file.{
+  FileVisitResult,
+  Files,
+  Path => NioPath,
+  SimpleFileVisitor,
+  NoSuchFileException
+}
+import java.nio.file.attribute.BasicFileAttributes
 import java.net.URLClassLoader
 import java.security.MessageDigest
 import Eval.{ getModule, getValue, WrapValName }
@@ -503,24 +511,33 @@ private[sbt] object Eval {
   def bytes(b: Seq[Array[Byte]]): Array[Byte] = bytes(b.length) ++ b.flatten.toArray[Byte]
   def bytes(b: Boolean): Array[Byte] = Array[Byte](if (b) 1 else 0)
 
-  // fileModifiedBytes is a hot method, taking up 0.85% of reload time
-  // This is a procedural version
+  // use NIO to squeeze some performance
+  // ignore NoSuchFileException if thrown by walkFileTree, this mirrors the behavior of previous java.io implementation
   def fileModifiedHash(f: File, digester: MessageDigest): Unit = {
-    if (f.isDirectory)
-      (f listFiles classDirFilter) foreach { x =>
-        fileModifiedHash(x, digester)
-      } else digester.update(bytes(getModifiedTimeOrZero(f)))
-
-    digester.update(bytes(f.getAbsolutePath))
-  }
-
-  // This uses NIO instead of the JNA-based IO.getModifiedTimeOrZero for speed
-  def getModifiedTimeOrZero(f: File): Long =
     try {
-      sbt.io.JavaMilli.getModifiedTime(f.getPath)
+      Files.walkFileTree(
+        f.toPath,
+        new SimpleFileVisitor[NioPath] {
+          override def visitFile(file: NioPath, attrs: BasicFileAttributes): FileVisitResult = {
+            if (file endsWith ".class")
+              digester.update(bytes(attrs.lastModifiedTime.toMillis))
+
+            digester.update(bytes(file.toAbsolutePath.toString))
+            FileVisitResult.CONTINUE
+          }
+
+          override def postVisitDirectory(dir: NioPath, exc: IOException): FileVisitResult = {
+            if (exc eq null) {
+              digester.update(bytes(dir.toAbsolutePath.toString))
+              FileVisitResult.CONTINUE
+            } else throw exc
+          }
+        }
+      )
     } catch {
-      case _: FileNotFoundException => 0L
+      case _: NoSuchFileException => // ignore
     }
+  }
 
   def fileExistsBytes(f: File): Array[Byte] =
     bytes(f.exists) ++


### PR DESCRIPTION
Preflight checklist:
- [X] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

Performance research:
I tried my best to estimate if this change actually speeds things up, so I've published this patched version locally as `1.1.5-LOCAL-4116` and then written small testing scripts using bash and ammonite. Results are on the bottom of the code, I include code for possible future reuse:

_sbtperftest.sh_
```bash
#!/bin/bash

touch sbt115-results.csv
touch sbt115-patched-results.csv

TIMEFORMAT=%R

echo "Running 100 tests for 1.1.5 branch..."
echo "1.1.5" > project/build.properties

echo "First run for 1.1.5, ignoring results."

sbt exit 2 >& 1 > /dev/null

echo "Starting 100 consecutive sbt start ups"

for i in {1..100}
  do
    echo "Executing $i iteration..."
    (time sbt exit) 2>&1 | grep -v "\[" >> sbt115-results.csv
  done

echo "Finished tests for 1.1.5 branch, switching to 1.1.5-LOCAL-4116..."
echo "1.1.5-LOCAL-4116" > project/build.properties

echo "First run for 1.1.5-LOCAL-4116, ignoring results."

sbt exit 2 >& 1 > /dev/null

echo "Starting 100 consecutive sbt start ups"

for i in {1..100}
  do
    echo "Executing $i iteration..."
    (time sbt exit) 2>&1 | grep -v "\[" >> sbt115-patched-results.csv
  done

echo "Finished tests for 1.1.5-LOCAL-4116..."
```

_calcaverages.scala_
```scala
import scala.io._ 
import java.io._

val notPatched = Source.fromFile(new File("sbt115-results.csv")).getLines.map(_.toDouble).toVector 
val patched = Source.fromFile(new File("sbt115-patched-results.csv")).getLines.map(_.toDouble).toVector

println(s"Average time of 100 runs before patch: ${notPatched.sum / notPatched.size}")
println(s"Average time of 100 runs after patch: ${patched.sum / patched.size}")
```

And the results from several runs:
```
λ amm calcaverages.scala
Average time of 100 runs before patch: 14.557729999999998
Average time of 100 runs after patch: 14.655130000000003
```

```
λ amm calcaverages.scala
Average time of 100 runs before patch: 14.702440000000001
Average time of 100 runs after patch: 14.387289999999997
```

```
λ amm calcaverages.scala
Average time of 100 runs before patch: 14.496339999999998
Average time of 100 runs after patch: 14.432229999999999
```

Results are inconclusive, but nothing suggests that there's a significant performance gain. I'll rerun this benchmark on my desktop PC as laptop might do weird stuff with power management. Will post results tomorrow.