### PR TITLE
port addSbtPluginCommand to sbt 0.13

### DIFF
--- a/main/command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main/command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -74,7 +74,8 @@ object BasicCommandStrings {
     val levelLongOptions = Level.values.toSeq map { "--" + _ }
     (s.startsWith(EarlyCommand + "(") && s.endsWith(")")) ||
       (levelShortOptions contains s) ||
-      (levelLongOptions contains s)
+      (levelLongOptions contains s) ||
+      (s.startsWith("-" + AddPluginSbtFileCommand) || s.startsWith("--" + AddPluginSbtFileCommand))
   }
 
   val OldEarlyCommand = "--"
@@ -86,6 +87,14 @@ object BasicCommandStrings {
 	Schedules an early command, which will be run before other commands on the command line.
 	The order is preserved between all early commands, so `sbt "early(a)" "early(b)"` executes `a` and `b` in order.
 """
+
+  def addPluginSbtFileHelp = {
+    val brief =
+      (s"--$AddPluginSbtFileCommand=<file>", "Adds the given *.sbt file to the plugin build.")
+    Help(brief)
+  }
+
+  val AddPluginSbtFileCommand = "addPluginSbtFile"
 
   def ReadCommand = "<"
   def ReadFiles = " file1 file2 ..."

--- a/main/command/src/main/scala/sbt/BasicCommands.scala
+++ b/main/command/src/main/scala/sbt/BasicCommands.scala
@@ -22,19 +22,44 @@ object BasicCommands {
   def ignore = Command.command(FailureWall)(idFun)
 
   def early = Command.arb(earlyParser, earlyHelp) { (s, other) => other :: s }
+
   private[this] def levelParser: Parser[String] =
     token(Level.Debug.toString) | token(Level.Info.toString) | token(Level.Warn.toString) | token(Level.Error.toString)
-  private[this] def earlyParser: State => Parser[String] = (s: State) =>
-    (token(EarlyCommand + "(") flatMap { _ =>
-      otherCommandParser(s) <~ token(")")
-    }) |
-      (token("-") flatMap { _ =>
-        levelParser
-      }) |
-      (token(OldEarlyCommand) flatMap { _ =>
-        levelParser
-      })
+
+  private[this] def addPluginSbtFileParser: Parser[File] = {
+    token(AddPluginSbtFileCommand) ~> (":" | "=" | Space) ~> (StringBasic)
+      .examples("/some/extra.sbt") map {
+        new File(_)
+      }
+  }
+
+  private[this] def addPluginSbtFileStringParser: Parser[String] = {
+    token(
+      token(AddPluginSbtFileCommand) ~ (":" | "=" | Space) ~ (StringBasic)
+        .examples("/some/extra.sbt") map {
+          case s1 ~ s2 ~ s3 => s1 + s2 + s3
+        }
+    )
+  }
+
+  private[this] def earlyParser: State => Parser[String] = (s: State) => {
+    val p1 = token(EarlyCommand + "(") flatMap (_ => otherCommandParser(s) <~ token(")"))
+    val p2 = (token("-") | token("--")) flatMap (_ => levelParser)
+    val p3 = (token("-") | token("--")) flatMap (_ => addPluginSbtFileStringParser)
+    p1 | p2 | p3
+  }
+
   private[this] def earlyHelp = Help(EarlyCommand, EarlyCommandBrief, EarlyCommandDetailed)
+
+  /**
+   * Adds additional *.sbt to the plugin build.
+   * This must be combined with early command as: --addPluginSbtFile=/tmp/extra.sbt
+   */
+  def addPluginSbtFile: Command = Command.arb(_ => addPluginSbtFileParser, addPluginSbtFileHelp) {
+    (s, extraSbtFile) =>
+      val extraFiles = s.get(BasicKeys.extraMetaSbtFiles).toList.flatten
+      s.put(BasicKeys.extraMetaSbtFiles, extraFiles :+ extraSbtFile)
+  }
 
   def help = Command.make(HelpCommand, helpBrief, helpDetailed)(helpParser)
 

--- a/main/command/src/main/scala/sbt/BasicKeys.scala
+++ b/main/command/src/main/scala/sbt/BasicKeys.scala
@@ -5,6 +5,13 @@ import sbt.template.TemplateResolver
 
 object BasicKeys {
   val historyPath = AttributeKey[Option[File]]("history", "The location where command line history is persisted.", 40)
+
+  val extraMetaSbtFiles = AttributeKey[Seq[File]](
+    "extraMetaSbtFile",
+    "Additional plugin.sbt files.",
+    10000
+  )
+
   val shellPrompt = AttributeKey[State => String]("shell-prompt", "The function that constructs the command prompt from the current build state.", 10000)
   val watch = AttributeKey[Watched]("watch", "Continuous execution configuration.", 1000)
   private[sbt] val interactive = AttributeKey[Boolean]("interactive", "True if commands are currently being entered from an interactive environment.", 10)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -95,6 +95,7 @@ object BuiltinCommands {
     projects, project, reboot, read, history, set, sessionCommand, inspect, loadProjectImpl, loadFailed,
     Cross.crossBuild, Cross.switchVersion, PluginCross.pluginCross, PluginCross.pluginSwitch,
     setOnFailure, clearOnFailure, stashOnFailure, popOnFailure, setLogLevel, plugin, plugins,
+    addPluginSbtFile,
     writeSbtVersion, notifyUsersAboutShell,
     ifLast, multi, shell, continuous, eval, alias, append, last, lastGrep, export, boot, nop, call, exit, early, initialize, act) ++
     compatCommands


### PR DESCRIPTION
Port #4211 to sbt 0.13 so that IntelliJ Scala plugin can use plugin injection without requiring users to upgrade their sbt builds to 1.x

edit: it actually does work as expected