### PR TITLE
Use custom classloader for scripted tests

### DIFF
--- a/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/test
@@ -1,5 +1,3 @@
-> debug
-
 > a/update
 
 > a/updateClassifiers

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/test
@@ -1,4 +1,3 @@
 > y1/publishLocal
 > y2/publishLocal
-> debug
 > check

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/test
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/test
@@ -1,4 +1,2 @@
-> debug
-
 > check
 

--- a/sbt/src/sbt-test/dependency-management/exclude-transitive/test
+++ b/sbt/src/sbt-test/dependency-management/exclude-transitive/test
@@ -1,4 +1,3 @@
-> debug
 # load the project definition with transitive dependencies enabled
 # and check that they are not downloaded
 #$ pause

--- a/sbt/src/sbt-test/dependency-management/ivy-settings-a/test
+++ b/sbt/src/sbt-test/dependency-management/ivy-settings-a/test
@@ -1,4 +1,3 @@
-> debug
 > update
 # works because scalaVersion is the same as sbtScalaVersion
 > compile

--- a/sbt/src/sbt-test/dependency-management/mvn-local/disabled
+++ b/sbt/src/sbt-test/dependency-management/mvn-local/disabled
@@ -19,7 +19,6 @@ $ copy-file changes/mainB1.scala main/B.scala
 -> main/compile
 
 $ copy-file changes/libA.scala library/A.scala
-> debug
 > library/publishM2
 # should succeed even without 'update' because Ivy should use the jar from the origin and not copy it to its cache
 > main/compile

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -125,7 +125,10 @@ final class ScriptedTests(
     if (labelsAndDirs.isEmpty) List()
     else {
       val totalSize = labelsAndDirs.size
-      val batchSize = totalSize / sbtInstances
+      val batchSize = totalSize / sbtInstances match {
+        case 0 => 1
+        case s => s
+      }
 
       val (launcherBasedTests, runFromSourceBasedTests) = labelsAndDirs.partition {
         case (testName, _) =>


### PR DESCRIPTION
We had previously used reflection to load the bridge class, but
continued using sbt's default classloader. This was problematic because
the metabuild could have a different classpath from that required by the
scripted tests.

Bonus: scalafmt

Fixes: #4514

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
