### PR TITLE
add allCredentials to emulate credential registration

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2364,6 +2364,7 @@ object Classpaths {
     ),
     ivySbt := ivySbt0.value,
     ivyModule := { val is = ivySbt.value; new is.Module(moduleSettings.value) },
+    allCredentials := LMCoursier.allCredentialsTask.value,
     transitiveUpdate := transitiveUpdateTask.value,
     updateCacheName := {
       val binVersion = scalaBinaryVersion.value

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -376,6 +376,7 @@ object Keys {
   val packagedArtifacts = taskKey[Map[Artifact, File]]("Packages all artifacts for publishing and maps the Artifact definition to the generated file.").withRank(CTask)
   val publishMavenStyle = settingKey[Boolean]("Configures whether to generate and publish a pom (true) or Ivy file (false).").withRank(BSetting)
   val credentials = taskKey[Seq[Credentials]]("The credentials to use for updating and publishing.").withRank(BMinusTask)
+  val allCredentials = taskKey[Seq[Credentials]]("Aggregated credentials.").withRank(DTask)
 
   val makePom = taskKey[File]("Generates a pom for publishing when publishing Maven-style.").withRank(BPlusTask)
   val deliver = taskKey[File]("Generates the Ivy file for publishing to a repository.").withRank(BTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -376,7 +376,7 @@ object Keys {
   val packagedArtifacts = taskKey[Map[Artifact, File]]("Packages all artifacts for publishing and maps the Artifact definition to the generated file.").withRank(CTask)
   val publishMavenStyle = settingKey[Boolean]("Configures whether to generate and publish a pom (true) or Ivy file (false).").withRank(BSetting)
   val credentials = taskKey[Seq[Credentials]]("The credentials to use for updating and publishing.").withRank(BMinusTask)
-  val allCredentials = taskKey[Seq[Credentials]]("Aggregated credentials.").withRank(DTask)
+  val allCredentials = taskKey[Seq[Credentials]]("Aggregated credentials across current and root subprojects. Do not rewire this task.").withRank(DTask)
 
   val makePom = taskKey[File]("Generates a pom for publishing when publishing Maven-style.").withRank(BPlusTask)
   val deliver = taskKey[File]("Generates the Ivy file for publishing to a repository.").withRank(BTask)

--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -204,7 +204,7 @@ object CoursierInputsTasks {
 
   val credentialsTask = Def.task {
     val log = streams.value.log
-    val creds = sbt.Keys.credentials.value
+    val creds = sbt.Keys.allCredentials.value
       .flatMap {
         case dc: IvyDirectCredentials => List(dc)
         case fc: FileCredentials =>


### PR DESCRIPTION
Fixes #4802

For Ivy integration sbt uses credential task in a peculiar way. https://github.com/sbt/sbt/blob/9fa25de84cf6fb521aa5f161c866837200ec17c4/main/src/main/scala/sbt/Defaults.scala#L2271-L2275

This lets the build user put `credential` task in various places, like metabuild or root project, but they would all act as if they were scoped globally. This PR adds `allCredentials` task to emulate the behavior to pass credentials into lm-coursier.