### PR TITLE
Move external hooks definition

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -609,12 +609,8 @@ object Defaults extends BuildCommon {
         else ""
       s"inc_compile$extra.zip"
     },
-    compileIncSetup := {
-      val base = compileIncSetupTask.value
-      val incOptions =
-        base.incrementalCompilerOptions.withExternalHooks(ExternalHooks.default.value)
-      base.withIncrementalCompilerOptions(incOptions)
-    },
+    incOptions := { incOptions.value.withExternalHooks(ExternalHooks.default.value) },
+    compileIncSetup := compileIncSetupTask.value,
     console := consoleTask.value,
     collectAnalyses := Definition.collectAnalysesTask.map(_ => ()).value,
     consoleQuick := consoleQuickTask.value,


### PR DESCRIPTION
I verified manually that ExternalHooks were still applied by default but
that I could set the incOptions in the Test and Compile configs so that
they weren't used.

Fixes #4624

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
