### PR TITLE
define whitesourceOnPush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ language: scala
 env:
   global:
     - TRAVIS_JDK=adopt@1.8.192-12
+    # WHITESOURCE_PASSWORD=
     - secure: d3bu2KNwsVHwfhbGgO+gmRfDKBJhfICdCJFGWKf2w3Gv86AJZX9nuTYRxz0KtdvEHO5Xw8WTBZLPb2thSJqhw9OCm4J8TBAVqCP0ruUj4+aqBUFy4bVexQ6WKE6nWHs4JPzPk8c6uC1LG3hMuzlC8RGETXtL/n81Ef1u7NjyXjs=
   matrix:
-    - SBT_CMD=";mimaReportBinaryIssues ;scalafmt::test ;test:scalafmt::test ;sbt:scalafmt::test ;headerCheck ;test:headerCheck ;whitesourceCheckPolicies ;test:compile ;mainSettingsProj/test ;safeUnitTests ;otherUnitTests; doc"
+    - SBT_CMD=";mimaReportBinaryIssues ;scalafmt::test ;test:scalafmt::test ;sbt:scalafmt::test ;headerCheck ;test:headerCheck ;whitesourceOnPush ;test:compile ;mainSettingsProj/test ;safeUnitTests ;otherUnitTests; doc"
     - SBT_CMD="scripted actions/*"
     - SBT_CMD="scripted apiinfo/* compiler-project/* ivy-deps-management/*"
     - SBT_CMD="scripted dependency-management/*1of4"

--- a/build.sbt
+++ b/build.sbt
@@ -842,6 +842,15 @@ def customCommands: Seq[Setting[_]] = Seq(
   otherUnitTests := {
     test.all(otherProjects).value
   },
+  commands += Command.command("whitesourceOnPush") { state =>
+    sys.env.get("TRAVIS_EVENT_TYPE") match {
+      case Some("push") =>
+        "whitesourceCheckPolicies" ::
+        "whitesourceUpdate" ::
+        state
+      case _ => state
+    }
+  },
   commands += Command.command("release-sbt-local") { state =>
     "clean" ::
       "so compile" ::
@@ -902,11 +911,23 @@ def customCommands: Seq[Setting[_]] = Seq(
   }
 )
 
-inThisBuild(Seq(
-  whitesourceProduct                   := "Lightbend Reactive Platform",
-  whitesourceAggregateProjectName      := "sbt-master",
-  whitesourceAggregateProjectToken     := "e7a1e55518c0489a98e9c7430c8b2ccd53d9f97c12ed46148b592ebe4c8bf128",
-  whitesourceIgnoredScopes            ++= Seq("plugin", "scalafmt", "sxr"),
-  whitesourceFailOnError               := sys.env.contains("WHITESOURCE_PASSWORD"), // fail if pwd is present
-  whitesourceForceCheckAllDependencies := true,
-))
+ThisBuild / whitesourceProduct                   := "Lightbend Reactive Platform"
+ThisBuild / whitesourceAggregateProjectName := {
+  // note this can get detached on tag build etc
+  val b = (ThisBuild / git.gitCurrentBranch).value
+  val Stable = """1\.([0-9]+)\.x""".r
+  b match {
+    case Stable(y) => "sbt-1." + y.toString + "-stable"
+    case _         => "sbt-master"
+  }
+}
+ThisBuild / whitesourceAggregateProjectToken := {
+  (ThisBuild / whitesourceAggregateProjectName).value match {
+    case "sbt-master"     => "e7a1e55518c0489a98e9c7430c8b2ccd53d9f97c12ed46148b592ebe4c8bf128"
+    case "sbt-1.2-stable" => "54f2313767aa47198971e65595670ee16e1ad0000d20458588e72d3ac2c34763"
+    case _                => "" // it's ok to fail here
+  }
+}
+ThisBuild / whitesourceIgnoredScopes             ++= Seq("plugin", "scalafmt", "sxr")
+ThisBuild / whitesourceFailOnError               := sys.env.contains("WHITESOURCE_PASSWORD") // fail if pwd is present
+ThisBuild / whitesourceForceCheckAllDependencies := true


### PR DESCRIPTION
whitesourceOnPush calls whitesourceCheckPolicies and whitesourceUpdate on push.
Since Travis CI secrets are not available during PR from a fork, there's no point in calling these during the PR validation.
