### PR TITLE
Preserve errors order when publishing diagnostics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -582,6 +582,8 @@ lazy val mainProj = (project in file("main"))
     mimaBinaryIssueFilters ++= Vector(
       // New and changed methods on KeyIndex. internal.
       exclude[ReversedMissingMethodProblem]("sbt.internal.KeyIndex.*"),
+      // internal
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.server.LanguageServerReporter.*"),
 
       // Changed signature or removed private[sbt] methods
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.unmanagedLibs0"),

--- a/main/src/main/scala/sbt/internal/server/LanguageServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerReporter.scala
@@ -51,7 +51,7 @@ class LanguageServerReporter(
     val pos = problem.position
     pos.sourceFile.toOption foreach { sourceFile: File =>
       problemsByFile.get(sourceFile) match {
-        case Some(xs: List[Problem]) => problemsByFile(sourceFile) = problem :: xs
+        case Some(xs: List[Problem]) => problemsByFile(sourceFile) = xs :+ problem
         case _                       => problemsByFile(sourceFile) = List(problem)
       }
     }


### PR DESCRIPTION
The `sbt-server` was prepending a new probem and not appending.

The result was a `textDocument/publishDiagnostics` notification
containing a inverted list of problems compare to what was show in the
sbt console.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
