### PR TITLE
Optimize imports

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -9,84 +9,31 @@ package sbt
 
 import java.io.{ File, InputStream }
 import java.net.URL
-import scala.concurrent.duration.{ FiniteDuration, Duration }
-import Def.ScopedKey
-import sbt.internal.inc.ScalaInstance
-import xsbti.compile.{
-  DefinesClass,
-  ClasspathOptions,
-  CompileAnalysis,
-  CompileOptions,
-  CompileOrder,
-  Compilers,
-  CompileResult,
-  ExternalHooks,
-  GlobalsCache,
-  IncOptions,
-  Inputs,
-  PreviousResult,
-  Setup
-}
-import scala.xml.{ Node => XNode, NodeSeq }
-import org.apache.ivy.core.module.{ descriptor, id }
-import descriptor.ModuleDescriptor, id.ModuleRevisionId
-import testing.Framework
-import KeyRanks._
 
-import sbt.internal.{
-  BuildStructure,
-  LoadedBuild,
-  PluginDiscovery,
-  BuildDependencies,
-  SessionSettings,
-  LogManager
-}
-import sbt.io.{ FileFilter, FileTreeDataView, TypedPath, WatchService }
-import sbt.io.FileEventMonitor.Event
-import sbt.internal.io.WatchState
-import sbt.internal.server.ServerHandler
-import sbt.internal.util.{ AttributeKey, SourcePosition }
-
-import sbt.librarymanagement.Configurations.CompilerPlugin
-import sbt.librarymanagement.LibraryManagementCodec._
-import sbt.librarymanagement.ivy.{ Credentials, UpdateOptions }
-import sbt.librarymanagement.{
-  Artifact,
-  ConfigRef,
-  Configuration,
-  ConflictManager,
-  ConflictWarning,
-  CrossVersion,
-  Developer,
-  DependencyResolution,
-  EvictionWarning,
-  EvictionWarningOptions,
-  GetClassifiersModule,
-  MakePomConfiguration,
-  MavenRepository,
-  ModuleConfiguration,
-  ModuleID,
-  ModuleInfo,
-  ModuleSettings,
-  PublishConfiguration,
-  Publisher,
-  Resolver,
-  RetrieveConfiguration,
-  ScalaModuleInfo,
-  ScalaVersion,
-  ScmInfo,
-  TrackLevel,
-  UnresolvedWarningConfiguration,
-  UpdateConfiguration,
-  UpdateLogging,
-  UpdateReport
-}
-import sbt.librarymanagement.InclExclRule
-import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
-import sbt.librarymanagement.ivy.{ IvyConfiguration, IvyPaths }
-import sbt.util.{ Level, Logger }
+import org.apache.ivy.core.module.descriptor.ModuleDescriptor
+import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.apache.logging.log4j.core.Appender
 import sbt.BuildSyntax._
+import sbt.Def.ScopedKey
+import sbt.KeyRanks._
+import sbt.internal._
+import sbt.internal.inc.ScalaInstance
+import sbt.internal.io.WatchState
+import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
+import sbt.internal.server.ServerHandler
+import sbt.internal.util.{ AttributeKey, SourcePosition }
+import sbt.io.FileEventMonitor.Event
+import sbt.io.{ FileFilter, FileTreeDataView, TypedPath, WatchService }
+import sbt.librarymanagement.Configurations.CompilerPlugin
+import sbt.librarymanagement.LibraryManagementCodec._
+import sbt.librarymanagement._
+import sbt.librarymanagement.ivy.{ Credentials, IvyConfiguration, IvyPaths, UpdateOptions }
+import sbt.testing.Framework
+import sbt.util.{ Level, Logger }
+import xsbti.compile._
+
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.xml.{ NodeSeq, Node => XNode }
 
 // format: off
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -7,63 +7,33 @@
 
 package sbt
 
-import sbt.internal.{
-  Act,
-  Aggregation,
-  BuildStructure,
-  CommandExchange,
-  CommandStrings,
-  CrossJava,
-  DefaultBackgroundJobService,
-  EvaluateConfigurations,
-  Inspect,
-  IvyConsole,
-  Load,
-  LoadedBuildUnit,
-  LogManager,
-  Output,
-  PluginsDebug,
-  ProjectNavigation,
-  Script,
-  SessionSettings,
-  SetResult,
-  SettingCompletions
-}
-import sbt.internal.util.{
-  AttributeKey,
-  AttributeMap,
-  ConsoleOut,
-  GlobalLogging,
-  LineRange,
-  MainAppender,
-  SimpleReader,
-  Types
-}
-import sbt.util.{ Level, Logger, Show }
-import sbt.internal.util.complete.{ DefaultParsers, Parser }
-import sbt.internal.inc.ScalaInstance
-import sbt.compiler.EvalImports
-import Types.{ const, idFun }
-import Aggregation.AnyKeys
-import Project.LoadAction
-import xsbti.compile.CompilerCache
-
-import scala.annotation.tailrec
-import sbt.io.{ FileTreeDataView, IO }
-import sbt.io.syntax._
 import java.io.{ File, IOException }
 import java.net.URI
 import java.util.{ Locale, Properties }
 
+import sbt.BasicCommandStrings.{ Shell, TemplateCommand }
+import sbt.Project.LoadAction
+import sbt.compiler.EvalImports
+import sbt.internal.Aggregation.AnyKeys
+import sbt.internal.CommandStrings.BootCommand
+import sbt.internal.inc.ScalaInstance
+import sbt.internal.util.Types.{ const, idFun }
+import sbt.internal.util.complete.Parser
+import sbt.internal.util._
+import sbt.internal._
+import sbt.io.syntax._
+import sbt.io.{ FileTreeDataView, IO }
+import sbt.util.{ Level, Logger, Show }
+import xsbti.compile.CompilerCache
+
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
-import BasicCommandStrings.{ Shell, TemplateCommand }
-import CommandStrings.BootCommand
 
 /** This class is the entry point for sbt. */
 final class xMain extends xsbti.AppMain {
   def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
+    import BasicCommandStrings.{ DashClient, DashDashClient, runEarly }
     import BasicCommands.early
-    import BasicCommandStrings.{ runEarly, DashClient, DashDashClient }
     import BuiltinCommands.defaults
     import sbt.internal.CommandStrings.{ BootCommand, DefaultsCommand, InitCommand }
     import sbt.internal.client.NetworkClient
@@ -188,12 +158,12 @@ object StandardMain {
   }
 }
 
-import DefaultParsers._
+import sbt.BasicCommandStrings._
+import sbt.BasicCommands._
+import sbt.CommandUtil._
+import sbt.TemplateCommandUtil.templateCommand
 import sbt.internal.CommandStrings._
-import BasicCommandStrings._
-import BasicCommands._
-import CommandUtil._
-import TemplateCommandUtil.templateCommand
+import sbt.internal.util.complete.DefaultParsers._
 
 object BuiltinCommands {
   def initialAttributes = AttributeMap.empty


### PR DESCRIPTION
It was becoming a pain to work on these files in intellij because the
auto-import feature would implicitly optimize all of the imports in
these files, leading to a large diff. I'd then have to go and manually
add the import that I care about. This change does add some wildcard
imports, which I don't always love, but these files are so unwieldy
already that I think it's worth it to have the imports follow the format
preferred by intellij.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
