### PR TITLE
Cleanup stack traces in error reporting (take 2)

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -112,16 +112,6 @@ object MainLoop {
       finally out.close()
     }
 
-  // /** Transfers logging and trace levels from the old global loggers to the new ones. */
-  // private[this] def transferLevels(state: State, logging: GlobalLogging): Unit = {
-  //   val old = state.globalLogging
-  //   Logger.transferLevels(old.backed, logging.backed)
-  //   (old.full, logging.full) match { // well, this is a hack
-  //     case (oldLog: AbstractLogger, newLog: AbstractLogger) => Logger.transferLevels(oldLog, newLog)
-  //     case _                                                => ()
-  //   }
-  // }
-
   sealed trait RunNext
   final class ClearGlobalLog(val state: State) extends RunNext
   final class KeepGlobalLog(val state: State) extends RunNext

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -479,10 +479,7 @@ object Project extends ProjectExtra {
       .put(sessionSettings, session)
       .put(Keys.onUnload.key, onUnload)
     val newState = unloaded.copy(attributes = newAttrs)
-    // TODO: Fix this
-    onLoad(
-      updateCurrent(newState) /*LogManager.setGlobalLogLevels(updateCurrent(newState), structure.data)*/
-    )
+    onLoad(updateCurrent(newState))
   }
 
   def orIdentity[T](opt: Option[T => T]): T => T = opt getOrElse idFun

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -218,26 +218,6 @@ object LogManager {
     log
   }
 
-  // TODO: Fix this
-  // if global logging levels are not explicitly set, set them from project settings
-  // private[sbt] def setGlobalLogLevels(s: State, data: Settings[Scope]): State =
-  //   if (hasExplicitGlobalLogLevels(s))
-  //     s
-  //   else {
-  //     val logging = s.globalLogging
-  //     def get[T](key: SettingKey[T]) = key in GlobalScope get data
-  //     def transfer(l: AbstractLogger, traceKey: SettingKey[Int], levelKey: SettingKey[Level.Value]): Unit = {
-  //       get(traceKey).foreach(l.setTrace)
-  //       get(levelKey).foreach(l.setLevel)
-  //     }
-  //     logging.full match {
-  //       case a: AbstractLogger => transfer(a, traceLevel, logLevel)
-  //       case _                 => ()
-  //     }
-  //     transfer(logging.backed, persistTraceLevel, persistLogLevel)
-  //     s
-  //   }
-
   def setGlobalLogLevel(s: State, level: Level.Value): State = {
     val s1 = s.put(BasicKeys.explicitGlobalLogLevels, true).put(Keys.logLevel.key, level)
     val gl = s1.globalLogging

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -168,7 +168,7 @@ object LogManager {
     }
 
   def defaultTraceLevel(state: State): Int =
-    if (state.interactive) -1 else Int.MaxValue
+    if (state.interactive) 0 else Int.MaxValue
 
   def suppressedMessage(
       key: ScopedKey[_],


### PR DESCRIPTION
This is a rework of https://github.com/sbt/sbt/pull/4962

### steps

```scala
lazy val check = taskKey[Unit]("")
check := {
  sys.error("boom")
}
```

### sbt 1.3.0-RC3 (current state)

```scala
sbt:hello> check
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $0d89407eaa29f35a5d10$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] 	at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:280)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:289)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:280)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:35:47 AM
sbt:hello> last
[debug] > Exec(check, Some(2451da86-cf61-4364-8b5c-042fa600b73f), Some(CommandSource(console0)))
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[debug] Evaluating tasks: check
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $0d89407eaa29f35a5d10$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] 	at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:280)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:289)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:280)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:35:47 AM
[debug] > Exec(shell, None, None)
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
sbt:hello> set check/traceLevel := 4
[info] Defining check / traceLevel
[info] The new value will be used by no settings or tasks.
[info] Reapplying settings...
[info] Set current project to hello (in build file:/Users/eed3si9n/work/hellotest/)
sbt:hello> check
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $0d89407eaa29f35a5d10$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] 	at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:36:09 AM
```

so somewhere in the history  #3793 seems to have been fixed.

### after

I'm just changing the default fallback traceLevel to `0`.

```scala
sbt:hello> check
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $6a2b20de9d7e7db0de61$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:40:22 AM
sbt:hello> last
[debug] > Exec(check, Some(26356a6f-3a09-4b89-bb1d-9d17b5492b4a), Some(CommandSource(console0)))
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[debug] Evaluating tasks: check
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $6a2b20de9d7e7db0de61$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] 	at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:280)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:289)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:280)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:40:22 AM
[debug] > Exec(shell, None, None)
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
```

