### PR TITLE
Don't include current ref in inter project dependencies

### DIFF
--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -145,9 +145,7 @@ object CoursierInputsTasks {
       val state = sbt.Keys.state.value
       val projectRef = sbt.Keys.thisProjectRef.value
       val projectRefs = Project.transitiveInterDependencies(state, projectRef)
-      Def.task {
-        csrProject.all(ScopeFilter(inProjects(projectRefs :+ projectRef: _*))).value
-      }
+      csrProject.all(ScopeFilter(inProjects(projectRefs: _*)))
     }
 
   private[sbt] def coursierExtraProjectsTask: Def.Initialize[sbt.Task[Seq[CProject]]] = {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4995. I tracked the doc failures
to 777cc39fcf49a4b8d19214207451d1d02f153ab3. I'm not sure why
projectRef was added to the scope filter in that commit, but removing it
fixes the doc issue.