### PR TITLE
Increase duration between polling from stdin

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -68,7 +68,7 @@ private[sbt] final class CommandExchange {
       Option(commandQueue.poll) match {
         case Some(x) => x
         case None =>
-          Thread.sleep(2)
+          Thread.sleep(20)
           val newDeadline = if (deadline.fold(false)(_.isOverdue())) {
             GCUtil.forceGcWithInterval(interval, logger)
             None

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -657,7 +657,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
     }
 
     (() => {
-      val actions = antiEntropyMonitor.poll(2.milliseconds).flatMap(onEvent)
+      val actions = antiEntropyMonitor.poll(20.milliseconds).flatMap(onEvent)
       if (actions.exists(_._2 != Watch.Ignore)) {
         val builder = new StringBuilder
         val min = actions.minBy {

--- a/main/src/main/scala/sbt/internal/Idle.scala
+++ b/main/src/main/scala/sbt/internal/Idle.scala
@@ -1,0 +1,19 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+private[sbt] object Idle {
+  val value: FiniteDuration =
+    try System.getProperty("sbt.idle.seconds", "300").toInt.seconds
+    catch { case NonFatal(_) => 5.minute }
+  val idleTimeout: FiniteDuration = 500.millis
+  val activeTimout: FiniteDuration = 20.millis
+}


### PR DESCRIPTION
I was testing the cpu utilization of sbt when idle and noticed that it
was a bit higher than I expected. It was using O(15%) of a cpu on
average. After increasing these periods, the value dropped to O(2%).

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
