### PR TITLE
projectMatrix (spatial representation of cross building)

### DIFF
--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -49,6 +49,12 @@ final case object LocalRootProject extends ProjectReference
 /** Identifies the project for the current context. */
 final case object ThisProject extends ProjectReference
 
+/** Identifies a project matrix. */
+sealed trait ProjectMatrixReference
+
+/** Identifies a project in the current build context. */
+final case class LocalProjectMatrix(id: String) extends ProjectMatrixReference
+
 object ProjectRef {
   def apply(base: File, id: String): ProjectRef = ProjectRef(IO toURI base, id)
 }

--- a/sbt/src/sbt-test/project/cross-project-matrix/build.sbt
+++ b/sbt/src/sbt-test/project/cross-project-matrix/build.sbt
@@ -1,0 +1,19 @@
+lazy val root = (project in file("."))
+  .aggregate(core.projectRefs ++ app.projectRefs: _*)
+  .settings(
+  )
+
+lazy val core = (projectMatrix in file("core"))
+  .scalaVersions("2.12.6", "2.11.12")
+  .settings(
+    name := "core"
+  )
+  .jvmPlatform()
+
+lazy val app = (projectMatrix in file("app"))
+  .dependsOn(core)
+  .scalaVersions("2.12.6", "2.11.12")
+  .settings(
+    name := "app"
+  )
+  .jvmPlatform()

--- a/sbt/src/sbt-test/project/cross-project-matrix/core/src/main/scala/Core.scala
+++ b/sbt/src/sbt-test/project/cross-project-matrix/core/src/main/scala/Core.scala
@@ -1,0 +1,6 @@
+package a
+
+class Core {
+}
+
+object Core extends Core

--- a/sbt/src/sbt-test/project/cross-project-matrix/test
+++ b/sbt/src/sbt-test/project/cross-project-matrix/test
@@ -1,0 +1,4 @@
+> compile
+
+$ exists core/target/jvm-2.12/classes/a/Core.class
+$ exists core/target/jvm-2.11/classes/a/Core.class


### PR DESCRIPTION
This implements basic `projectMatrix`.
See https://discuss.lightbend.com/t/spatial-representation-of-cross-building/1277

```scala
lazy val core = (projectMatrix in file("core"))
  .scalaVersions("2.12.6", "2.11.12")
  .settings(
    name := "core"
  )
  .jvmPlatform()

lazy val app = (projectMatrix in file("app"))
  .dependsOn(core)
  .scalaVersions("2.12.6", "2.11.12")
  .settings(
    name := "app"
  )
  .jvmPlatform()
```

The above will automatically generate four subprojects `coreJVM2_12`, `coreJVM2_11`, `appJVM2_12`, and `appJVM2_11` with appJVM* depending on coreJVM*.