### PR TITLE
add human readable total time

### DIFF
--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -147,7 +147,19 @@ object Aggregation {
 
   def timing(format: java.text.DateFormat, startTime: Long, endTime: Long): String = {
     val nowString = format.format(new java.util.Date(endTime))
-    "Total time: " + (endTime - startTime + 500) / 1000 + " s, completed " + nowString
+    val total = (endTime - startTime + 500) / 1000
+    val totalString = s"$total s" +
+      (if (total <= 60) ""
+       else {
+         val maybeHours = total / 3600 match {
+           case 0 => ""
+           case h => f"$h%02d:"
+         }
+         val mins = f"${total % 3600 / 60}%02d"
+         val secs = f"${total % 60}%02d"
+         s" ($maybeHours$mins:$secs)"
+       })
+    s"Total time: $totalString, completed $nowString"
   }
 
   def defaultFormat: DateFormat = {

--- a/main/src/test/scala/sbt/internal/AggregationSpec.scala
+++ b/main/src/test/scala/sbt/internal/AggregationSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * sbt
+ * Copyright 2011 - 2017, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under BSD-3-Clause license (see LICENSE)
+ */
+
+package sbt.internal
+
+import org.specs2.mutable.Specification
+
+class AggregationSpec extends Specification {
+  val timing = Aggregation.timing(Aggregation.defaultFormat, 0, _: Long)
+
+  "timing" should {
+    "format total time properly" in {
+      timing(101) must be startWith "Total time: 0 s,"
+      timing(1000) must be startWith "Total time: 1 s,"
+      timing(3000) must be startWith "Total time: 3 s,"
+      timing(30399) must be startWith "Total time: 30 s,"
+      timing(60399) must be startWith "Total time: 60 s,"
+      timing(60699) must be startWith "Total time: 61 s (01:01),"
+      timing(303099) must be startWith "Total time: 303 s (05:03),"
+      timing(6003099) must be startWith "Total time: 6003 s (01:40:03),"
+      timing(96003099) must be startWith "Total time: 96003 s (26:40:03),"
+    }
+  }
+
+}


### PR DESCRIPTION
- [X] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

Not sure this requires change.md file, but let me know if it's needed

**Motivation:**
 for big multimodule projects sbt often report `Total time: 123456 s, ...`
Which is not human friendly. So this PR adds some human friendly duration. Please see spec for examples 
