### PR TITLE
Fix clean performance

### DIFF
--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -164,6 +164,7 @@ object Keys {
     taskKey[Seq[Path]]("The dependency classpath for a task.").withRank(Invisible)
   private[sbt] val classpathFiles =
     taskKey[Seq[Path]]("The classpath for a task.").withRank(Invisible)
+  private[sbt] val compileOutputs = taskKey[Seq[Path]]("Compilation outputs").withRank(Invisible)
 
   private[this] val hasCheckedMetaBuildMsg =
     "Indicates whether or not we have called the checkBuildSources task. This is to avoid warning " +

--- a/sbt/src/sbt-test/nio/clean/build.sbt
+++ b/sbt/src/sbt-test/nio/clean/build.sbt
@@ -3,9 +3,9 @@ import java.nio.file.Path
 import sjsonnew.BasicJsonProtocol._
 
 val copyFile = taskKey[Int]("dummy task")
+copyFile / target := target.value / "out"
 copyFile / fileInputs += baseDirectory.value.toGlob / "base" / "*.txt"
-copyFile / fileOutputs += baseDirectory.value.toGlob / "out" / "*.txt"
-copyFile / target := baseDirectory.value / "out"
+copyFile / fileOutputs += (copyFile / target).value.toGlob / "*.txt"
 
 copyFile := Def.task {
   val prev = copyFile.previous
@@ -17,7 +17,7 @@ copyFile := Def.task {
     case Some(v: Int) if changes.isEmpty => v
     case _ =>
       changes.getOrElse(copyFile.inputFiles).foreach { p =>
-        val outDir = baseDirectory.value / "out"
+        val outDir = (copyFile / target).value
         IO.createDirectory(outDir)
         IO.copyFile(p.toFile, outDir / p.getFileName.toString)
       }
@@ -27,13 +27,13 @@ copyFile := Def.task {
 
 val checkOutDirectoryIsEmpty = taskKey[Unit]("validates that the output directory is empty")
 checkOutDirectoryIsEmpty := {
-  assert(fileTreeView.value.list(baseDirectory.value.toGlob / "out" / **).isEmpty)
+  assert(fileTreeView.value.list((copyFile / target).value.toGlob / **).isEmpty)
 }
 
 val checkOutDirectoryHasFile = taskKey[Unit]("validates that the output directory is empty")
 checkOutDirectoryHasFile := {
-  val result = fileTreeView.value.list(baseDirectory.value.toGlob / "out" / **).map(_._1.toFile)
-  assert(result == Seq(baseDirectory.value / "out" / "Foo.txt"))
+  val result = fileTreeView.value.list((copyFile / target).value.toGlob / **).map(_._1.toFile)
+  assert(result == Seq((copyFile / target).value / "Foo.txt"))
 }
 
 commands += Command.single("checkCount") { (s, digits) =>


### PR DESCRIPTION
The clean task got a lot slower in 1.3.0
(https://github.com/sbt/sbt/issues/4972). The reason for this was that
sbt 1.3.0 generated many custom clean tasks for any tasks that returned
`File` or `Seq[File]`. Each of these tasks was tagged with
Tags.Clean which meant that only one of them could run at a time. As a
result, it took a long time to evaluate all of the custom tasks, even if
they were no-ops. In the akka project, a no-op clean was taking 35
seconds which is simply unacceptable. After this change, a no-op clean
takes less than a second in akka (a full clean only takes about 6
seconds after running test:compile)

To fix this, I stopped aggregating the clean task across configs and
projects. Because I removed the aggregation, I needed to manually
implement clean in the `Compile` and `Test` configurations to make
`Compile / clean` and `Test / compile` clean work correctly.