### PR TITLE
Don't validate multi commands

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -189,13 +189,6 @@ object BasicCommands {
   def multiParser(s: State): Parser[List[String]] = multiParserImpl(Some(s))
 
   def multiApplied(state: State): Parser[() => State] = {
-    def generateCommands(commands: List[String]): State =
-      commands
-        .takeWhile(_ != "reload")
-        .collectFirst {
-          case c if Parser.parse(c, state.combinedParser).isLeft => c :: state
-        }
-        .getOrElse(commands ::: state)
     Command.applyEffect(multiParserImpl(Some(state))) {
       // the (@ _ :: _) ensures tail length >= 1.
       case commands @ first :: (tail @ _ :: _) =>
@@ -238,9 +231,9 @@ object BasicCommands {
           }
         }.headOption match {
           case Some(s) => s()
-          case _       => generateCommands(commands)
+          case _       => commands ::: state
         }
-      case commands => generateCommands(commands)
+      case commands => commands ::: state
     }
   }
 


### PR DESCRIPTION
Fixes #4875

We tried to prevent users from doing something like running a multi
command "foo; bar" where foo is valid but bar is invalid so that we
wouldn't run foo only to discover bar was an invalid key. It isn't
possible to know in general if any command other than the first command
in a multi command is valid because it might update the state and add
the initially invalid command.

The validation caused the intellij plugin to not work with 1.3.0-RC3.