### PR TITLE
Update TypedPath apis

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -150,8 +150,8 @@ object Watched {
       projectSources: Seq[WatchSource]
   ): Event[StampedFile] => Watched.Action =
     event =>
-      if (sources.exists(_.accept(event.entry.typedPath.getPath))) Watched.Trigger
-      else if (projectSources.exists(_.accept(event.entry.typedPath.getPath))) event match {
+      if (sources.exists(_.accept(event.entry.typedPath.toPath))) Watched.Trigger
+      else if (projectSources.exists(_.accept(event.entry.typedPath.toPath))) event match {
         case Update(prev, cur, _) if prev.value.map(_.stamp) != cur.value.map(_.stamp) => Reload
         case _: Creation[_] | _: Deletion[_]                                           => Reload
         case _                                                                         => Ignore
@@ -365,14 +365,14 @@ object Watched {
                   if (action == HandleError) "error"
                   else if (action.isInstanceOf[Custom]) action.toString
                   else "cancellation"
-                logger.debug(s"Stopping watch due to $cause from ${event.entry.typedPath.getPath}")
+                logger.debug(s"Stopping watch due to $cause from ${event.entry.typedPath.toPath}")
                 action
               case (Trigger, Some(event)) =>
-                logger.debug(s"Triggered by ${event.entry.typedPath.getPath}")
+                logger.debug(s"Triggered by ${event.entry.typedPath.toPath}")
                 config.triggeredMessage(event.entry.typedPath, count).foreach(info)
                 Trigger
               case (Reload, Some(event)) =>
-                logger.info(s"Reload triggered by ${event.entry.typedPath.getPath}")
+                logger.info(s"Reload triggered by ${event.entry.typedPath.toPath}")
                 Reload
               case _ =>
                 nextAction()
@@ -580,18 +580,18 @@ object StampedFile {
   val binaryConverter: TypedPath => StampedFile =
     new StampedFileImpl(_: TypedPath, forceLastModified = true)
   val converter: TypedPath => StampedFile = (tp: TypedPath) =>
-    tp.getPath.toString match {
+    tp.toPath.toString match {
       case s if s.endsWith(".jar")   => binaryConverter(tp)
       case s if s.endsWith(".class") => binaryConverter(tp)
       case _                         => sourceConverter(tp)
   }
 
   private class StampedFileImpl(typedPath: TypedPath, forceLastModified: Boolean)
-      extends java.io.File(typedPath.getPath.toString)
+      extends java.io.File(typedPath.toPath.toString)
       with StampedFile {
     override val stamp: Stamp =
       if (forceLastModified || typedPath.isDirectory)
-        Stamper.forLastModified(typedPath.getPath.toFile)
-      else Stamper.forHash(typedPath.getPath.toFile)
+        Stamper.forLastModified(typedPath.toPath.toFile)
+      else Stamper.forHash(typedPath.toPath.toFile)
   }
 }

--- a/main-command/src/test/scala/sbt/WatchedSpec.scala
+++ b/main-command/src/test/scala/sbt/WatchedSpec.scala
@@ -78,12 +78,12 @@ class WatchedSpec extends FlatSpec with Matchers {
     val config = Defaults.config(
       sources = Seq(WatchSource(realDir)),
       preWatch = (count, _) => if (count == 2) CancelWatch else Ignore,
-      onWatchEvent = e => if (e.entry.typedPath.getPath == foo) Trigger else Ignore,
+      onWatchEvent = e => if (e.entry.typedPath.toPath == foo) Trigger else Ignore,
       triggeredMessage = (tp, _) => { queue += tp; None },
       watchingMessage = _ => { Files.createFile(bar); Thread.sleep(5); Files.createFile(foo); None }
     )
     Watched.watch(NullInputStream, () => Right(true), config) shouldBe CancelWatch
-    queue.toIndexedSeq.map(_.getPath) shouldBe Seq(foo)
+    queue.toIndexedSeq.map(_.toPath) shouldBe Seq(foo)
   }
   it should "enforce anti-entropy" in IO.withTemporaryDirectory { dir =>
     val realDir = dir.toRealPath
@@ -107,7 +107,7 @@ class WatchedSpec extends FlatSpec with Matchers {
       }
     )
     Watched.watch(NullInputStream, () => Right(true), config) shouldBe CancelWatch
-    queue.toIndexedSeq.map(_.getPath) shouldBe Seq(bar, foo)
+    queue.toIndexedSeq.map(_.toPath) shouldBe Seq(bar, foo)
   }
   it should "halt on error" in IO.withTemporaryDirectory { dir =>
     val halted = new AtomicBoolean(false)

--- a/main/src/main/scala/sbt/internal/ExternalHooks.scala
+++ b/main/src/main/scala/sbt/internal/ExternalHooks.scala
@@ -41,7 +41,7 @@ private[sbt] object ExternalHooks {
     options.classpath.foreach { f =>
       view.listEntries(f.toPath, Integer.MAX_VALUE, _ => true) foreach { e =>
         e.value match {
-          case Right(value) => allBinaries.put(e.typedPath.getPath.toFile, value.stamp)
+          case Right(value) => allBinaries.put(e.typedPath.toPath.toFile, value.stamp)
           case _            =>
         }
       }
@@ -49,7 +49,7 @@ private[sbt] object ExternalHooks {
       // rather than a directory.
       view.listEntries(f.toPath, -1, _ => true) foreach { e =>
         e.value match {
-          case Right(value) => allBinaries.put(e.typedPath.getPath.toFile, value.stamp)
+          case Right(value) => allBinaries.put(e.typedPath.toPath.toFile, value.stamp)
           case _            =>
         }
       }

--- a/main/src/main/scala/sbt/internal/FileManagement.scala
+++ b/main/src/main/scala/sbt/internal/FileManagement.scala
@@ -61,7 +61,7 @@ private[sbt] object FileManagement {
         view.register(dir.toPath, maxDepth = Integer.MAX_VALUE)
         view
           .listEntries(dir.toPath, maxDepth = Integer.MAX_VALUE, sourceFilter)
-          .map(e => e.value.getOrElse(e.typedPath.getPath.toFile))
+          .map(e => e.value.getOrElse(e.typedPath.toPath.toFile))
       }
     }
 
@@ -86,7 +86,7 @@ private[sbt] object FileManagement {
                  * these methods in java.io.File, FileFilters may be applied without needing to
                  * stat the file (which is expensive) for isDirectory and isFile checks.
                  */
-                val file = new java.io.File(tp.getPath.toString) {
+                val file = new java.io.File(tp.toPath.toString) {
                   override def isDirectory: Boolean = tp.isDirectory
                   override def isFile: Boolean = tp.isFile
                 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val baseScalaVersion = scala212
 
   // sbt modules
-  private val ioVersion = "1.3.0-M4"
+  private val ioVersion = "1.3.0-M5"
   private val utilVersion = "1.3.0-M3"
   private val lmVersion =
     sys.props.get("sbt.build.lm.version") match {


### PR DESCRIPTION
I renamed getPath to toPath in io so we need to update sbt to using the
correct api.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
