### PR TITLE
Fix performance regression in test classloader

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2041,7 +2041,6 @@ object Classpaths {
         excludeFilter in unmanagedJars value
       )
     ).map(exportClasspath) ++ Seq(
-      sbt.nio.Keys.classpathFiles := data(fullClasspath.value).map(_.toPath),
       sbt.nio.Keys.dependencyClasspathFiles := data(dependencyClasspath.value).map(_.toPath),
     )
 

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -30,7 +30,10 @@ private[sbt] object ClassLoaders {
    */
   private[sbt] def testTask: Def.Initialize[Task[ClassLoader]] = Def.task {
     val si = scalaInstance.value
-    val rawCP = modifiedTimes((outputFileStamps in classpathFiles).value)
+    val cp = fullClasspath.value.map(_.data)
+    val dependencyStamps = modifiedTimes((outputFileStamps in dependencyClasspathFiles).value).toMap
+    def getLm(f: File): Long = dependencyStamps.getOrElse(f, IO.getModifiedTimeOrZero(f))
+    val rawCP = cp.map(f => f -> getLm(f))
     val fullCP =
       if (si.isManagedVersion) rawCP
       else si.libraryJars.map(j => j -> IO.getModifiedTimeOrZero(j)).toSeq ++ rawCP

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -165,8 +165,6 @@ object Keys {
       .withRank(Invisible)
   private[sbt] val dependencyClasspathFiles =
     taskKey[Seq[Path]]("The dependency classpath for a task.").withRank(Invisible)
-  private[sbt] val classpathFiles =
-    taskKey[Seq[Path]]("The classpath for a task.").withRank(Invisible)
   private[sbt] val compileOutputs = taskKey[Seq[Path]]("Compilation outputs").withRank(Invisible)
   private[sbt] val compileSourceFileInputs =
     taskKey[Map[String, Seq[(Path, FileStamp)]]]("Source file stamps stored by scala version")


### PR DESCRIPTION
In 5eab9df0df60a14bf8e219ddfc149636bd59206f, I updated the
outputFileStamps task to compute all of the stamps for a directory
recursively if an output file is a directory. Prior to that, it had only
computed the stamp for the directory itself. This caused a significant
performance regression in creating the test classloader because it was
computing the last modified time for all of the classfiles in the class path.
The test for 5000 source files in
https://github.com/eatkins/scala-build-watch-performance was running roughly
400ms slower due to this regression.