### PR TITLE
Fix CTRL-C exception

### DIFF
--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -258,9 +258,19 @@ final public class ForkMain {
 				final Task[] tasks = runner.tasks(filteredTests.toArray(new TaskDef[filteredTests.size()]));
 				logDebug(os, "Runner for " + framework.getClass().getName() + " produced " + tasks.length + " initial tasks for " + filteredTests.size() + " tests.");
 
+				Thread callDoneOnShutdown = new Thread() {
+                    @Override
+                    public void run() {
+                        runner.done();
+                    }
+                };
+                Runtime.getRuntime().addShutdownHook(callDoneOnShutdown);
+
 				runTestTasks(executor, tasks, loggers, os);
 
 				runner.done();
+
+				Runtime.getRuntime().removeShutdownHook(callDoneOnShutdown);
 			}
 			write(os, ForkTags.Done);
 			is.readObject();


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

ref: #4197 

Adds a shutdown hook in the forked jvm that calls `done` when a jvm shutdown is requested . 
For successful terminating tests, the hook is removed so that `done` is not called twice.