### PR TITLE
Add launcher interface dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -589,6 +589,7 @@ lazy val zincLmIntegrationProj = (project in file("zinc-lm-integration"))
     buildInfoObject in Test := "ZincLmIntegrationBuildInfo",
     buildInfoKeys in Test := List[BuildInfoKey]("zincVersion" -> zincVersion),
     mimaSettingsSince(sbt13Plus),
+    libraryDependencies += launcherInterface,
   )
   .configure(addSbtZincCompileCore, addSbtLmCore, addSbtLmIvyTest)
 

--- a/build.sbt
+++ b/build.sbt
@@ -251,7 +251,7 @@ lazy val testingProj = (project in file("testing"))
   .settings(
     baseSettings,
     name := "Testing",
-    libraryDependencies ++= Seq(testInterface, launcherInterface, sjsonNewScalaJson.value),
+    libraryDependencies ++= scalaXml.value ++ Seq(testInterface, launcherInterface, sjsonNewScalaJson.value),
     Compile / scalacOptions += "-Ywarn-unused:-locals,-explicits,-privates",
     managedSourceDirectories in Compile +=
       baseDirectory.value / "src" / "main" / "contraband-scala",


### PR DESCRIPTION
Previously the zincLmIntegrationProj would compile if the meta build classpath
leaked into the compilation classpath. I found that the project would
not compile a clean build running an sbt built off of origin/develop.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
