### PR TITLE
Clear compiler cache in clearCaches

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -837,6 +837,7 @@ object BuiltinCommands {
   }
 
   def registerCompilerCache(s: State): State = {
+    s.get(Keys.stateCompilerCache).foreach(_.clear())
     val maxCompilers = System.getProperty("sbt.resident.limit")
     val cache =
       if (maxCompilers == null)
@@ -875,7 +876,7 @@ object BuiltinCommands {
 
   def clearCaches: Command = {
     val help = Help.more(ClearCaches, ClearCachesDetailed)
-    Command.command(ClearCaches, help)(registerGlobalCaches)
+    Command.command(ClearCaches, help)(registerGlobalCaches _ andThen registerCompilerCache)
   }
 
   def shell: Command = Command.command(Shell, Help.more(Shell, ShellDetailed)) { s0 =>


### PR DESCRIPTION
Resident compilation actually works pretty well most of the time*,
but if there ever is an issue with the cached compilation, we should be
able to easily clear the cache.

* I've only had issues when package objects are involved

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
