### PR TITLE
Bump scala version 2.12.8

### DIFF
--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -96,7 +96,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.7"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.8"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.7"
+  val scala212 = "2.12.8"
   lazy val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala212
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.8"
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
 addSbtPlugin("org.scala-sbt"     % "sbt-houserules"  % "0.3.9")

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
@@ -3,7 +3,7 @@ lazy val check = taskKey[Unit]("Runs the check")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junit = "junit" % "junit" % "4.11"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(

--- a/sbt/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt/src/sbt-test/project/semanticdb/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbIncludeInJar := true
 

--- a/sbt/src/sbt-test/run/fork-loader/build.sbt
+++ b/sbt/src/sbt-test/run/fork-loader/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/source-dependencies/binary/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/binary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val dep = project
 

--- a/sbt/src/sbt-test/source-dependencies/cross-source/test
+++ b/sbt/src/sbt-test/source-dependencies/cross-source/test
@@ -1,3 +1,3 @@
 # A.scala needs B.scala, it would be in source list
-> ++2.12.7!
+> ++2.12.8!
 > compile

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val paradiseVersion = "2.1.1"
 val commonSettings = Seq(

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/tests/arguments/build.sbt
+++ b/sbt/src/sbt-test/tests/arguments/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/do-not-discover/build.sbt
+++ b/sbt/src/sbt-test/tests/do-not-discover/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/done/build.sbt
+++ b/sbt/src/sbt-test/tests/done/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/fork-async/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-async/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-parallel/build.sbt
@@ -1,7 +1,7 @@
 import Tests._
 import Defaults._
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 val check = taskKey[Unit]("Check that tests are executed in parallel")
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/tests/fork-test-group-parallel/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-test-group-parallel/build.sbt
@@ -1,5 +1,5 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 Global / concurrentRestrictions := Seq(Tags.limitAll(4))
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/fork-uncaught2/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-uncaught2/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
 

--- a/sbt/src/sbt-test/tests/fork/build.sbt
+++ b/sbt/src/sbt-test/tests/fork/build.sbt
@@ -11,7 +11,7 @@ val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 def groupId(idx: Int) = "group_" + (idx + 1)
 def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / organization := "org.example"
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/tests/fork2/build.sbt
+++ b/sbt/src/sbt-test/tests/fork2/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 fork := true
 libraryDependencies += scalatest % Test

--- a/sbt/src/sbt-test/tests/it/build.sbt
+++ b/sbt/src/sbt-test/tests/it/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
 

--- a/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
+++ b/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
@@ -14,7 +14,7 @@ val nestedSuitesReportFile = "target/test-reports/my.scalatest.MyNestedSuites.xm
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-subproc/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-subproc/build.sbt
@@ -1,7 +1,7 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-tests/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-tests/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / version := "0.0.1" 
 ThisBuild / organization := "org.catastrophe"
 

--- a/sbt/src/sbt-test/tests/one-class-multi-framework/build.sbt
+++ b/sbt/src/sbt-test/tests/one-class-multi-framework/build.sbt
@@ -1,5 +1,5 @@
 val specsJunit = "org.specs2" %% "specs2-junit" % "4.3.4"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 libraryDependencies += junitinterface % Test
 libraryDependencies += specsJunit % Test

--- a/sbt/src/sbt-test/tests/order/build.sbt
+++ b/sbt/src/sbt-test/tests/order/build.sbt
@@ -1,5 +1,5 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 Test / parallelExecution := false
 libraryDependencies += scalcheck % Test

--- a/sbt/src/sbt-test/tests/resources/build.sbt
+++ b/sbt/src/sbt-test/tests/resources/build.sbt
@@ -1,3 +1,3 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/scala-instance-classloader/build.sbt
+++ b/sbt/src/sbt-test/tests/scala-instance-classloader/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.ScalaInstance
 lazy val OtherScala = config("other-scala").hide
 lazy val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.5.17"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .configs(OtherScala)
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       val rawJars = (managedClasspath in OtherScala).value.map(_.data)
       val scalaHome = (target.value / "scala-home")
       def removeVersion(name: String): String =
-        name.replaceAll("\\-2.12.7", "")
+        name.replaceAll("\\-2.12.8", "")
       for(jar <- rawJars) {
         val tjar = scalaHome / s"lib/${removeVersion(jar.getName)}"
         IO.copyFile(jar, tjar)

--- a/sbt/src/sbt-test/tests/serial/build.sbt
+++ b/sbt/src/sbt-test/tests/serial/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / organization := "com.example"
 ThisBuild / version      := "0.0.1-SNAPSHOT"
 

--- a/sbt/src/sbt-test/tests/setup-cleanup/base.sbt
+++ b/sbt/src/sbt-test/tests/setup-cleanup/base.sbt
@@ -1,3 +1,3 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 libraryDependencies += scalatest

--- a/sbt/src/sbt-test/tests/single-runner/build.sbt
+++ b/sbt/src/sbt-test/tests/single-runner/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/specs-run/build.sbt
+++ b/sbt/src/sbt-test/tests/specs-run/build.sbt
@@ -1,4 +1,4 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/t543/build.sbt
+++ b/sbt/src/sbt-test/tests/t543/build.sbt
@@ -7,7 +7,7 @@ val check = TaskKey[Unit]("check", "Check correct error has been returned.")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt/src/sbt-test/tests/task/build.sbt
+++ b/sbt/src/sbt-test/tests/task/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/test-exclude/build.sbt
+++ b/sbt/src/sbt-test/tests/test-exclude/build.sbt
@@ -1,5 +1,5 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/test-quick/build.sbt
+++ b/sbt/src/sbt-test/tests/test-quick/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/server-test/handshake/build.sbt
+++ b/sbt/src/server-test/handshake/build.sbt
@@ -1,6 +1,6 @@
 import sbt.internal.server.{ ServerHandler, ServerIntent }
 
-ThisBuild / scalaVersion := "2.12.7"
+ThisBuild / scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
I ran a zsh one liner to generate this:
git grep "2.12.7" | cut -d ':' -f1 | sort | uniq | xargs perl -p -i -e "s/2.12.7/2.12.8/"

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
