### PR TITLE
Multi command

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -39,7 +39,6 @@ object BasicCommands {
     ignore,
     help,
     completionsCommand,
-    multi,
     ifLast,
     append,
     setOnFailure,
@@ -164,7 +163,10 @@ object BasicCommands {
     )
     def commandParser = state.map(s => (s.combinedParser & cmdPart) | cmdPart).getOrElse(cmdPart)
     val part = semi.flatMap(_ => matched(commandParser) <~ token(OptSpace)).map(_.trim)
-    part.+ map (_.toList)
+    (cmdPart.? ~ part.+).map {
+      case (Some(h), t) => h.mkString.trim +: t.toList
+      case (_, t)       => t.toList
+    }
   }
 
   def multiParser(s: State): Parser[List[String]] = multiParserImpl(Some(s))

--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -21,7 +21,7 @@ import sbt.internal.LegacyWatched
 import sbt.internal.inc.Stamper
 import sbt.internal.io.{ EventMonitor, Source, WatchState }
 import sbt.internal.util.Types.const
-import sbt.internal.util.complete.DefaultParsers
+import sbt.internal.util.complete.{ DefaultParsers, Parser }
 import sbt.internal.util.{ AttributeKey, JLine }
 import sbt.io.FileEventMonitor.{ Creation, Deletion, Event, Update }
 import sbt.io._
@@ -279,9 +279,9 @@ object Watched {
       onFailure = Some(Exec(failureCommandName, None)),
       definedCommands = s0.definedCommands :+ onFail
     )
-    val commands = command.split(";") match {
-      case Array("", rest @ _*) => rest
-      case Array(cmd)           => Seq(cmd)
+    val commands = Parser.parse(command, BasicCommands.multiParserImpl(Some(s))) match {
+      case Left(_)  => command :: Nil
+      case Right(c) => c
     }
     val parser = Command.combine(s.definedCommands)(s)
     val tasks = commands.foldLeft(Nil: Seq[Either[String, () => Either[Exception, Boolean]]]) {

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -14,6 +14,7 @@ object MultiParserSpec {
   val parser: Parser[Seq[String]] = BasicCommands.multiParserImpl(None)
   implicit class StringOps(val s: String) {
     def parse: Seq[String] = Parser.parse(s, parser).right.get
+    def parseEither: Either[String, Seq[String]] = Parser.parse(s, parser)
   }
 }
 import MultiParserSpec._
@@ -44,5 +45,21 @@ class MultiParserSpec extends FlatSpec with Matchers {
     """; foo "bar;\"baz\""; bar""".parse shouldBe Seq("""foo "bar;\"baz\""""", "bar")
     """; setStringValue "foo;bar"; checkStringValue "foo;bar"""".parse shouldBe
       Seq("""setStringValue "foo;bar"""", """checkStringValue "foo;bar"""")
+  }
+  it should "parse commands without leading ';'" in {
+    "setStringValue foo; setStringValue bar".parse shouldBe Seq(
+      "setStringValue foo",
+      "setStringValue bar"
+    )
+    "foo; bar".parse shouldBe Seq("foo", "bar")
+    "foo bar ;bar".parse shouldBe Seq("foo bar", "bar")
+    "foo \"a;b\"; bar".parse shouldBe Seq("foo \"a;b\"", "bar")
+    " foo ; bar \"b;c\"".parse shouldBe Seq("foo", "bar \"b;c\"")
+  }
+  it should "not parse single commands without leading ';'" in {
+    "foo".parseEither shouldBe Left("Expected ';'\nfoo\n   ^")
+    "foo bar baz".parseEither shouldBe Left("Expected ';'\nfoo bar baz\n           ^")
+    "foo bar baz;".parseEither shouldBe
+      Left("Expected not ';'\nExpected '\"'\nfoo bar baz;\n            ^")
   }
 }

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import org.scalatest.{ FlatSpec, Matchers }
+import sbt.internal.util.complete.Parser
+
+object MultiParserSpec {
+  val parser: Parser[Seq[String]] = BasicCommands.multiParserImpl(None)
+  implicit class StringOps(val s: String) {
+    def parse: Seq[String] = Parser.parse(s, parser).right.get
+  }
+}
+import MultiParserSpec._
+class MultiParserSpec extends FlatSpec with Matchers {
+  "parsing" should "parse single commands" in {
+    ";foo".parse shouldBe Seq("foo")
+    ";   foo".parse shouldBe Seq("foo")
+  }
+  it should "parse multiple commands" in {
+    ";foo;bar".parse shouldBe Seq("foo", "bar")
+  }
+  it should "parse single command with leading spaces" in {
+    ";     foo".parse shouldBe Seq("foo")
+  }
+  it should "parse multiple commands with leading spaces" in {
+    ";     foo;bar".parse shouldBe Seq("foo", "bar")
+    ";     foo;    bar".parse shouldBe Seq("foo", "bar")
+    ";foo; bar".parse shouldBe Seq("foo", "bar")
+  }
+}

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -33,4 +33,16 @@ class MultiParserSpec extends FlatSpec with Matchers {
     ";     foo;    bar".parse shouldBe Seq("foo", "bar")
     ";foo; bar".parse shouldBe Seq("foo", "bar")
   }
+  it should "parse command with string literal" in {
+    "; foo \"barbaz\"".parse shouldBe Seq("foo \"barbaz\"")
+    "; foo \"bar;baz\"".parse shouldBe Seq("foo \"bar;baz\"")
+    "; foo \"barbaz\"; bar".parse shouldBe Seq("foo \"barbaz\"", "bar")
+    "; foo \"barbaz\"; bar \"blah\"".parse shouldBe Seq("foo \"barbaz\"", "bar \"blah\"")
+    "; foo \"bar;baz\"; bar".parse shouldBe Seq("foo \"bar;baz\"", "bar")
+    "; foo \"bar;baz\"; bar \"buzz\"".parse shouldBe Seq("foo \"bar;baz\"", "bar \"buzz\"")
+    "; foo \"bar;baz\"; bar \"buzz;two\"".parse shouldBe Seq("foo \"bar;baz\"", "bar \"buzz;two\"")
+    """; foo "bar;\"baz\""; bar""".parse shouldBe Seq("""foo "bar;\"baz\""""", "bar")
+    """; setStringValue "foo;bar"; checkStringValue "foo;bar"""".parse shouldBe
+      Seq("""setStringValue "foo;bar"""", """checkStringValue "foo;bar"""")
+  }
 }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -241,6 +241,7 @@ object BuiltinCommands {
       export,
       boot,
       initialize,
+      BasicCommands.multi,
       act,
       continuous,
       flushFileTreeRepository

--- a/sbt/src/sbt-test/actions/multi-command/build.sbt
+++ b/sbt/src/sbt-test/actions/multi-command/build.sbt
@@ -1,0 +1,14 @@
+import Build._
+
+organization := "sbt"
+
+name := "scripted-multi-command-parser"
+
+setStringValue := setStringValueImpl.evaluated
+
+checkStringValue := checkStringValueImpl.evaluated
+
+taskThatFails := {
+  throw new IllegalArgumentException("")
+  ()
+}

--- a/sbt/src/sbt-test/actions/multi-command/project/Build.scala
+++ b/sbt/src/sbt-test/actions/multi-command/project/Build.scala
@@ -1,0 +1,18 @@
+import sbt._
+
+object Build {
+  private[this] var string: String = ""
+  private[this] val stringFile = file("string.txt")
+  val setStringValue = inputKey[Unit]("set a global string to a value")
+  val checkStringValue = inputKey[Unit]("check the value of a global")
+  val taskThatFails = taskKey[Unit]("this should fail")
+  def setStringValueImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    string = Def.spaceDelimited().parsed.mkString(" ").trim
+    IO.write(stringFile, string)
+  }
+  def checkStringValueImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    val actual = Def.spaceDelimited().parsed.mkString(" ").trim
+    assert(string == actual)
+    assert(IO.read(stringFile) == string)
+  }
+}

--- a/sbt/src/sbt-test/actions/multi-command/test
+++ b/sbt/src/sbt-test/actions/multi-command/test
@@ -1,0 +1,9 @@
+> ; setStringValue baz
+
+> ; checkStringValue baz
+
+> ; setStringValue foo; setStringValue bar
+
+> checkStringValue bar
+
+> ; setStringValue foo; setStringValue bar; setStringValue baz; checkStringValue baz

--- a/sbt/src/sbt-test/actions/multi-command/test
+++ b/sbt/src/sbt-test/actions/multi-command/test
@@ -7,3 +7,15 @@
 > checkStringValue bar
 
 > ; setStringValue foo; setStringValue bar; setStringValue baz; checkStringValue baz
+
+> setStringValue foo; setStringValue bar
+
+> checkStringValue bar
+
+> setStringValue foo; setStringValue bar; setStringValue baz
+
+> checkStringValue baz
+
+-> setStringValue foo; taskThatFails; setStringValue bar
+
+> checkStringValue foo

--- a/sbt/src/sbt-test/watch/watch-parser/build.sbt
+++ b/sbt/src/sbt-test/watch/watch-parser/build.sbt
@@ -1,0 +1,13 @@
+import Build._
+
+organization := "sbt"
+
+name := "scripted-watch-parser"
+
+setStringValue := setStringValueImpl.evaluated
+
+checkStringValue := checkStringValueImpl.evaluated
+
+watchSources += file("string.txt")
+
+watchOnEvent := { _ => Watched.CancelWatch }

--- a/sbt/src/sbt-test/watch/watch-parser/project/Build.scala
+++ b/sbt/src/sbt-test/watch/watch-parser/project/Build.scala
@@ -1,0 +1,16 @@
+import sbt._
+
+object Build {
+  private[this] var string: String = ""
+  private[this] val stringFile = file("string.txt")
+  val setStringValue = inputKey[Unit]("set a global string to a value")
+  val checkStringValue = inputKey[Unit]("check the value of a global")
+  def setStringValueImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    string = Def.spaceDelimited().parsed.mkString(" ").trim
+    IO.write(stringFile, string)
+  }
+  def checkStringValueImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    assert(string == Def.spaceDelimited().parsed.mkString(" ").trim)
+    assert(IO.read(stringFile) == string)
+  }
+}

--- a/sbt/src/sbt-test/watch/watch-parser/test
+++ b/sbt/src/sbt-test/watch/watch-parser/test
@@ -8,6 +8,9 @@
 
 > ~; setStringValue foo; setStringValue bar; checkStringValue bar
 
+# no leading semicolon
+> ~ setStringValue foo; setStringValue bar; checkStringValue bar
+
 > ~ setStringValue foo
 
 > checkStringValue foo

--- a/sbt/src/sbt-test/watch/watch-parser/test
+++ b/sbt/src/sbt-test/watch/watch-parser/test
@@ -1,0 +1,18 @@
+> ~; setStringValue foo; setStringValue bar
+
+> checkStringValue bar
+
+> ~;setStringValue foo;setStringValue bar; checkStringValue bar
+
+> ~;   setStringValue foo;setStringValue bar; checkStringValue bar
+
+> ~; setStringValue foo; setStringValue bar; checkStringValue bar
+
+> ~ setStringValue foo
+
+> checkStringValue foo
+
+# All of the other tests have involved input tasks, so include commands with regular tasks as well.
+> ~; compile; setStringValue baz; checkStringValue baz
+# No trailing semicolons are allowed
+-> ~; compile; setStringValue baz; checkStringValue baz;


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines

This PR enhances the parser for multiple commands/tasks and shares the improved parser with the command parser used by Watched.watch so that there should be parity between which commands are valid on the command line and which commands are valid in a continuous build.

The two main features this PR adds is
1. proper support for string literals in a multi command -- prior to this change, if you tried to run something like
```
> ;bash "touch src/main/scala/Foo.scala; rm target/classes/Foo.class"; compile
```
it would not work correctly because the `;` in the bash command string would be interpreted as a command separator. Now the string will be interpreted as a literal value and the `;` in the bash command string is not considered a token.
2. drop the requirement that multiple commands need to be prefixed with a leading ';'. Now the command above could just be
```
> bash "touch src/main/scala/Foo.scala; rm target/classes/Foo.class"; compile
```

Also, the `~` will now use the multi command parser rather than the naive string split on `;` that it was doing before. This should make it so that any multi command that is valid on the console can be prefixed with `~` and things should work mostly as expected.

I also verified manually that tab completions still work for `;` prefixed tasks/commands.

Fixes sbt/sbt#3051