### PR TITLE
Close the current global file tree view on unload

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -883,7 +883,7 @@ object BuiltinCommands {
       val (_, config: FileTreeViewConfig) = extracted.runTask(Keys.fileTreeViewConfig, s)
       val view: FileTreeDataView[StampedFile] = config.newDataView()
       val newState = s.addExitHook {
-        view.close()
+        s.get(BasicKeys.globalFileTreeView).foreach(_.close())
         s.attributes.remove(BasicKeys.globalFileTreeView)
         ()
       }


### PR DESCRIPTION
I noticed that when using the latest nightly, triggered execution would
fail to work if I switched projects with, e.g. ++2.10.7. This was
because the background thread that filled the file cache was incorrectly shutdown.
To fix this, we just need to close whatever view is cached in the
globalFileTreeView attribute in the exit hook rather than the view
created by the method.

After making this change and publishing a local SNAPSHOT build, I was
able to switch projects with ++ and have triggeredExecution continue to
work.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
