### PR TITLE
Properly close a number of classloaders

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -50,6 +50,11 @@ final class xMain extends xsbti.AppMain {
       case e: InvocationTargetException =>
         // This propogates xsbti.FullReload to the launcher
         throw e.getCause
+    } finally {
+      loader match {
+        case a: AutoCloseable => a.close()
+        case _                =>
+      }
     }
   }
   /*

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -226,6 +226,11 @@ private[sbt] object SbtMetaBuildClassLoader {
     }
     new URLClassLoader(rest, updatedLibraryLoader) {
       override def toString: String = s"SbtMetaBuildClassLoader"
+      override def close(): Unit = {
+        super.close()
+        updatedLibraryLoader.close()
+        interfaceLoader.close()
+      }
     }
   }
 }


### PR DESCRIPTION
I discovered there were a number of places where closing a ClassLoader
didn't work correctly because I was assuming it was a URLClassLoader
when it was actually a ClasspathFilter. I also incorrectly imported the
wrong kind of URLClassLoader in Run.scala. Finally, I close the
SbtMetaBuildClassLoader when xMain exits now.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
