### PR TITLE
exclude preloaded local repos for now

### DIFF
--- a/main/src/main/scala/sbt/internal/librarymanagement/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/CoursierRepositoriesTasks.scala
@@ -83,7 +83,9 @@ private[sbt] object CoursierRepositoriesTasks {
       Def.task {
         val result0 = resultTask(bootResOpt, overrideFlag).value
         val reorderResolvers = true // coursierReorderResolvers.value
-        val keepPreloaded = true // coursierKeepPreloaded.value
+        // local-preloaded-ivy contains dangling ivy.xml without JAR files
+        // https://github.com/sbt/sbt/issues/4661
+        val keepPreloaded = false // coursierKeepPreloaded.value
 
         val paths = ivyPaths.value
         val result1 =


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/4661
local-preloaded-ivy contains dangling ivy.xml without JAR files.
We might include local-preloaded again once we have a preloaded in Maven layout.
