### PR TITLE
Fix settings in ScriptMain

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -36,9 +36,9 @@ import scala.util.control.NonFatal
 /** This class is the entry point for sbt. */
 final class xMain extends xsbti.AppMain {
   def run(configuration: xsbti.AppConfiguration): xsbti.MainResult =
-    new XMainConfiguration().runXMain(configuration)
+    new XMainConfiguration().run("xMain", configuration)
 }
-private[sbt] object xMainImpl {
+private[sbt] object xMain {
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult =
     try {
       import BasicCommandStrings.{ DashClient, DashDashClient, runEarly }
@@ -72,7 +72,11 @@ private[sbt] object xMainImpl {
 }
 
 final class ScriptMain extends xsbti.AppMain {
-  def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
+  def run(configuration: xsbti.AppConfiguration): xsbti.MainResult =
+    new XMainConfiguration().run("ScriptMain", configuration)
+}
+private[sbt] object ScriptMain {
+  private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     import BasicCommandStrings.runEarly
     val state = StandardMain.initialState(
       configuration,
@@ -84,7 +88,11 @@ final class ScriptMain extends xsbti.AppMain {
 }
 
 final class ConsoleMain extends xsbti.AppMain {
-  def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
+  def run(configuration: xsbti.AppConfiguration): xsbti.MainResult =
+    new XMainConfiguration().run("ConsoleMain", configuration)
+}
+private[sbt] object ConsoleMain {
+  private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     val state = StandardMain.initialState(
       configuration,
       BuiltinCommands.ConsoleCommands,

--- a/main/src/main/scala/sbt/internal/XMainConfiguration.scala
+++ b/main/src/main/scala/sbt/internal/XMainConfiguration.scala
@@ -28,7 +28,7 @@ private[sbt] class XMainConfiguration {
     case a: AutoCloseable => a.close()
     case _                =>
   }
-  def runXMain(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
+  def run(moduleName: String, configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     val updatedConfiguration =
       if (configuration.provider.scalaProvider.launcher.topLoader.getClass.getCanonicalName
             .contains("TestInterfaceLoader")) {
@@ -38,7 +38,7 @@ private[sbt] class XMainConfiguration {
       }
     val loader = updatedConfiguration.provider.loader
     Thread.currentThread.setContextClassLoader(loader)
-    val clazz = loader.loadClass("sbt.xMainImpl$")
+    val clazz = loader.loadClass(s"sbt.$moduleName$$")
     val instance = clazz.getField("MODULE$").get(null)
     val runMethod = clazz.getMethod("run", classOf[xsbti.AppConfiguration])
     try {

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -56,7 +56,7 @@ object RunFromSourceMain {
     }
 
   @tailrec private def launch(conf: AppConfiguration): Option[Int] =
-    xMainImpl.run(conf) match {
+    xMain.run(conf) match {
       case e: xsbti.Exit     => Some(e.code)
       case _: xsbti.Continue => None
       case r: xsbti.Reboot   => launch(getConf(conf.baseDirectory(), r.arguments()))


### PR DESCRIPTION
It was reported in https://github.com/sbt/sbt/issues/4973 that the
scalaVersion setting was not being correctly set in a script running
with ScriptMain using 1.3.0-RC4. Using git bisect, I found that the
issue was introduced in
https://github.com/sbt/sbt/commit/73cfd7c8bdd484b49ff6695ef006f5f7ba995c0b.
That commit manipulates the classloaders passed in by the launcher, but
only for the xMain entry point. I found that the script ran correctly if
I updated the classloader for ScriptedMain as well.

After these changes, the example script in #4973 correctly prints 2.13.0
for the scala version with a locally published sbt.

Bonus: rename xMainImpl object xMain. It was private[sbt] anyway.