### PR TITLE
Fix windows reload loop

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -621,14 +621,8 @@ object Defaults extends BuildCommon {
     consoleProject := consoleProjectTask.value,
     watchTransitiveSources := watchTransitiveSourcesTask.value,
     watchProjectTransitiveSources := watchTransitiveSourcesTaskImpl(watchProjectSources).value,
-    watchOnEvent := {
-      val sources = watchTransitiveSources.value
-      val projectSources = watchProjectTransitiveSources.value
-      e =>
-        if (sources.exists(_.accept(e.entry.typedPath.getPath))) Watched.Trigger
-        else if (projectSources.exists(_.accept(e.entry.typedPath.getPath))) Watched.Reload
-        else Watched.Ignore
-    },
+    watchOnEvent := Watched
+      .onEvent(watchTransitiveSources.value, watchProjectTransitiveSources.value),
     watchHandleInput := Watched.handleInput,
     watchPreWatch := { (_, _) =>
       Watched.Ignore


### PR DESCRIPTION
On windows* it was possible to get into a loop where the build would
continually restart because for some reason the build.sbt file would get
touched during test (I did not see this behavior on osx). Thankfully,
the repository keeps track of the file hash and when we detect that the
build file has been updated, we check the file hash to see if it
actually changed.

Note that had this bug shipped, it would have been fixable by overriding
the watchOnEvent task in user builds.

The loop would occur if I ran ~filesJVM/test in
https://github.com/swoval/swoval. It would not occur if I ran
test:compile, so the fact that the build file is being touched seems
to be related to the test run itself.

- [ ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
