### PR TITLE
Allow calling TaskKey.previous in input tasks

### DIFF
--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -450,6 +450,7 @@ object TaskMacro {
 
     def expand(nme: String, tpe: Type, tree: Tree): Converted[c.type] = nme match {
       case WrapInitTaskName         => Converted.Success(wrapInitTask(tree)(c.WeakTypeTag(tpe)))
+      case WrapPreviousName         => Converted.Success(wrapInitTask(tree)(c.WeakTypeTag(tpe)))
       case ParserInput.WrapInitName => Converted.Success(wrapInitParser(tree)(c.WeakTypeTag(tpe)))
       case WrapInitInputName        => Converted.Success(wrapInitInput(tree)(c.WeakTypeTag(tpe)))
       case WrapInputName            => Converted.Success(wrapInput(tree)(c.WeakTypeTag(tpe)))

--- a/sbt/src/sbt-test/actions/previous-in-input-task/build.sbt
+++ b/sbt/src/sbt-test/actions/previous-in-input-task/build.sbt
@@ -1,0 +1,10 @@
+import sjsonnew.BasicJsonProtocol._
+
+val cacheTask = taskKey[Int]("task")
+cacheTask := 1
+
+val checkTask = inputKey[Unit]("validate that the correct value is set by cacheTask")
+checkTask := {
+  val expected = Def.spaceDelimited("").parsed.head.toInt
+  assert(cacheTask.previous.getOrElse(0) == expected)
+}

--- a/sbt/src/sbt-test/actions/previous-in-input-task/test
+++ b/sbt/src/sbt-test/actions/previous-in-input-task/test
@@ -1,0 +1,5 @@
+> checkTask 0
+
+> cacheTask
+
+> checkTask 1


### PR DESCRIPTION
I discovered that it wasn't possible to call .previous in an input task.
While I understand why you can't call .previous on an InputKey, I think
it makes sense to allow calling .previous on a TaskKey within an input
task.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
