### PR TITLE
remove gittatributes, assume core.autocrlf=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,3 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
-
-# Explicitly declare text files we want to always be normalized and converted 
-# to native line endings on checkout.
-*.scala text
-*.java text
-
 # Exclude contraband generated files from diff (by default - you can see it if you want)
 **/contraband-scala/**/* -diff merge=ours
 **/contraband-scala/**/* linguist-generated=true


### PR DESCRIPTION
scalafmt is configured to use lf, as your editor should be, so there is no point having git tinker with line endings
otherwise on checkout on windows source files get converted to crlf (by git) and on compile they get converted back to lf (by scalafmt)

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
