### PR TITLE
Don't ever invalidate rt.jar

### DIFF
--- a/main/src/main/scala/sbt/internal/ExternalHooks.scala
+++ b/main/src/main/scala/sbt/internal/ExternalHooks.scala
@@ -84,6 +84,7 @@ private[sbt] object ExternalHooks {
               case _ =>
                 javaHome match {
                   case Some(h) if file.toPath.startsWith(h) => None
+                  case _ if file.getName == "rt.jar"        => None
                   case _                                    => Some(file)
                 }
             }


### PR DESCRIPTION
There are issues when using jdk > 8 where the rt.jar file can be
invalidated by ExternalHooks. This causes spurious rebuilds. I think
it's fair to assume that rt.jar never changes. If a dependency is named
rt.jar, then invalidation may not work correctly but I think that this
is the more important case to handle.

I verified that before this change, it was impossible to run
akka-actor/compile twice in a row using adopt jdk 11 and, after this
change, re-compilation worked as expected.

- [ ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
