### PR TITLE
Use the classpath obtained by the launcher for metabuild

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -172,6 +172,7 @@ object Defaults extends BuildCommon {
       testForkedParallel :== false,
       javaOptions :== Nil,
       sbtPlugin :== false,
+      isMetaBuild :== false,
       crossPaths :== true,
       sourcePositionMappers :== Nil,
       artifactClassifier in packageSrc :== Some(SourceClassifier),

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -234,6 +234,7 @@ object Keys {
   val classpathOptions = settingKey[ClasspathOptions]("Configures handling of Scala classpaths.").withRank(DSetting)
   val discoveredSbtPlugins = taskKey[PluginDiscovery.DiscoveredNames]("The names of sbt plugin-related modules (modules that extend Build, Plugin, AutoPlugin) defined by this project.").withRank(CTask)
   val sbtPlugin = settingKey[Boolean]("If true, enables adding sbt as a dependency and auto-generation of the plugin descriptor file.").withRank(BMinusSetting)
+  val isMetaBuild = settingKey[Boolean]("If true, this is a metabuild, a project inside project/ directory, and sbt is added to the classpath.").withRank(DSetting)
   val pluginCrossBuild = taskKey[Unit]("Dummy task to scope `sbtVersion in pluginCrossBuild`, which gets used for plugin compilation.")
   val crossSbtVersions = settingKey[Seq[String]]("The versions of Sbt used when cross-building an sbt plugin.")
   val printWarnings = taskKey[Unit]("Shows warnings from compilation, including ones that weren't printed initially.").withRank(BPlusTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -455,6 +455,7 @@ object Keys {
   val libraryDependencies = settingKey[Seq[ModuleID]]("Declares managed dependencies.").withRank(APlusSetting)
   val dependencyOverrides = settingKey[Seq[ModuleID]]("Declares managed dependency overrides.").withRank(BSetting)
   val excludeDependencies = settingKey[Seq[InclExclRule]]("Declares managed dependency exclusions.").withRank(BSetting)
+  val allExcludeDependencies = settingKey[Seq[InclExclRule]]("User-defined dependency exclusions and sbt itself in the case of metabuild.").withRank(CTask)
   val allDependencies = taskKey[Seq[ModuleID]]("Inter-project and library dependencies.").withRank(CTask)
   val projectDependencies = taskKey[Seq[ModuleID]]("Inter-project dependencies.").withRank(DTask)
   val ivyXML = settingKey[NodeSeq]("Defines inline Ivy XML for configuring dependency management.").withRank(BSetting)

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -22,6 +22,7 @@ import Keys.{
   exportedProducts,
   fullClasspath,
   fullResolvers,
+  isMetaBuild,
   loadedBuild,
   onLoadMessage,
   pluginData,
@@ -1180,6 +1181,7 @@ private[sbt] object Load {
   val autoPluginSettings: Seq[Setting[_]] = inScope(GlobalScope in LocalRootProject)(
     Seq(
       sbtPlugin :== true,
+      isMetaBuild :== true,
       pluginData := {
         val prod = (exportedProducts in Configurations.Runtime).value
         val cp = (fullClasspath in Configurations.Runtime).value


### PR DESCRIPTION
Ref #4183
Fixes #3436

This implements isMetaBuild setting that is explicitly for meta build only,
unlike sbtPlugin setting which can be used for both meta build and plugin development purpose.

Fixes #4437

Until now, sbt was resolved twice once by the launcher, and the second time by the metabuild.
This excludes sbt from the metabuild graph, and instead uses app classpath from the launcher.
