### PR TITLE
Store compile file stamps for each scala version

### DIFF
--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -168,6 +168,12 @@ object Keys {
   private[sbt] val classpathFiles =
     taskKey[Seq[Path]]("The classpath for a task.").withRank(Invisible)
   private[sbt] val compileOutputs = taskKey[Seq[Path]]("Compilation outputs").withRank(Invisible)
+  private[sbt] val compileSourceFileInputs =
+    taskKey[Map[String, Seq[(Path, FileStamp)]]]("Source file stamps stored by scala version")
+      .withRank(Invisible)
+  private[sbt] val compileBinaryFileInputs =
+    taskKey[Map[String, Seq[(Path, FileStamp)]]]("Source file stamps stored by scala version")
+      .withRank(Invisible)
 
   private[this] val hasCheckedMetaBuildMsg =
     "Indicates whether or not we have called the checkBuildSources task. This is to avoid warning " +

--- a/sbt/src/sbt-test/actions/cross-incremental/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-incremental/build.sbt
@@ -1,0 +1,22 @@
+scalaVersion := "2.12.8"
+crossScalaVersions := List("2.12.8", "2.13.0")
+
+val setLastModified = taskKey[Unit]("Sets the last modified time for classfiles")
+setLastModified := {
+  val versions = crossScalaVersions.value
+  versions.map(_.split('.').take(2).mkString("scala-", ".", "")).foreach { v =>
+    val f = target.value / v / "classes" / "A.class"
+    Stamps.value.put(f, IO.getModifiedTimeOrZero(f))
+  }
+}
+
+val checkLastModified = taskKey[Unit]("Checks the last modified time for classfiles")
+checkLastModified := {
+  val versions = crossScalaVersions.value
+  versions.map(_.split('.').take(2).mkString("scala-", ".", "")).foreach { v =>
+    val classFile = target.value / v / "classes" / "A.class"
+    val actual = IO.getModifiedTimeOrZero(classFile)
+    val previous = Stamps.value.get(classFile)
+    assert(actual == previous, s"$actual did not equal $previous for $classFile")
+  }
+}

--- a/sbt/src/sbt-test/actions/cross-incremental/project/src/main/scala/Stamps.scala
+++ b/sbt/src/sbt-test/actions/cross-incremental/project/src/main/scala/Stamps.scala
@@ -1,0 +1,3 @@
+object Stamps {
+  val value = new java.util.HashMap[java.io.File, Long]
+}

--- a/sbt/src/sbt-test/actions/cross-incremental/src/main/scala/A.scala
+++ b/sbt/src/sbt-test/actions/cross-incremental/src/main/scala/A.scala
@@ -1,0 +1,3 @@
+object A {
+  def a = 1
+}

--- a/sbt/src/sbt-test/actions/cross-incremental/test
+++ b/sbt/src/sbt-test/actions/cross-incremental/test
@@ -1,0 +1,7 @@
+> +compile
+
+> setLastModified
+
+> +compile
+
+> checkLastModified

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -184,6 +184,7 @@ final class ScriptedTests(
     val (group, name) = testName
     s"$group/$name" match {
       case "actions/add-alias"          => LauncherBased // sbt/Package$
+      case "actions/cross-incremental"  => LauncherBased // tbd
       case "actions/cross-multiproject" => LauncherBased // tbd
       case "actions/cross-multi-parser" =>
         LauncherBased // java.lang.ClassNotFoundException: javax.tools.DiagnosticListener when run with java 11 and an old sbt launcher


### PR DESCRIPTION
https://github.com/sbt/sbt/issues/4986 reported that +compile would
always recompile everything in the project even when the sources hadn't
changed. This was because the dependency classpath was changing between
calls to compile, which caused the external hooks cache introduced in
32a6d0d5d76716c7e85f05ea66bc9cd639611918 to invalidate the scala
library. To fix this, I cache the file stamps on a per scala version
basis. I added a scripted test that checks that there is no
recompilation in two consecutive calls to `+compile` in a multi scala
version build. It failed prior to these changes.