### PR TITLE
Rename typesafe release resolver in sbt build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
   ),
   scalaVersion := baseScalaVersion,
   componentID := None,
-  resolvers += Resolver.typesafeIvyRepo("releases"),
+  resolvers += Resolver.typesafeIvyRepo("releases").withName("typesafe-sbt-build-ivy-releases"),
   resolvers += Resolver.sonatypeRepo("snapshots"),
   resolvers += "bintray-sbt-maven-releases" at "https://dl.bintray.com/sbt/maven-releases/",
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary),

--- a/project/NightlyPlugin.scala
+++ b/project/NightlyPlugin.scala
@@ -23,6 +23,6 @@ object NightlyPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     crossVersion in update := CrossVersion.full,
-    resolvers += Resolver.typesafeIvyRepo("releases")
+    resolvers += Resolver.typesafeIvyRepo("releases").withName("typesafe-alt-project-releases")
   )
 }


### PR DESCRIPTION
I was still seeing a number of warnings in the sbt project itself in
spite of 9bb88cd3427cc62d01185c7d356799ac044f766b. This made those go
away.