### PR TITLE
Stop injecting file management settings for io tasks

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -415,7 +415,6 @@ object Defaults extends BuildCommon {
     },
     unmanagedSources := (unmanagedSources / inputFileStamps).value.map(_._1.toFile),
     managedSourceDirectories := Seq(sourceManaged.value),
-    managedSources / outputFileStamper := sbt.nio.FileStamper.Hash,
     managedSources := {
       val stamper = inputFileStamper.value
       val cache = managedFileStampCache.value
@@ -425,6 +424,8 @@ object Defaults extends BuildCommon {
       }
       res
     },
+    managedSourcePaths / outputFileStamper := sbt.nio.FileStamper.Hash,
+    managedSourcePaths := managedSources.value.map(_.toPath),
     sourceGenerators :== Nil,
     sourceDirectories := Classpaths
       .concatSettings(unmanagedSourceDirectories, managedSourceDirectories)
@@ -618,7 +619,7 @@ object Defaults extends BuildCommon {
     externalHooks := {
       import sbt.nio.FileStamp.Formats.seqPathFileStampJsonFormatter
       val currentInputs =
-        (unmanagedSources / inputFileStamps).value ++ (managedSources / outputFileStamps).value
+        (unmanagedSources / inputFileStamps).value ++ (managedSourcePaths / outputFileStamps).value
       val previousInputs = (externalHooks / inputFileStamps).previous
       val inputChanges = previousInputs
         .map(sbt.nio.Settings.changedFiles(_, currentInputs))
@@ -632,7 +633,7 @@ object Defaults extends BuildCommon {
     },
     externalHooks / inputFileStamps := {
       compile.value // ensures the inputFileStamps previous value is only set if compile succeeds.
-      (unmanagedSources / inputFileStamps).value ++ (managedSources / outputFileStamps).value
+      (unmanagedSources / inputFileStamps).value ++ (managedSourcePaths / outputFileStamps).value
     },
     externalHooks / inputFileStamps := (externalHooks / inputFileStamps).triggeredBy(compile).value,
     externalHooks / outputFileStamps := {

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -160,6 +160,9 @@ object Keys {
   private[sbt] val managedFileStampCache = taskKey[FileStamp.Cache](
     "Map of managed file stamps that may be cleared between task evaluation runs."
   ).withRank(Invisible)
+  private[sbt] val managedSourcePaths =
+    taskKey[Seq[Path]]("Transforms the managedSources to Seq[Path] to induce setting injection.")
+      .withRank(Invisible)
   private[sbt] val dependencyClasspathFiles =
     taskKey[Seq[Path]]("The dependency classpath for a task.").withRank(Invisible)
   private[sbt] val classpathFiles =

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -8,7 +8,6 @@
 package sbt
 package nio
 
-import java.io.File
 import java.nio.file.{ Files, Path }
 import java.util.concurrent.ConcurrentHashMap
 
@@ -82,11 +81,9 @@ private[sbt] object Settings {
         ak.manifest.typeArguments match {
           case t :: Nil if seqClass.isAssignableFrom(t.runtimeClass) =>
             t.typeArguments match {
-              case f :: Nil if fileClass.isAssignableFrom(f.runtimeClass) => mkSetting[Seq[File]]
               case p :: Nil if pathClass.isAssignableFrom(p.runtimeClass) => mkSetting[Seq[Path]]
               case _                                                      => default
             }
-          case t :: Nil if fileClass.isAssignableFrom(t.runtimeClass) => mkSetting[File]
           case t :: Nil if pathClass.isAssignableFrom(t.runtimeClass) => mkSetting[Path]
           case _                                                      => default
         }
@@ -147,7 +144,6 @@ private[sbt] object Settings {
 
   private[this] val taskClass = classOf[Task[_]]
   private[this] val seqClass = classOf[Seq[_]]
-  private[this] val fileClass = classOf[java.io.File]
   private[this] val pathClass = classOf[java.nio.file.Path]
 
   /**


### PR DESCRIPTION
It turns out that injecting the keys necessary for incremental tasks
causes a significant startup penalty for many larger projects. For
example, akka starts up about 3 seconds faster if do not inject these
settings for the tasks returning `File` or `Seq[File]`. Given that all
of these apis use java.nio.file anyway, it makes sense to not backport
them to older tasks.