### PR TITLE
Create directory before touch

### DIFF
--- a/tasks-standard/src/main/scala/sbt/std/Streams.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Streams.scala
@@ -184,6 +184,9 @@ object Streams {
       def make[T <: Closeable](a: Key, sid: String)(f: File => T): T = synchronized {
         checkOpen()
         val file = taskDirectory(a) / sid
+        // The call to IO.createDirectory is an attempt to reduce scripted test failures in the
+        // call to IO.touch. It may be removed if it doesn't affect the scripted failures.
+        Option(file.getParentFile).foreach(IO.createDirectory)
         IO.touch(file, false)
         val t = f(file)
         opened ::= t


### PR DESCRIPTION
Sometimes scripted tests fail at the IO.touch line. I can't reproduce,
but I don't think it should hurt to try and create the parent directory
before touching the file.