### PR TITLE
Multi cleanup

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -83,7 +83,8 @@ object JLineCompletion {
     val (insert, display) =
       ((Set.empty[String], Set.empty[String]) /: cs) {
         case (t @ (insert, display), comp) =>
-          if (comp.isEmpty) t else (insert + comp.append, appendNonEmpty(display, comp.display))
+          if (comp.isEmpty) t
+          else (appendNonEmpty(insert, comp.append), appendNonEmpty(display, comp.display))
       }
     (insert.toSeq, display.toSeq.sorted)
   }

--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -52,8 +52,11 @@ private[sbt] final class SimpleCommand(
 private[sbt] final class ArbitraryCommand(
     val parser: State => Parser[() => State],
     val help: State => Help,
-    val tags: AttributeMap
+    val tags: AttributeMap,
+    override val nameOption: Option[String]
 ) extends Command {
+  def this(parser: State => Parser[() => State], help: State => Help, tags: AttributeMap) =
+    this(parser, help, tags, None)
   def tag[T](key: AttributeKey[T], value: T): ArbitraryCommand =
     new ArbitraryCommand(parser, help, tags.put(key, value))
 }
@@ -124,6 +127,8 @@ object Command {
   def customHelp(parser: State => Parser[() => State], help: State => Help): Command =
     new ArbitraryCommand(parser, help, AttributeMap.empty)
 
+  private[sbt] def custom(parser: State => Parser[() => State], help: Help, name: String): Command =
+    new ArbitraryCommand(parser, const(help), AttributeMap.empty, Some(name))
   def custom(parser: State => Parser[() => State], help: Help = Help.empty): Command =
     customHelp(parser, const(help))
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -190,6 +190,7 @@ object BuiltinCommands {
 
   def DefaultCommands: Seq[Command] =
     Seq(
+      multi,
       about,
       tasks,
       settingsCommand,

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -146,9 +146,9 @@ private[sbt] object Continuous extends DeprecatedContinuous {
       val ocp = BasicCommands.multiParserImpl(Some(state)) |
         BasicCommands.otherCommandParser(state).map(_ :: Nil)
       (digitParser.? ~ ocp).flatMap {
-        case (i, cmds) if cmds.exists(_.nonEmpty) =>
-          Parser.success((i.getOrElse(0), cmds.filter(_.nonEmpty)))
-        case (_, cmds) => Parser.failure("Couldn't parse any commands")
+        case (i, commands) if commands.exists(_.nonEmpty) =>
+          Parser.success((i.getOrElse(0), commands.filter(_.nonEmpty)))
+        case (_, _) => Parser.failure("Couldn't parse any commands")
       }
   }
 

--- a/sbt/src/sbt-test/actions/multi-command/build.sbt
+++ b/sbt/src/sbt-test/actions/multi-command/build.sbt
@@ -18,3 +18,5 @@ checkInput := checkInputImpl.evaluated
 val dynamicTask = taskKey[Unit]("dynamic input task")
 
 dynamicTask := { println("not yet et") }
+
+crossScalaVersions := "2.11.12" :: "2.12.8" :: Nil

--- a/sbt/src/sbt-test/actions/multi-command/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/actions/multi-command/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/sbt/src/sbt-test/actions/multi-command/test
+++ b/sbt/src/sbt-test/actions/multi-command/test
@@ -34,3 +34,7 @@
 > checkInput foo
 
 > compile; checkInput foo
+
+> ++ 2.11.12 compile; setStringValue bar; checkStringValue bar
+
+> ++2.12.8 compile; setStringValue foo; checkStringValue foo

--- a/sbt/src/sbt-test/watch/command-parser/test
+++ b/sbt/src/sbt-test/watch/command-parser/test
@@ -19,3 +19,6 @@
 > ~; compile; setStringValue string.txt baz; checkStringValue string.txt baz
 # Ensure that trailing semi colons work
 > ~ compile; setStringValue string.txt baz; checkStringValue string.txt baz;
+
+# Ensure that no space is required between '~' and the command
+> ~compile;setStringValue string.txt foo;checkStringValue string.txt foo

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -185,6 +185,8 @@ final class ScriptedTests(
       case "actions/cross-multiproject" => LauncherBased // tbd
       case "actions/cross-multi-parser" =>
         LauncherBased // java.lang.ClassNotFoundException: javax.tools.DiagnosticListener when run with java 11 and an old sbt launcher
+      case "actions/multi-command" =>
+        LauncherBased // java.lang.ClassNotFoundException: javax.tools.DiagnosticListener when run with java 11 and an old sbt launcher
       case "actions/external-doc"   => LauncherBased // sbt/Package$
       case "actions/input-task"     => LauncherBased // sbt/Package$
       case "actions/input-task-dyn" => LauncherBased // sbt/Package$


### PR DESCRIPTION
This improves the performance for the multi parser when there are more than a few commands. It also fixes tab completion to the right of a ';' if there was no leading ';' in the semicolon.