### PR TITLE
Improve auto-reload

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -200,26 +200,25 @@ object MainLoop {
         }
         newState
       }
-      val checkCommand = state.currentCommand match {
-        // If the user runs reload directly, we want to be sure that we update the previous
-        // cache for checkBuildSources / changedInputFiles but we don't want to display any
-        // warnings. Without filling the previous cache, it's possible for the user to run
-        // reload and be prompted with a warning in spite of reload having just run and no build
-        // sources having changed.
-        case Some(exec) if exec.commandLine == "reload" => "checkBuildSources / changedInputFiles"
-        case _                                          => "checkBuildSources"
-      }
-      Parser.parse(
-        checkCommand,
-        state.copy(remainingCommands = Nil).put(Aggregation.suppressShow, true).combinedParser
-      ) match {
-        case Right(cmd) =>
-          cmd() match {
-            case s if s.remainingCommands.headOption.map(_.commandLine).contains("reload") =>
-              Exec("reload", None, None) +: exec +: state
+      // The split on space is to handle 'reboot full' and 'reboot'.
+      state.currentCommand.flatMap(_.commandLine.trim.split(" ").headOption) match {
+        case Some("reload") =>
+          // Reset the hasCheckedMetaBuild parameter so that the next call to checkBuildSources
+          // updates the previous cache for checkBuildSources / fileInputStamps but doesn't log.
+          state.get(hasCheckedMetaBuild).foreach(_.set(false))
+          process()
+        case Some("exit") | Some("reboot") => process()
+        case _ =>
+          val emptyState = state.copy(remainingCommands = Nil).put(Aggregation.suppressShow, true)
+          Parser.parse("checkBuildSources", emptyState.combinedParser) match {
+            case Right(cmd) =>
+              cmd() match {
+                case s if s.remainingCommands.headOption.map(_.commandLine).contains("reload") =>
+                  Exec("reload", None, None) +: exec +: state
+                case _ => process()
+              }
             case _ => process()
           }
-        case Left(_) => process()
       }
     } catch {
       case err: Throwable =>


### PR DESCRIPTION
I noticed that sometimes if I changed a build source and then ran reload
in the shell, I'd still see a warning about build sources having
changed. We can eliminate this behavior by resetting the
hasCheckedMetaBuild state attribute to false and skipping the
checkBuildSources step if the current command is 'reload'. We also now
skip checking the build source step if the command is exit or reboot.