### PR TITLE
reimplement stack trace suppression

### DIFF
--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -12,7 +12,6 @@ import java.io.PrintWriter
 import Def.ScopedKey
 import Scope.GlobalScope
 import Keys.{ logLevel, logManager, persistLogLevel, persistTraceLevel, sLog, traceLevel }
-import scala.Console.{ BLUE, RESET }
 import sbt.internal.util.{
   AttributeKey,
   ConsoleAppender,
@@ -177,9 +176,14 @@ object LogManager {
     val display = Project.showContextKey(state)
     def commandBase = "last " + display.show(unwrapStreamsKey(key))
     def command(useFormat: Boolean) =
-      if (useFormat) BLUE + commandBase + RESET else s"'$commandBase'"
-    context =>
-      Some("Stack trace suppressed: run %s for the full output.".format(command(context.useFormat)))
+      if (useFormat) s"${scala.Console.MAGENTA}$commandBase${scala.Console.RESET}"
+      else s"'$commandBase'"
+
+    { context =>
+      Some(
+        s"stack trace is suppressed; run ${command(context.useFormat)} for the full output"
+      )
+    }
   }
 
   def unwrapStreamsKey(key: ScopedKey[_]): ScopedKey[_] = key.scope.task match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.3.0-M16")
-  private val utilVersion = nightlyVersion.getOrElse("1.3.0-M9")
+  private val utilVersion = nightlyVersion.getOrElse("1.3.0-M10")
   private val lmVersion =
     sys.props.get("sbt.build.lm.version") match {
       case Some(version) => version


### PR DESCRIPTION
Fixes #4964
This is a rework of https://github.com/sbt/sbt/pull/4962

Together with https://github.com/sbt/util/pull/211, this brings back stack trace suppression for custom tasks by default.
Debug levels logs are available in `last`, and this prints a message informing the user of the fact. BLUE on dark background is difficult to read, so I am changing the color hilight to MAGENTA.

<img width="894" alt="stack trace" src="https://user-images.githubusercontent.com/184683/63371740-ad13c780-c352-11e9-9b8a-703ce55374d4.png">

<details>

```
sbt:hello> check2
[error] stack trace is suppressed; run last check for the full output
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 1:51:04 PM
sbt:hello> last
[debug] > Exec(check2, Some(889adcc0-32f2-4562-98fc-84fab6d31773), Some(CommandSource(console0)))
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[debug] Evaluating tasks: check2
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $4b6eccca23d3f767ebec$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:17)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:280)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:289)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:280)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 1:51:04 PM
[debug] > Exec(shell, None, None)
[debug] Evaluating tasks: checkBuildSources
[debug] Running task... Cancel: Signal, check cycles: false, forcegc: true
sbt:hello> set ThisBuild/traceLevel := 0
[info] Defining ThisBuild / traceLevel
[info] The new value will be used by no settings or tasks.
[info] Reapplying settings...
[info] Set current project to hello (in build file:/Users/eed3si9n/work/hellotest/)
sbt:hello> check2
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $4b6eccca23d3f767ebec$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:17)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] stack trace is suppressed; run last check for the full output
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 1:51:25 PM
```
</details>