### PR TITLE
Wait for akka termination in test

### DIFF
--- a/sbt/src/sbt-test/tests/scala-instance-classloader/src/test/scala/Test.scala
+++ b/sbt/src/sbt-test/tests/scala-instance-classloader/src/test/scala/Test.scala
@@ -1,6 +1,8 @@
 package akka.actor
 
 import org.junit._
+import scala.concurrent._
+import scala.concurrent.duration._
 
 class BadTest {
 
@@ -13,7 +15,7 @@ class BadTest {
     val system = ActorSystem()
     def evilGetThreadExectionContextName =
       system.asInstanceOf[ActorSystemImpl].internalCallingThreadExecutionContext.getClass.getName
-    system.terminate()
+    Await.result(system.terminate(), 5.seconds)
     val expected = "scala.concurrent.Future$InternalCallbackExecutor$"
     Assert.assertEquals("Failed to grab appropriate Akka name", expected, evilGetThreadExectionContextName)
   }


### PR DESCRIPTION
We now correctly close the test classloader which can cause this
scripted test to fail if the classloader is closed before the actor
system finishes terminating.