### PR TITLE
Add explicit dependency for checkBuildSources

### DIFF
--- a/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
@@ -19,7 +19,7 @@ private[sbt] object CheckBuildSources {
     val logger = streams.value.log
     val checkMetaBuildParam = state.value.get(hasCheckedMetaBuild)
     val firstTime = checkMetaBuildParam.fold(true)(_.get == false)
-    (onChangedBuildSource in Scope.Global).value match {
+    onChangedBuildSource.value match {
       case IgnoreSourceChanges => ()
       case o =>
         logger.debug("Checking for meta build source updates")

--- a/sbt/src/sbt-test/nio/intraproject-inputs/project/Build.scala
+++ b/sbt/src/sbt-test/nio/intraproject-inputs/project/Build.scala
@@ -17,6 +17,7 @@ object Build {
   val checkTest = taskKey[Unit]("check test inputs")
 
   val root = (project in file(".")).settings(
+    Global / onChangedBuildSource := IgnoreSourceChanges,
     Compile / cached / fileInputs := (Compile / unmanagedSources / fileInputs).value ++
       (Compile / unmanagedResources / fileInputs).value,
     Test / cached / fileInputs := (Test / unmanagedSources / fileInputs).value ++

--- a/sbt/src/sbt-test/watch/on-start-watch/build.sbt
+++ b/sbt/src/sbt-test/watch/on-start-watch/build.sbt
@@ -16,4 +16,4 @@ failingTask := {
   throw new IllegalStateException("failed")
 }
 
-onChangedBuildSource := ReloadOnSourceChanges
+Global / onChangedBuildSource := ReloadOnSourceChanges


### PR DESCRIPTION
Rather than adding some custom logic to EvaluateTask.runTask, it makes
more sense to explicitly add a dependency on checkBuildSources to every
(non-injected) task in the build. This both reduces the amount of custom
logic for the checkBuildSources task and also makes it show up in the
`inspect` command

I also reordered the injected settings so that they come before the
project settings. This should allow the user to override the injected
settings if they wanted. The injected settings do not have the
dependency on checkBuildSources added which allows the other file stamp
tasks to run concurrently with the build source check. This means that
for tasks like compile there is often effectively zero overhead for the
build source check.

Finally, I simplified Continuous so that there is no custom logic for
tracking the meta build. By adding the dependency on checkBuildSources
to every task, the tasks end up automatically watching the build files
anyway.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
