### PR TITLE
Allow same file to be packaged more than once

### DIFF
--- a/notes/1.3.0/enable-multiple-source-file-in-mappings.md
+++ b/notes/1.3.0/enable-multiple-source-file-in-mappings.md
@@ -1,0 +1,9 @@
+[@muuki88]: https://github.com/muuki88
+[@gutefrageIT]: https://twitter.com/gutefrageIT
+
+[#1972]: https://github.com/sbt/sbt/issues/1972
+[#4329]: https://github.com/sbt/sbt/pull/4329
+
+### Bug Fixes
+
+- Enable packaging of the same file more than once  [#1972][]/[#4329][] by [@muuki88][] (sponsored by [@gutefrageIT][])

--- a/sbt/src/sbt-test/package/mappings/build.sbt
+++ b/sbt/src/sbt-test/package/mappings/build.sbt
@@ -1,0 +1,16 @@
+name := "Mappings Test"
+
+version := "0.2"
+
+mappings in (Compile, packageBin) ++= {
+  val test = file("test")
+  Seq(
+    test -> "test1",
+    test -> "test2"
+  )
+}
+
+lazy val unzipPackage = taskKey[Unit]("extract jar file")
+unzipPackage := {
+  IO.unzip((packageBin in Compile).value, target.value / "extracted")
+}

--- a/sbt/src/sbt-test/package/mappings/test
+++ b/sbt/src/sbt-test/package/mappings/test
@@ -1,0 +1,3 @@
+> unzipPackage
+$ exists target/extracted/test2
+$ exists target/extracted/test1


### PR DESCRIPTION
Allow files to be packaged more than once. This works now as expected

```scala
mappings ++= Seq(
  foo -> "foo1",
  foo -> "foo2"
)
```