### PR TITLE
Add missing match case

### DIFF
--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -365,6 +365,7 @@ object State {
                     case _ =>
                   }
               }
+            case _ =>
           }
       }
       s.put(BasicKeys.extendedClassLoaderCache, cache)


### PR DESCRIPTION
There was an incomplete pattern match that assumed that the jars in the
scala provider included one with the name  "scala-library.jar". In
practice, I think this is always true, but it's safer to have a fallback
case and it also removes the compiler warning.