### PR TITLE
Fix depth condition on GlobLister.aggregate

### DIFF
--- a/main/src/main/scala/sbt/internal/GlobLister.scala
+++ b/main/src/main/scala/sbt/internal/GlobLister.scala
@@ -74,8 +74,8 @@ private[internal] object GlobListers {
   private def covers(left: Glob, right: Glob): Boolean = {
     right.base.startsWith(left.base) && {
       left.depth == Int.MaxValue || {
-        val depth = left.base.relativize(right.base).getNameCount
-        depth < left.depth - right.depth
+        val depth = left.base.relativize(right.base).getNameCount - 1
+        depth <= left.depth - right.depth
       }
     }
   }

--- a/sbt/src/sbt-test/tests/glob-dsl/build.sbt
+++ b/sbt/src/sbt-test/tests/glob-dsl/build.sbt
@@ -52,3 +52,20 @@ checkSet := {
   val expected = Seq("Bar.md", "Foo.txt").map(baseDirectory.value / "base/subdir/nested-subdir" / _)
   assert(deduped.sorted == expected)
 }
+
+val depth = taskKey[Seq[File]]("Specify redundant sources with limited depth")
+val checkDepth = taskKey[Unit]("Check that the Bar.md file is retrieved")
+
+depth / fileInputs ++= Seq(
+  sbt.io.Glob(baseDirectory.value / "base", -DirectoryFilter, 2),
+  sbt.io.Glob(baseDirectory.value / "base" / "subdir", -DirectoryFilter, 1)
+)
+
+checkDepth := {
+  val redundant = (depth / fileInputs).value.all.map(_._1.toFile)
+  assert(redundant.size == 2)
+
+  val deduped = (depth / fileInputs).value.toSet[Glob].all.map(_._1.toFile)
+  val expected = Seq("Bar.md", "Foo.txt").map(baseDirectory.value / "base/subdir/nested-subdir" / _)
+  assert(deduped.sorted == expected)
+}

--- a/sbt/src/sbt-test/tests/glob-dsl/test
+++ b/sbt/src/sbt-test/tests/glob-dsl/test
@@ -5,3 +5,5 @@
 > checkAll
 
 > checkSet
+
+> checkDepth


### PR DESCRIPTION
I wrote this check in a rush and realized that it didn't quite match the
correct glob semantics. The depth parameter is effectively the index of
the array of sorted child directories of the base. That index is
computed with getNameCount - 1, not getNameCount. It is also inclusive,
not exclusive, hence the switch from `<` to `<=`.

This change was motivated by my reviewing the initial change in the
context of the fix to https://github.com/sbt/sbt/issues/4591.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
