### PR TITLE
Fix '~' for dependent projects with a broken parent

### DIFF
--- a/sbt/src/sbt-test/watch/watch-sources/build.sbt
+++ b/sbt/src/sbt-test/watch/watch-sources/build.sbt
@@ -1,0 +1,3 @@
+lazy val root = (project in file(".")).aggregate(parent, child)
+lazy val parent = project
+lazy val child = project.enablePlugins(JmhPlugin).dependsOn(parent)

--- a/sbt/src/sbt-test/watch/watch-sources/changes/Foo.scala
+++ b/sbt/src/sbt-test/watch/watch-sources/changes/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/sbt/src/sbt-test/watch/watch-sources/child/src/main/scala/Bar.scala
+++ b/sbt/src/sbt-test/watch/watch-sources/child/src/main/scala/Bar.scala
@@ -1,0 +1,1 @@
+class Bar

--- a/sbt/src/sbt-test/watch/watch-sources/parent/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/watch/watch-sources/parent/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo {

--- a/sbt/src/sbt-test/watch/watch-sources/project/plugin.sbt
+++ b/sbt/src/sbt-test/watch/watch-sources/project/plugin.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")

--- a/sbt/src/sbt-test/watch/watch-sources/test
+++ b/sbt/src/sbt-test/watch/watch-sources/test
@@ -1,0 +1,9 @@
+> watchTransitiveSources
+
+-> compile
+
+$ copy-file changes/Foo.scala parent/src/main/scala/Foo.scala
+
+> watchTransitiveSources
+
+> compile


### PR DESCRIPTION
This is forward port of https://github.com/sbt/sbt/pull/4447

In #4446, @japgolly reported that in some projects, if a parent project
was broken, then '~' would immediately exit upon startup. I tracked it
down to this managed sources filter. The idea of this filter is to avoid
getting stuck in a build loop if managedSources writes into an unmanaged
source directory. If the (managedSources in ThisScope).value line
failed, however, it would cause the watchSources, and by delegation,
watchTransitiveSources task to fail. The fix is to only create this
filter if the managedSources task succeeds.

I'm not 100% sure if we shouldn't just get rid of this filter entirely
and just document that '~' will probably loop if a build writes the
result of managedSources into an unmanaged source directory.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
