### PR TITLE
silence coursier log when supershell is off

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -242,7 +242,7 @@ object Defaults extends BuildCommon {
       forceUpdatePeriod :== None,
       // coursier settings
       csrExtraCredentials :== Nil,
-      csrLogger :== None,
+      csrLogger := LMCoursier.coursierLoggerTask.value,
       csrCachePath :== LMCoursier.defaultCacheLocation,
       csrMavenProfiles :== Set.empty,
     )

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2438,7 +2438,7 @@ object Classpaths {
     csrConfiguration := LMCoursier.coursierConfigurationTask(false, false).value,
     csrResolvers := CoursierRepositoriesTasks.coursierResolversTask.value,
     csrRecursiveResolvers := CoursierRepositoriesTasks.coursierRecursiveResolversTask.value,
-    csrSbtResolvers := LMCoursier.coursierSbtResolversTask.value,
+    csrSbtResolvers := CoursierRepositoriesTasks.coursierSbtResolversTask.value,
     csrInterProjectDependencies := CoursierInputsTasks.coursierInterProjectDependenciesTask.value,
     csrFallbackDependencies := CoursierInputsTasks.coursierFallbackDependenciesTask.value,
   ) ++

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -243,7 +243,7 @@ object Defaults extends BuildCommon {
       // coursier settings
       csrExtraCredentials :== Nil,
       csrLogger := LMCoursier.coursierLoggerTask.value,
-      csrCachePath :== LMCoursier.defaultCacheLocation,
+      csrCacheDirectory :== LMCoursier.defaultCacheLocation,
       csrMavenProfiles :== Set.empty,
     )
 
@@ -2160,8 +2160,8 @@ object Classpaths {
       }).value,
     moduleName := normalizedName.value,
     ivyPaths := IvyPaths(baseDirectory.value, bootIvyHome(appConfiguration.value)),
-    csrCachePath := {
-      val old = csrCachePath.value
+    csrCacheDirectory := {
+      val old = csrCacheDirectory.value
       val ip = ivyPaths.value
       val defaultIvyCache = bootIvyHome(appConfiguration.value)
       if (old != LMCoursier.defaultCacheLocation) old

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -324,7 +324,7 @@ object Keys {
   val internalDependencyConfigurations = settingKey[Seq[(ProjectRef, Set[String])]]("The project configurations that this configuration depends on")
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
-  val csrCachePath = settingKey[File]("Coursier cache path").withRank(CSetting)
+  val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)
   val csrMavenProfiles = settingKey[Set[String]]("").withRank(CSetting)
   private[sbt] val csrConfiguration = taskKey[CoursierConfiguration]("General dependency management (Coursier) settings, such as the resolvers and options to use.").withRank(DTask)
   private[sbt] val csrProject = taskKey[lmcoursier.definitions.Project]("")

--- a/main/src/main/scala/sbt/internal/LMCoursier.scala
+++ b/main/src/main/scala/sbt/internal/LMCoursier.scala
@@ -15,9 +15,14 @@ import sbt.librarymanagement._
 import Keys._
 import sbt.internal.librarymanagement.{ CoursierArtifactsTasks, CoursierInputsTasks }
 import sbt.util.Logger
+import sbt.io.syntax._
 
 private[sbt] object LMCoursier {
-  def defaultCacheLocation: File = CoursierDependencyResolution.defaultCacheLocation
+  def defaultCacheLocation: File =
+    sys.props.get("sbt.coursier.home") match {
+      case Some(home) => new File(home).getAbsoluteFile / "cache"
+      case _          => CoursierDependencyResolution.defaultCacheLocation
+    }
 
   def coursierConfigurationTask(
       withClassifiers: Boolean,
@@ -56,7 +61,7 @@ private[sbt] object LMCoursier {
 
         val createLogger = csrLogger.value
 
-        val cache = csrCachePath.value
+        val cache = csrCacheDirectory.value
 
         val internalSbtScalaProvider = appConfiguration.value.provider.scalaProvider
         val sbtBootJars = internalSbtScalaProvider.jars()

--- a/main/src/main/scala/sbt/internal/LMCoursier.scala
+++ b/main/src/main/scala/sbt/internal/LMCoursier.scala
@@ -89,37 +89,6 @@ private[sbt] object LMCoursier {
       }
     }
 
-  private val pluginIvySnapshotsBase = Resolver.SbtRepositoryRoot.stripSuffix("/") + "/ivy-snapshots"
-
-  def coursierSbtResolversTask: Def.Initialize[sbt.Task[Seq[Resolver]]] = Def.task {
-    val resolvers =
-      sbt.Classpaths
-        .bootRepositories(appConfiguration.value)
-        .toSeq
-        .flatten ++ // required because of the hack above it seems
-        externalResolvers.in(updateSbtClassifiers).value
-
-    val pluginIvySnapshotsFound = resolvers.exists {
-      case repo: URLRepository =>
-        repo.patterns.artifactPatterns.headOption
-          .exists(_.startsWith(pluginIvySnapshotsBase))
-      case _ => false
-    }
-
-    val resolvers0 =
-      if (pluginIvySnapshotsFound && !resolvers.contains(Classpaths.sbtPluginReleases))
-        resolvers :+ Classpaths.sbtPluginReleases
-      else
-        resolvers
-    val keepPreloaded = true // coursierKeepPreloaded.value
-    if (keepPreloaded)
-      resolvers0
-    else
-      resolvers0.filter { r =>
-        !r.name.startsWith("local-preloaded")
-      }
-  }
-
   def publicationsSetting(packageConfigs: Seq[(Configuration, CConfiguration)]): Def.Setting[_] = {
     csrPublications := CoursierArtifactsTasks.coursierPublicationsTask(packageConfigs: _*).value
   }


### PR DESCRIPTION
CI logs are filled up with Downloaded, so I am turning the Coursier log off.

Ref https://github.com/coursier/coursier/pull/872