### PR TITLE
Override zinc compile analysis for source changes

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -212,6 +212,7 @@ object Keys {
   val copyResources = taskKey[Seq[(File, File)]]("Copies resources to the output directory.").withRank(AMinusTask)
   val aggregate = settingKey[Boolean]("Configures task aggregation.").withRank(BMinusSetting)
   val sourcePositionMappers = taskKey[Seq[xsbti.Position => Option[xsbti.Position]]]("Maps positions in generated source files to the original source it was generated from").withRank(DTask)
+  private[sbt] val externalHooks = taskKey[ExternalHooks]("The external hooks used by zinc.")
 
   // package keys
   val packageBin = taskKey[File]("Produces a main artifact, such as a binary jar.").withRank(ATask)

--- a/sbt/src/sbt-test/nio/external-hooks/build.sbt
+++ b/sbt/src/sbt-test/nio/external-hooks/build.sbt
@@ -1,0 +1,23 @@
+val generateSourceFile = taskKey[Unit]("generate source file")
+generateSourceFile := {
+  val testDir = ((Test / scalaSource).value.toPath / "Foo.scala").toString
+  val content = s"object Foo { val x = 2 }"
+  val src =
+    s"""
+       |import scala.language.experimental.macros
+       |import scala.reflect.macros.blackbox
+       |import java.nio.file.{ Files, Paths }
+       |
+       |object Generate {
+       |  def gen: Unit = macro genImpl
+       |  def genImpl(c: blackbox.Context): c.Expr[Unit] = {
+       |    Files.write(Paths.get("${testDir.replace("\\", "\\\\")}"), "$content".getBytes)
+       |    c.universe.reify(())
+       |  }
+       |}
+       |""".stripMargin
+  IO.write((Compile / scalaSource).value / "Generate.scala", src)
+}
+
+libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"

--- a/sbt/src/sbt-test/nio/external-hooks/src/test/scala/Foo.scala
+++ b/sbt/src/sbt-test/nio/external-hooks/src/test/scala/Foo.scala
@@ -1,0 +1,3 @@
+object Foo {
+  def x = 1
+}

--- a/sbt/src/sbt-test/nio/external-hooks/src/test/scala/FooTest.scala
+++ b/sbt/src/sbt-test/nio/external-hooks/src/test/scala/FooTest.scala
@@ -1,0 +1,8 @@
+import org.scalatest.FlatSpec
+
+class FooTest extends FlatSpec {
+  Generate.gen
+  it should "work" in {
+    assert(Foo.x == 2)
+  }
+}

--- a/sbt/src/sbt-test/nio/external-hooks/test
+++ b/sbt/src/sbt-test/nio/external-hooks/test
@@ -1,0 +1,5 @@
+> generateSourceFile
+
+-> test
+
+> test

--- a/sbt/src/sbt-test/source-dependencies/restore-classes/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/restore-classes/build.sbt
@@ -14,6 +14,7 @@ recordPreviousIterations := {
         log.info("No previous analysis detected")
         0
       case Some(a: Analysis) => a.compilations.allCompilations.size
+      case Some(_) => -1 // should be unreachable but causes warnings
     }
   }
 }


### PR DESCRIPTION
Zinc records all of the compile source file hashes when compilation
completes. This is problematic because its possible that a source file
was changed during compilation. From the user perspective,
this may mean that their source change will not be recompiled even if a
build is triggered by the change.

To overcome this, I add logic in the sbt provided external hooks to
override the zinc analysis stamps. This is done by writing the source
file stamps to the previous cache after compilation completes. This
allows us to see the source differences from sbt's perspective, rather
than zinc's perspective. We then merge the combined differences in the
actual implementation of ExternalHooks. In some cases this may result in
over-compilation but generally over-compilation is preferred to under
compilation. Most of the time, the results should be the same.

The scripted test that I added modifies a file during compilation by
invoking a macro. It then effectively asserts that the file is
recompiled during the next test run by validating the compilation result
in the test. The test fails on the latest develop hash.