### PR TITLE
Don't use global execution context

### DIFF
--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -93,9 +93,9 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
       val workingDirectory: File,
       val job: BackgroundJob
   ) extends AbstractJobHandle {
+    implicit val executionContext: ExecutionContext = StandardMain.executionContext
     def humanReadableName: String = job.humanReadableName
     // EC for onStop handler below
-    import ExecutionContext.Implicits.global
     job.onStop { () =>
       // TODO: Fix this
       // logger.close()

--- a/main/src/main/scala/sbt/internal/server/Definition.scala
+++ b/main/src/main/scala/sbt/internal/server/Definition.scala
@@ -234,7 +234,7 @@ private[sbt] object Definition {
 
   private[sbt] def getAnalyses: Future[Seq[Analysis]] = {
     import scalacache.modes.scalaFuture._
-    import scala.concurrent.ExecutionContext.Implicits.global
+    implicit val executionContext: ExecutionContext = StandardMain.executionContext
     AnalysesAccess
       .getFrom(StandardMain.cache)
       .collect { case Some(a) => a }

--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -13,13 +13,15 @@ import sjsonnew.JsonFormat
 import sjsonnew.shaded.scalajson.ast.unsafe.JValue
 import sjsonnew.support.scalajson.unsafe.Converter
 import sbt.protocol.Serialization
-import sbt.protocol.{ SettingQuery => Q, CompletionParams => CP }
+import sbt.protocol.{ CompletionParams => CP, SettingQuery => Q }
 import sbt.internal.langserver.{ CancelRequestParams => CRP }
 import sbt.internal.protocol._
 import sbt.internal.protocol.codec._
 import sbt.internal.langserver._
 import sbt.internal.util.ObjectEvent
 import sbt.util.Logger
+
+import scala.concurrent.ExecutionContext
 
 private[sbt] final case class LangServerError(code: Long, message: String)
     extends Throwable(message)
@@ -70,7 +72,7 @@ private[sbt] object LanguageServerProtocol {
               jsonRpcRespond(InitializeResult(serverCapabilities), Option(r.id))
 
             case r: JsonRpcRequestMessage if r.method == "textDocument/definition" =>
-              import scala.concurrent.ExecutionContext.Implicits.global
+              implicit val executionContext: ExecutionContext = StandardMain.executionContext
               Definition.lspDefinition(json(r), r.id, CommandSource(name), log)
               ()
             case r: JsonRpcRequestMessage if r.method == "sbt/exec" =>


### PR DESCRIPTION
Because we are sharing the scala library classloader with test and run,
it is possible that sbt will be competing with for resources with the
test and run tasks when trying to get threads from the global execution
context. Also, by using our own execution context, we can shut it down
when sbt exits.

The motivation for this change is that I was looking at the active jvm
threads of an idle sbt process and noticed a bunch of global execution
context threads.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
