### PR TITLE
Drop the checkbox in the PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,3 @@
-- [ ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines
-
 ## steps
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-- [ ] I've read the [CONTRIBUTING](https://github.com/sbt/sbt/blob/develop/CONTRIBUTING.md) guidelines


### PR DESCRIPTION
The intent was to bring prominence to the desires expressed in the
contributing guidelines.  But nowadays GitHub has ways in which it
informs users (e.g. "the contributing guidelines have changed since you
last contributed").  So I think we can drop this now.