### PR TITLE
Fixes file watching when -Dsbt.global.base is set to a relative path

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -100,7 +100,10 @@ private[sbt] object Load {
     val delegates = defaultDelegates
     val pluginMgmt = PluginManagement(loader)
     val inject = InjectSettings(injectGlobal(state), Nil, const(Nil))
-    System.setProperty("swoval.tmpdir", System.getProperty("swoval.tmpdir", globalBase.toString))
+    System.setProperty(
+      "swoval.tmpdir",
+      System.getProperty("swoval.tmpdir", globalBase.getAbsolutePath.toString)
+    )
     LoadBuildConfiguration(
       stagingDirectory,
       classpath,

--- a/notes/1.3.0/set-swovalpath-with-absolutepath.md
+++ b/notes/1.3.0/set-swovalpath-with-absolutepath.md
@@ -1,0 +1,8 @@
+[@yamachu]: https://github.com/yamachu
+
+[#5047]: https://github.com/sbt/sbt/issues/5047
+[#5048]: https://github.com/sbt/sbt/pull/5048
+
+### Bug Fixes
+
+- Enable file watching when setting relative path to sbt.global.base [#5047][5047]/[#5048][5048] by [@yamachu][@yamachu]


### PR DESCRIPTION
close: https://github.com/sbt/sbt/issues/5047

`swoval.tmpdir` is used here
https://github.com/swoval/swoval/blob/2e7944c10ff0f050d89e1512cbb1d4e122d2b718/files/jvm/src/main/java/com/swoval/runtime/NativeLoader.java#L108

It seems to be no problem even if this value is changed to an absolute path.
So I set an absolute path and prevent crashes by passing a relative path.