### PR TITLE
Add meaningful toString to values in TypeFunctions

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -8,19 +8,22 @@
 package sbt.internal.util
 
 trait TypeFunctions {
+  import TypeFunctions._
   type Id[X] = X
   type NothingK[X] = Nothing
   sealed trait Const[A] { type Apply[B] = A }
   sealed trait ConstK[A] { type l[L[x]] = A }
   sealed trait Compose[A[_], B[_]] { type Apply[T] = A[B[T]] }
   sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
+  type AnyLeft[T] = Left[T, Nothing]
+  type AnyRight[T] = Right[Nothing, T]
 
-  final val left = λ[Id ~> Left[?, Nothing]](Left(_))
-  final val right = λ[Id ~> Right[Nothing, ?]](Right(_))
-  final val some = λ[Id ~> Some](Some(_))
-  final def idFun[T]: T => T = (t: T) => t
-  final def const[A, B](b: B): A => B = _ => b
-  final def idK[M[_]]: M ~> M = λ[M ~> M](m => m)
+  final val left = λ[Id ~> AnyLeft](Left(_)).setToString("TypeFunctions.left")
+  final val right = λ[Id ~> AnyRight](Right(_)).setToString("TypeFunctions.right")
+  final val some = λ[Id ~> Some](Some(_)).setToString("TypeFunctions.some")
+  final def idFun[T]: T => T = ((t: T) => t).setToString("TypeFunctions.id")
+  final def const[A, B](b: B): A => B = ((_: A) => b).setToString(s"TypeFunctions.const($b)")
+  final def idK[M[_]]: M ~> M = λ[M ~> M](m => m).setToString("TypeFunctions.idK")
 
   def nestCon[M[_], N[_], G[_]](f: M ~> N): (M ∙ G)#l ~> (N ∙ G)#l =
     f.asInstanceOf[(M ∙ G)#l ~> (N ∙ G)#l] // implemented with a cast to avoid extra object+method call.
@@ -31,7 +34,24 @@ trait TypeFunctions {
   type ~>|[A[_], B[_]] = A ~> Compose[Option, B]#Apply
 }
 
-object TypeFunctions extends TypeFunctions
+object TypeFunctions extends TypeFunctions {
+  private implicit class Ops[T[_], R[_]](val underlying: T ~> R) extends AnyVal {
+    def setToString(string: String): T ~> R = new (T ~> R) {
+      override def apply[U](a: T[U]): R[U] = underlying(a)
+      override def toString: String = string
+      override def equals(o: Any): Boolean = underlying.equals(o)
+      override def hashCode: Int = underlying.hashCode
+    }
+  }
+  private implicit class FunctionOps[A, B](val f: A => B) extends AnyVal {
+    def setToString(string: String): A => B = new (A => B) {
+      override def apply(a: A): B = f(a)
+      override def toString: String = string
+      override def equals(o: Any): Boolean = f.equals(o)
+      override def hashCode: Int = f.hashCode
+    }
+  }
+}
 
 trait ~>[-A[_], +B[_]] { outer =>
   def apply[T](a: A[T]): B[T]

--- a/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -15,12 +15,14 @@ trait TypeFunctions {
   sealed trait ConstK[A] { type l[L[x]] = A }
   sealed trait Compose[A[_], B[_]] { type Apply[T] = A[B[T]] }
   sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
-  type AnyLeft[T] = Left[T, Nothing]
-  type AnyRight[T] = Right[Nothing, T]
+  private type AnyLeft[T] = Left[T, Nothing]
+  private type AnyRight[T] = Right[Nothing, T]
 
-  final val left = λ[Id ~> AnyLeft](Left(_)).setToString("TypeFunctions.left")
-  final val right = λ[Id ~> AnyRight](Right(_)).setToString("TypeFunctions.right")
-  final val some = λ[Id ~> Some](Some(_)).setToString("TypeFunctions.some")
+  final val left: Id ~> Left[?, Nothing] =
+    λ[Id ~> AnyLeft](Left(_)).setToString("TypeFunctions.left")
+  final val right: Id ~> Right[Nothing, ?] =
+    λ[Id ~> AnyRight](Right(_)).setToString("TypeFunctions.right")
+  final val some: Id ~> Some[?] = λ[Id ~> Some](Some(_)).setToString("TypeFunctions.some")
   final def idFun[T]: T => T = ((t: T) => t).setToString("TypeFunctions.id")
   final def const[A, B](b: B): A => B = ((_: A) => b).setToString(s"TypeFunctions.const($b)")
   final def idK[M[_]]: M ~> M = λ[M ~> M](m => m).setToString("TypeFunctions.idK")

--- a/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -18,7 +18,7 @@ trait TypeFunctions {
   final val left = λ[Id ~> Left[?, Nothing]](Left(_))
   final val right = λ[Id ~> Right[Nothing, ?]](Right(_))
   final val some = λ[Id ~> Some](Some(_))
-  final def idFun[T] = (t: T) => t
+  final def idFun[T]: T => T = (t: T) => t
   final def const[A, B](b: B): A => B = _ => b
   final def idK[M[_]]: M ~> M = λ[M ~> M](m => m)
 
@@ -38,11 +38,11 @@ trait ~>[-A[_], +B[_]] { outer =>
   // directly on ~> because of type inference limitations
   final def ∙[C[_]](g: C ~> A): C ~> B = λ[C ~> B](c => outer.apply(g(c)))
   final def ∙[C, D](g: C => D)(implicit ev: D <:< A[D]): C => B[D] = i => apply(ev(g(i)))
-  final def fn[T] = (t: A[T]) => apply[T](t)
+  final def fn[T]: A[T] => B[T] = (t: A[T]) => apply[T](t)
 }
 
 object ~> {
   import TypeFunctions._
   val Id: Id ~> Id = idK[Id]
-  implicit def tcIdEquals: (Id ~> Id) = Id
+  implicit def tcIdEquals: Id ~> Id = Id
 }


### PR DESCRIPTION
The kind projector syntax is confusing for beginners (e.g. myself 30
minutes before writing this). Moreover, the toString on these values
would be something like: TypeFunctions$$anon$5$aa23ra23 which made it
impossible to tell what transformer was being applied. I addressed these
issues by removing the syntactic sugar provided by the kind projector
plugin and overriding toString.

This should have no impact whatsoever on how sbt works, but should help
make debugging setting initialization easier.

This also removes all of the warning from this file in intelij, but that
wasn't actually the motivation.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
