### PR TITLE
Use global classloader cache for ScalaInstance

### DIFF
--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
@@ -8,6 +8,7 @@
 package sbt.internal.inc
 
 import java.io.File
+import java.net.URLClassLoader
 
 import sbt.io.IO
 import sbt.io.syntax._
@@ -59,6 +60,8 @@ abstract class IvyBridgeProviderSpecification extends FlatSpec with Matchers {
     val provider = getZincProvider(bridge1, targetDir, log)
     val scalaInstance = provider.fetchScalaInstance(scalaVersion, log)
     val bridge = provider.fetchCompiledBridge(scalaInstance, log)
+    scalaInstance.loader.asInstanceOf[URLClassLoader].close()
+    scalaInstance.loaderLibraryOnly.asInstanceOf[URLClassLoader].close()
     val target = targetDir / s"target-bridge-$scalaVersion.jar"
     IO.copyFile(bridge, target)
     target


### PR DESCRIPTION
I noticed in a heap dump of sbt that there were many classloaders for
the scala instance. I then realized that we were making a new
classloader for the scala library on every test run. Even worse, the
ScalaInstanceLoader instance was never closed which lead to a metaspace
leak. I moved the scala instance classloader to the global classloader
cache. Not only will these be correctly cached, they will be closed if
evicted from the cache.

Fixes #4639 