### PR TITLE
Fixes the stacktrace of run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -302,7 +302,7 @@ lazy val runProj = (project in file("run"))
       exclude[DirectMissingMethodProblem]("sbt.OutputStrategy#LoggedOutput.copy$default$*"),
     )
   )
-  .configure(addSbtIO, addSbtUtilLogging, addSbtCompilerClasspath)
+  .configure(addSbtIO, addSbtUtilLogging, addSbtUtilControl, addSbtCompilerClasspath)
 
 val sbtProjDepsCompileScopeFilter =
   ScopeFilter(inDependencies(LocalProject("sbtProj"), includeRoot = false), inConfigurations(Compile))

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -154,6 +154,8 @@ object Defaults extends BuildCommon {
       classpathEntryDefinesClass :== FileValueCache(Locate.definesClass _).get,
       traceLevel in run :== 0,
       traceLevel in runMain :== 0,
+      traceLevel in bgRun :== 0,
+      traceLevel in fgRun :== 0,
       traceLevel in console :== Int.MaxValue,
       traceLevel in consoleProject :== Int.MaxValue,
       autoCompilerPlugins :== true,

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -12,6 +12,7 @@ import java.lang.reflect.{ Method, Modifier }
 import Modifier.{ isPublic, isStatic }
 import sbt.internal.inc.classpath.ClasspathUtilities
 import sbt.internal.inc.ScalaInstance
+import sbt.internal.util.MessageOnlyException
 
 import sbt.io.Path
 
@@ -29,7 +30,9 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
       if (exitCode == 0) Success(())
       else
         Failure(
-          new RuntimeException(s"""Nonzero exit code returned from $label: $exitCode""".stripMargin)
+          new MessageOnlyException(
+            s"""Nonzero exit code returned from $label: $exitCode""".stripMargin
+          )
         )
     val process = fork(mainClass, classpath, options, log)
     def cancel() = {
@@ -124,6 +127,6 @@ object Run {
     if (exitCode == 0) {
       log.debug("Exited with code 0")
       Success(())
-    } else Failure(new RuntimeException("Nonzero exit code: " + exitCode))
+    } else Failure(new MessageOnlyException("Nonzero exit code: " + exitCode))
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4121

sbt already has the facility to trim stack traces. This sets the trace level of the background run, which fixes the upper half of the `run` stacktrace. For the bottom half, I am going to use `MessageOnlyException` to skip the stacktrace.

### before

```
[error] (run-main-0) java.lang.Exception
[error] java.lang.Exception
[error] 	at Hello$.delayedEndpoint$Hello$1(Hello.scala:5)
[error] 	at Hello$delayedInit$body.apply(Hello.scala:1)
[error] 	at scala.Function0.apply$mcV$sp(Function0.scala:34)
[error] 	at scala.Function0.apply$mcV$sp$(Function0.scala:34)
[error] 	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
[error] 	at scala.App.$anonfun$main$1$adapted(App.scala:76)
[error] 	at scala.collection.immutable.List.foreach(List.scala:389)
[error] 	at scala.App.main(App.scala:76)
[error] 	at scala.App.main$(App.scala:74)
[error] 	at Hello$.main(Hello.scala:1)
[error] 	at Hello.main(Hello.scala)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.lang.reflect.Method.invoke(Method.java:498)
[error] 	at sbt.Run.invokeMain(Run.scala:93)
[error] 	at sbt.Run.run0(Run.scala:87)
[error] 	at sbt.Run.execute$1(Run.scala:65)
[error] 	at sbt.Run.$anonfun$run$4(Run.scala:77)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at sbt.util.InterfaceUtil$$anon$1.get(InterfaceUtil.scala:10)
[error] 	at sbt.TrapExit$App.run(TrapExit.scala:252)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] java.lang.RuntimeException: Nonzero exit code: 1
[error] 	at sbt.Run$.executeTrapExit(Run.scala:124)
[error] 	at sbt.Run.run(Run.scala:77)
[error] 	at sbt.Defaults$.$anonfun$bgRunTask$5(Defaults.scala:1185)
[error] 	at sbt.Defaults$.$anonfun$bgRunTask$5$adapted(Defaults.scala:1180)
[error] 	at sbt.internal.BackgroundThreadPool.$anonfun$run$1(DefaultBackgroundJobService.scala:366)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[error] 	at scala.util.Try$.apply(Try.scala:209)
[error] 	at sbt.internal.BackgroundThreadPool$BackgroundRunnable.run(DefaultBackgroundJobService.scala:289)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (Compile / run) Nonzero exit code: 1
```

### after

```
[error] (run-main-0) java.lang.Exception
[error] java.lang.Exception
[error] 	at Hello$.delayedEndpoint$Hello$1(Hello.scala:5)
[error] 	at Hello$delayedInit$body.apply(Hello.scala:1)
[error] 	at scala.Function0.apply$mcV$sp(Function0.scala:34)
[error] 	at scala.Function0.apply$mcV$sp$(Function0.scala:34)
[error] 	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
[error] 	at scala.App.$anonfun$main$1$adapted(App.scala:76)
[error] 	at scala.collection.immutable.List.foreach(List.scala:389)
[error] 	at scala.App.main(App.scala:76)
[error] 	at scala.App.main$(App.scala:74)
[error] 	at Hello$.main(Hello.scala:1)
[error] 	at Hello.main(Hello.scala)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.lang.reflect.Method.invoke(Method.java:498)
[error] Nonzero exit code: 1
[error] (Compile / run) Nonzero exit code: 1
```

