### PR TITLE
Fixes deprecation warnings for watch related changes

### DIFF
--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -161,17 +161,20 @@ object Watched {
   val Configuration =
     AttributeKey[Watched]("watched-configuration", "Configures continuous execution.")
 
-  @deprecated("Use defaultStartWatch in conjunction with the watchStartMessage key", "1.3.0")
+  @deprecated("Use Watch.defaultStartWatch in conjunction with the watchStartMessage key", "1.3.0")
   val defaultWatchingMessage: WatchState => String =
     ((ws: WatchState) => s"${ws.count}. ${waitMessage("")} ")
       .label("Watched.projectWatchingMessage")
   @deprecated(
-    "Use defaultOnTriggerMessage in conjunction with the watchTriggeredMessage key",
+    "Use Watch.defaultOnTriggerMessage in conjunction with the watchTriggeredMessage key",
     "1.3.0"
   )
   val defaultTriggeredMessage: WatchState => String =
     const("").label("Watched.defaultTriggeredMessage")
-  @deprecated("Use clearOnTrigger in conjunction with the watchTriggeredMessage key", "1.3.0")
+  @deprecated(
+    "Use Watch.clearScreenOnTrigger in conjunction with the watchTriggeredMessage key",
+    "1.3.0"
+  )
   val clearWhenTriggered: WatchState => String =
     const(clearScreen).label("Watched.clearWhenTriggered")
 }

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -120,6 +120,17 @@ object Keys {
   ).withRank(DSetting)
   val watchTriggers =
     settingKey[Seq[Glob]]("Describes files that should trigger a new continuous build.")
+
+  /**
+   * Sets the message to display after a new build is triggered. By default,
+   * it prints the file that triggered the build and what command(s) will be run.
+   * To clear the screen, add
+   * {{{
+   *   watchTriggeredMessage := Watch.clearScreenOnTrigger
+   * }}}
+   * to the build.
+   *
+   */
   val watchTriggeredMessage = settingKey[(Int, Path, Seq[String]) => Option[String]](
     "The message to show before triggered execution executes an action after sources change. The parameters are the current watch iteration count, the path that triggered the build and the names of the commands to run."
   ).withRank(DSetting)


### PR DESCRIPTION
During refactoring, these warnings got out of date. I also added
scaladoc to the watchTriggeredMessage key.

Ref: https://github.com/sbt/sbt/issues/5051.