### PR TITLE
Improve managed file management in watch

### DIFF
--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -142,11 +142,11 @@ object Keys {
   private[sbt] val allInputPathsAndAttributes =
     taskKey[Seq[(Path, FileAttributes)]]("Get all of the file inputs for a task")
       .withRank(Invisible)
-  private[sbt] val fileStampCache = taskKey[FileStamp.Cache](
-    "Map of file stamps that may be cleared between task evaluation runs."
+  private[sbt] val unmanagedFileStampCache = taskKey[FileStamp.Cache](
+    "Map of managed file stamps that may be cleared between task evaluation runs."
   ).withRank(Invisible)
-  private[sbt] val pathToFileStamp = taskKey[Path => Option[FileStamp]](
-    "A function that computes a file stamp for a path. It may have the side effect of updating a cache."
+  private[sbt] val managedFileStampCache = taskKey[FileStamp.Cache](
+    "Map of managed file stamps that may be cleared between task evaluation runs."
   ).withRank(Invisible)
   private[sbt] val classpathFiles =
     taskKey[Seq[Path]]("The classpath for a task.").withRank(Invisible)

--- a/sbt/src/sbt-test/watch/managed/build.sbt
+++ b/sbt/src/sbt-test/watch/managed/build.sbt
@@ -1,0 +1,23 @@
+import java.nio.file.Files
+
+import sbt.nio.Watch
+
+import scala.concurrent.duration._
+
+Compile / sourceGenerators += Def.task {
+  baseDirectory.value / "sources" / "Write.scala" :: Nil
+}.taskValue
+
+val runTest = taskKey[Unit]("run the test")
+runTest := Def.taskDyn {
+  val args = s" ${baseDirectory.value}"
+  (Runtime / run).toTask(args)
+}.value
+
+runTest / watchTriggers += baseDirectory.value.toGlob / "*.txt"
+watchAntiEntropy := 0.milliseconds
+watchOnFileInputEvent := { (count, e) =>
+  if (new String(Files.readAllBytes(e.path)) == "ok") Watch.CancelWatch
+  else if (count < 2) Watch.Trigger
+  else new Watch.HandleError(new IllegalStateException(s"Wrong event triggered the build: $e"))
+}

--- a/sbt/src/sbt-test/watch/managed/changes/Write.scala
+++ b/sbt/src/sbt-test/watch/managed/changes/Write.scala
@@ -1,0 +1,7 @@
+import java.nio.file._
+
+object Write {
+  def main(args: Array[String]): Unit = {
+    Files.write(Paths.get(args(0)).resolve("output.txt"), "ok".getBytes)
+  }
+}

--- a/sbt/src/sbt-test/watch/managed/sources/Write.scala
+++ b/sbt/src/sbt-test/watch/managed/sources/Write.scala
@@ -1,0 +1,12 @@
+import java.nio.file._
+object Write {
+  def main(args: Array[String]): Unit = {
+    val dir = Paths.get(args(0))
+    Files.write(
+      dir.resolve("sources").resolve("Write.scala"),
+      Files.readAllBytes(dir.resolve("changes").resolve("Write.scala")),
+    )
+    val output = dir.resolve("output.txt")
+    Files.write(output, "failure".getBytes)
+  }
+}

--- a/sbt/src/sbt-test/watch/managed/test
+++ b/sbt/src/sbt-test/watch/managed/test
@@ -1,0 +1,1 @@
+> ~runTest

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -232,6 +232,7 @@ final class ScriptedTests(
       case "source-dependencies/linearization"           => LauncherBased // sbt/Package$
       case "source-dependencies/named"                   => LauncherBased // sbt/Package$
       case "source-dependencies/specialized"             => LauncherBased // sbt/Package$
+      case "watch/managed"                               => LauncherBased // sbt/Package$
       case "tests/test-cross" =>
         LauncherBased // the sbt metabuild classpath leaks into the test interface classloader in older versions of sbt
       case _ => RunFromSourceBased


### PR DESCRIPTION
@olegych reported in https://github.com/sbt/sbt/issues/4722 that
sometimes even when a build was triggered during watch that no
recompilation would occur. The cause of this was that we never
invalidated the file stamp cache for managed sources or output files.
The optimization of persisting the source file stamps between task
evaluations in a continuous build only really makes sense for unmanaged
sources. We make the implicit assumption that unmanaged sources are
infrequently updated and generally one at a time. That assumption does
not hold for unmanaged source or output files.

To fix this, I split the fileStampCache into two caches: one for
unmanaged sources and one for everything else. We only persist the
unmanagedFileStampCache during continuous builds. The
managedFileStampCache gets invalidated every time.

I added a scripted test that simulates changing a generated source file.
Prior to this change, the test would fail because the file stamp was not
invalidated for the new source file content.

Fixes #4722

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
