### PR TITLE
ThisBuild / semanticdbEnabled

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -443,6 +443,7 @@ object Defaults extends BuildCommon {
   def addBaseSources = FileManagement.appendBaseSources
   lazy val outputConfigPaths = Seq(
     classDirectory := crossTarget.value / (prefix(configuration.value.name) + "classes"),
+    semanticdbTargetRoot := crossTarget.value / (prefix(configuration.value.name) + "meta"),
     target in doc := crossTarget.value / (prefix(configuration.value.name) + "api")
   )
 
@@ -3328,6 +3329,8 @@ object Classpaths {
     }
   }
 }
+
+private[sbt] object Build0 extends BuildExtra
 
 trait BuildExtra extends BuildCommon with DefExtra {
   import Defaults._

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -243,6 +243,12 @@ object Keys {
   val scalaArtifacts = settingKey[Seq[String]]("Configures the list of artifacts which should match the Scala binary version").withRank(CSetting)
   val enableBinaryCompileAnalysis = settingKey[Boolean]("Writes the analysis file in binary format")
   val crossJavaVersions = settingKey[Seq[String]]("The java versions used during JDK cross testing").withRank(BPlusSetting)
+  val semanticdbEnabled = settingKey[Boolean]("Enables SemanticDB Scalac plugin").withRank(CSetting)
+  val semanticdbCompilerPlugin = settingKey[ModuleID]("SemanticDB Scalac plugin").withRank(CSetting)
+  val semanticdbVersion = settingKey[String]("SemanticDB version").withRank(CSetting)
+  val semanticdbIncludeInJar = settingKey[Boolean]("Include *.semanticdb files in published artifacts").withRank(CSetting)
+  val semanticdbTargetRoot = settingKey[File]("The output directory to produce META-INF/semanticdb/**/*.semanticdb files").withRank(CSetting)
+  val semanticdbOptions = settingKey[Seq[String]]("The Scalac options introduced for SemanticDB").withRank(CSetting)
 
   val clean = taskKey[Unit]("Deletes files produced by the build, such as generated sources, compiled classes, and task caches.").withRank(APlusTask)
   val console = taskKey[Unit]("Starts the Scala interpreter with the project classes on the classpath.").withRank(APlusTask)

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -49,8 +49,9 @@ object PluginDiscovery {
       "sbt.plugins.CorePlugin" -> sbt.plugins.CorePlugin,
       "sbt.ScriptedPlugin" -> sbt.ScriptedPlugin,
       "sbt.plugins.SbtPlugin" -> sbt.plugins.SbtPlugin,
+      "sbt.plugins.SemanticdbPlugin" -> sbt.plugins.SemanticdbPlugin,
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
-      "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin
+      "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin,
     )
     val detectedAutoPlugins = discover[AutoPlugin](AutoPlugins)
     val allAutoPlugins = (defaultAutoPlugins ++ detectedAutoPlugins.modules) map {

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -1,0 +1,58 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+import Keys._
+import sbt.librarymanagement.syntax._
+import sbt.librarymanagement.CrossVersion
+import Project.inConfig
+
+object SemanticdbPlugin extends AutoPlugin {
+  override def requires = JvmPlugin
+  override def trigger = allRequirements
+
+  override lazy val globalSettings = Seq(
+    semanticdbEnabled := false,
+    semanticdbIncludeInJar := false,
+    semanticdbOptions := List("-Yrangepos"),
+    semanticdbVersion := "4.0.0",
+    semanticdbCompilerPlugin := {
+      val v = semanticdbVersion.value
+      ("org.scalameta" % "semanticdb-scalac" % v).cross(CrossVersion.full)
+    }
+  )
+
+  override lazy val projectSettings = Seq(
+    allDependencies ++= {
+      val sdb = semanticdbEnabled.value
+      val m = semanticdbCompilerPlugin.value
+      if (sdb) List(Build0.compilerPlugin(m))
+      else Nil
+    }
+  ) ++ inConfig(Compile)(configurationSettings) ++ inConfig(Test)(configurationSettings)
+
+  lazy val configurationSettings: Seq[Def.Setting[_]] = List(
+    scalacOptions := {
+      val old = scalacOptions.value
+      val sdb = semanticdbEnabled.value
+      val sdbOptions = semanticdbOptions.value
+      if (sdb) (old.toVector ++ sdbOptions.toVector).distinct
+      else old
+    },
+    semanticdbTargetRoot := {
+      val in = semanticdbIncludeInJar.value
+      if (in) classDirectory.value
+      else semanticdbTargetRoot.value
+    },
+    semanticdbOptions ++= {
+      val tr = semanticdbTargetRoot.value
+      List(s"-P:semanticdb:targetroot:$tr")
+    }
+  )
+}

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -30,6 +30,7 @@ object Util {
       "0",
       "-language:existentials",
       "-language:postfixOps",
+      "-Yrangepos",
     ),
     Compile / doc / scalacOptions -= "-Xlint",
     Compile / doc / scalacOptions -= "-Xfatal-warnings",

--- a/sbt/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt/src/sbt-test/project/semanticdb/build.sbt
@@ -1,0 +1,5 @@
+ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbIncludeInJar := true
+
+lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/project/semanticdb/src/main/scala/foo/Test.scala
+++ b/sbt/src/sbt-test/project/semanticdb/src/main/scala/foo/Test.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println("hello world")
+  }
+}

--- a/sbt/src/sbt-test/project/semanticdb/test
+++ b/sbt/src/sbt-test/project/semanticdb/test
@@ -1,0 +1,2 @@
+> compile
+$ exists target/scala-2.12/classes/META-INF/semanticdb/src/main/scala/foo/Test.scala.semanticdb


### PR DESCRIPTION
This enables SemanticDB build-wide with a single line:

```scala
ThisBuild / scalaVersion := "2.12.7"
ThisBuild / semanticdbEnabled := true

 lazy val root = (project in file("."))
```

SemanticDB currently requires per-subproject settings. This makes it easier to enable it build-wide for multi-project build.

Another motivation is so various tool chains that need SemanticDB to coordinate whether it is available or not.