### PR TITLE
Remove err.printStackTrace in MainLoop

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -223,7 +223,6 @@ object MainLoop {
       }
     } catch {
       case err: Throwable =>
-        err.printStackTrace()
         val errorEvent = ExecStatusEvent(
           "Error",
           channelName,


### PR DESCRIPTION
I added this for debugging and did not mean to leave it in. It causes
massive walls of text to be printed sometimes when compilation fails.