### PR TITLE
Disable supershell in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ init:
 install:
   - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
   - SET PATH=%JAVA_HOME%\bin;%PATH%
+  - SET CI=true
 
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -20,7 +21,7 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
       }
   - SET PATH=C:\sbt\sbt\bin;%PATH%
-  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF8
+  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dsbt.supershell=never -Dfile.encoding=UTF8
 test_script:
   - sbt "scripted actions/*" "testOnly sbt.ServerSpec"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 
 script:
   # It doesn't need that much memory because compile and run are forked
-  - sbt -Dsbt.version=1.2.6 -J-XX:ReservedCodeCacheSize=128m -J-Xmx800M -J-Xms800M -J-server "$SBT_CMD"
+  - sbt -Dsbt.version=1.2.6 -Dsbt.ci=true -J-XX:ReservedCodeCacheSize=128m -J-Xmx800M -J-Xms800M -J-server "$SBT_CMD"
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -264,7 +264,7 @@ object Defaults extends BuildCommon {
         () =>
           Clean.deleteContents(tempDirectory, _ => false)
       },
-      useSuperShell :== sbt.internal.TaskProgress.isEnabled,
+      useSuperShell := { if (insideCI.value) false else sbt.internal.TaskProgress.isEnabled },
       progressReports := { (s: State) =>
         val progress = useSuperShell.value
         val rs = EvaluateTask.taskTimingProgress.toVector ++
@@ -329,7 +329,8 @@ object Defaults extends BuildCommon {
           ++ serverHandlers.value
           ++ Vector(ServerHandler.fallback))
       },
-      insideCI :== sys.env.contains("BUILD_NUMBER") || sys.env.contains("CI"),
+      insideCI :== sys.env.contains("BUILD_NUMBER") ||
+        sys.env.contains("CI") || System.getProperty("sbt.ci", "false") == "true",
     )
   )
 


### PR DESCRIPTION
The supershell output is distracting in CI. I added a system property,
sbt.ci, to explicitly set whether or not sbt is running in a ci build.
It was not at all obvious to me if the BUILD_NUMBER or CI environment
variables were set on travis or appveyor.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
