### PR TITLE
avoid force gc during load

### DIFF
--- a/main/src/main/scala/sbt/internal/GCUtil.scala
+++ b/main/src/main/scala/sbt/internal/GCUtil.scala
@@ -18,7 +18,7 @@ private[sbt] object GCUtil {
   // as specified by system properties.
   val defaultForceGarbageCollection: Boolean = true
   val defaultMinForcegcInterval: Duration = 10.minutes
-  val lastGcCheck: AtomicLong = new AtomicLong(0L)
+  val lastGcCheck: AtomicLong = new AtomicLong(System.currentTimeMillis)
 
   def forceGcWithInterval(minForcegcInterval: Duration, log: Logger): Unit = {
     val now = System.currentTimeMillis


### PR DESCRIPTION
This initializes the lastGcCheck to the current time so it won't force GC in the first 10 minutes, avoiding unnecessary GC during load.