### PR TITLE
Fix task timings

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -156,12 +156,8 @@ object EvaluateTask {
 
   lazy private val sharedProgress = new TaskTimings(reportOnShutdown = true)
   def taskTimingProgress: Option[ExecuteProgress[Task]] =
-    if (SysProp.taskTimings) {
-      if (SysProp.taskTimingsOnShutdown)
-        Some(sharedProgress)
-      else
-        Some(new TaskTimings(reportOnShutdown = false))
-    } else None
+    if (SysProp.taskTimingsOnShutdown) Some(sharedProgress)
+    else None
 
   lazy private val sharedTraceEvent = new TaskTraceEvent()
   def taskTraceEvent: Option[ExecuteProgress[Task]] =
@@ -240,7 +236,8 @@ object EvaluateTask {
       extracted,
       structure
     )
-    val reporters = maker map { _.progress }
+    val reporters = maker.map(_.progress) ++
+      (if (SysProp.taskTimings) new TaskTimings(reportOnShutdown = false) :: Nil else Nil)
     // configure the logger for super shell
     ConsoleAppender.setShowProgress((reporters collect {
       case p: TaskProgress => ()


### PR DESCRIPTION
I noticed that the reports generated when using sbt.task.timings=true
made very little sense. They were displaying timings for tests that
couldn't possibly have been run. I tracked this down to the TaskTimings
be stored in the progressReport setting which meant they were reused
across multiple task runs. After this change, the reports made a lot
more sense.

Note that there are still issues with the shutdown reporter because, like all of the reporters, it creates a new timer every time a task is run. It's likely that the results are inaccurate, but I find the shutdown reports less useful and it was more work to refactor them so I left that for another PR.