### PR TITLE
Apply failOnException to parsers in Command.combine

### DIFF
--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -151,7 +151,7 @@ object Command {
   def combine(cmds: Seq[Command]): State => Parser[() => State] = {
     val (simple, arbs) = separateCommands(cmds)
     state =>
-      (simpleParser(simple)(state) /: arbs.map(_ parser state))(_ | _)
+      arbs.map(_.parser(state).failOnException).foldLeft(simpleParser(simple)(state))(_ | _.failOnException)
   }
 
   private[this] def separateCommands(


### PR DESCRIPTION
Rather than allow a bad parser to crash the whole chain, we can just
fail each parser that threw an exception.

Fixes #5013