### PR TITLE
[1.2.x] Fix second part of #4091: server responses should not be broadcasted

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,9 +9,9 @@ object Dependencies {
 
   // sbt modules
   private val ioVersion = "1.2.1"
-  private val utilVersion = "1.2.0"
-  private val lmVersion = "1.2.0"
-  private val zincVersion = "1.2.1"
+  private val utilVersion = "1.2.2"
+  private val lmVersion = "1.2.1"
+  private val zincVersion = "1.2.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 


### PR DESCRIPTION
Backport https://github.com/sbt/sbt/pull/4346 and bump modules.
