### PR TITLE
Open up setPlugins to private[sbt]

### DIFF
--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -270,7 +270,7 @@ sealed trait Project extends ProjectDefinition[ProjectReference] with CompositeP
   def disablePlugins(ps: AutoPlugin*): Project =
     setPlugins(Plugins.and(plugins, Plugins.And(ps.map(p => Plugins.Exclude(p)).toList)))
 
-  private[this] def setPlugins(ns: Plugins): Project = copy2(plugins = ns)
+  private[sbt] def setPlugins(ns: Plugins): Project = copy2(plugins = ns)
 
   /** Definitively set the [[AutoPlugin]]s for this project. */
   private[sbt] def setAutoPlugins(autos: Seq[AutoPlugin]): Project = copy2(autoPlugins = autos)


### PR DESCRIPTION
This would make it easier for projectMatrix to be a plugin.

Ref https://github.com/sbt/sbt/pull/4200