### PR TITLE
Manage shutdown hooks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -666,6 +666,7 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.Defaults.allTestGroupsTask"),
       exclude[DirectMissingMethodProblem]("sbt.Plugins.topologicalSort"),
       exclude[IncompatibleMethTypeProblem]("sbt.Defaults.allTestGroupsTask"),
+      exclude[DirectMissingMethodProblem]("sbt.StandardMain.shutdownHook")
     )
   )
   .configure(

--- a/main/src/main/scala/sbt/internal/LayeredClassLoader.scala
+++ b/main/src/main/scala/sbt/internal/LayeredClassLoader.scala
@@ -49,12 +49,10 @@ private[sbt] class LayeredClassLoader(
 
 private[internal] object NativeLibs {
   private[this] val nativeLibs = new jutil.HashSet[File].asScala
-  Runtime.getRuntime.addShutdownHook(new Thread("sbt.internal.native-library-deletion") {
-    override def run(): Unit = {
-      nativeLibs.foreach(IO.delete)
-      IO.deleteIfEmpty(nativeLibs.map(_.getParentFile).toSet)
-      nativeLibs.clear()
-    }
+  ShutdownHooks.add(() => {
+    nativeLibs.foreach(IO.delete)
+    IO.deleteIfEmpty(nativeLibs.map(_.getParentFile).toSet)
+    nativeLibs.clear()
   })
   def addNativeLib(lib: String): Unit = {
     nativeLibs.add(new File(lib))

--- a/main/src/main/scala/sbt/internal/ShutdownHooks.scala
+++ b/main/src/main/scala/sbt/internal/ShutdownHooks.scala
@@ -1,0 +1,45 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+
+import scala.util.control.NonFatal
+
+private[sbt] object ShutdownHooks extends AutoCloseable {
+  private[this] val idGenerator = new AtomicInteger(0)
+  private[this] val hooks = new ConcurrentHashMap[Int, () => Any]
+  private[this] val ranHooks = new AtomicBoolean(false)
+  private[this] val thread = new Thread("shutdown-hooks-run-all") {
+    override def run(): Unit = runAll()
+  }
+  private[this] val runtime = Runtime.getRuntime
+  runtime.addShutdownHook(thread)
+  private[sbt] def add[R](task: () => R): AutoCloseable = {
+    val id = idGenerator.getAndIncrement()
+    hooks.put(
+      id,
+      () =>
+        try task()
+        catch {
+          case NonFatal(e) =>
+            System.err.println(s"Caught exception running shutdown hook: $e")
+            e.printStackTrace(System.err)
+        }
+    )
+    () => Option(hooks.remove(id)).foreach(_.apply())
+  }
+  private def runAll(): Unit = if (ranHooks.compareAndSet(false, true)) {
+    hooks.forEachValue(Runtime.getRuntime.availableProcessors, _.apply())
+  }
+  override def close(): Unit = {
+    runtime.removeShutdownHook(thread)
+    runAll()
+  }
+}

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -38,9 +38,7 @@ private[sbt] final class TaskTimings(reportOnShutdown: Boolean)
 
   if (reportOnShutdown) {
     start = System.nanoTime
-    Runtime.getRuntime.addShutdownHook(new Thread {
-      override def run() = report()
-    })
+    ShutdownHooks.add(() => report())
   }
 
   override def initial(): Unit = {

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -36,9 +36,7 @@ private[sbt] final class TaskTraceEvent
   override def stop(): Unit = ()
 
   start = System.nanoTime
-  Runtime.getRuntime.addShutdownHook(new Thread {
-    override def run() = report()
-  })
+  ShutdownHooks.add(() => report())
 
   private[this] def report() = {
     if (timings.asScala.nonEmpty) {


### PR DESCRIPTION
I discovered that some registered shutdown hooks would crash due to
67df72ab019e32935588e1a58e636e07f4ed65ce because they would try to load
classes from the closed classloader. To fix this, I add a internal
shutdown hooks mechanism that can be managed by sbt. Any unevaluated
shutdown hooks will be run when the sbt main method exits. This means
that they will be run when the user calls reboot. I think that is
reasonable.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
