### PR TITLE
Https

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,7 @@ maxColumn = 100
 project.git = true
 project.excludeFilters = [ "\\Wsbt-test\\W", "\\Winput_sources\\W", "\\Wcontraband-scala\\W" ]
 
-# http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
+# https://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
 docstrings = JavaDoc
 
@@ -11,7 +11,7 @@ docstrings = JavaDoc
 spaces.inImportCurlyBraces = true
 
 # This is more idiomatic Scala.
-# http://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
+# https://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
 align.openParenCallSite = false
 align.openParenDefnSite = false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-  [StackOverflow]: http://stackoverflow.com/tags/sbt
+  [StackOverflow]: https://stackoverflow.com/tags/sbt
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [Issues]: https://github.com/sbt/sbt/issues
   [sbt-contrib]: https://gitter.im/sbt/sbt-contrib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
   [StackOverflow]: https://stackoverflow.com/tags/sbt
-  [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
+  [Setup]: https://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [Issues]: https://github.com/sbt/sbt/issues
   [sbt-contrib]: https://gitter.im/sbt/sbt-contrib
   [327]: https://github.com/sbt/sbt/issues/327

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -160,7 +160,7 @@ suite with `sbt testOnly`
 Scripted integration tests reside in `sbt/src/sbt-test` and are
 written using the same testing infrastructure sbt plugin authors can
 use to test their own plugins with sbt. You can read more about this
-style of tests [here](http://www.scala-sbt.org/1.0/docs/Testing-sbt-plugins).
+style of tests [here](https://www.scala-sbt.org/1.0/docs/Testing-sbt-plugins).
 
 You can run the integration tests with the `sbt scripted` sbt
 command. To run a single test, such as the test in

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
   [FAQ]: http://www.scala-sbt.org/release/docs/Faq.html
   [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
-  [searching]: http://stackoverflow.com/tags/sbt
+  [searching]: https://stackoverflow.com/tags/sbt
   [asking]: https://stackoverflow.com/questions/ask?tags=sbt
   [LICENSE]: LICENSE
   [sbt/io]: https://github.com/sbt/io

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
   [sbt/sbt-zero-seven]: https://github.com/sbt/sbt-zero-seven
   [CONTRIBUTING]: CONTRIBUTING.md
-  [Setup]: http://www.scala-sbt.org/release/docs/Getting-Started/Setup
-  [FAQ]: http://www.scala-sbt.org/release/docs/Faq.html
+  [Setup]: https://www.scala-sbt.org/release/docs/Getting-Started/Setup
+  [FAQ]: https://www.scala-sbt.org/release/docs/Faq.html
   [sbt-dev]: https://groups.google.com/d/forum/sbt-dev
   [searching]: https://stackoverflow.com/tags/sbt
   [asking]: https://stackoverflow.com/questions/ask?tags=sbt
@@ -21,7 +21,7 @@ sbt
 
 sbt is a build tool for Scala, Java, and more.
 
-For general documentation, see http://www.scala-sbt.org/.
+For general documentation, see https://www.scala-sbt.org/.
 
 sbt 1.x
 ---------

--- a/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
@@ -11,7 +11,7 @@ import Types._
 
 /**
  * A minimal heterogeneous list type.  For background, see
- * http://apocalisp.wordpress.com/2010/07/06/type-level-programming-in-scala-part-6a-heterogeneous-list basics/
+ * https://apocalisp.wordpress.com/2010/07/06/type-level-programming-in-scala-part-6a-heterogeneous-list basics/
  */
 sealed trait HList {
   type Wrap[M[_]] <: HList

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -597,7 +597,7 @@ object Scoped {
 
 /** The sbt 0.10 style DSL was deprecated in 0.13.13, favouring the use of the '.value' macro.
  *
- * See http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style for how to migrate.
+ * See https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+from+sbt+0.12+style for how to migrate.
  */
 trait TupleSyntax {
   import Scoped._

--- a/main-settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main-settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -140,7 +140,7 @@ object InputWrapper {
             c.abort(
               pos,
               """`value` is removed from input tasks. Use `evaluated` or `inputTaskValue`.
-                           |See http://www.scala-sbt.org/1.0/docs/Input-Tasks.html for more details.""".stripMargin
+                           |See https://www.scala-sbt.org/1.0/docs/Input-Tasks.html for more details.""".stripMargin
             )
           }
           InputWrapper.wrapInit[T](c)(ts, pos)

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -93,12 +93,12 @@ object TaskMacro {
   final val InputTaskCreateDynName = "createDyn"
   final val InputTaskCreateFreeName = "createFree"
   final val append1Migration =
-    "`<+=` operator is removed. Try `lhs += { x.value }`\n  or see http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html."
+    "`<+=` operator is removed. Try `lhs += { x.value }`\n  or see https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html."
   final val appendNMigration =
-    "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html."
+    "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html."
   final val assignMigration =
     """`<<=` operator is removed. Use `key := { x.value }` or `key ~= (old => { newValue })`.
-      |See http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html""".stripMargin
+      |See https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html""".stripMargin
 
   import LinterDSL.{ Empty => EmptyLinter }
 

--- a/notes/0.13.11.markdown
+++ b/notes/0.13.11.markdown
@@ -1,14 +1,14 @@
 
   [@eed3si9n]: https://github.com/eed3si9n
   [@jsuereth]: https://github.com/jsuereth
-  [@dwijnand]: http://github.com/dwijnand
-  [@Duhemm]: http://github.com/Duhemm
+  [@dwijnand]: https://github.com/dwijnand
+  [@Duhemm]: https://github.com/Duhemm
   [@gkossakowski]: https://github.com/gkossakowski
   [@adriaanm]: https://github.com/adriaanm
   [@jrudolph]: https://github.com/jrudolph
   [@stuhood]: https://github.com/stuhood
   [@pdalpra]: https://github.com/pdalpra
-  [@fkorotkov]: http://github.com/fkorotkov
+  [@fkorotkov]: https://github.com/fkorotkov
   [@hgiddens]: https://github.com/hgiddens
   [@DavidPerezIngeniero]: https://github.com/DavidPerezIngeniero
   [@romanowski]: https://github.com/romanowski

--- a/notes/0.13.12.markdown
+++ b/notes/0.13.12.markdown
@@ -60,14 +60,14 @@
 
   [@eed3si9n]: https://github.com/eed3si9n
   [@jsuereth]: https://github.com/jsuereth
-  [@dwijnand]: http://github.com/dwijnand
-  [@Duhemm]: http://github.com/Duhemm
+  [@dwijnand]: https://github.com/dwijnand
+  [@Duhemm]: https://github.com/Duhemm
   [@gkossakowski]: https://github.com/gkossakowski
   [@adriaanm]: https://github.com/adriaanm
   [@jrudolph]: https://github.com/jrudolph
   [@stuhood]: https://github.com/stuhood
   [@pdalpra]: https://github.com/pdalpra
-  [@fkorotkov]: http://github.com/fkorotkov
+  [@fkorotkov]: https://github.com/fkorotkov
   [@hgiddens]: https://github.com/hgiddens
   [@DavidPerezIngeniero]: https://github.com/DavidPerezIngeniero
   [@romanowski]: https://github.com/romanowski

--- a/notes/0.13.13.markdown
+++ b/notes/0.13.13.markdown
@@ -121,7 +121,7 @@ This becomes:
 
     run := docsRunSetting.evaluated
 
-See [Migrating from sbt 0.12.x](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html) for more details.
+See [Migrating from sbt 0.12.x](https://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html) for more details.
 
 [#2716][2716]/[#2763][2763]/[#2764][2764] by [@eed3si9n][@eed3si9n] and [@dwijnand][@dwijnand]
 

--- a/notes/0.13.14.markdown
+++ b/notes/0.13.14.markdown
@@ -58,7 +58,7 @@ since the resolution happens off of a local-preloaded repository.
 
 No changes should be necessary to your project definition and all plugins published for sbt 0.13.{x|x<14} should still work.
 
-See [Migrating from sbt 0.12.x](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html) for details on the old operator deprecation.
+See [Migrating from sbt 0.12.x](https://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html) for details on the old operator deprecation.
 
 Special thanks to the contributors for making this release a success. According to `git shortlog -sn --no-merges v0.13.13..0.13`, compared to 0.13.13, there were 42 (non-merge) commits, by ten contributors: Dale Wijnand, Eugene Yokota,  Guillaume Martres, Jason Zaugg, Petro Verkhogliad, Eric Richardson, Claudio Bley, Haochi Chen, Paul Draper, Ashley Mercer. Thank you!
 

--- a/notes/0.13.7.markdown
+++ b/notes/0.13.7.markdown
@@ -1,5 +1,5 @@
 
-  [Cached-Resolution]: http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html
+  [Cached-Resolution]: https://www.scala-sbt.org/0.13/docs/Cached-Resolution.html
   [@cunei]: https://github.com/cunei
   [@eed3si9n]: https://github.com/eed3si9n
   [@gkossakowski]: https://github.com/gkossakowski

--- a/notes/0.13.8.markdown
+++ b/notes/0.13.8.markdown
@@ -13,7 +13,7 @@
   [@j-keck]: https://github.com/j-keck
   [@xuwei-k]: https://github.com/xuwei-k
   [SI-9027]: https://issues.scala-lang.org/browse/SI-9027
-  [Custom-Settings0]: http://www.scala-sbt.org/0.13/tutorial/Custom-Settings.html
+  [Custom-Settings0]: https://www.scala-sbt.org/0.13/tutorial/Custom-Settings.html
   [321]: https://github.com/sbt/sbt/issues/321
   [647]: https://github.com/sbt/sbt/issues/647
   [679]: https://github.com/sbt/sbt/issues/679

--- a/notes/0.13.8.markdown
+++ b/notes/0.13.8.markdown
@@ -6,7 +6,7 @@
   [@aerskine]: https://github.com/aerskine
   [@ajozwik]: https://github.com/ajozwik
   [@dwickern]: https://github.com/dwickern
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@Duhemm]: https://github.com/Duhemm
   [@kretes]: https://github.com/kretes
   [@indrajitr]: https://github.com/indrajitr

--- a/notes/0.13.9.markdown
+++ b/notes/0.13.9.markdown
@@ -3,14 +3,14 @@
   [@eed3si9n]: https://github.com/eed3si9n
   [@gkossakowski]: https://github.com/gkossakowski
   [@jsuereth]: https://github.com/jsuereth
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@ajsquared]: https://github.com/ajsquared
   [@jroper]: https://github.com/jroper
   [@kamilkloch]: https://github.com/kamilkloch
   [@DavidPerezIngeniero]: https://github.com/DavidPerezIngeniero
   [@PanAeon]: https://github.com/PanAeon
-  [@asflierl]: http://github.com/asflierl
-  [@matthewfarwell]: http://github.com/matthewfarwell
+  [@asflierl]: https://github.com/asflierl
+  [@matthewfarwell]: https://github.com/matthewfarwell
   [SI9027]: https://issues.scala-lang.org/browse/SI-9027
   [1950]: https://github.com/sbt/sbt/pull/1950
   [1987]: https://github.com/sbt/sbt/pull/1987

--- a/notes/1.0.0.markdown
+++ b/notes/1.0.0.markdown
@@ -270,7 +270,7 @@ Too many people to thank here. See [Credits][Credits]
   [@Duhemm]: https://github.com/Duhemm
   [@jsuereth]: https://github.com/jsuereth
   [@gkossakowski]: https://github.com/gkossakowski
-  [sbt-1-0-roadmap]: http://developer.lightbend.com/blog/2017-04-18-sbt-1-0-roadmap-and-beta1/
+  [sbt-1-0-roadmap]: https://developer.lightbend.com/blog/2017-04-18-sbt-1-0-roadmap-and-beta1/
   [@eed3si9n]: https://github.com/eed3si9n
   [@jroper]: https://github.com/jroper
   [@valydia]: https://github.com/valydia

--- a/notes/1.0.0.markdown
+++ b/notes/1.0.0.markdown
@@ -265,7 +265,7 @@ Too many people to thank here. See [Credits][Credits]
   [Credits]: http://www.scala-sbt.org/1.x/docs/Credits.html
   [Migrating-from-sbt-013x]: http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html
   [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@jvican]: https://github.com/jvican
   [@Duhemm]: https://github.com/Duhemm
   [@jsuereth]: https://github.com/jsuereth

--- a/notes/1.0.0.markdown
+++ b/notes/1.0.0.markdown
@@ -262,8 +262,8 @@ that would should work together to allow dependency locking.
 
 Too many people to thank here. See [Credits][Credits]
 
-  [Credits]: http://www.scala-sbt.org/1.x/docs/Credits.html
-  [Migrating-from-sbt-013x]: http://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html
+  [Credits]: https://www.scala-sbt.org/1.x/docs/Credits.html
+  [Migrating-from-sbt-013x]: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html
   [@eed3si9n]: https://github.com/eed3si9n
   [@dwijnand]: https://github.com/dwijnand
   [@jvican]: https://github.com/jvican

--- a/notes/1.0.1.markdown
+++ b/notes/1.0.1.markdown
@@ -43,7 +43,7 @@ If you have a list of files:
   [3481]: https://github.com/sbt/sbt/pull/3481
   [util121]: https://github.com/sbt/util/pull/121
   [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@jvican]: https://github.com/jvican
   [@Duhemm]: https://github.com/Duhemm
   [@jroper]: https://github.com/jroper

--- a/notes/1.1.0.markdown
+++ b/notes/1.1.0.markdown
@@ -138,7 +138,7 @@ For all scripted tests in which `project/build.properties` exist, the value of t
 This allows you to define scripted tests that track the minimum supported sbt versions, e.g. 0.13.9 and 1.0.0-RC2. [#3564][3564]/[#3566][3566] by [@jonas][@jonas]
 
   [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@cunei]: https://github.com/cunei
   [@jvican]: https://github.com/jvican
   [@Duhemm]: https://github.com/Duhemm

--- a/notes/1.1.1.markdown
+++ b/notes/1.1.1.markdown
@@ -22,7 +22,7 @@ When set to `true`, sbt shell will automatically start sbt server. Otherwise, it
 [#3922][3922] by [@swaldman][@swaldman]
 
   [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
+  [@dwijnand]: https://github.com/dwijnand
   [@cunei]: https://github.com/cunei
   [@jvican]: https://github.com/jvican
   [@Duhemm]: https://github.com/Duhemm

--- a/notes/about.markdown
+++ b/notes/about.markdown
@@ -1,1 +1,1 @@
-[sbt](http://www.scala-sbt.org/) is the interactive build tool.
+[sbt](https://www.scala-sbt.org/) is the interactive build tool.

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/Command.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/Command.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionContext.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionContext.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionItem.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionItem.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionList.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionList.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/CompletionParams.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/TextEdit.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/TextEdit.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CommandFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CommandFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionContextFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionContextFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionItemFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionItemFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionListFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionListFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/CompletionParamsFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/TextEditFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/langserver/codec/TextEditFormats.scala
@@ -1,5 +1,5 @@
 /**
- * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
  */
 
 // DO NOT EDIT MANUALLY

--- a/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
@@ -16,7 +16,7 @@ object ErrorCodes {
   // format: off
 
   // Defined by the JSON-RPC 2.0 Specification
-  // http://www.jsonrpc.org/specification#error_object
+  // https://www.jsonrpc.org/specification#error_object
   //
   // The error codes from and including -32768 to -32000 are reserved for pre-defined errors.
   // Any code within this range, but not defined explicitly below is reserved for future use.

--- a/protocol/src/main/scala/sbt/protocol/Serialization.scala
+++ b/protocol/src/main/scala/sbt/protocol/Serialization.scala
@@ -69,13 +69,13 @@ object Serialization {
     CompactPrinter(json).getBytes("UTF-8")
   }
 
-  /** This formats the message according to JSON-RPC. http://www.jsonrpc.org/specification */
+  /** This formats the message according to JSON-RPC. https://www.jsonrpc.org/specification */
   private[sbt] def serializeResponseMessage(message: JsonRpcResponseMessage): Array[Byte] = {
     import sbt.internal.protocol.codec.JsonRPCProtocol._
     serializeResponse(message)
   }
 
-  /** This formats the message according to JSON-RPC. http://www.jsonrpc.org/specification */
+  /** This formats the message according to JSON-RPC. https://www.jsonrpc.org/specification */
   private[sbt] def serializeNotificationMessage(
       message: JsonRpcNotificationMessage,
   ): Array[Byte] = {

--- a/sbt/src/sbt-test/actions/external-doc/build.sbt
+++ b/sbt/src/sbt-test/actions/external-doc/build.sbt
@@ -24,7 +24,7 @@ val bResolver = Def.setting {
 
 val apiBaseSetting = apiURL := Some(apiBase(name.value))
 def apiBase(projectName: String) = url(s"http://example.org/${projectName}")
-def scalaLibraryBase(v: String) = url(s"http://www.scala-lang.org/api/$v/")
+def scalaLibraryBase(v: String) = url(s"https://www.scala-lang.org/api/$v/")
 def addDep(projectName: String) =
 	libraryDependencies += organization.value %% projectName % version.value
 

--- a/sbt/src/sbt-test/actions/external-doc/build.sbt
+++ b/sbt/src/sbt-test/actions/external-doc/build.sbt
@@ -24,7 +24,7 @@ val bResolver = Def.setting {
 
 val apiBaseSetting = apiURL := Some(apiBase(name.value))
 def apiBase(projectName: String) = url(s"http://example.org/${projectName}")
-def scalaLibraryBase(v: String) = url(s"https://www.scala-lang.org/api/$v/")
+def scalaLibraryBase(v: String) = url(s"http://www.scala-lang.org/api/$v/")
 def addDep(projectName: String) =
 	libraryDependencies += organization.value %% projectName % version.value
 

--- a/sbt/src/sbt-test/actions/input-task-dyn/build.sbt
+++ b/sbt/src/sbt-test/actions/input-task-dyn/build.sbt
@@ -1,6 +1,6 @@
 import complete.Parser
 
-// http://www.scala-sbt.org/0.13/docs/Input-Tasks.html
+// https://www.scala-sbt.org/0.13/docs/Input-Tasks.html
 
 val runFoo = inputKey[Unit]("Runs Foo with passed arguments")
 val check = taskKey[Unit]("")

--- a/sbt/src/sbt-test/actions/input-task/build.sbt
+++ b/sbt/src/sbt-test/actions/input-task/build.sbt
@@ -1,6 +1,6 @@
 import complete.Parser
 
-// http://www.scala-sbt.org/0.13/docs/Input-Tasks.html
+// https://www.scala-sbt.org/0.13/docs/Input-Tasks.html
 
 val run2 = inputKey[Unit](
     "Runs the main class twice with different argument lists separated by --")

--- a/sbt/src/sbt-test/apiinfo/show-circular-structure/test
+++ b/sbt/src/sbt-test/apiinfo/show-circular-structure/test
@@ -1,4 +1,4 @@
-# test case for http://github.com/sbt/sbt/issues/676
+# test case for https://github.com/sbt/sbt/issues/676
 > compile
 # fails with StackOverflowException
 > showApis

--- a/sbt/src/sbt-test/dependency-management/info/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/info/build.sbt
@@ -20,8 +20,8 @@ lazy val customInfo = settingKey[Boolean]("")
 def inlineXML(addInfo: Boolean, organization: String, moduleID: String, version: String): NodeSeq =
   if (addInfo)
     (<info organisation={organization} module={moduleID} revision={version}>
-      <license name="Two-clause BSD-style" url="http://github.com/szeiger/scala-query/blob/master/LICENSE.txt" />
-      <description homepage="http://github.com/szeiger/scala-query/">
+      <license name="Two-clause BSD-style" url="https://github.com/szeiger/scala-query/blob/master/LICENSE.txt" />
+      <description homepage="https://github.com/szeiger/scala-query/">
         ScalaQuery is a type-safe database query API for Scala.
       </description>
     </info>

--- a/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-compiler/2.11.8/ivy.xml
+++ b/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-compiler/2.11.8/ivy.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
   <info publication="20160520164059" status="release" revision="2.11.8" module="scala-compiler" organisation="org.other">
-    <license url="http://www.scala-lang.org/license.html" name="BSD 3-Clause"/>
-    <description homepage="http://www.scala-lang.org">
+    <license url="https://www.scala-lang.org/license.html" name="BSD 3-Clause"/>
+    <description homepage="https://www.scala-lang.org">
     Scala Compiler
     </description>
   </info>

--- a/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-library/2.11.8/ivy.xml
+++ b/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-library/2.11.8/ivy.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
   <info publication="20160520164058" status="release" revision="2.11.8" module="scala-library" organisation="org.other">
-    <license url="http://www.scala-lang.org/license.html" name="BSD 3-Clause"/>
-    <description homepage="http://www.scala-lang.org">
+    <license url="https://www.scala-lang.org/license.html" name="BSD 3-Clause"/>
+    <description homepage="https://www.scala-lang.org">
     Scala Standard Library
     </description>
   </info>

--- a/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-reflect/2.11.8/ivy.xml
+++ b/sbt/src/sbt-test/dependency-management/scala-organization/repo/org.other/scala-reflect/2.11.8/ivy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
   <info organisation="org.other" module="scala-reflect" revision="2.11.8" status="release" publication="20160520164058">
-    <license name="BSD 3-Clause" url="http://www.scala-lang.org/license.html"/>
-    <description homepage="http://www.scala-lang.org">
+    <license name="BSD 3-Clause" url="https://www.scala-lang.org/license.html"/>
+    <description homepage="https://www.scala-lang.org">
     Scala Reflection Library
     </description>
   </info>

--- a/sbt/src/sbt-test/dependency-management/url/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/url/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.classpath.ClasspathUtilities
 lazy val root = (project in file(".")).
   settings(
     ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
-    libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1" % Test from "http://jsoup.org/packages/jsoup-1.9.1.jar",
+    libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1" % Test from "https://jsoup.org/packages/jsoup-1.9.1.jar",
     ivyLoggingLevel := UpdateLogging.Full,
     TaskKey[Unit]("checkInTest") := checkClasspath(Test).value,
     TaskKey[Unit]("checkInCompile") := checkClasspath(Compile).value

--- a/sbt/src/sbt-test/nio/code-formatter/.scalafmt.conf
+++ b/sbt/src/sbt-test/nio/code-formatter/.scalafmt.conf
@@ -3,7 +3,7 @@ maxColumn = 100
 project.git = true
 project.excludeFilters = [ "\\Wsbt-test\\W", "\\Winput_sources\\W", "\\Wcontraband-scala\\W" ]
 
-# http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
+# https://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
 docstrings = JavaDoc
 
@@ -11,7 +11,7 @@ docstrings = JavaDoc
 spaces.inImportCurlyBraces = true
 
 # This is more idiomatic Scala.
-# http://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
+# https://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
 align.openParenCallSite = false
 align.openParenDefnSite = false
 

--- a/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
+++ b/sbt/src/sbt-test/project/auto-plugins/project/Q.scala
@@ -1,4 +1,4 @@
-package sbttest // you need package http://stackoverflow.com/questions/9822008/
+package sbttest // you need package https://stackoverflow.com/questions/9822008/
 
 	import sbt._, Keys._
 	import java.util.concurrent.atomic.{AtomicInteger => AInt}

--- a/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
+++ b/sbt/src/sbt-test/project/binary-plugin/changes/define/A.scala
@@ -1,4 +1,4 @@
-package sbttest // you need package http://stackoverflow.com/questions/9822008/
+package sbttest // you need package https://stackoverflow.com/questions/9822008/
 
 import sbt._, Keys._
 

--- a/vscode-sbt-scala/client/syntaxes/Scala.tmLanguage
+++ b/vscode-sbt-scala/client/syntaxes/Scala.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>


### PR DESCRIPTION
The web is moving to https for security... These servers seem to support HTTPS (some even speak HTTP2 when the https urls are used).

I skipped databinder.net because while the server speaks https, http://databinder.net/repo seems to be gone.
https://github.com/sbt/sbt/blob/4c3cd4e535a89d220a0d20f360f36212ceff9b09/launch/src/main/resources/sbt.boot.properties0.7#L14

I suspect that means that someone trying to ask sbt for sbt0.7 will be unhappy, although I'm not really sure how to prove it.
