### PR TITLE
Failing tests for +foo/testOnly foo.Test

### DIFF
--- a/sbt/src/sbt-test/tests/cross-multiproject/build.sbt
+++ b/sbt/src/sbt-test/tests/cross-multiproject/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / crossScalaVersions := Seq("2.12.8")
+
+lazy val root = (project in file("."))
+  .aggregate(foo)
+
+lazy val foo = (project in file("foo"))
+  .settings(
+    name := "foo",
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.8" % "test"
+  )

--- a/sbt/src/sbt-test/tests/cross-multiproject/foo/src/test/scala/PassTest.scala
+++ b/sbt/src/sbt-test/tests/cross-multiproject/foo/src/test/scala/PassTest.scala
@@ -1,0 +1,8 @@
+package foo
+
+import org.junit.Test
+
+class PassTest {
+  @Test
+  def pass: Unit = {}
+}

--- a/sbt/src/sbt-test/tests/cross-multiproject/test
+++ b/sbt/src/sbt-test/tests/cross-multiproject/test
@@ -1,0 +1,15 @@
+> test
+> testOnly foo.PassTest
+> testOnly -- -v
+
+> foo/test
+> foo/testOnly foo.PassTest
+> foo/testOnly -- -v
+
+> +test
+> +testOnly foo.PassTest
+> +testOnly -- -v
+
+> +foo/test
+> +foo/testOnly foo.PassTest
+> +foo/testOnly -- -v


### PR DESCRIPTION
This is the scripted test to verify #4715.  I don't have the sbt chops to fix this.  

Feel free to close this PR once the CI completes (and hopefully fails on this new test).

In summary, sbt 0.13 used to be able to run:

```
> +foo/testOnly foo.Test
```

But sbt 1.2.8, fails with:

```
sbt:sbtRoot> scripted tests/cross-multiproject
Running tests/cross-multiproject
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.02s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 5 s, completed May 22, 2019 9:36:45 AM
[info] [info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] [info] No tests to run for Test / testOnly
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.011s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:36:45 AM
[info] [info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] [info] No tests to run for Test / testOnly
[info] [info] Test run started
[info] [info] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.015s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:36:46 AM
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.015s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:36:46 AM
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.012s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:36:46 AM
[info] [info] Test run started
[info] [info] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.016s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 1 s, completed May 22, 2019 9:36:47 AM
[info] [info] Setting Scala version to 2.12.8 on 2 projects.
[info] [info] Reapplying settings...
[info] [info] Updating ...
[info] [info] Updating foo...
[info] [info] Done updating.
[info] [info] Done updating.
[info] [info] Done compiling.
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.012s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 9 s, completed May 22, 2019 9:36:57 AM
[info] [info] Reapplying settings...
[info] [info] Forcing Scala version to 2.12.8 on all projects.
[info] [info] Reapplying settings...
[info] [info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] [info] No tests to run for Test / testOnly
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.009s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:36:58 AM
[info] [info] Reapplying settings...
[info] [info] Forcing Scala version to 2.12.8 on all projects.
[info] [info] Reapplying settings...
[info] [info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] [info] No tests to run for Test / testOnly
[info] [info] Test run started
[info] [info] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.028s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 2 s, completed May 22, 2019 9:37:00 AM
[info] [info] Reapplying settings...
[info] [info] Setting Scala version to 2.12.8 on 2 projects.
[info] [info] Reapplying settings...
[info] [debug] Test run started
[info] [debug] Test foo.PassTest.pass started
[info] [debug] Test foo.PassTest.pass finished
[info] [debug] Test run finished: 0 failed, 0 ignored, 1 total, 0.009s
[info] [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[info] [success] Total time: 0 s, completed May 22, 2019 9:37:01 AM
[info] [info] Reapplying settings...
[error] java.util.NoSuchElementException: key not found: ProjectRef(file:/tmp/sbt_ea88e34b/,root)
[error] 	at scala.collection.immutable.Map$Map1.apply(Map.scala:114)
[error] 	at sbt.Cross$.crossBuildCommandImpl(Cross.scala:167)
[error] 	at sbt.Cross$.$anonfun$crossBuild$2(Cross.scala:123)
[error] 	at sbt.Cross$$$Lambda$469/276714561.apply(Unknown Source)
[error] 	at sbt.Command$.$anonfun$applyEffect$4(Command.scala:142)
[error] 	at sbt.Command$$$Lambda$413/1285463992.apply(Unknown Source)
[error] 	at sbt.Command$.$anonfun$applyEffect$2(Command.scala:137)
[error] 	at sbt.Command$$$Lambda$439/215478702.apply(Unknown Source)
[error] 	at sbt.Command$.process(Command.scala:181)
[error] 	at sbt.MainLoop$.processCommand(MainLoop.scala:151)
[error] 	at sbt.MainLoop$.$anonfun$next$2(MainLoop.scala:139)
[error] 	at sbt.MainLoop$$$Lambda$394/467401150.apply(Unknown Source)
[error] 	at sbt.State$$anon$1.runCmd$1(State.scala:246)
[error] 	at sbt.State$$anon$1.process(State.scala:250)
[error] 	at sbt.MainLoop$.$anonfun$next$1(MainLoop.scala:139)
[error] 	at sbt.MainLoop$$$Lambda$393/761863997.apply(Unknown Source)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.MainLoop$.next(MainLoop.scala:139)
[error] 	at sbt.MainLoop$.run(MainLoop.scala:132)
[error] 	at sbt.MainLoop$.$anonfun$runWithNewLog$1(MainLoop.scala:110)
[error] 	at sbt.MainLoop$$$Lambda$386/1537689020.apply(Unknown Source)
[error] 	at sbt.io.Using.apply(Using.scala:22)
[error] 	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:104)
[error] 	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:59)
[error] 	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:44)
[error] 	at sbt.MainLoop$.runLogged(MainLoop.scala:35)
[error] 	at sbt.StandardMain$.runManaged(Main.scala:138)
[error] 	at sbt.xMain.run(Main.scala:89)
[error] java.util.NoSuchElementException: key not found: ProjectRef(file:/tmp/sbt_ea88e34b/,root)
[error] Use 'last' for the full log.
[error] x tests/cross-multiproject 
[error]  Cause of test exception: {line 14}  Command failed: +foo/testOnly failed
[error] java.lang.RuntimeException: Failed tests:
[error] 	tests/cross-multiproject
[error] 
[error] (scripted) Failed tests:
[error] 	tests/cross-multiproject
[error] Total time: 268 s, completed May 22, 2019 9:37:15 AM
```