### PR TITLE
sbt-4038 add regression test for fork-options

### DIFF
--- a/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
@@ -1,0 +1,31 @@
+// test setup
+lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+lazy val SlowTests = config("slowtests").extend(Test)
+
+configs(SlowTests)
+inConfig(SlowTests)(Defaults.testSettings)
+name := "fork-options-custom-config-test"
+
+libraryDependencies += scalaTest % Test
+
+SlowTests / javaOptions += "-Dtest.init.fail=true"
+
+// assertions
+lazy val check = taskKey[Unit]("check")
+check := {
+  val slowtestJavaOptions = (SlowTests / javaOptions).value
+  val slowtestJavaOptionsInTest = (SlowTests / test / javaOptions).value
+  val slowtestJavaOptionsInRun = (SlowTests / run / javaOptions).value
+  val slowtestForkOptions = (SlowTests / forkOptions).value
+  val slowtestForkOptionsInTest = (SlowTests / test / forkOptions).value
+  val slowtestForkOptionsInRun = (SlowTests / run / forkOptions).value
+  val testForkOptions = (Test / forkOptions).value
+
+  assert(slowtestJavaOptions.nonEmpty, "Slowtests / javaOptions should not be empty")
+  assert(slowtestJavaOptionsInTest.nonEmpty, "Slowtests / test / javaOptions should not be empty")
+  assert(slowtestJavaOptionsInRun.nonEmpty, "Slowtests / run / javaOptions should not be empty")
+  assert(slowtestForkOptions.runJVMOptions.nonEmpty, "(Slowtests / forkOptions).runJVMOptions should not be empty")
+  assert(slowtestForkOptionsInTest.runJVMOptions.nonEmpty, "Slowtests / test / forkOptions).runJVMOptions should not be empty")
+  assert(slowtestForkOptionsInRun.runJVMOptions.nonEmpty, "Slowtests / run / forkOptions).runJVMOptions should not be empty")
+  assert(testForkOptions.runJVMOptions.isEmpty, "test forkOptions should be empty")
+}

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
@@ -8,6 +8,10 @@ name := "fork-options-custom-config-test"
 
 libraryDependencies += scalaTest % Test
 
+// fork processes so the forkOptions kick in
+fork := true
+
+// make the test fail in "SlowTests / test"
 SlowTests / javaOptions += "-Dtest.init.fail=true"
 
 // assertions

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/build.sbt
@@ -32,4 +32,14 @@ check := {
   assert(slowtestForkOptionsInTest.runJVMOptions.nonEmpty, "Slowtests / test / forkOptions).runJVMOptions should not be empty")
   assert(slowtestForkOptionsInRun.runJVMOptions.nonEmpty, "Slowtests / run / forkOptions).runJVMOptions should not be empty")
   assert(testForkOptions.runJVMOptions.isEmpty, "test forkOptions should be empty")
+
+  // check if tests are properly detected
+  val testTestNames = (Test / definedTestNames).value
+  val slowtestTestNames = (SlowTests / definedTestNames).value
+
+  assert(testTestNames.length == 1, "Test / definedTestNames has no entries. Should have one entry 'foo.test.FooTest'")
+  assert(testTestNames.head == "foo.test.FooTest", "Test / definedTestNames one entry 'foo.test.FooTest'")
+  assert(slowtestTestNames.length == 1, "SlowTests / definedTestNames has no entries. Should have one entry 'foo.test.FooTest'")
+  assert(slowtestTestNames.head == "foo.test.FooTest", "SlowTests / definedTestNames one entry 'foo.test.FooTest'")
+
 }

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/src/main/scala/Foo.scala
@@ -1,0 +1,3 @@
+package foo.test
+
+object Foo { val foo = 5 }

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/src/test/scala/FooTest.scala
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/src/test/scala/FooTest.scala
@@ -1,0 +1,15 @@
+package foo.test
+
+import org.scalatest._
+
+class FooTest extends FunSpec with Matchers {
+
+	if(java.lang.Boolean.getBoolean("test.init.fail"))
+		sys.error("exception during construction")
+
+	describe("Foo.foo should") {
+		it("always return 5") {
+			Foo.foo should equal (5)
+		}
+	}
+}

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/test
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/test
@@ -1,3 +1,3 @@
 > check
 > test
--> slowtests:test
+-> Slowtests / test

--- a/sbt/src/sbt-test/tests/fork-options-custom-config/test
+++ b/sbt/src/sbt-test/tests/fork-options-custom-config/test
@@ -1,0 +1,3 @@
+> check
+> test
+-> slowtests:test


### PR DESCRIPTION
This pull request adds a regression test for #4038 

I noticed a couple of things

It's unlikely that 0419098d655a574cb81821786538a1955c68850a introduced this regression. The new default `forkOptions := forkOptionsTask.value` is set `Defaults.configTasks`, which isn't used by `Defaults.testTasks`. I wonder how things worked before. You should always use `inConfig(SlowTests)(Defaults.testSettings)` otherwise all the test related settings aren't set and sbt tries to resolve the values somewhere else. In the given regression test it would be the `Test` scope as `config("slowtests").extends(Test)`.

The change in [74cfbd4a9ca162dbe9d6fc236ac19671ff16d951](https://github.com/sbt/sbt/commit/74cfbd4a9ca162dbe9d6fc236ac19671ff16d951#diff-6373e7f7122325e753b75fe1cc76ff5fR1166) introduces the `forkOptions` to the `run` configuration, which are used in various places. Not sure if this could be related as well.

The regression test checks for the `javaOptions` and `runJVMOptions` to be set. This works fine when `Defaults.testSettings` are used. However the actual executed test doesn't seem to use the `javaOptions`.

- [ ] Document `inConfig(SlowTests)(Defaults.testSettings)` 
- [ ] Fix `javaOptions` not being available in the executed test

