### PR TITLE
[sbt-server] Refactor cancellations

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
@@ -13,6 +13,7 @@ import sjsonnew.JsonFormat
 import sbt.internal.protocol._
 import sbt.util.Logger
 import sbt.protocol.{ SettingQuery => Q, CompletionParams => CP }
+import sbt.internal.langserver.{ CancelRequestParams => CRP }
 
 /**
  * ServerHandler allows plugins to extend sbt server.
@@ -71,4 +72,5 @@ trait ServerCallback {
   private[sbt] def setInitialized(value: Boolean): Unit
   private[sbt] def onSettingQuery(execId: Option[String], req: Q): Unit
   private[sbt] def onCompletionRequest(execId: Option[String], cp: CP): Unit
+  private[sbt] def onCancellationRequest(execId: Option[String], crp: CRP): Unit
 }

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -384,7 +384,8 @@ object EvaluateTask {
     )
 
   val lastEvaluatedState: AtomicReference[SafeState] = new AtomicReference()
-  val currentlyRunningEngine: AtomicReference[(State, RunningTaskEngine)] = new AtomicReference()
+  val currentlyRunningEngine: AtomicReference[(SafeState, RunningTaskEngine)] =
+    new AtomicReference()
 
   /**
    * The main method for the task engine.
@@ -445,7 +446,7 @@ object EvaluateTask {
         shutdown()
       }
     }
-    currentlyRunningEngine.set((state, runningEngine))
+    currentlyRunningEngine.set((SafeState(state), runningEngine))
     // Register with our cancel handler we're about to start.
     val strat = config.cancelStrategy
     val cancelState = strat.onTaskEngineStart(runningEngine)


### PR DESCRIPTION
- [X] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines

As promised this build on top of the other two PRs.
A refactoring of the Cancellation Requests handling.

This also make it clear why I kept the name `SafeState` @eed3si9n 