### PR TITLE
Support discovering JDK 11 in JAVA_HOME for CrossJava

### DIFF
--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -369,8 +369,7 @@ private[sbt] object CrossJava {
           }
     }
 
-    class WindowsDiscoverConfig extends JavaDiscoverConf {
-      val base: File = file("C://Program Files/Java")
+    class WindowsDiscoverConfig(base: File) extends JavaDiscoverConf {
 
       def candidates() = wrapNull(base.list())
 
@@ -403,7 +402,8 @@ private[sbt] object CrossJava {
       new LinuxDiscoverConfig(file("/usr") / "java"),
       new LinuxDiscoverConfig(file("/usr") / "lib" / "jvm"),
       new MacOsDiscoverConfig,
-      new WindowsDiscoverConfig,
+      new WindowsDiscoverConfig(file("C://Program Files/Java")),
+      new WindowsDiscoverConfig(file("C://Program Files (x86)/Java")),
       new JavaHomeDiscoverConfig,
     )
   }

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -331,11 +331,13 @@ private[sbt] object CrossJava {
   }
 
   object JavaDiscoverConfig {
+    private val JavaHomeDir = """(java-|jdk-?)(1\.)?([0-9]+).*""".r
+
     class LinuxDiscoverConfig(base: File) extends JavaDiscoverConf {
-      def candidates = wrapNull(base.list())
-      val JavaHomeDir = """(java-|jdk)(1\.)?([0-9]+).*""".r
+      def candidates() = wrapNull(base.list())
+
       def javaHomes: Vector[(String, File)] =
-        candidates
+        candidates()
           .collect {
             case dir @ JavaHomeDir(_, m, n) =>
               JavaVersion(nullBlank(m) + n).toString -> (base / dir)
@@ -344,11 +346,11 @@ private[sbt] object CrossJava {
 
     class MacOsDiscoverConfig extends JavaDiscoverConf {
       val base: File = file("/Library") / "Java" / "JavaVirtualMachines"
-      val JavaHomeDir = """jdk-?(1\.)?([0-9]+).*""".r
+
       def javaHomes: Vector[(String, File)] =
         wrapNull(base.list())
           .collect {
-            case dir @ JavaHomeDir(m, n) =>
+            case dir @ JavaHomeDir(_, m, n) =>
               JavaVersion(nullBlank(m) + n).toString -> (base / dir / "Contents" / "Home")
           }
     }
@@ -367,11 +369,42 @@ private[sbt] object CrossJava {
           }
     }
 
+    class WindowsDiscoverConfig extends JavaDiscoverConf {
+      val base: File = file("C://Program Files/Java")
+
+      def candidates() = wrapNull(base.list())
+
+      def javaHomes: Vector[(String, File)] =
+        candidates()
+          .collect {
+            case dir @ JavaHomeDir(_, m, n) =>
+              JavaVersion(nullBlank(m) + n).toString -> (base / dir)
+          }
+    }
+
+    class JavaHomeDiscoverConfig extends JavaDiscoverConf {
+      def home() = sys.env.get("JAVA_HOME")
+      def javaHomes: Vector[(String, File)] =
+        home()
+          .map(new java.io.File(_))
+          .flatMap { javaHome =>
+            val base = javaHome.getParentFile
+            javaHome.getName match {
+              case dir @ JavaHomeDir(_, m, n) =>
+                Some(JavaVersion(nullBlank(m) + n).toString -> (base / dir))
+              case _ => None
+            }
+          }
+          .toVector
+    }
+
     val configs = Vector(
       new JabbaDiscoverConfig,
       new LinuxDiscoverConfig(file("/usr") / "java"),
       new LinuxDiscoverConfig(file("/usr") / "lib" / "jvm"),
-      new MacOsDiscoverConfig
+      new MacOsDiscoverConfig,
+      new WindowsDiscoverConfig,
+      new JavaHomeDiscoverConfig,
     )
   }
 

--- a/main/src/test/scala/sbt/internal/CrossJavaTest.scala
+++ b/main/src/test/scala/sbt/internal/CrossJavaTest.scala
@@ -52,7 +52,7 @@ class CrossJavaTest extends Specification {
 
   "The Windows Java home selector" should {
     "correctly pick up a JDK" in {
-      val conf = new WindowsDiscoverConfig {
+      val conf = new WindowsDiscoverConfig(sbt.io.syntax.file(".")) {
         override def candidates() = Vector("jdk1.7.0")
       }
       val (version, file) = conf.javaHomes.sortWith(CrossJava.versionOrder).last

--- a/main/src/test/scala/sbt/internal/CrossJavaTest.scala
+++ b/main/src/test/scala/sbt/internal/CrossJavaTest.scala
@@ -8,7 +8,7 @@
 package sbt.internal
 
 import org.specs2.mutable.Specification
-import sbt.internal.CrossJava.JavaDiscoverConfig.LinuxDiscoverConfig
+import sbt.internal.CrossJava.JavaDiscoverConfig._
 
 class CrossJavaTest extends Specification {
   "The Java home selector" should {
@@ -22,7 +22,7 @@ class CrossJavaTest extends Specification {
   "The Linux Java home selector" should {
     "correctly pick up fedora java installations" in {
       val conf = new LinuxDiscoverConfig(sbt.io.syntax.file(".")) {
-        override def candidates: Vector[String] =
+        override def candidates(): Vector[String] =
           """
             |java-1.8.0-openjdk-1.8.0.162-3.b12.fc28.x86_64
             |java-1.8.0-openjdk-1.8.0.172-9.b11.fc28.x86_64
@@ -42,11 +42,33 @@ class CrossJavaTest extends Specification {
 
     "correctly pick up Oracle RPM installations" in {
       val conf = new LinuxDiscoverConfig(sbt.io.syntax.file(".")) {
-        override def candidates: Vector[String] = Vector("jdk1.8.0_172-amd64")
+        override def candidates(): Vector[String] = Vector("jdk1.8.0_172-amd64")
       }
       val (version, file) = conf.javaHomes.sortWith(CrossJava.versionOrder).last
       version must be equalTo ("1.8")
       file.getName must be equalTo ("jdk1.8.0_172-amd64")
+    }
+  }
+
+  "The Windows Java home selector" should {
+    "correctly pick up a JDK" in {
+      val conf = new WindowsDiscoverConfig {
+        override def candidates() = Vector("jdk1.7.0")
+      }
+      val (version, file) = conf.javaHomes.sortWith(CrossJava.versionOrder).last
+      version must equalTo("1.7")
+      file.getName must be equalTo ("jdk1.7.0")
+    }
+  }
+
+  "The JAVA_HOME selector" should {
+    "correctly pick up a JDK " in {
+      val conf = new JavaHomeDiscoverConfig {
+        override def home() = Some("/opt/jdk8")
+      }
+      val (version, file) = conf.javaHomes.sortWith(CrossJava.versionOrder).last
+      version must equalTo("8")
+      file.getName must be equalTo ("jdk8")
     }
   }
 }


### PR DESCRIPTION
* Allow an optional '-' after the 'jdk' prefix in the directory name
* Allow discovering JDK's in `$JAVA_HOME`
* Allow discovering JDK's in `C://Program Files/Java`

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
