### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ val mimaSettings = Def settings (
     }.toSet
   },
   mimaBinaryIssueFilters ++= Seq(
-    // Changes in the internal pacakge
+    // Changes in the internal package
     exclude[DirectMissingMethodProblem]("sbt.internal.*"),
     exclude[FinalClassProblem]("sbt.internal.*"),
     exclude[FinalMethodProblem]("sbt.internal.*"),

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -920,8 +920,8 @@ private final class Repeat[T](
     max: UpperBound,
     accumulatedReverse: List[T]
 ) extends ValidParser[Seq[T]] {
-  assume(0 <= min, "Minimum occurences must be non-negative")
-  assume(max >= min, "Minimum occurences must be less than the maximum occurences")
+  assume(0 <= min, "Minimum occurrences must be non-negative")
+  assume(max >= min, "Minimum occurrences must be less than the maximum occurrences")
 
   def derive(c: Char) =
     partial match {

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -194,7 +194,7 @@ trait Parsers {
   private[this] def toInt(neg: Option[Char], digits: Seq[Char]): Int =
     (neg.toSeq ++ digits).mkString.toInt
 
-  /** Parses the lower-case values `true` and `false` into their respesct Boolean values.  */
+  /** Parses the lower-case values `true` and `false` into their corresponding Boolean values.  */
   lazy val Bool = ("true" ^^^ true) | ("false" ^^^ false)
 
   /**

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/UpperBound.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/UpperBound.scala
@@ -49,7 +49,7 @@ case object Infinite extends UpperBound {
  *  It must positive.
  */
 final case class Finite(value: Int) extends UpperBound {
-  assume(value >= 0, "Maximum occurences must be nonnegative.")
+  assume(value >= 0, "Maximum occurrences must be nonnegative.")
 
   def >=(min: Int) = value >= min
   def isOne = value == 1

--- a/internal/util-logic/src/test/scala/sbt/logic/Test.scala
+++ b/internal/util-logic/src/test/scala/sbt/logic/Test.scala
@@ -20,7 +20,7 @@ object LogicTest extends Properties("Logic") {
   property("Handles cycles without negation") = secure(expect(cycles, Set(F, A, B)))
   property("Handles basic exclusion.") = secure(expect(excludedPos, Set()))
   property("Handles exclusion of head proved by negation.") = secure(expect(excludedNeg, Set()))
-  // TODO: actually check ordering, probably as part of a check that dependencies are satisifed
+  // TODO: actually check ordering, probably as part of a check that dependencies are satisfied
   property("Properly orders results.") = secure(expect(ordering, Set(B, A, C, E, F)))
   property("Detects cyclic negation") = secure(
     Logic.reduceAll(badClauses, Set()) match {

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -90,7 +90,7 @@ object Tags {
   /** Returns a Rule that limits the maximum number of concurrently executing tasks without a tag to `max`.  */
   def limitUntagged(max: Int): Rule = limit(Untagged, max)
 
-  /** Returns a Rule that limits the maximum number of concurrent executings tasks tagged with `tag` to `max`.*/
+  /** Returns a Rule that limits the maximum number of concurrent executing tasks tagged with `tag` to `max`.*/
   def limit(tag: Tag, max: Int): Rule = new Single(tag, max)
 
   def limitSum(max: Int, tags: Tag*): Rule = new Sum(tags, max)

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -20,7 +20,7 @@ import TaskName._
  * - -Dsbt.task.timings.on.shutdown=true|false
  * - -Dsbt.task.timings.unit=number
  * - -Dsbt.task.timings.threshold=number
- * @param shutdown    Should the report be given when exiting the JVM (true) or immediatelly (false)?
+ * @param shutdown    Should the report be given when exiting the JVM (true) or immediately (false)?
  */
 private[sbt] final class TaskTimings(shutdown: Boolean) extends ExecuteProgress[Task] {
   private[this] val calledBy = new ConcurrentHashMap[Task[_], Task[_]]

--- a/notes/0.13.16.markdown
+++ b/notes/0.13.16.markdown
@@ -41,7 +41,7 @@ In sbt 0.13.15, in addition to notifying the user about the existence of sbt's s
 allow the user to switch to sbt's shell - a more pro-active approach to just displaying a message.
 
 Unfortunately sbt is often unintentionally invoked in shell scripts in "interactive mode" when no interaction is
-expected by, for exmaple, invoking `sbt package` instead of `sbt package < /dev/null`. In that case hitting
+expected by, for example, invoking `sbt package` instead of `sbt package < /dev/null`. In that case hitting
 \[ENTER\] would silently trigger sbt to run its shell, easily wrecking the script. In addition to that I was
 unhappy with the implementation as it created a tight coupling between sbt's command processing abstraction to
 sbt's shell command.

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -130,7 +130,7 @@ and stale JSON files will be cleaned up after few days.
 
 sbt 0.13.9 also fixes a correctness issue that was found in the earlier releases.
 Under some circumstances, libraries that shouldn't have been evicted was being evicted.
-This occured when library `A1` depended on `B2`, but a newer `A2` dropped the dependency,
+This occurred when library `A1` depended on `B2`, but a newer `A2` dropped the dependency,
 and `A2` and `B1` are also is in the graph. This is fixed by sorting the graph prior to eviction.
 
 [#2030][2030]/[#1721][1721]/[#2014][2014]/[#2046][2046]/[#2097][2097]/[#2129][2129] by [@eed3si9n][@eed3si9n]

--- a/notes/1.0.1.markdown
+++ b/notes/1.0.1.markdown
@@ -6,12 +6,12 @@ This is a hotfix release for sbt 1.0.x series.
 
 ### Bug fixes
 
-- Fixes command support for cross building `+` command. The `+` added to sbt 1.0 traveres over the subprojects, respecting `crossScalaVersions`; however, it no longer accepted commands as arguments. This brings back the support for it. [#3446][3446] by [@jroper][@jroper]
+- Fixes command support for cross building `+` command. The `+` added to sbt 1.0 traverses over the subprojects, respecting `crossScalaVersions`; however, it no longer accepted commands as arguments. This brings back the support for it. [#3446][3446] by [@jroper][@jroper]
 - Fixes `addSbtPlugin` to use the correct version of sbt during cross building. [#3442][3442] by [@dwijnand][@dwijnand]
 - Fixes `run in Compile` task not including `Runtime` configuration, by reimplementing `run` in terms of `bgRun`. [#3477][3477] by [@eed3si9n][@eed3si9n]
 - Shows `actual` as a potential option of `inspect` [#3335][3335] by [@Duhemm][@Duhemm]
 - Includes base directory to watched sources. [#3439][3439] by [@Duhemm][@Duhemm]
-- Adds an attempt to workaround intermittent `NullPointerException` arround logging. [util#121][util121] by [@eed3si9n][@eed3si9n]
+- Adds an attempt to workaround intermittent `NullPointerException` around logging. [util#121][util121] by [@eed3si9n][@eed3si9n]
 - Reverts a bad forward porting. [#3481][3481] by [@eed3si9n][@eed3si9n]
 
 ### WatchSource
@@ -20,7 +20,7 @@ The watch source feature went through a major change from sbt 0.13 to sbt 1.0 us
 
 First, `sbt.WatchSource` is a new alias for `sbt.internal.io.Source`. Hopefully this is easy enough to remember because the key is named `watchSources`. Next, `def apply(base: File)` and `def apply(base: File, includeFilter: FileFilter, excludeFilter: FileFilter)` constructors were added to the companion object of `sbt.WatchSource`.
 
-For backward compatiblity, sbt 1.0.1 adds `+=` support (`Append` instance) from `File` to `Seq[WatchSource]`.
+For backward compatibility, sbt 1.0.1 adds `+=` support (`Append` instance) from `File` to `Seq[WatchSource]`.
 
 So, if you have a directory you want to watch:
 


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

In this pull request, I've modified the past release notes as well. If changing them afterward is not appropriate, I will revert the changes. 

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines

```
$ misspell .
build.sbt:89:31: "pacakge" is a misspelling of "package"
internal/util-complete/src/main/scala/sbt/internal/util/complete/UpperBound.scala:52:30: "occurences" is a misspelling of "occurrences"
internal/util-logic/src/test/scala/sbt/logic/Test.scala:23:86: "satisifed" is a misspelling of "satisfied"
internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala:197:65: "respesct" is a misspelling of "respects"
internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala:923:28: "occurences" is a misspelling of "occurrences"
internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala:924:30: "occurences" is a misspelling of "occurrences"
internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala:924:71: "occurences" is a misspelling of "occurrences"
main/src/main/scala/sbt/EvaluateTask.scala:436:8: "strat" is a misspelling of "start"
main/src/main/scala/sbt/Tags.scala:93:66: "executings" is a misspelling of "executions"
main/src/main/scala/sbt/internal/TaskTimings.scala:23:80: "immediatelly" is a misspelling of "immediately"
notes/0.13.16.markdown:44:17: "exmaple" is a misspelling of "example"
notes/0.13.9.markdown:133:5: "occured" is a misspelling of "occurred"
notes/1.0.1.markdown:9:81: "traveres" is a misspelling of "traverse"
notes/1.0.1.markdown:14:68: "arround" is a misspelling of "around"
notes/1.0.1.markdown:23:13: "compatiblity" is a misspelling of "compatibility"
```