### PR TITLE
Bump source-dependencies/macro-annotation to 2.12.9

### DIFF
--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.9"
 
 val paradiseVersion = "2.1.1"
 val commonSettings = Seq(


### PR DESCRIPTION
The paradise library is now available for 2.12.9.