### PR TITLE
Update ExternalHooks to look up changed binaries

### DIFF
--- a/main/src/main/scala/sbt/internal/ExternalHooks.scala
+++ b/main/src/main/scala/sbt/internal/ExternalHooks.scala
@@ -101,7 +101,7 @@ private[sbt] object ExternalHooks {
       override def changedBinaries(previousAnalysis: CompileAnalysis): Option[Set[File]] = {
         Some(previousAnalysis.readStamps.getAllBinaryStamps.asScala.flatMap {
           case (file, stamp) =>
-            managedCache.get(file.toPath) match {
+            managedCache.getOrElseUpdate(file.toPath, FileStamper.LastModified) match {
               case Some(cachedStamp) if equiv(cachedStamp.stamp, stamp) => None
               case _ =>
                 javaHome match {

--- a/main/src/main/scala/sbt/internal/ExternalHooks.scala
+++ b/main/src/main/scala/sbt/internal/ExternalHooks.scala
@@ -26,7 +26,8 @@ import scala.collection.JavaConverters._
 
 private[sbt] object ExternalHooks {
   private val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
-  private type Func = (FileChanges, FileTreeView[(Path, FileAttributes)]) => ExternalHooks
+  private type Func =
+    (FileChanges, FileChanges, FileTreeView[(Path, FileAttributes)]) => ExternalHooks
   def default: Def.Initialize[sbt.Task[Func]] = Def.task {
     val unmanagedCache = unmanagedFileStampCache.value
     val managedCache = managedFileStampCache.value
@@ -37,15 +38,16 @@ private[sbt] object ExternalHooks {
     }
     val classGlob = classDirectory.value.toGlob / RecursiveGlob / "*.class"
     val options = (compileOptions in compile).value
-    (fc: FileChanges, fileTreeView: FileTreeView[(Path, FileAttributes)]) => {
+    ((inputFileChanges, outputFileChanges, fileTreeView) => {
       fileTreeView.list(classGlob).foreach {
         case (path, _) => managedCache.update(path, FileStamper.LastModified)
       }
-      apply(fc, options, unmanagedCache, managedCache)
-    }
+      apply(inputFileChanges, outputFileChanges, options, unmanagedCache, managedCache)
+    }): Func
   }
   private def apply(
-      changedFiles: FileChanges,
+      inputFileChanges: FileChanges,
+      outputFileChanges: FileChanges,
       options: CompileOptions,
       unmanagedCache: FileStamp.Cache,
       managedCache: FileStamp.Cache
@@ -62,7 +64,7 @@ private[sbt] object ExternalHooks {
           }
           private def add(f: File, set: java.util.Set[File]): Unit = { set.add(f); () }
           val allChanges = new java.util.HashSet[File]
-          changedFiles match {
+          inputFileChanges match {
             case FileChanges(c, d, m, _) =>
               c.foreach(add(_, getAdded, allChanges))
               d.foreach(add(_, getRemoved, allChanges))
@@ -99,7 +101,11 @@ private[sbt] object ExternalHooks {
         Optional.empty[Array[FileHash]]
 
       override def changedBinaries(previousAnalysis: CompileAnalysis): Option[Set[File]] = {
-        Some(previousAnalysis.readStamps.getAllBinaryStamps.asScala.flatMap {
+        val base =
+          (outputFileChanges.modified ++ outputFileChanges.created ++ outputFileChanges.deleted)
+            .map(_.toFile)
+            .toSet
+        Some(base ++ previousAnalysis.readStamps.getAllBinaryStamps.asScala.flatMap {
           case (file, stamp) =>
             managedCache.getOrElseUpdate(file.toPath, FileStamper.LastModified) match {
               case Some(cachedStamp) if equiv(cachedStamp.stamp, stamp) => None
@@ -110,7 +116,7 @@ private[sbt] object ExternalHooks {
                   case _                                    => Some(file)
                 }
             }
-        }.toSet)
+        })
       }
 
       override def removedProducts(previousAnalysis: CompileAnalysis): Option[Set[File]] = {

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -160,6 +160,8 @@ object Keys {
   private[sbt] val managedFileStampCache = taskKey[FileStamp.Cache](
     "Map of managed file stamps that may be cleared between task evaluation runs."
   ).withRank(Invisible)
+  private[sbt] val dependencyClasspathFiles =
+    taskKey[Seq[Path]]("The dependency classpath for a task.").withRank(Invisible)
   private[sbt] val classpathFiles =
     taskKey[Seq[Path]]("The classpath for a task.").withRank(Invisible)
 

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -242,12 +242,12 @@ private[sbt] object Settings {
     }
     prevMap.forEach((p, _) => deletedBuilder += p)
     val unmodified = unmodifiedBuilder.result()
-    if (unmodified.size == current.size) {
+    val deleted = deletedBuilder.result()
+    val created = createdBuilder.result()
+    val modified = modifiedBuilder.result()
+    if (created.isEmpty && deleted.isEmpty && modified.isEmpty) {
       FileChanges.unmodified(unmodifiedBuilder.result)
     } else {
-      val created = createdBuilder.result()
-      val deleted = deletedBuilder.result()
-      val modified = modifiedBuilder.result()
       FileChanges(created, deleted, modified, unmodified)
     }
   }


### PR DESCRIPTION
It was reported that in community builds, sometimes there was
spurious over-compilation due to invalidation of the scala library jar
(https://github.com/sbt/sbt/issues/4948). The reason for this was that
the external hooks prefills the managed cache with all of the time
stamps for the project dependencies but was not looking up any jars that
weren't in the cache. I suspect I did this because I didn't realize that
zinc also includes its own classpath in the binaries which is not
a part of the dependencyClasspath. The fix is to just add the jar to the
cache if it doesn't already exist by switching to getOrElseUpdate from
get.

I followed the steps in #4948 and published a version of sbt locally
with this change and the spurious re-builds stopped.