### PR TITLE
disable "Reload" exception stack trace

### DIFF
--- a/main-command/src/main/scala/sbt/MainControl.scala
+++ b/main-command/src/main/scala/sbt/MainControl.scala
@@ -21,7 +21,7 @@ final case class Reboot(
   def arguments = argsList.toArray
 }
 
-case object Reload extends Exception
+case object Reload extends Exception(null, null, false, false)
 
 final case class ApplicationID(
     groupID: String,


### PR DESCRIPTION
- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines

I think we should disable stacktrace or change to `class`.


```scala
package example

object Foo extends Exception

object Main {
  def x() = Foo
  def y() = Foo

  def main(args: Array[String]): Unit = {
    x()
    y().printStackTrace // unexpected stack trace!

    // example.Foo$
    //   at example.Foo$.<clinit>(A.scala)
    //   at example.Main$.x(A.scala:6)
    //   at example.Main$.main(A.scala:10)
    //   at example.Main.main(A.scala)
  }
}
```