### PR TITLE
Add scripted test for excludeFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - SBT_CMD=";mimaReportBinaryIssues ;scalafmtCheckAll ;headerCheck ;test:headerCheck ;whitesourceOnPush ;test:compile; publishLocal ;mainSettingsProj/test ;safeUnitTests ;otherUnitTests; doc"
     - SBT_CMD="scripted actions/* apiinfo/* compiler-project/* ivy-deps-management/* reporter/* tests/* watch/* classloader-cache/* package/*"
-    - SBT_CMD="scripted dependency-management/* plugins/* project-load/* java/* run/*"
+    - SBT_CMD="scripted dependency-management/* plugins/* project-load/* java/* run/* nio/*"
     - SBT_CMD="repoOverrideTest:scripted dependency-management/*; scripted source-dependencies/* project/*"
 
 matrix:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   def nightlyVersion: Option[String] = sys.props.get("sbt.build.version")
 
   // sbt modules
-  private val ioVersion = nightlyVersion.getOrElse("1.3.0-M12")
+  private val ioVersion = nightlyVersion.getOrElse("1.3.0-M13")
   private val utilVersion = nightlyVersion.getOrElse("1.3.0-M8")
   private val lmVersion =
     sys.props.get("sbt.build.lm.version") match {

--- a/sbt/src/sbt-test/nio/file-hashes/build.sbt
+++ b/sbt/src/sbt-test/nio/file-hashes/build.sbt
@@ -32,10 +32,10 @@ val checkAdded = taskKey[Unit]("check that modified files are returned")
 checkAdded := Def.taskDyn {
   val files = (foo / allInputFiles).value
   val added = (foo / changedInputFiles).value.map(_.created).getOrElse(Nil)
-  if (added.isEmpty || files.sameElements(added)) Def.task(assert(true))
+  if (added.isEmpty || (files.toSet == added.toSet)) Def.task(assert(true))
   else Def.task {
     val base = baseDirectory.value / "base"
-    assert(files.sameElements(Seq("Bar.md", "Foo.txt").map(p => (base / p).toPath)))
+    assert(files.toSet == Set("Bar.md", "Foo.txt").map(p => (base / p).toPath))
     assert(added == Seq((baseDirectory.value / "base" / "Bar.md").toPath))
   }
 }.value

--- a/sbt/src/sbt-test/nio/legacy-filters/build.sbt
+++ b/sbt/src/sbt-test/nio/legacy-filters/build.sbt
@@ -1,0 +1,8 @@
+Compile / excludeFilter := "Bar.scala" || "Baz.scala"
+
+val checkSources = inputKey[Unit]("Check that the compile sources match the input file names")
+checkSources := {
+  val sources = Def.spaceDelimited("").parsed.toSet
+  val actual = (Compile / unmanagedSources).value.map(_.getName).toSet
+  assert(sources == actual)
+}

--- a/sbt/src/sbt-test/nio/legacy-filters/src/main/scala/Bar.scala
+++ b/sbt/src/sbt-test/nio/legacy-filters/src/main/scala/Bar.scala
@@ -1,0 +1,1 @@
+class Bar {

--- a/sbt/src/sbt-test/nio/legacy-filters/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/nio/legacy-filters/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/sbt/src/sbt-test/nio/legacy-filters/test
+++ b/sbt/src/sbt-test/nio/legacy-filters/test
@@ -1,0 +1,9 @@
+> checkSources Foo.scala
+
+> compile
+
+> set Compile / excludeFilter := HiddenFileFilter
+
+> checkSources Foo.scala Bar.scala
+
+-> compile


### PR DESCRIPTION
It was reported in #4868 that exclueFilters didn't work correctly if
there was an || in the filter. This was an upstream issue in io, but
this commit adds a scripted test in sbt.