### PR TITLE
open up ExecuteProgress, and adds a few keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -291,7 +291,10 @@ lazy val taskProj = (project in file("tasks"))
     name := "Tasks",
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
-      exclude[ReversedMissingMethodProblem]("sbt.ExecuteProgress.stop")
+      // ok because sbt.ExecuteProgress has been under private[sbt]
+      exclude[IncompatibleResultTypeProblem]("sbt.ExecuteProgress.initial"),
+      exclude[DirectMissingMethodProblem]("sbt.ExecuteProgress.*"),
+      exclude[ReversedMissingMethodProblem]("sbt.ExecuteProgress.*"),
     )
   )
   .configure(addSbtUtilControl)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -259,6 +259,15 @@ object Defaults extends BuildCommon {
         () =>
           { IO.delete(dir); IO.createDirectory(dir) }
       },
+      useSuperShell :== sbt.internal.TaskProgress.isEnabled,
+      progressReports := { (s: State) =>
+        val progress = useSuperShell.value
+        val rs = EvaluateTask.taskTimingProgress.toVector ++ {
+          if (progress) Vector(EvaluateTask.taskProgress(s))
+          else Vector()
+        }
+        rs map { Keys.TaskProgress(_) }
+      },
       Previous.cache := new Previous(
         Def.streamsManagerKey.value,
         Previous.references.value.getReferences

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -138,20 +138,6 @@ object StandardMain {
     // This is to workaround https://github.com/sbt/io/issues/110
     sys.props.put("jna.nosys", "true")
 
-    ConsoleAppender.setTerminalWidth(JLine.usingTerminal(_.getWidth))
-    ConsoleAppender.setShowProgress(
-      ConsoleAppender.formatEnabledInEnv && sys.props
-        .get("sbt.progress")
-        .flatMap({ s =>
-          ConsoleAppender.parseLogOption(s) match {
-            case LogOption.Always => Some(true)
-            case LogOption.Never  => Some(false)
-            case _                => None
-          }
-        })
-        .getOrElse(true)
-    )
-
     import BasicCommandStrings.isEarlyCommand
     val userCommands = configuration.arguments.map(_.trim)
     val (earlyCommands, normalCommands) = (preCommands ++ userCommands).partition(isEarlyCommand)

--- a/tasks/src/main/scala/sbt/ExecuteProgress.scala
+++ b/tasks/src/main/scala/sbt/ExecuteProgress.scala
@@ -14,32 +14,29 @@ import sbt.internal.util.RMap
  * All methods are called from the same thread except `started` and `finished`,
  * which is called from the executing task's thread.
  * All methods should return quickly to avoid task execution overhead.
- *
- * This class is experimental and subject to binary and source incompatible changes at any time.
  */
-private[sbt] trait ExecuteProgress[F[_]] {
-  type S
-  def initial: S
+trait ExecuteProgress[F[_]] {
+  def initial(): Unit
 
   /**
    * Notifies that a `task` has been registered in the system for execution.
    * The dependencies of `task` are `allDeps` and the subset of those dependencies that
    * have not completed are `pendingDeps`.
    */
-  def registered(state: S, task: F[_], allDeps: Iterable[F[_]], pendingDeps: Iterable[F[_]]): S
+  def afterRegistered(task: F[_], allDeps: Iterable[F[_]], pendingDeps: Iterable[F[_]]): Unit
 
   /**
    * Notifies that all of the dependencies of `task` have completed and `task` is therefore
    * ready to run.  The task has not been scheduled on a thread yet.
    */
-  def ready(state: S, task: F[_]): S
+  def afterReady(task: F[_]): Unit
 
   /**
    * Notifies that the work for `task` is starting after this call returns.
    * This is called from the thread the task executes on, unlike most other methods in this callback.
    * It is called immediately before the task's work starts with minimal intervening executor overhead.
    */
-  def workStarting(task: F[_]): Unit
+  def beforeWork(task: F[_]): Unit
 
   /**
    * Notifies that the work for `task` work has finished.  The task may have computed the next task to
@@ -49,34 +46,68 @@ private[sbt] trait ExecuteProgress[F[_]] {
    * This is called from the thread the task executes on, unlike most other methods in this callback.
    * It is immediately called after the task's work is complete with minimal intervening executor overhead.
    */
-  def workFinished[A](task: F[A], result: Either[F[A], Result[A]]): Unit
+  def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit
 
   /**
    * Notifies that `task` has completed.
    * The task's work is done with a final `result`.
    * Any tasks called by `task` have completed.
    */
-  def completed[A](state: S, task: F[A], result: Result[A]): S
+  def afterCompleted[A](task: F[A], result: Result[A]): Unit
 
   /** All tasks have completed with the final `results` provided. */
-  def allCompleted(state: S, results: RMap[F, Result]): S
+  def afterAllCompleted(results: RMap[F, Result]): Unit
 
   /** Notifies that either all tasks have finished or cancelled. */
   def stop(): Unit
 }
 
 /** This module is experimental and subject to binary and source incompatible changes at any time. */
-private[sbt] object ExecuteProgress {
+object ExecuteProgress {
   def empty[F[_]]: ExecuteProgress[F] = new ExecuteProgress[F] {
-    type S = Unit
-    def initial = ()
-    def registered(state: Unit, task: F[_], allDeps: Iterable[F[_]], pendingDeps: Iterable[F[_]]) =
+    override def initial(): Unit = ()
+    override def afterRegistered(
+        task: F[_],
+        allDeps: Iterable[F[_]],
+        pendingDeps: Iterable[F[_]]
+    ): Unit =
       ()
-    def ready(state: Unit, task: F[_]) = ()
-    def workStarting(task: F[_]) = ()
-    def workFinished[A](task: F[A], result: Either[F[A], Result[A]]) = ()
-    def completed[A](state: Unit, task: F[A], result: Result[A]) = ()
-    def allCompleted(state: Unit, results: RMap[F, Result]) = ()
-    def stop(): Unit = ()
+    override def afterReady(task: F[_]): Unit = ()
+    override def beforeWork(task: F[_]): Unit = ()
+    override def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit = ()
+    override def afterCompleted[A](task: F[A], result: Result[A]): Unit = ()
+    override def afterAllCompleted(results: RMap[F, Result]): Unit = ()
+    override def stop(): Unit = ()
+  }
+
+  def aggregate[F[_]](reporters: Seq[ExecuteProgress[F]]) = new ExecuteProgress[F] {
+    override def initial(): Unit = {
+      reporters foreach { _.initial() }
+    }
+    override def afterRegistered(
+        task: F[_],
+        allDeps: Iterable[F[_]],
+        pendingDeps: Iterable[F[_]]
+    ): Unit = {
+      reporters foreach { _.afterRegistered(task, allDeps, pendingDeps) }
+    }
+    override def afterReady(task: F[_]): Unit = {
+      reporters foreach { _.afterReady(task) }
+    }
+    override def beforeWork(task: F[_]): Unit = {
+      reporters foreach { _.beforeWork(task) }
+    }
+    override def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit = {
+      reporters foreach { _.afterWork(task, result) }
+    }
+    override def afterCompleted[A](task: F[A], result: Result[A]): Unit = {
+      reporters foreach { _.afterCompleted(task, result) }
+    }
+    override def afterAllCompleted(results: RMap[F, Result]): Unit = {
+      reporters foreach { _.afterAllCompleted(results) }
+    }
+    override def stop(): Unit = {
+      reporters foreach { _.stop() }
+    }
   }
 }


### PR DESCRIPTION
Fixes #4461

This opens up ExecuteProgress API that's been around under private[sbt].
Since the state passing mechanism hasn't been used, I got rid of it.

The build user can configure the build using two keys Boolean `taskProgress` and `State => Seq[TaskProgress]` `progressReports`. `taskProgress` is lightweight key on/off switch for the super shell that can be used as follows:

```scala
Global / SettingKey[Boolean]("taskProgress") := false
```
