### PR TITLE
Allow trailing semicolon in multi commands

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -163,7 +163,7 @@ object BasicCommands {
     )
     def commandParser = state.map(s => (s.combinedParser & cmdPart) | cmdPart).getOrElse(cmdPart)
     val part = semi.flatMap(_ => matched(commandParser) <~ token(OptSpace)).map(_.trim)
-    (cmdPart.? ~ part.+).map {
+    (cmdPart.? ~ part.+ <~ semi.?).map {
       case (Some(h), t) => h.mkString.trim +: t.toList
       case (_, t)       => t.toList
     }

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -61,5 +61,10 @@ class MultiParserSpec extends FlatSpec with Matchers {
     "foo bar baz".parseEither shouldBe Left("Expected ';'\nfoo bar baz\n           ^")
     "foo bar baz;".parseEither shouldBe
       Left("Expected not ';'\nExpected '\"'\nfoo bar baz;\n            ^")
+    "foo;".parseEither shouldBe Left("Expected not ';'\nExpected '\"'\nfoo;\n    ^")
+  }
+  it should "parse commands with trailing semi-colon" in {
+    "foo;bar;".parse shouldBe Seq("foo", "bar")
+    "foo;   bar    ;".parse shouldBe Seq("foo", "bar")
   }
 }

--- a/sbt/src/sbt-test/watch/watch-parser/test
+++ b/sbt/src/sbt-test/watch/watch-parser/test
@@ -17,5 +17,5 @@
 
 # All of the other tests have involved input tasks, so include commands with regular tasks as well.
 > ~; compile; setStringValue baz; checkStringValue baz
-# No trailing semicolons are allowed
--> ~; compile; setStringValue baz; checkStringValue baz;
+# Ensure that trailing semi colons work
+> ~ compile; setStringValue baz; checkStringValue baz;


### PR DESCRIPTION
It was a mistake to disallow trailing semicolons for multi commands.
Firstly this was a mistake because previous versions of sbt supported a
trailing semi colon. It was also inconsistent with how commands work in
a regular shell (e.g. bash or zsh).

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
