### PR TITLE
Remove warnings about configuration

### DIFF
--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -148,7 +148,7 @@ final case class Extracted(
   ): State = {
     val appendSettings =
       Load.transformSettings(Load.projectScope(currentRef), currentRef.build, rootProject, settings)
-    val newStructure = Load.reapply(sessionSettings ++ appendSettings, structure, state.log)
+    val newStructure = Load.reapply(sessionSettings ++ appendSettings, structure)
     Project.setProject(session, newStructure, state)
   }
 }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -472,7 +472,7 @@ object BuiltinCommands {
     val loggerInject = LogManager.settingsLogger(s)
     val withLogger = newSession.appendRaw(loggerInject :: Nil)
     val show = Project.showContextKey2(newSession)
-    val newStructure = Load.reapply(withLogger.mergeSettings, structure, s.log)(show)
+    val newStructure = Load.reapply(withLogger.mergeSettings, structure)(show)
     Project.setProject(newSession, newStructure, s)
   }
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -50,7 +50,7 @@ private[sbt] object PluginCross {
             scalaVersion := scalaVersionSetting.value
           )
         val cleared = session.mergeSettings.filterNot(crossExclude)
-        val newStructure = Load.reapply(cleared ++ add, structure, state.log)
+        val newStructure = Load.reapply(cleared ++ add, structure)
         Project.setProject(session, newStructure, command :: state)
     }
   }

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -267,7 +267,7 @@ private[sbt] object Load {
     }
     Project.checkTargets(data) foreach sys.error
     val index = timed("Load.apply: structureIndex", log) {
-      structureIndex(data, settings, loaded.extra(data), projects, log)
+      structureIndex(data, settings, loaded.extra(data), projects)
     }
     val streams = timed("Load.apply: mkStreams", log) { mkStreams(projects, loaded.root, data) }
     val bs = new BuildStructure(
@@ -321,8 +321,7 @@ private[sbt] object Load {
       data: Settings[Scope],
       settings: Seq[Setting[_]],
       extra: KeyIndex => BuildUtil[_],
-      projects: Map[URI, LoadedBuildUnit],
-      log: Logger
+      projects: Map[URI, LoadedBuildUnit]
   ): StructureIndex = {
     val keys = Index.allKeys(settings)
     val attributeKeys = Index.attributeKeys(data) ++ keys.map(_.key)
@@ -331,7 +330,6 @@ private[sbt] object Load {
     val configsMap: Map[String, Seq[Configuration]] =
       projects.values.flatMap(bu => bu.defined map { case (k, v) => (k, v.configurations) }).toMap
     val keyIndex = KeyIndex(scopedKeys.toVector, projectsMap, configsMap)
-    checkConfigurations(keyIndex, log)
     val aggIndex = KeyIndex.aggregate(scopedKeys.toVector, extra(keyIndex), projectsMap, configsMap)
     new StructureIndex(
       Index.stringToKeyMap(attributeKeys),
@@ -342,33 +340,14 @@ private[sbt] object Load {
     )
   }
 
-  private def checkConfigurations(keyIndex: KeyIndex, log: Logger): Unit = {
-    keyIndex.guessedConfigIdents
-      .collect {
-        // Filter out any global configurations since we don't have a way of fixing them.
-        // Chances are this is only going to be the Test configuration which will have guessed correctly.
-        case (Some(projectRef), config, guess) =>
-          (Reference.display(projectRef), config, guess)
-      }
-      .foreach {
-        case (project, config, guess) =>
-          log.warn(
-            s"""The project $project references an unknown configuration "$config" and was guessed to be "$guess"."""
-          )
-          log.warn("This configuration should be explicitly added to the project.")
-      }
-  }
-
   // Reevaluates settings after modifying them.  Does not recompile or reload any build components.
-  def reapply(
-      newSettings: Seq[Setting[_]],
-      structure: BuildStructure,
-      log: Logger
-  )(implicit display: Show[ScopedKey[_]]): BuildStructure = {
+  def reapply(newSettings: Seq[Setting[_]], structure: BuildStructure)(
+      implicit display: Show[ScopedKey[_]]
+  ): BuildStructure = {
     val transformed = finalTransforms(newSettings)
     val newData = Def.make(transformed)(structure.delegates, structure.scopeLocal, display)
     def extra(index: KeyIndex) = BuildUtil(structure.root, structure.units, index, newData)
-    val newIndex = structureIndex(newData, transformed, extra, structure.units, log)
+    val newIndex = structureIndex(newData, transformed, extra, structure.units)
     val newStreams = mkStreams(structure.units, structure.root, newData)
     new BuildStructure(
       units = structure.units,
@@ -380,6 +359,15 @@ private[sbt] object Load {
       delegates = structure.delegates,
       scopeLocal = structure.scopeLocal
     )
+  }
+
+  @deprecated("No longer used. For binary compatibility", "1.2.1")
+  def reapply(
+      newSettings: Seq[Setting[_]],
+      structure: BuildStructure,
+      log: Logger
+  )(implicit display: Show[ScopedKey[_]]): BuildStructure = {
+    reapply(newSettings, structure)
   }
 
   def buildConfigurations(

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -65,7 +65,7 @@ object Script {
         scriptSettings ++ embeddedSettings
       )
 
-      val newStructure = Load.reapply(session.original ++ append, structure, state.log)
+      val newStructure = Load.reapply(session.original ++ append, structure)
       val arguments = state.remainingCommands.drop(1).map(e => s""""${e.commandLine}"""")
       val newState = arguments.mkString("run ", " ", "") :: state.copy(remainingCommands = Nil)
       Project.setProject(session, newStructure, newState)

--- a/main/src/test/scala/PluginCommandTest.scala
+++ b/main/src/test/scala/PluginCommandTest.scala
@@ -104,7 +104,7 @@ object FakeState {
     val extra: KeyIndex => BuildUtil[_] = (keyIndex) =>
       BuildUtil(base.toURI, Map.empty, keyIndex, data)
     val structureIndex: StructureIndex =
-      Load.structureIndex(data, settings, extra, Map.empty, Logger.Null)
+      Load.structureIndex(data, settings, extra, Map.empty)
     val streams: (State) => BuildStreams.Streams = null
 
     val loadedDefinitions: LoadedDefinitions = new LoadedDefinitions(

--- a/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
+++ b/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
@@ -174,7 +174,7 @@ object SettingQueryTest extends org.specs2.mutable.Specification {
     val data: Settings[Scope] = Def.make(settings)(delegates, scopeLocal, display)
     val extra: KeyIndex => BuildUtil[_] = index => BuildUtil(baseUri, units, index, data)
 
-    val index: StructureIndex = structureIndex(data, settings, extra, units, Logger.Null)
+    val index: StructureIndex = structureIndex(data, settings, extra, units)
     val streams: State => Streams = mkStreams(units, baseUri, data)
 
     val structure: BuildStructure =


### PR DESCRIPTION
Fixes #4293
Ref #4231, #4065

This fixes the regression on sbt 1.2.0 that displays a lot of warnings about configurations.

The warning was added in #4231 in an attempt to fix #4065. This actually highlights somewhat loose usage of configurations among the builds in the wild, and the limitation on the current slash syntax implementation.

I think we can remove this warning for now, and try to fix #4065 by making slash syntax more robust. In particular, we need to memorize the mapping between the configuration name and Scala identifier across the entire build, and use that in the shell.
