### PR TITLE
Addresses #4206 - Introduces fgRun and fgRunMain

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -559,6 +559,8 @@ object Defaults extends BuildCommon {
     mainClass := pickMainClassOrWarn(discoveredMainClasses.value, streams.value.log),
     runMain := foregroundRunMainTask.evaluated,
     run := foregroundRunTask.evaluated,
+    fgRun := runTask(fullClasspath, mainClass in run, runner in run).evaluated,
+    fgRunMain := runMainTask(fullClasspath, runner in run).evaluated,
     copyResources := copyResourcesTask.value,
     // note that we use the same runner and mainClass as plain run
     mainBgRunMainTaskForConfig(This),

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -286,7 +286,9 @@ object Keys {
   val bgStop = inputKey[Unit]("Stop a background job by providing its ID.")
   val bgWaitFor = inputKey[Unit]("Wait for a background job to finish by providing its ID.")
   val bgRun = inputKey[JobHandle]("Start an application's default main class as a background job")
+  val fgRun = inputKey[Unit]("Start an application's default main class as a foreground job")
   val bgRunMain = inputKey[JobHandle]("Start a provided main class as a background job")
+  val fgRunMain = inputKey[Unit]("Start a provided main class as a foreground job")
   val bgCopyClasspath = settingKey[Boolean]("Copies classpath on bgRun to prevent conflict.")
 
   // Test Keys


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

Fixes #4206 

- adds fgRun to work like the `run` command in 0.13
- adds fgRunMain to work like the `runMain` command in 0.13
