### PR TITLE
Don't use exception for reloading

### DIFF
--- a/main-command/src/main/scala/sbt/MainControl.scala
+++ b/main-command/src/main/scala/sbt/MainControl.scala
@@ -21,8 +21,6 @@ final case class Reboot(
   def arguments = argsList.toArray
 }
 
-private[sbt] case object Reload extends Exception(null, null, false, false)
-
 final case class ApplicationID(
     groupID: String,
     name: String,

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -346,7 +346,7 @@ object EvaluateTask {
       ExceptionCategory(ex) match {
         case AlreadyHandled => ()
         case m: MessageOnly => if (msg.isEmpty) log.error(m.message)
-        case f: Full        => if (f.exception != Reload) log.trace(f.exception)
+        case f: Full        => log.trace(f.exception)
       }
     }
 
@@ -354,7 +354,7 @@ object EvaluateTask {
       val msgString = (msg.toList ++ ex.toList.map(ErrorHandling.reducedToString)).mkString("\n\t")
       val log = getStreams(key, streams).log
       val display = contextDisplay(state, ConsoleAppender.formatEnabledInEnv)
-      if (!ex.contains(Reload)) log.error("(" + display.show(key) + ") " + msgString)
+      log.error("(" + display.show(key) + ") " + msgString)
     }
   }
 

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -144,10 +144,7 @@ object MainLoop {
         case Right(s)                  => s
         case Left(t: xsbti.FullReload) => throw t
         case Left(t: RebootCurrent)    => throw t
-        case Left(Reload) =>
-          val remaining = state.currentCommand.toList ::: state.remainingCommands
-          state.copy(remainingCommands = Exec("reload", None, None) :: remaining)
-        case Left(t) => state.handleError(t)
+        case Left(t)                   => state.handleError(t)
       }
     } catch {
       case oom: OutOfMemoryError if oom.getMessage.contains("Metaspace") =>

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -50,7 +50,7 @@ object Keys {
     taskKey[FileTreeView.Nio[FileAttributes]]("A view of the local file system tree")
 
   val checkBuildSources =
-    taskKey[Unit]("Check if any meta build sources have changed").withRank(DSetting)
+    taskKey[StateTransform]("Check if any meta build sources have changed").withRank(DSetting)
 
   // watch related settings
   val watchAntiEntropyRetentionPeriod = settingKey[FiniteDuration](


### PR DESCRIPTION
I completely forgot about the StateTransform class which allows a task
to modify the state through its return value.