### PR TITLE
trim update and add updateFull

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -370,6 +370,7 @@ object Keys {
   val ivyModule = taskKey[IvySbt#Module]("Provides the sbt interface to a configured Ivy module.").withRank(CTask)
   val updateCacheName = taskKey[String]("Defines the directory name used to store the update cache files (inside the streams cacheDirectory).").withRank(DTask)
   val update = taskKey[UpdateReport]("Resolves and optionally retrieves dependencies, producing a report.").withRank(ATask)
+  val updateFull = taskKey[UpdateReport]("Resolves and optionally retrieves dependencies, producing a full report with callers.").withRank(CTask)
   val evicted = taskKey[EvictionWarning]("Display detailed eviction warnings.").withRank(CTask)
   val evictionWarningOptions = settingKey[EvictionWarningOptions]("Options on eviction warnings after resolving managed dependencies.").withRank(DSetting)
   val transitiveUpdate = taskKey[Seq[UpdateReport]]("UpdateReports for the internal dependencies of this project.").withRank(DTask)

--- a/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
@@ -31,7 +31,9 @@ lazy val root = (project in file("."))
     // sbt resolves dependencies every compile when using %% with dependencyOverrides
     TaskKey[Unit]("check") := {
       val s = (streams in update).value
-      val cacheStoreFactory = s.cacheStoreFactory sub updateCacheName.value
+
+      val cacheDirectory = crossTarget.value / "update" / updateCacheName.value
+      val cacheStoreFactory = sbt.util.CacheStoreFactory.directory(cacheDirectory)
       val module = ivyModule.value
       val updateConfig = updateConfiguration.value
       val extraInputHash0 = module.extraInputHash


### PR DESCRIPTION
Fixes #4438

This slims down update's UpdateReport by removing evicted modules caller information. The larger the graph, the effect would be more pronounced. For example, I saw a graph reduce from 5.9MB to 1.1MB in JSON file.
