### PR TITLE
Unseal Parser

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -18,7 +18,7 @@ import sbt.internal.util.Util.{ makeList, separate }
  * The methods in this trait are what must be implemented to define a new Parser implementation, but are not typically useful for common usage.
  * Instead, most useful methods for combining smaller parsers into larger parsers are implicitly added by the [[RichParser]] type.
  */
-sealed trait Parser[+T] {
+trait Parser[+T] {
   def derive(i: Char): Parser[T]
   def resultEmpty: Result[T]
   def result: Option[T]


### PR DESCRIPTION
Although this is technically in the internal package, it is exposed to
users when they write a custom input task. I do not think that we should
prevent users/plugin authors from writing their own parser
implementations if there is a different library they prefer. By my
count, there are 21 implementations of this interface in sbt, so it's
unlikely that there is much benefit from a pattern matching perspective.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
