### PR TITLE
Startup perf

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -537,9 +537,9 @@ trait Init[ScopeType] {
     // Take all the original defs and DerivedSettings along with locals, replace each DerivedSetting with the actual
     // settings that were derived.
     val allDefs = addLocal(init)(scopeLocal)
-    allDefs flatMap {
-      case d: DerivedSetting[_] => (derivedToStruct get d map (_.outputs)).toStream.flatten;
-      case s                    => Stream(s)
+    allDefs.flatMap {
+      case d: DerivedSetting[_] => (derivedToStruct get d map (_.outputs)).toSeq.flatten
+      case s                    => s :: Nil
     }
   }
 

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -234,7 +234,7 @@ trait Init[ScopeType] {
     if (s.definitive) s :: Nil else ss :+ s
 
   def addLocal(init: Seq[Setting[_]])(implicit scopeLocal: ScopeLocal): Seq[Setting[_]] =
-    init.flatMap(_.dependencies flatMap scopeLocal) ++ init
+    init.par.map(_.dependencies flatMap scopeLocal).toVector.flatten ++ init
 
   def delegate(sMap: ScopedMap)(
       implicit delegates: ScopeType => Seq[ScopeType],


### PR DESCRIPTION
There were a number of serial bottlenecks during load. I was able to parallelize a number of them. In the akka project, these changes reduces startup time by about 1.5 seconds on my computer. When paired with https://github.com/sbt/sbt/pull/4980, the total startup time dropped from about 22.5 seconds to 19-19.5 seconds. sbt 1.2.8 was around 20 seconds even though sbt 1.3.0 generates 46770 settings compared to 38962 for sbt 1.2.8.