### PR TITLE
Suppress stack trace on run/runMain task exit with failure

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -66,6 +66,7 @@ import sbt.util._
 import sbt.util.CacheImplicits._
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
+import scala.util.{ Success, Failure }
 import scala.xml.NodeSeq
 import Scope.{ fillTaskAxis, GlobalScope, ThisScope }
 import sjsonnew.{ IsoLList, JsonFormat, LList, LNil, :*: }
@@ -1160,7 +1161,12 @@ object Defaults extends BuildCommon {
           if (copyClasspath.value)
             service.copyClasspath(products.value, classpath.value, workingDir)
           else classpath.value
-        scalaRun.value.run(mainClass, data(cp), args, logger).get
+        scalaRun.value.run(mainClass, data(cp), args, logger) match {
+          case Success(_) => ()
+          case Failure(e) =>
+            e.setStackTrace(Array.empty)
+            throw e
+        }
       }
     }
   }
@@ -1182,7 +1188,12 @@ object Defaults extends BuildCommon {
           if (copyClasspath.value)
             service.copyClasspath(products.value, classpath.value, workingDir)
           else classpath.value
-        scalaRun.value.run(mainClass, data(cp), parser.parsed, logger).get
+        scalaRun.value.run(mainClass, data(cp), parser.parsed, logger) match {
+          case Success(_) => ()
+          case Failure(e) =>
+            e.setStackTrace(Array.empty)
+            throw e
+        }
       }
     }
   }


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

Address https://github.com/sbt/sbt/issues/4121

---

This PR suppresses stack trace on run/runMain task exit with failure.
For example, now `run` on project that have main method specified on https://github.com/sbt/sbt/issues/4121#issue-317683560 prints below.

```
sbt:test_project> run
[info] Running Main
[error] (run-main-0) java.lang.Exception
[error] java.lang.Exception
[error]         at Main$.main(Main.scala:3)
[error]         at Main.main(Main.scala)
[error]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error]         at java.lang.reflect.Method.invoke(Method.java:498)
[error]         at sbt.Run.invokeMain(Run.scala:93)
[error]         at sbt.Run.run0(Run.scala:87)
[error]         at sbt.Run.execute$1(Run.scala:65)
[error]         at sbt.Run.$anonfun$run$4(Run.scala:77)
[error]         at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error]         at sbt.util.InterfaceUtil$$anon$1.get(InterfaceUtil.scala:10)
[error]         at sbt.TrapExit$App.run(TrapExit.scala:252)
[error]         at java.lang.Thread.run(Thread.java:745)
[error] java.lang.RuntimeException: Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1
[error] Total time: 1 s, completed 2018/06/16 22:04:21
```