### PR TITLE
Remove Dotty handling in scalaInstance

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -737,10 +737,7 @@ object Defaults extends BuildCommon {
     val allJars = toolReport.modules.flatMap(_.artifacts.map(_._2))
     val libraryJar = file(ScalaArtifacts.LibraryID)
     val binVersion = scalaBinaryVersion.value
-    val compilerJar =
-      if (ScalaInstance.isDotty(scalaVersion.value))
-        file(ScalaArtifacts.dottyID(binVersion))
-      else file(ScalaArtifacts.CompilerID)
+    val compilerJar = file(ScalaArtifacts.CompilerID)
     new ScalaInstance(
       scalaVersion.value,
       makeClassLoader(state.value)(allJars.toList),


### PR DESCRIPTION
sbt-dotty 0.3.0 (https://github.com/lampepfl/dotty/pull/5835) sets
`managedScalaInstance := false` and does everything by itself, so this
isn't needed anymore.