### PR TITLE
addPluginSbtFile command

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -83,7 +83,8 @@ $HelpCommand <regular expression>
       List("-" + elem, "--" + elem)
     }
     (s.startsWith(EarlyCommand + "(") && s.endsWith(")")) ||
-    (levelOptions contains s)
+    (levelOptions contains s) ||
+    (s.startsWith("-" + AddPluginSbtFileCommand) || s.startsWith("--" + AddPluginSbtFileCommand))
   }
 
   val EarlyCommand = "early"
@@ -95,6 +96,14 @@ $HelpCommand <regular expression>
 	Schedules an early command, which will be run before other commands on the command line.
 	The order is preserved between all early commands, so `sbt "early(a)" "early(b)"` executes `a` and `b` in order.
 """
+
+  def addPluginSbtFileHelp = {
+    val brief =
+      (s"--$AddPluginSbtFileCommand=<file>", "Adds the given *.sbt file to the plugin build.")
+    Help(brief)
+  }
+
+  val AddPluginSbtFileCommand = "addPluginSbtFile"
 
   def ReadCommand = "<"
   def ReadFiles = " file1 file2 ..."

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -20,6 +20,13 @@ object BasicKeys {
     "The location where command line history is persisted.",
     40
   )
+
+  val extraMetaSbtFiles = AttributeKey[Seq[File]](
+    "extraMetaSbtFile",
+    "Additional plugin.sbt files.",
+    10000
+  )
+
   val shellPrompt = AttributeKey[State => String](
     "shell-prompt",
     "The function that constructs the command prompt from the current build state.",

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -216,6 +216,7 @@ object BuiltinCommands {
       setLogLevel,
       plugin,
       plugins,
+      addPluginSbtFile,
       writeSbtVersion,
       notifyUsersAboutShell,
       shell,

--- a/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
+++ b/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
@@ -142,6 +142,7 @@ object SettingQueryTest extends org.specs2.mutable.Specification {
           loadedPlugins,
           injectSettings,
           fileToLoadedSbtFileMap,
+          Nil,
           state.log
         )
       }

--- a/notes/1.2.0/add-plugin.md
+++ b/notes/1.2.0/add-plugin.md
@@ -1,0 +1,14 @@
+Adds `--addPluginSbtFile=<file>` command, which adds the given .sbt file to the plugin build.
+Using this mechanism editors or IDEs can start a build with required plugin.
+
+```
+$ cat /tmp/extra.sbt
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
+
+$ sbt --addPluginSbtFile=/tmp/extra.sbt
+...
+sbt:helloworld> plugins
+In file:/xxxx/hellotest/
+  ...
+  sbtassembly.AssemblyPlugin: enabled in root
+```


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/1502

This adds `--addPluginSbtFile=<file>` command, which adds the given .sbt file to the plugin build.
Using this mechanism editors or IDEs can start a build with required plugin.

```
$ cat /tmp/extra.sbt
addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")

$ sbt --addPluginSbtFile=/tmp/extra.sbt
...
sbt:helloworld> plugins
In file:/xxxx/hellotest/
  ...
  sbtassembly.AssemblyPlugin: enabled in root
```

/cc @jastice 
