### PR TITLE
Allow supershell in no color mode

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -88,7 +88,7 @@ object SysProp {
 
   def fileCacheSize: Long =
     SizeParser(System.getProperty("sbt.file.cache.size", "128M")).getOrElse(128L * 1024 * 1024)
-  def supershell: Boolean = color && getOrTrue("sbt.supershell")
+  def supershell: Boolean = booleanOpt("sbt.supershell").getOrElse(color)
 
   def supershellSleep: Long = long("sbt.supershell.sleep", 100L)
 


### PR DESCRIPTION
Disabling supershell when color mode is disabled is a sensible default
(especially for piped output). However, I think it should still be
possible to use supershell in no color mode.

This requires a util change that also enables supershell in no color
mode (see https://github.com/sbt/util/pull/216).