### PR TITLE
Don't require newline for failure options

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -37,6 +37,15 @@ abstract class JLine extends LineReader {
         Option("")
     }
 
+  def readCharacter(prompt: String): Char = {
+    reader.setPrompt(prompt)
+    reader.println(prompt)
+    reader.flush()
+    val wrapped = JLine.terminal.wrapInIfNeeded(System.in)
+    JLine.terminal.init()
+    wrapped.read().toChar
+  }
+
   private[this] def unsynchronizedReadLine(prompt: String, mask: Option[Char]): Option[String] =
     readLineWithHistory(prompt, mask) map { x =>
       x.trim

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -740,9 +740,9 @@ object BuiltinCommands {
 
   @tailrec
   private[this] def doLoadFailed(s: State, loadArg: String): State = {
-    val result = (SimpleReader.readLine(
-      "Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? "
-    ) getOrElse Quit)
+    val result = SimpleReader
+      .readCharacter("Project loading failed: (r)etry (default), (q)uit, (l)ast, or (i)gnore? ")
+      .toString
       .toLowerCase(Locale.ENGLISH)
     def matches(s: String) = !result.isEmpty && (s startsWith result)
     def retry = loadProjectCommand(LoadProject, loadArg) :: s.clearGlobalLog
@@ -750,12 +750,12 @@ object BuiltinCommands {
       if (Project.isProjectLoaded(s)) "using previously loaded project" else "no project loaded"
 
     result match {
-      case ""                     => retry
+      case "\n" | "\r"            => retry
       case _ if matches("retry")  => retry
       case _ if matches(Quit)     => s.exit(ok = false)
       case _ if matches("ignore") => s.log.warn(s"Ignoring load failure: $ignoreMsg."); s
       case _ if matches("last")   => LastCommand :: loadProjectCommand(LoadFailed, loadArg) :: s
-      case _                      => println("Invalid response."); doLoadFailed(s, loadArg)
+      case c                      => println(s"Invalid response '$c'."); doLoadFailed(s, loadArg)
     }
   }
 


### PR DESCRIPTION
I can't think of any real reason to force the users to type a newline.
Also the prompt makes it look like just typing the single character is
sufficient. Finally, this behavior is inconsistent with watch, where we
do not require new lines.

Also try to make it clear that retry is the default if the user presses
enter.

- [x] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
