### PR TITLE
Change default FileTree implementation

### DIFF
--- a/main/src/main/scala/sbt/internal/FileTree.scala
+++ b/main/src/main/scala/sbt/internal/FileTree.scala
@@ -21,7 +21,7 @@ object FileTree {
   private sealed trait CacheOptions
   private case object NoCache extends CacheOptions
   private case object UseCache extends CacheOptions
-  private case object LogDifferences extends CacheOptions
+  private case object Validate extends CacheOptions
   private def toPair(
       filter: Entry[FileAttributes] => Boolean
   )(e: Entry[FileAttributes]): Option[(Path, FileAttributes)] =
@@ -55,14 +55,14 @@ object FileTree {
   private class CachingRepository(underlying: FileTreeRepository[FileAttributes])
       extends Repository {
     lazy val cacheOptions = System.getProperty("sbt.io.filecache") match {
-      case "false" => NoCache
-      case "true"  => UseCache
-      case _       => LogDifferences
+      case "true"     => UseCache
+      case "validate" => Validate
+      case _          => NoCache
     }
     override def get(key: Glob): Seq[(Path, FileAttributes)] = {
       underlying.register(key)
       cacheOptions match {
-        case LogDifferences =>
+        case Validate =>
           val res = Repository.polling.get(key)
           val filter = key.toEntryFilter
           val cacheRes = underlying


### PR DESCRIPTION
I have noticed on linux that the file cache updates aren't fast enough
for ExternalHooks. Say you have project b that depends on project a.
With a clean build, if you run b/compile, the file cache may not yet see
the changes to *.class files generated by project a. There are multiple
ways to fix this:
* don't use the file cache for binary products
* use the analysis results to invalidate the cache
* switch over to my hypothetical replacement file system

In the meantime, we should stop spamming users by default.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
