### PR TITLE
[fport] Ignore files in scripted group dirs

### DIFF
--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -53,7 +53,11 @@ final class ScriptedTests(
   ): Seq[TestRunner] = {
 
     // Test group and names may be file filters (like '*')
-    for (groupDir <- (resourceBaseDirectory * group).get; nme <- (groupDir * name).get) yield {
+    for {
+      groupDir <- (resourceBaseDirectory * group).get
+      nme <- (groupDir * name).get
+      if !(nme.isFile)
+    } yield {
       val g = groupDir.getName
       val n = nme.getName
       val label = s"$g / $n"
@@ -110,7 +114,7 @@ final class ScriptedTests(
 
     type TestInfo = ((String, String), File)
 
-    val labelsAndDirs = groupAndNameDirs.map {
+    val labelsAndDirs = groupAndNameDirs.filterNot(_._2.isFile).map {
       case (groupDir, nameDir) =>
         val groupName = groupDir.getName
         val testName = nameDir.getName


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/4463
Fixes #4457

Scripted tests, in src/sbt-test/<group>/<name> blow up if <name> is a
plain file.  Filter them out.
