### PR TITLE
Add an implicit class for StateOps

### DIFF
--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -61,7 +61,7 @@ trait Identity {
 }
 
 /** Convenience methods for State transformations and operations. */
-trait StateOps {
+trait StateOps extends Any {
   def process(f: (Exec, State) => State): State
 
   /** Schedules `commands` to be run before any remaining commands.*/
@@ -233,8 +233,11 @@ object State {
     )
   }
 
+  @deprecated("Import State._ or State.StateOpsImpl to access state extension methods", "1.3.0")
+  def stateOps(s: State): StateOps = new StateOpsImpl(s)
+
   /** Provides operations and transformations on State. */
-  implicit def stateOps(s: State): StateOps = new StateOps {
+  implicit class StateOpsImpl(val s: State) extends AnyVal with StateOps {
     def process(f: (Exec, State) => State): State = {
       def runCmd(cmd: Exec, remainingCommands: List[Exec]) = {
         log.debug(s"> $cmd")


### PR DESCRIPTION
The State file in intellij was littered with red squiggly lines wherever
the extension methods of State called a different extension method of
State.  These went away when I switched to an implicit class, which is
the preferred way of adding extension methods since scala 2.10. As a
bonus, I was able to switch the implicit class to be a value class, so
it should not actually make a new object in most use cases.

I had to re-implement the stateOps method to delegate to the implicit
class for binary compatibility.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md) guidelines
