### PR TITLE
Display only valid pages in scripted completions

### DIFF
--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -136,8 +136,10 @@ object ScriptedPlugin extends AutoPlugin {
     val groupP = token(id.examples(pairMap.keySet)) <~ token('/')
 
     // A parser for page definitions
-    val pageP: Parser[ScriptedTestPage] = ("*" ~ NatBasic ~ "of" ~ NatBasic) map {
-      case _ ~ page ~ _ ~ total => ScriptedTestPage(page, total)
+    val pageNumber = NatBasic & not('0', "zero page number")
+    val pageP: Parser[ScriptedTestPage] = ("*" ~> pageNumber ~ ("of" ~> pageNumber)) flatMap {
+      case (page, total) if page <= total => success(ScriptedTestPage(page, total))
+      case (page, total)                  => failure(s"Page $page was greater than $total")
     }
 
     // Grabs the filenames from a given test group in the current page definition.

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -53,8 +53,10 @@ object Scripted {
     val groupP = token(id.examples(pairMap.keySet)) <~ token('/')
 
     // A parser for page definitions
-    val pageP: Parser[ScriptedTestPage] = ("*" ~ NatBasic ~ "of" ~ NatBasic) map {
-      case _ ~ page ~ _ ~ total => ScriptedTestPage(page, total)
+    val pageNumber = NatBasic & not('0', "zero page number")
+    val pageP: Parser[ScriptedTestPage] = ("*" ~> pageNumber ~ ("of" ~> pageNumber)) flatMap {
+      case (page, total) if page <= total => success(ScriptedTestPage(page, total))
+      case (page, total)                  => failure(s"Page $page was greater than $total")
     }
 
     // Grabs the filenames from a given test group in the current page definition.


### PR DESCRIPTION
The tab completions for scripted have long been broken. They display a
number of non-sensical pages like '*0of9' or '*1of0'. Some of the
multiparser changes seem to have caused these invalid