### PR TITLE
Add warning for unknown configurations

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -166,7 +166,7 @@ trait Parsers {
     }, "non-double-quote-backslash character")
 
   /** Matches a single character that is valid somewhere in a URI. */
-  lazy val URIChar = charClass(alphanum) | chars("_-!.~'()*,;:$&+=?/[]@%#")
+  lazy val URIChar = charClass(alphanum, "alphanum") | chars("_-!.~'()*,;:$&+=?/[]@%#")
 
   /** Returns true if `c` is an ASCII letter or digit. */
   def alphanum(c: Char) =

--- a/internal/util-complete/src/test/scala/ParserTest.scala
+++ b/internal/util-complete/src/test/scala/ParserTest.scala
@@ -121,8 +121,8 @@ object ParserTest extends Properties("Completing Parser") {
   property("repeatDep accepts two tokens") = matches(repeat, colors.toSeq.take(2).mkString(" "))
 }
 object ParserExample {
-  val ws = charClass(_.isWhitespace).+
-  val notws = charClass(!_.isWhitespace).+
+  val ws = charClass(_.isWhitespace, "whitespace").+
+  val notws = charClass(!_.isWhitespace, "not whitespace").+
 
   val name = token("test")
   val options = (ws ~> token("quick" | "failed" | "new")).*

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -146,7 +146,7 @@ object BasicCommands {
   }
 
   def multiParser(s: State): Parser[List[String]] = {
-    val nonSemi = token(charClass(_ != ';').+, hide = const(true))
+    val nonSemi = token(charClass(_ != ';', "not ';'").+, hide = const(true))
     val semi = token(';' ~> OptSpace)
     val part = semi flatMap (
         _ => matched((s.combinedParser & nonSemi) | nonSemi) <~ token(OptSpace)

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -148,7 +148,7 @@ final case class Extracted(
   ): State = {
     val appendSettings =
       Load.transformSettings(Load.projectScope(currentRef), currentRef.build, rootProject, settings)
-    val newStructure = Load.reapply(sessionSettings ++ appendSettings, structure)
+    val newStructure = Load.reapply(sessionSettings ++ appendSettings, structure, state.log)
     Project.setProject(session, newStructure, state)
   }
 }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -459,7 +459,7 @@ object BuiltinCommands {
     val loggerInject = LogManager.settingsLogger(s)
     val withLogger = newSession.appendRaw(loggerInject :: Nil)
     val show = Project.showContextKey2(newSession)
-    val newStructure = Load.reapply(withLogger.mergeSettings, structure)(show)
+    val newStructure = Load.reapply(withLogger.mergeSettings, structure, s.log)(show)
     Project.setProject(newSession, newStructure, s)
   }
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -50,7 +50,7 @@ private[sbt] object PluginCross {
             scalaVersion := scalaVersionSetting.value
           )
         val cleared = session.mergeSettings.filterNot(crossExclude)
-        val newStructure = Load.reapply(cleared ++ add, structure)
+        val newStructure = Load.reapply(cleared ++ add, structure, state.log)
         Project.setProject(session, newStructure, command :: state)
     }
   }

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -129,7 +129,7 @@ object ScriptedPlugin extends AutoPlugin {
     }
     val pairMap = pairs.groupBy(_._1).mapValues(_.map(_._2).toSet)
 
-    val id = charClass(c => !c.isWhitespace && c != '/').+.string
+    val id = charClass(c => !c.isWhitespace && c != '/', "not whitespace and not '/'").+.string
     val groupP = token(id.examples(pairMap.keySet)) <~ token('/')
 
     // A parser for page definitions

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -57,7 +57,7 @@ object IvyConsole {
         depSettings
       )
 
-      val newStructure = Load.reapply(session.original ++ append, structure)
+      val newStructure = Load.reapply(session.original ++ append, structure, state.log)
       val newState = state.copy(remainingCommands = Exec(Keys.consoleQuick.key.label, None) :: Nil)
       Project.setProject(session, newStructure, newState)
     }

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -65,7 +65,7 @@ object Script {
         scriptSettings ++ embeddedSettings
       )
 
-      val newStructure = Load.reapply(session.original ++ append, structure)
+      val newStructure = Load.reapply(session.original ++ append, structure, state.log)
       val arguments = state.remainingCommands.drop(1).map(e => s""""${e.commandLine}"""")
       val newState = arguments.mkString("run ", " ", "") :: state.copy(remainingCommands = Nil)
       Project.setProject(session, newStructure, newState)

--- a/main/src/test/scala/ParseKey.scala
+++ b/main/src/test/scala/ParseKey.scala
@@ -7,11 +7,18 @@
 
 package sbt
 
-import Def.{ displayFull, displayMasked, ScopedKey }
-import sbt.internal.{ TestBuild, Resolve }, TestBuild._
-import sbt.internal.util.complete.Parser
+import java.net.URI
 
-import org.scalacheck._, Arbitrary.arbitrary, Gen._, Prop._
+import org.scalacheck.Arbitrary.{ arbBool, arbitrary }
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
+import org.scalacheck._
+import sbt.Def.{ ScopedKey, displayFull, displayMasked }
+import sbt.internal.TestBuild._
+import sbt.internal.util.AttributeKey
+import sbt.internal.util.complete.{ DefaultParsers, Parser }
+import sbt.internal.{ Resolve, TestBuild }
+import sbt.librarymanagement.Configuration
 
 /**
  * Tests that the scoped key parser in Act can correctly parse a ScopedKey converted by Def.show*Key.
@@ -26,10 +33,7 @@ object ParseKey extends Properties("Key parser test") {
       // Note that this explicitly displays the configuration axis set to Zero.
       // This is to disambiguate `proj/Zero/name`, which could render potentially
       // as `Zero/name`, but could be interpreted as `Zero/Zero/name`.
-      val expected = ScopedKey(
-        Resolve(structure.extra, Select(structure.current), key.key, mask)(key.scope),
-        key.key
-      )
+      val expected = resolve(structure, key, mask)
       parseCheck(structure, key, mask, hasZeroConfig)(
         sk =>
           Project.equal(sk, expected, mask)
@@ -75,14 +79,20 @@ object ParseKey extends Properties("Key parser test") {
       scopes <- pickN(loadFactor, env.allFullScopes)
       current <- oneOf(env.allProjects.unzip._1)
       structure <- {
-        val settings = for (scope <- scopes; t <- env.tasks)
-          yield Def.setting(ScopedKey(scope, t.key), Def.value(""))
+        val settings = structureSettings(scopes, env)
         TestBuild.structure(env, settings, current)
       }
     } yield structure
   }
 
-  final class StructureKeyMask(val structure: Structure, val key: ScopedKey[_], val mask: ScopeMask)
+  def structureSettings(scopes: Seq[Scope], env: Env): Seq[Def.Setting[String]] = {
+    for {
+      scope <- scopes
+      t <- env.tasks
+    } yield Def.setting(ScopedKey(scope, t.key), Def.value(""))
+  }
+
+  final case class StructureKeyMask(structure: Structure, key: ScopedKey[_], mask: ScopeMask)
 
   implicit val arbStructureKeyMask: Arbitrary[StructureKeyMask] = Arbitrary {
     for {
@@ -92,8 +102,34 @@ object ParseKey extends Properties("Key parser test") {
         scope <- TestBuild.scope(structure.env)
         key <- oneOf(structure.allAttributeKeys.toSeq)
       } yield ScopedKey(scope, key)
-    } yield new StructureKeyMask(structure, key, mask)
+      skm = StructureKeyMask(structure, key, mask)
+      if configExistsInIndex(skm)
+    } yield skm
   }
+
+  private def configExistsInIndex(skm: StructureKeyMask): Boolean = {
+    import skm._
+    val resolvedKey = resolve(structure, key, mask)
+    val proj = resolvedKey.scope.project.toOption
+    val maybeResolvedProj = proj.collect {
+      case ref: ResolvedReference => ref
+    }
+    val checkName = for {
+      configKey <- resolvedKey.scope.config.toOption
+    } yield {
+      val configID = Scope.display(configKey)
+      // This only works for known configurations or those that were guessed correctly.
+      val name = structure.keyIndex.fromConfigIdent(maybeResolvedProj)(configID)
+      name == configKey.name
+    }
+    checkName.getOrElse(true)
+  }
+
+  def resolve(structure: Structure, key: ScopedKey[_], mask: ScopeMask): ScopedKey[_] =
+    ScopedKey(
+      Resolve(structure.extra, Select(structure.current), key.key, mask)(key.scope),
+      key.key
+    )
 
   def parseCheck(
       structure: Structure,
@@ -118,4 +154,200 @@ object ParseKey extends Properties("Key parser test") {
   // The rest of the tests expect at least one item, so I changed it to return 1 in case of 0.
   def pickN[T](load: Double, from: Seq[T]): Gen[Seq[T]] =
     pick((load * from.size).toInt max 1, from)
+
+  implicit val shrinkStructureKeyMask: Shrink[StructureKeyMask] = Shrink { skm =>
+    Shrink
+      .shrink(skm.structure)
+      .map(s => skm.copy(structure = s))
+      .flatMap(fixKey)
+  }
+
+  def fixKey(skm: StructureKeyMask): Stream[StructureKeyMask] = {
+    for {
+      scope <- fixScope(skm)
+      attributeKey <- fixAttributeKey(skm)
+    } yield skm.copy(key = ScopedKey(scope, attributeKey))
+  }
+
+  def fixScope(skm: StructureKeyMask): Stream[Scope] = {
+    def validScope(scope: Scope) = scope match {
+      case Scope(Select(BuildRef(build)), _, _, _) if !validBuild(build) => false
+      case Scope(Select(ProjectRef(build, project)), _, _, _) if !validProject(build, project) =>
+        false
+      case Scope(Select(ProjectRef(build, project)), Select(ConfigKey(config)), _, _)
+          if !validConfig(build, project, config) =>
+        false
+      case Scope(_, Select(ConfigKey(config)), _, _) if !configExists(config) =>
+        false
+      case Scope(_, _, Select(task), _) => validTask(task)
+      case _                            => true
+    }
+    def validBuild(build: URI) = skm.structure.env.buildMap.contains(build)
+    def validProject(build: URI, project: String) = {
+      skm.structure.env.buildMap
+        .get(build)
+        .exists(_.projectMap.contains(project))
+    }
+    def validConfig(build: URI, project: String, config: String) = {
+      skm.structure.env.buildMap
+        .get(build)
+        .toSeq
+        .flatMap(_.projectMap.get(project))
+        .flatMap(_.configurations.map(_.name))
+        .contains(config)
+    }
+    def configExists(config: String) = {
+      val configs = for {
+        build <- skm.structure.env.builds
+        project <- build.projects
+        config <- project.configurations
+      } yield config.name
+      configs.contains(config)
+    }
+    def validTask(task: AttributeKey[_]) = skm.structure.env.taskMap.contains(task)
+    if (validScope(skm.key.scope)) {
+      Stream(skm.key.scope)
+    } else {
+      // We could return all scopes here but we want to explore the other paths first since there
+      // is a greater chance of a successful shrink. If necessary these could be appended to the end.
+      Stream.empty
+    }
+  }
+
+  def fixAttributeKey(skm: StructureKeyMask): Stream[AttributeKey[_]] = {
+    if (skm.structure.allAttributeKeys.contains(skm.key.key)) {
+      Stream(skm.key.key)
+    } else {
+      // Likewise here, we should try other paths before trying different attribute keys.
+      Stream.empty
+    }
+  }
+
+  implicit val shrinkStructure: Shrink[Structure] = Shrink { s =>
+    Shrink.shrink(s.env).flatMap { env =>
+      val scopes = s.data.scopes intersect env.allFullScopes.toSet
+      val settings = structureSettings(scopes.toSeq, env)
+      if (settings.nonEmpty) {
+        val currents = env.allProjects.find {
+          case (ref, _) => ref == s.current
+        } match {
+          case Some((current, _)) => Stream(current)
+          case None               => env.allProjects.map(_._1).toStream
+        }
+        currents.map(structure(env, settings, _))
+      } else {
+        Stream.empty
+      }
+    }
+  }
+
+  implicit val shrinkEnv: Shrink[Env] = Shrink { env =>
+    val shrunkBuilds = Shrink
+      .shrink(env.builds)
+      .filter(_.nonEmpty)
+      .map(b => env.copy(builds = b))
+      .map(fixProjectRefs)
+      .map(fixConfigurations)
+    val shrunkTasks = shrinkTasks(env.tasks)
+      .map(t => env.copy(tasks = t))
+    shrunkBuilds ++ shrunkTasks
+  }
+
+  private def fixProjectRefs(env: Env): Env = {
+    def fixBuild(build: Build): Build = {
+      build.copy(projects = build.projects.map(fixProject))
+    }
+    def fixProject(project: Proj): Proj = {
+      project.copy(delegates = project.delegates.filter(delegateExists))
+    }
+    def delegateExists(delegate: ProjectRef): Boolean = {
+      env.buildMap
+        .get(delegate.build)
+        .flatMap(_.projectMap.get(delegate.project))
+        .nonEmpty
+    }
+    env.copy(builds = env.builds.map(fixBuild))
+  }
+
+  private def fixConfigurations(env: Env): Env = {
+    val configs = env.allProjects.map {
+      case (_, proj) => proj -> proj.configurations.toSet
+    }.toMap
+
+    def fixBuild(build: Build): Build = {
+      build.copy(projects = build.projects.map(fixProject(build.uri)))
+    }
+    def fixProject(buildURI: URI)(project: Proj): Proj = {
+      val projConfigs = configs(project)
+      project.copy(configurations = project.configurations.map(fixConfig(projConfigs)))
+    }
+    def fixConfig(projConfigs: Set[Configuration])(config: Configuration): Configuration = {
+      import config.{ name => configName, _ }
+      val extendsConfigs = config.extendsConfigs.filter(projConfigs.contains)
+      Configuration.of(id, configName, description, isPublic, extendsConfigs, transitive)
+    }
+    env.copy(builds = env.builds.map(fixBuild))
+  }
+
+  implicit val shrinkBuild: Shrink[Build] = Shrink { build =>
+    Shrink
+      .shrink(build.projects)
+      .filter(_.nonEmpty)
+      .map(p => build.copy(projects = p))
+  // Could also shrink the URI here but that requires updating all the references.
+  }
+
+  implicit val shrinkProject: Shrink[Proj] = Shrink { project =>
+    val shrunkDelegates = Shrink
+      .shrink(project.delegates)
+      .map(d => project.copy(delegates = d))
+    val shrunkConfigs = Shrink
+      .shrink(project.configurations)
+      .map(c => project.copy(configurations = c))
+    val shrunkID = shrinkID(project.id)
+      .map(id => project.copy(id = id))
+    shrunkDelegates ++ shrunkConfigs ++ shrunkID
+  }
+
+  implicit val shrinkDelegate: Shrink[ProjectRef] = Shrink { delegate =>
+    val shrunkBuild = Shrink
+      .shrink(delegate.build)
+      .map(b => delegate.copy(build = b))
+    val shrunkProject = Shrink
+      .shrink(delegate.project)
+      .map(p => delegate.copy(project = p))
+    shrunkBuild ++ shrunkProject
+  }
+
+  implicit val shrinkConfiguration: Shrink[Configuration] = Shrink { configuration =>
+    import configuration.{ name => configName, _ }
+    val shrunkExtends = Shrink
+      .shrink(configuration.extendsConfigs)
+      .map(configuration.withExtendsConfigs)
+    val shrunkID = Shrink.shrink(id.tail).map { tail =>
+      Configuration
+        .of(id.head + tail, configName, description, isPublic, extendsConfigs, transitive)
+    }
+    shrunkExtends ++ shrunkID
+  }
+
+  val shrinkStringLength: Shrink[String] = Shrink { s =>
+    // Only change the string length don't change the characters.
+    implicit val shrinkChar: Shrink[Char] = Shrink.shrinkAny
+    Shrink.shrinkContainer[List, Char].shrink(s.toList).map(_.mkString)
+  }
+
+  def shrinkID(id: String): Stream[String] = {
+    Shrink.shrink(id).filter(DefaultParsers.validID)
+  }
+
+  def shrinkTasks(tasks: Vector[Taskk]): Stream[Vector[Taskk]] = {
+    Shrink.shrink(tasks)
+  }
+
+  implicit val shrinkTask: Shrink[Taskk] = Shrink { task =>
+    Shrink.shrink((task.delegates, task.key)).map {
+      case (delegates, key) => Taskk(key, delegates)
+    }
+  }
 }

--- a/main/src/test/scala/ParserSpec.scala
+++ b/main/src/test/scala/ParserSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+import java.net.URI
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ Matchers, PropSpec }
+import sbt.Def._
+import sbt._
+import sbt.internal.TestBuild
+import sbt.internal.TestBuild._
+import sbt.internal.util.AttributeKey
+import sbt.internal.util.complete.DefaultParsers
+import sbt.librarymanagement.Configuration
+
+class ParserSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("can parse any build") {
+    forAll(TestBuild.uriGen) { uri =>
+      parse(buildURI = uri)
+    }
+  }
+
+  property("can parse any project") {
+    forAll(TestBuild.idGen) { id =>
+      parse(projectID = id)
+    }
+  }
+
+  property("can parse any configuration") {
+    forAll(TestBuild.scalaIDGen) { name =>
+      parse(configName = name)
+    }
+  }
+
+  property("can parse any attribute") {
+    forAll(TestBuild.lowerIDGen) { name =>
+      parse(attributeName = name)
+    }
+  }
+
+  private def parse(
+      buildURI: URI = new java.net.URI("s", "p", null),
+      projectID: String = "p",
+      configName: String = "c",
+      attributeName: String = "a"
+  ) = {
+    val attributeKey = AttributeKey[String](attributeName)
+    val scope = Scope(
+      Select(BuildRef(buildURI)),
+      Select(ConfigKey(configName)),
+      Select(attributeKey),
+      Zero
+    )
+    val scopedKey = ScopedKey(scope, attributeKey)
+    val config = Configuration.of(configName.capitalize, configName)
+    val project = Proj(projectID, Nil, Seq(config))
+    val projects = Vector(project)
+    val build = Build(buildURI, projects)
+    val builds = Vector(build)
+    val task = Taskk(attributeKey, Nil)
+    val tasks = Vector(task)
+    val env = Env(builds, tasks)
+    val settings = env.tasks.map { t =>
+      Def.setting(ScopedKey(scope, t.key), Def.value("value"))
+    }
+    val structure = TestBuild.structure(env, settings, build.allProjects.head._1)
+    val string = displayMasked(scopedKey, ScopeMask())
+    val parser = makeParser(structure)
+    val result = DefaultParsers.result(parser, string).left.map(_().toString)
+    result shouldBe Right(scopedKey)
+  }
+}

--- a/main/src/test/scala/PluginCommandTest.scala
+++ b/main/src/test/scala/PluginCommandTest.scala
@@ -10,7 +10,6 @@ package sbt
 import java.io._
 
 import org.specs2.mutable.Specification
-
 import sbt.internal._
 import sbt.internal.util.{
   AttributeEntry,
@@ -20,6 +19,7 @@ import sbt.internal.util.{
   MainAppender,
   Settings
 }
+import sbt.util.Logger
 
 object PluginCommandTestPlugin0 extends AutoPlugin { override def requires = empty }
 
@@ -103,7 +103,8 @@ object FakeState {
     val data: Settings[Scope] = Def.make(settings)(delegates, scopeLocal, Def.showFullKey)
     val extra: KeyIndex => BuildUtil[_] = (keyIndex) =>
       BuildUtil(base.toURI, Map.empty, keyIndex, data)
-    val structureIndex: StructureIndex = Load.structureIndex(data, settings, extra, Map.empty)
+    val structureIndex: StructureIndex =
+      Load.structureIndex(data, settings, extra, Map.empty, Logger.Null)
     val streams: (State) => BuildStreams.Streams = null
 
     val loadedDefinitions: LoadedDefinitions = new LoadedDefinitions(

--- a/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
+++ b/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
@@ -16,7 +16,7 @@ import java.util.concurrent._
 
 import scala.collection.mutable
 
-import xsbti._
+import xsbti.{ Logger => _, _ }
 import sbt.io.IO
 import sbt.internal.util._
 import sbt.internal.BuildStreams.{ Streams => _, _ }
@@ -174,7 +174,7 @@ object SettingQueryTest extends org.specs2.mutable.Specification {
     val data: Settings[Scope] = Def.make(settings)(delegates, scopeLocal, display)
     val extra: KeyIndex => BuildUtil[_] = index => BuildUtil(baseUri, units, index, data)
 
-    val index: StructureIndex = structureIndex(data, settings, extra, units)
+    val index: StructureIndex = structureIndex(data, settings, extra, units, Logger.Null)
     val streams: State => Streams = mkStreams(units, baseUri, data)
 
     val structure: BuildStructure =

--- a/notes/1.2.0/unknown-config-warning.md
+++ b/notes/1.2.0/unknown-config-warning.md
@@ -1,0 +1,8 @@
+[@steinybot]: https://github.com/steinybot
+
+[#4065]: https://github.com/sbt/sbt/issues/4065
+[#4231]: https://github.com/sbt/sbt/pull/4231
+
+### Improvements
+
+- Add a warning for unknown project configurations.  [#4065][]/[#4231][] by [@steinybot][]


### PR DESCRIPTION
Adds a warning for unknown configurations. This helps to mitigate the issue in #4065 where the id's of unknown configurations are guessed incorrectly and cannot be used with the new unified `/` scope syntax.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
