### PR TITLE
Name test tasks with the test name

### DIFF
--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -306,7 +306,10 @@ object Tests {
       fun: TestFunction,
       tags: Seq[(Tag, Int)]
   ): Task[Map[String, SuiteResult]] = {
-    val base = task { (name, fun.apply()) }
+    val base = Task[(String, (SuiteResult, Seq[TestTask]))](
+      Info[(String, (SuiteResult, Seq[TestTask]))]().setName(name),
+      Pure(() => (name, fun.apply()), `inline` = false)
+    )
     val taggedBase = base.tagw(tags: _*).tag(fun.tags.map(ConcurrentRestrictions.Tag(_)): _*)
     taggedBase flatMap {
       case (name, (result, nested)) =>


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/4911. This names each parallel
test task with the name of the task so that supershell can display it.
It only applies for parallel tests. When run sequentially, supershell
will still display executeTests.