### PR TITLE
[1.2.x] Duplicate reports for backwards-compat adding a name-compliant copy

### DIFF
--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -226,9 +226,11 @@ class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends Tests
     d.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
   private def writeSuite() = {
-    val file = new File(targetDir, s"${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
+    val legacyFile = new File(targetDir, s"${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
+    val file = new File(targetDir, s"TEST-${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
     // TODO would be nice to have a logger and log this with level debug
     // System.err.println("Writing JUnit XML test report: " + file)
+    XML.save(legacyFile, withTestSuite(_.stop()), "UTF-8", true, null)
     XML.save(file, withTestSuite(_.stop()), "UTF-8", true, null)
     testSuite.remove()
   }


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/4343
This issue is expedited via the Lightbend subscription.

## original description

Fixes #3150 by duplicating the reports generated so given a test `com.example.MyTest.java` the following will be created:

 - `com.example.MyTest.xml`
 - `TEST-com.example.MyTest.xml`

I used this approach so tooling that expects the report to not have the `TEST-` prefix still works and we could mark that filename as deprecated.
