### PR TITLE
Validate commands in multiparser

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -161,8 +161,8 @@ object BasicCommands {
       ((nonSemi & nonQuote).map(_.toString) | StringEscapable.map(c => s""""$c"""")).+,
       hide = const(true)
     )
-    def commandParser = state.map(s => (s.combinedParser & cmdPart) | cmdPart).getOrElse(cmdPart)
-    val part = semi.flatMap(_ => matched(commandParser) <~ token(OptSpace)).map(_.trim)
+    lazy val combinedParser = state.map(s => s.combinedParser & cmdPart).getOrElse(cmdPart)
+    val part = semi.flatMap(_ => matched(combinedParser) <~ token(OptSpace)).map(_.trim)
     (cmdPart.? ~ part.+ <~ semi.?).map {
       case (Some(h), t) => h.mkString.trim +: t.toList
       case (_, t)       => t.toList

--- a/sbt/src/sbt-test/actions/multi-command/build.sbt
+++ b/sbt/src/sbt-test/actions/multi-command/build.sbt
@@ -12,3 +12,5 @@ taskThatFails := {
   throw new IllegalArgumentException("")
   ()
 }
+
+checkInputContainsSemicolon := checkInputContainsSemicolonImpl.evaluated

--- a/sbt/src/sbt-test/actions/multi-command/project/Build.scala
+++ b/sbt/src/sbt-test/actions/multi-command/project/Build.scala
@@ -1,11 +1,14 @@
 import sbt._
 
+import sbt.internal.util.complete.Parser._
+
 object Build {
   private[this] var string: String = ""
   private[this] val stringFile = file("string.txt")
   val setStringValue = inputKey[Unit]("set a global string to a value")
   val checkStringValue = inputKey[Unit]("check the value of a global")
   val taskThatFails = taskKey[Unit]("this should fail")
+  val checkInputContainsSemicolon = inputKey[Unit]("this should extract arguments that are semicolon delimited")
   def setStringValueImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
     string = Def.spaceDelimited().parsed.mkString(" ").trim
     IO.write(stringFile, string)
@@ -14,5 +17,10 @@ object Build {
     val actual = Def.spaceDelimited().parsed.mkString(" ").trim
     assert(string == actual)
     assert(IO.read(stringFile) == string)
+  }
+
+  def checkInputContainsSemicolonImpl: Def.Initialize[InputTask[Unit]] = Def.inputTask {
+    val actual = (charClass(_ != ';').+ <~ ';'.?).map(_.mkString.trim).+.parsed
+    assert(actual == Seq("foo", "bar"))
   }
 }

--- a/sbt/src/sbt-test/actions/multi-command/test
+++ b/sbt/src/sbt-test/actions/multi-command/test
@@ -19,3 +19,10 @@
 -> setStringValue foo; taskThatFails; setStringValue bar
 
 > checkStringValue foo
+
+> checkInputContainsSemicolon foo; bar
+
+> checkInputContainsSemicolon foo; bar;
+
+# This fails because the parser interprets this as 'compile', 'checkInputContainsSemicolon foo', 'bar'
+-> compile; checkInputContainsSemicolon foo; bar


### PR DESCRIPTION
It was reported in https://github.com/sbt/sbt/issues/4808 that compared
to 1.2.8, sbt 1.3.0-RC2 will truncate the command args of an input task
that contains semicolons. To address this, I slightly reworked the
multiparser to only accept multi commands if the each semicolon
delimited part is a valid command. This was achieved by changing
(s.combinedParser & cmdPart) | cmdPart to (s.combinedParser & cmdPart).
This fixes the issue because say the user is running an input task, foo,
with the arguments `bar;baz`, then the multi parser will parse it as:
List("foo bar", "baz"). If "baz" isn't a valid command, it gets rejected and we fallback on the remaining parsers defined for the state.

This isn't a perfect solution, because certain multi commands that
theoretically could work do not (this is illustrated in the last
scripted test), but it should at least resolve #4808.