### PR TITLE
Update semanticdb-scalac to v4.1.0

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -21,7 +21,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := false,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List("-Yrangepos"),
-    semanticdbVersion := "4.0.0",
+    semanticdbVersion := "4.1.0",
     semanticdbCompilerPlugin := {
       val v = semanticdbVersion.value
       ("org.scalameta" % "semanticdb-scalac" % v).cross(CrossVersion.full)


### PR DESCRIPTION
This release supports more Scala versions, works on Java 11 and
is ~8mb smaller than v4.0.0.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
