### PR TITLE
Fix +foo/testOnly foo.BarTest

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -124,7 +124,6 @@ object Cross {
 
   private def crossBuildCommandImpl(state: State, args: CrossArgs): State = {
     val x = Project.extract(state)
-    import x._
     val (aggs, aggCommand) = parseSlashCommand(x)(args.command)
 
     val projCrossVersions = aggs map { proj =>
@@ -164,9 +163,10 @@ object Cross {
           }
 
           // Execute using a blanket switch
-          projCrossVersions.toMap.apply(currentRef).flatMap { version =>
-            // Force scala version
-            Seq(s"$SwitchCommand $verbose $version!", aggCommand)
+          projVersions.flatMap {
+            case (proj, version) =>
+              // Force scala version
+              Seq(s"$SwitchCommand $verbose $version!", s"${proj}/$aggCommand")
           }
 
         case Right(_) =>

--- a/sbt/src/sbt-test/tests/cross-multiproject/build.sbt
+++ b/sbt/src/sbt-test/tests/cross-multiproject/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / crossScalaVersions := Seq("2.12.8")
+
+lazy val root = (project in file("."))
+  .aggregate(foo)
+
+lazy val foo = (project in file("foo"))
+  .settings(
+    name := "foo",
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.8" % "test"
+  )

--- a/sbt/src/sbt-test/tests/cross-multiproject/foo/src/test/scala/PassTest.scala
+++ b/sbt/src/sbt-test/tests/cross-multiproject/foo/src/test/scala/PassTest.scala
@@ -1,0 +1,8 @@
+package foo
+
+import org.junit.Test
+
+class PassTest {
+  @Test
+  def pass: Unit = {}
+}

--- a/sbt/src/sbt-test/tests/cross-multiproject/test
+++ b/sbt/src/sbt-test/tests/cross-multiproject/test
@@ -1,0 +1,15 @@
+> test
+> testOnly foo.PassTest
+> testOnly -- -v
+
+> foo/test
+> foo/testOnly foo.PassTest
+> foo/testOnly -- -v
+
+> +test
+> +testOnly foo.PassTest
+> +testOnly -- -v
+
+> +foo/test
+> +foo/testOnly foo.PassTest
+> +foo/testOnly -- -v


### PR DESCRIPTION
After tracking down the change that caused #4715, I took a stab at trying to fix it.  I may have managed to bring back cross-building a sub-project command again, but I'm not sure if it is correct, or if it breaks other things.

In particular, the change here breaks the ability to cross-build a command alias, which I only noticed because be91300 added a test for it.  There may be a way to make it work, but I couldn't see how.
