### PR TITLE
Rename typesafeRelease Resolver

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3347,7 +3347,8 @@ object Classpaths {
   def flatten[T](o: Option[Option[T]]): Option[T] = o flatMap idFun
 
   val sbtIvySnapshots: URLRepository = Resolver.sbtIvyRepo("snapshots")
-  val typesafeReleases: URLRepository = Resolver.typesafeIvyRepo("releases")
+  val typesafeReleases: URLRepository =
+    Resolver.typesafeIvyRepo("releases").withName("typesafe-alt-ivy-releases")
   val sbtPluginReleases: URLRepository = Resolver.sbtPluginRepo("releases")
   val sbtMavenSnapshots: MavenRepository =
     MavenRepository("sbt-maven-snapshot", Resolver.SbtRepositoryRoot + "/" + "maven-snapshots/")


### PR DESCRIPTION
This Resolver had the same name as the typesafe ivy resolver specified
in the launcher boot.properties. It was creating a number of verbose
warnings about having multiple resolvers with the same name. I noticed
that the ivy pattern is slightly different for the boot resolver with
this name. It didn't seem to be causing any problems to have both
resolvers.

Fixes #4839