### PR TITLE
Avoid NPE on Run.<init>

### DIFF
--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -89,7 +89,10 @@ final class Eval(
    */
   final class EvalGlobal(settings: Settings, reporter: Reporter)
       extends Global(settings, reporter) {
-    override def currentRun: Run = curRun
+    override def currentRun: Run = curRun match {
+      case null => super.currentRun // https://github.com/scala/bug/issues/11381
+      case r    => r
+    }
     var curRun: Run = null
   }
   lazy val global: EvalGlobal = new EvalGlobal(settings, reporter)


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines

Manually tested:

```
$ tail project/plugins.sbt build.sbt
==> project/plugins.sbt <==
scalacOptions += "-Ydebug"

scalaVersion := "2.12.8" //

==> build.sbt <==
scalaVersion := "2.12.8"

scalacOptions += "-Ydebug"
```

Before:

```
$ echo "sbt.version=1.3.0-JZ1" > project/build.properties ; rm -rf project/{project,target}; sbt  update;

error: error while loading String, class file '/modules/java.base/java/lang/String.class' is broken
(class java.lang.NullPointerException/null)

[info] Loading settings for project scratch6-build from plugins.sbt ...
java.lang.NullPointerExceptionion from /Users/jz/code/scratch6/project
	at scala.tools.nsc.GlobalSymbolLoaders.lookupMemberAtTyperPhaseIfPossible(GlobalSymbolLoaders.scala:29)
	at scala.tools.nsc.symtab.SymbolLoaders$ClassfileLoader$classfileParser$.lookupMemberAtTyperPhaseIfPossible(SymbolLoaders.scala:312)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$innerClasses$.innerSymbol(ClassfileParser.scala:1278)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$innerClasses$.innerSymbol(ClassfileParser.scala:1269)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.classNameToSymbol(ClassfileParser.scala:439)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.sig2type$1(ClassfileParser.scala:715)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.sig2type$1(ClassfileParser.scala:747)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.scala$tools$nsc$symtab$classfile$ClassfileParser$$sigToType(ClassfileParser.scala:800)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$ConstantPool.getType(ClassfileParser.scala:305)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseMethod(ClassfileParser.scala:592)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parseClass$4(ClassfileParser.scala:506)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.queueLoad$1(ClassfileParser.scala:506)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parseClass$5(ClassfileParser.scala:516)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parseClass(ClassfileParser.scala:521)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parse$1(ClassfileParser.scala:162)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parse(ClassfileParser.scala:133)
	at scala.tools.nsc.symtab.SymbolLoaders$ClassfileLoader.doComplete(SymbolLoaders.scala:332)
	at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.complete(SymbolLoaders.scala:231)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1542)
	at scala.reflect.internal.Definitions.scala$reflect$internal$Definitions$$enterNewMethod(Definitions.scala:50)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus$lzycompute(Definitions.scala:1123)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus(Definitions.scala:1123)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods$lzycompute(Definitions.scala:1397)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods(Definitions.scala:1379)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode$lzycompute(Definitions.scala:1409)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode(Definitions.scala:1409)
	at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1465)
	at scala.tools.nsc.Global$Run.<init>(Global.scala:1194)
	at sbt.compiler.Eval$$anon$3.<init>(Eval.scala:206)
	at sbt.compiler.Eval.run$lzycompute$1(Eval.scala:206)
	at sbt.compiler.Eval.run$1(Eval.scala:206)
	at sbt.compiler.Eval.evalCommon(Eval.scala:218)
	at sbt.compiler.Eval.eval(Eval.scala:128)
	at sbt.internal.EvaluateConfigurations$.evaluateDslEntry(EvaluateConfigurations.scala:239)
	at sbt.internal.EvaluateConfigurations$.$anonfun$evaluateSbtFile$2(EvaluateConfigurations.scala:158)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:237)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at scala.collection.TraversableLike.map(TraversableLike.scala:237)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:230)
	at scala.collection.immutable.List.map(List.scala:298)
	at sbt.internal.EvaluateConfigurations$.evaluateSbtFile(EvaluateConfigurations.scala:156)
	at sbt.internal.Load$.loadSettingsFile$1(Load.scala:1138)
	at sbt.internal.Load$.$anonfun$discoverProjects$2(Load.scala:1146)
	at scala.collection.MapLike.getOrElse(MapLike.scala:131)
	at scala.collection.MapLike.getOrElse$(MapLike.scala:129)
	at scala.collection.AbstractMap.getOrElse(Map.scala:63)
	at sbt.internal.Load$.memoLoadSettingsFile$1(Load.scala:1145)
	at sbt.internal.Load$.$anonfun$discoverProjects$4(Load.scala:1153)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:237)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at scala.collection.TraversableLike.map(TraversableLike.scala:237)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:230)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at sbt.internal.Load$.loadFiles$1(Load.scala:1153)
	at sbt.internal.Load$.discoverProjects(Load.scala:1167)
	at sbt.internal.Load$.discover$1(Load.scala:864)
	at sbt.internal.Load$.loadTransitive(Load.scala:939)
	at sbt.internal.Load$.loadProjects$1(Load.scala:728)
	at sbt.internal.Load$.$anonfun$loadUnit$11(Load.scala:731)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.$anonfun$loadUnit$1(Load.scala:731)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.loadUnit(Load.scala:690)
	at sbt.internal.Load$.$anonfun$builtinLoader$4(Load.scala:486)
	at sbt.internal.BuildLoader$.$anonfun$componentLoader$5(BuildLoader.scala:176)
	at sbt.internal.BuildLoader.apply(BuildLoader.scala:241)
	at sbt.internal.Load$.loadURI$1(Load.scala:548)
	at sbt.internal.Load$.loadAll(Load.scala:564)
	at sbt.internal.Load$.loadURI(Load.scala:494)
	at sbt.internal.Load$.load(Load.scala:473)
	at sbt.internal.Load$.$anonfun$apply$1(Load.scala:253)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.apply(Load.scala:253)
	at sbt.internal.Load$.defaultLoad(Load.scala:70)
	at sbt.BuiltinCommands$.liftedTree1$1(Main.scala:825)
	at sbt.BuiltinCommands$.doLoadProject(Main.scala:825)
	at sbt.BuiltinCommands$.$anonfun$loadProjectImpl$2(Main.scala:787)
	at sbt.Command$.$anonfun$applyEffect$4(Command.scala:142)
	at sbt.Command$.$anonfun$applyEffect$2(Command.scala:137)
	at sbt.Command$.process(Command.scala:181)
	at sbt.MainLoop$.$anonfun$processCommand$1(MainLoop.scala:148)
	at sbt.MainLoop$.processCommand(MainLoop.scala:160)
	at sbt.MainLoop$.processCommand(MainLoop.scala:148)
	at sbt.MainLoop$.$anonfun$next$2(MainLoop.scala:139)
	at sbt.State$StateOpsImpl$.runCmd$1(State.scala:269)
	at sbt.State$StateOpsImpl$.process$extension(State.scala:273)
	at sbt.MainLoop$.$anonfun$next$1(MainLoop.scala:139)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
	at sbt.MainLoop$.next(MainLoop.scala:139)
	at sbt.MainLoop$.run(MainLoop.scala:132)
	at sbt.MainLoop$.$anonfun$runWithNewLog$1(MainLoop.scala:110)
	at sbt.io.Using.apply(Using.scala:22)
	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:104)
	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:59)
	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:44)
	at sbt.MainLoop$.runLogged(MainLoop.scala:35)
	at sbt.StandardMain$.runManaged(Main.scala:110)
	at sbt.xMain.run(Main.scala:59)
	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
	at xsbt.boot.Launch$.run(Launch.scala:109)
	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
	at xsbt.boot.Launch$.launch(Launch.scala:117)
	at xsbt.boot.Launch$.apply(Launch.scala:18)
	at xsbt.boot.Boot$.runImpl(Boot.scala:56)
	at xsbt.boot.Boot$.main(Boot.scala:18)
	at xsbt.boot.Boot.main(Boot.scala)
java.io.IOException: class file '/modules/java.base/java/lang/String.class' is broken
(class java.lang.NullPointerException/null)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.scala$tools$nsc$symtab$classfile$ClassfileParser$$handleError(ClassfileParser.scala:116)
	at scala.tools.nsc.symtab.classfile.ClassfileParser$$anonfun$scala$tools$nsc$symtab$classfile$ClassfileParser$$parseErrorHandler$1.applyOrElse(ClassfileParser.scala:124)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
	at scala.tools.nsc.symtab.classfile.ClassfileParser.parse(ClassfileParser.scala:134)
	at scala.tools.nsc.symtab.SymbolLoaders$ClassfileLoader.doComplete(SymbolLoaders.scala:332)
	at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.complete(SymbolLoaders.scala:231)
	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1542)
	at scala.reflect.internal.Definitions.scala$reflect$internal$Definitions$$enterNewMethod(Definitions.scala:50)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus$lzycompute(Definitions.scala:1123)
	at scala.reflect.internal.Definitions$DefinitionsClass.String_$plus(Definitions.scala:1123)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods$lzycompute(Definitions.scala:1397)
	at scala.reflect.internal.Definitions$DefinitionsClass.syntheticCoreMethods(Definitions.scala:1379)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode$lzycompute(Definitions.scala:1409)
	at scala.reflect.internal.Definitions$DefinitionsClass.symbolsNotPresentInBytecode(Definitions.scala:1409)
	at scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1465)
	at scala.tools.nsc.Global$Run.<init>(Global.scala:1194)
	at sbt.compiler.Eval$$anon$3.<init>(Eval.scala:206)
	at sbt.compiler.Eval.run$lzycompute$1(Eval.scala:206)
	at sbt.compiler.Eval.run$1(Eval.scala:206)
	at sbt.compiler.Eval.evalCommon(Eval.scala:218)
	at sbt.compiler.Eval.eval(Eval.scala:128)
	at sbt.internal.EvaluateConfigurations$.evaluateDslEntry(EvaluateConfigurations.scala:239)
	at sbt.internal.EvaluateConfigurations$.$anonfun$evaluateSbtFile$2(EvaluateConfigurations.scala:158)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:237)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at scala.collection.TraversableLike.map(TraversableLike.scala:237)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:230)
	at scala.collection.immutable.List.map(List.scala:298)
	at sbt.internal.EvaluateConfigurations$.evaluateSbtFile(EvaluateConfigurations.scala:156)
	at sbt.internal.Load$.loadSettingsFile$1(Load.scala:1138)
	at sbt.internal.Load$.$anonfun$discoverProjects$2(Load.scala:1146)
	at scala.collection.MapLike.getOrElse(MapLike.scala:131)
	at scala.collection.MapLike.getOrElse$(MapLike.scala:129)
	at scala.collection.AbstractMap.getOrElse(Map.scala:63)
	at sbt.internal.Load$.memoLoadSettingsFile$1(Load.scala:1145)
	at sbt.internal.Load$.$anonfun$discoverProjects$4(Load.scala:1153)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:237)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at scala.collection.TraversableLike.map(TraversableLike.scala:237)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:230)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at sbt.internal.Load$.loadFiles$1(Load.scala:1153)
	at sbt.internal.Load$.discoverProjects(Load.scala:1167)
	at sbt.internal.Load$.discover$1(Load.scala:864)
	at sbt.internal.Load$.loadTransitive(Load.scala:939)
	at sbt.internal.Load$.loadProjects$1(Load.scala:728)
	at sbt.internal.Load$.$anonfun$loadUnit$11(Load.scala:731)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.$anonfun$loadUnit$1(Load.scala:731)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.loadUnit(Load.scala:690)
	at sbt.internal.Load$.$anonfun$builtinLoader$4(Load.scala:486)
	at sbt.internal.BuildLoader$.$anonfun$componentLoader$5(BuildLoader.scala:176)
	at sbt.internal.BuildLoader.apply(BuildLoader.scala:241)
	at sbt.internal.Load$.loadURI$1(Load.scala:548)
	at sbt.internal.Load$.loadAll(Load.scala:564)
	at sbt.internal.Load$.loadURI(Load.scala:494)
	at sbt.internal.Load$.load(Load.scala:473)
	at sbt.internal.Load$.$anonfun$apply$1(Load.scala:253)
	at sbt.internal.Load$.timed(Load.scala:1398)
	at sbt.internal.Load$.apply(Load.scala:253)
	at sbt.internal.Load$.defaultLoad(Load.scala:70)
	at sbt.BuiltinCommands$.liftedTree1$1(Main.scala:825)
	at sbt.BuiltinCommands$.doLoadProject(Main.scala:825)
	at sbt.BuiltinCommands$.$anonfun$loadProjectImpl$2(Main.scala:787)
	at sbt.Command$.$anonfun$applyEffect$4(Command.scala:142)
	at sbt.Command$.$anonfun$applyEffect$2(Command.scala:137)
	at sbt.Command$.process(Command.scala:181)
	at sbt.MainLoop$.$anonfun$processCommand$1(MainLoop.scala:148)
	at sbt.MainLoop$.processCommand(MainLoop.scala:160)
	at sbt.MainLoop$.processCommand(MainLoop.scala:148)
	at sbt.MainLoop$.$anonfun$next$2(MainLoop.scala:139)
	at sbt.State$StateOpsImpl$.runCmd$1(State.scala:269)
	at sbt.State$StateOpsImpl$.process$extension(State.scala:273)
	at sbt.MainLoop$.$anonfun$next$1(MainLoop.scala:139)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
	at sbt.MainLoop$.next(MainLoop.scala:139)
	at sbt.MainLoop$.run(MainLoop.scala:132)
	at sbt.MainLoop$.$anonfun$runWithNewLog$1(MainLoop.scala:110)
	at sbt.io.Using.apply(Using.scala:22)
	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:104)
	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:59)
	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:44)
	at sbt.MainLoop$.runLogged(MainLoop.scala:35)
	at sbt.StandardMain$.runManaged(Main.scala:110)
	at sbt.xMain.run(Main.scala:59)
	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
	at xsbt.boot.Launch$.run(Launch.scala:109)
	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
	at xsbt.boot.Launch$.launch(Launch.scala:117)
	at xsbt.boot.Launch$.apply(Launch.scala:18)
	at xsbt.boot.Boot$.runImpl(Boot.scala:56)
	at xsbt.boot.Boot$.main(Boot.scala:18)
	at xsbt.boot.Boot.main(Boot.scala)
error: error while loading String, class file '/modules/java.base/java/lang/String.class' is broken
(class java.lang.NullPointerException/null)
[running phase namer on /Users/jz/code/scratch6/build.sbt]
...
```

After:

```
$ echo "sbt.version=1.3.0-JZ2-fix" > project/build.properties ; rm -rf project/{project,target}; sbt  update;

[info] Loading settings for project global-plugins from idea.sbt,dirtymoney.sbt,gpg.sbt ...
[info] Loading settings for project scratch6-build from plugins.sbt ...
[running phase namer on /Users/jz/code/scratch6/build.sbt]tch6/project
...
```

Fixes the problem reported in https://github.com/scala/bug/issues/11381

I'm not sure why this only shows up with JDK12.

I'd appreciate a backport to 1.2.x if a new release is planned.