### PR TITLE
Fix for #4191 (active.json should be removed on JVM shutdown)

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -105,11 +105,18 @@ object StandardMain {
   import scalacache.caffeine._
   private[sbt] lazy val cache: Cache[Any] = CaffeineCache[Any]
 
+  private[sbt] val shutdownHook = new Thread(new Runnable {
+    def run(): Unit = {
+      exchange.shutdown
+    }
+  })
+
   def runManaged(s: State): xsbti.MainResult = {
     val previous = TrapExit.installManager()
     try {
       try {
         try {
+          Runtime.getRuntime.addShutdownHook(shutdownHook)
           MainLoop.runLogged(s)
         } finally exchange.shutdown
       } finally DefaultBackgroundJobService.backgroundJobService.shutdown()


### PR DESCRIPTION
Fixes #4191

    Added a shutdown hook to clean up active.json file

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
