### PR TITLE
Only set close classloader for interactive sessions

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -882,6 +882,7 @@ object BuiltinCommands {
 
   def shell: Command = Command.command(Shell, Help.more(Shell, ShellDetailed)) { s0 =>
     import sbt.internal.{ ConsolePromptEvent, ConsoleUnpromptEvent }
+    SysProp.setCloseClassLoaders()
     val exchange = StandardMain.exchange
     val welcomeState = displayWelcomeBanner(s0)
     val s1 = exchange run welcomeState

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -84,7 +84,9 @@ object SysProp {
    */
   lazy val color: Boolean = ConsoleAppender.formatEnabledInEnv
 
-  def closeClassLoaders: Boolean = getOrTrue("sbt.classloader.close")
+  def closeClassLoaders: Boolean = getOrFalse("sbt.classloader.close")
+  def setCloseClassLoaders(): Unit =
+    System.getProperties.putIfAbsent("sbt.classloader.close", "true")
 
   def fileCacheSize: Long =
     SizeParser(System.getProperty("sbt.file.cache.size", "128M")).getOrElse(128L * 1024 * 1024)


### PR DESCRIPTION
The purpose of closing the classloaders is to prevent resource leaks in
long running sessions. If a user is running batch
commands, then it's fine if they want to use shutdown hooks or leak
threads.

This commit makes it so that we set the `sbt.classloader.close`
property when we enter shell if it isn't already set. I change the
default value of `SysProp.closeClassLoaders` to be false when the
variable is unset. This prevents us from closing classloaders for
non-interactive sessions.