### PR TITLE
use the official sbt script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,19 @@ env:
     - SBT_CMD="scripted tests/*"
     - SBT_CMD="repoOverrideTest:scripted dependency-management/*"
 
+before_install:
+  - export JAVA_OPTS="-server -Dfile.encoding=UTF-8 -Xss2M -Xms1024M -Xmx1024M -XX:ReservedCodeCacheSize=128m"
+  - export SBT_OPTS=
+  - export PATH=/usr/bin:$PATH
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
+        key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=sbt'
+    packages:
+      - sbt=1.1.6
+
 notifications:
   email:
     - sbt-dev-bot@googlegroups.com
@@ -54,7 +67,7 @@ before_script:
 
 script:
   # It doesn't need that much memory because compile and run are forked
-  - sbt -J-XX:ReservedCodeCacheSize=128m -J-Xmx800M -J-Xms800M -J-server "$SBT_CMD"
+  - sbt "$SBT_CMD"
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete


### PR DESCRIPTION
This is a workaround for Travis CI is using an old cut of sbt-extras, which prevents the use of sbt 1 published on Maven Central.

Ref https://github.com/travis-ci/travis-ci/issues/9816
