### PR TITLE
Clear meta build state on session save

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -18,6 +18,7 @@ import sbt.internal.util.{ ErrorHandling, GlobalLogBacking }
 import sbt.io.{ IO, Using }
 import sbt.protocol._
 import sbt.util.Logger
+import sbt.nio.Keys._
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
@@ -185,6 +186,8 @@ object MainLoop {
     try {
       def process(): State = {
         val newState = Command.process(exec.commandLine, state)
+        if (exec.commandLine.contains("session"))
+          newState.get(hasCheckedMetaBuild).foreach(_.set(false))
         val doneEvent = ExecStatusEvent(
           "Done",
           channelName,


### PR DESCRIPTION
The `session save` command has the side effect of modifying a "*.sbt"
file so we don't want to warn about changes or automatically reload when
we return to the shell. Setting the hasCheckedMetaBuild attribute key to
false is sufficient to prevent this.

Fixes https://github.com/sbt/sbt/issues/4813