### PR TITLE
Fix java.util.zip.ZipException: duplicate entry

### DIFF
--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -104,7 +104,7 @@ object Package {
     }
 
     val inputFiles = conf.sources.map(_._1).toSet
-    val inputs = conf.sources :+: lastModified(inputFiles) :+: manifest :+: HNil
+    val inputs = conf.sources.distinct :+: lastModified(inputFiles) :+: manifest :+: HNil
     cachedMakeJar(inputs)(() => exists(conf.jar))
     ()
   }

--- a/sbt/src/sbt-test/package/mappings/build.sbt
+++ b/sbt/src/sbt-test/package/mappings/build.sbt
@@ -6,6 +6,7 @@ mappings in (Compile, packageBin) ++= {
   val test = file("test")
   Seq(
     test -> "test1",
+    test -> "test1",
     test -> "test2"
   )
 }


### PR DESCRIPTION
Fixes #4889

#4329 switched from using Map to Seq during packaging. That allowed multiple files to be included with different paths, but it also started admitting duplicate files causing ZipException.