### PR TITLE
Fixes #4375

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -930,10 +930,7 @@ private[sbt] object Load {
           )
         case Nil if makeOrDiscoverRoot =>
           log.debug(s"[Loading] Scanning directory ${buildBase}")
-          val auto =
-            if (context.globalPluginProject)
-              AddSettings.seq(AddSettings.defaultSbtFiles, AddSettings.sbtFiles(extraSbtFiles: _*))
-            else AddSettings.defaultSbtFiles
+          val auto = AddSettings.seq(AddSettings.defaultSbtFiles, AddSettings.sbtFiles(extraSbtFiles: _*))
           discover(auto, buildBase) match {
             case DiscoveredProjects(Some(root), discovered, files, generated) =>
               log.debug(


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines

I notice that there is not a test project to exercise the `--addPluginSbtFile` option.
I think it would make sense to add one in `sbt/src/sbt-test/project`; however, I'm not sure if the scripted machinery supports this, and if it does, how to write such a test.
