### PR TITLE
Switch to ZincLmUtil

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -28,7 +28,7 @@ import sbt.Scope.{ GlobalScope, ThisScope, fillTaskAxis }
 import sbt.internal.CommandStrings.ExportStream
 import sbt.internal._
 import sbt.internal.inc.JavaInterfaceUtil._
-import sbt.internal.inc.ZincUtil
+import sbt.internal.inc.{ ZincLmUtil, ZincUtil }
 import sbt.internal.io.{ Source, WatchState }
 import sbt.internal.librarymanagement._
 import sbt.internal.librarymanagement.mavenint.{
@@ -470,7 +470,7 @@ object Defaults extends BuildCommon {
       IvyActions.cleanCachedResolutionCache(ivyModule.value, streams.value.log)
     },
     scalaCompilerBridgeBinaryJar := None,
-    scalaCompilerBridgeSource := ZincUtil.getDefaultBridgeModule(scalaVersion.value),
+    scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(scalaVersion.value),
   )
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(
@@ -532,7 +532,7 @@ object Defaults extends BuildCommon {
               compilerBridgeJar = jar
             )
           case _ =>
-            ZincUtil.scalaCompiler(
+            ZincLmUtil.scalaCompiler(
               scalaInstance = scalaInstance.value,
               classpathOptions = classpathOptions.value,
               globalLock = launcher.globalLock,

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -10,7 +10,7 @@ package internal
 
 import sbt.util.Logger
 import sbt.internal.util.JLine
-import sbt.internal.inc.{ ScalaInstance, ZincUtil }
+import sbt.internal.inc.{ ScalaInstance, ZincLmUtil, ZincUtil }
 import xsbti.compile.ClasspathOptionsUtil
 
 object ConsoleProject {
@@ -41,7 +41,7 @@ object ConsoleProject {
           compilerBridgeJar = jar
         )
       case None =>
-        ZincUtil.scalaCompiler(
+        ZincLmUtil.scalaCompiler(
           scalaInstance = scalaInstance,
           classpathOptions = ClasspathOptionsUtil.repl,
           globalLock = launcher.globalLock,

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -37,7 +37,7 @@ import Keys.{
 import Project.inScope
 import sbt.internal.inc.classpath.ClasspathUtilities
 import sbt.librarymanagement.ivy.{ InlineIvyConfiguration, IvyDependencyResolution, IvyPaths }
-import sbt.internal.inc.{ ZincUtil, ScalaInstance }
+import sbt.internal.inc.{ ZincLmUtil, ZincUtil, ScalaInstance }
 import sbt.internal.util.Attributed.data
 import sbt.internal.util.Types.const
 import sbt.internal.util.{ Attributed, Settings, ~> }
@@ -93,14 +93,14 @@ private[sbt] object Load {
     val si = ScalaInstance(scalaProvider.version, scalaProvider.launcher)
     val zincDir = BuildPaths.getZincDirectory(state, globalBase)
     val classpathOptions = ClasspathOptionsUtil.boot
-    val scalac = ZincUtil.scalaCompiler(
+    val scalac = ZincLmUtil.scalaCompiler(
       scalaInstance = si,
       classpathOptions = classpathOptions,
       globalLock = launcher.globalLock,
       componentProvider = app.provider.components,
       secondaryCacheDir = Option(zincDir),
       dependencyResolution = dependencyResolution,
-      compilerBridgeSource = ZincUtil.getDefaultBridgeModule(scalaProvider.version),
+      compilerBridgeSource = ZincLmUtil.getDefaultBridgeModule(scalaProvider.version),
       scalaJarsTarget = zincDir,
       log = log
     )


### PR DESCRIPTION
The sbt-side PR for breaking the dependency that Zinc had on LM, and thus Ivy, aka https://github.com/sbt/zinc/pull/655.

From local testing it looks like the dependency graph doesn't need amending (which I found surprising, but let's see what sbt-validator says).