### PR TITLE
[1.3.x] lm-coursier-shaded 2.0.0-RC3-4 + Scala 2.12.10

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
@@ -74,7 +74,7 @@ object KListBuilder extends TupleBuilder {
        * The type constructor is tcVariable, so that it can be applied to [X] X or M later.
        * When applied to `M`, this type gives the type of the `input` KList.
        */
-      val klistType: Type = (inputs :\ knilType)((in, klist) => kconsType(in.tpe, klist))
+      val klistType: Type = inputs.foldRight(knilType)((in, klist) => kconsType(in.tpe, klist))
 
       val representationC = internal.polyType(tcVariable :: Nil, klistType)
       val input = klist

--- a/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
@@ -48,7 +48,7 @@ object AList {
   def seq[T]: SeqList[T] = new SeqList[T] {
     def transform[M[_], N[_]](s: List[M[T]], f: M ~> N) = s.map(f.fn[T])
     def foldr[M[_], A](s: List[M[T]], f: (M[_], A) => A, init: A): A =
-      (init /: s.reverse)((t, m) => f(m, t))
+      s.reverse.foldLeft(init)((t, m) => f(m, t))
 
     override def apply[M[_], C](s: List[M[T]], f: List[T] => C)(
         implicit ap: Applicative[M]

--- a/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
@@ -36,5 +36,5 @@ final case class HCons[H, T <: HList](head: H, tail: T) extends HList {
 object HList {
   // contains no type information: not even A
   implicit def fromList[A](list: Traversable[A]): HList =
-    ((HNil: HList) /: list)((hl, v) => HCons(v, hl))
+    list.foldLeft(HNil: HList)((hl, v) => HCons(v, hl))
 }

--- a/internal/util-collection/src/main/scala/sbt/internal/util/INode.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/INode.scala
@@ -77,7 +77,7 @@ abstract class EvaluateSettings[ScopeType] {
   }
 
   private[this] def getResults(implicit delegates: ScopeType => Seq[ScopeType]) =
-    (empty /: static.toTypedSeq) {
+    static.toTypedSeq.foldLeft(empty) {
       case (ss, static.TPair(key, node)) =>
         if (key.key.isLocal) ss else ss.set(key.scope, key.key, node.get)
     }

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -225,7 +225,7 @@ trait Init[ScopeType] {
     }.toMap
 
   def grouped(init: Seq[Setting[_]]): ScopedMap =
-    ((IMap.empty: ScopedMap) /: init)((m, s) => add(m, s))
+    init.foldLeft(IMap.empty: ScopedMap)((m, s) => add(m, s))
 
   def add[T](m: ScopedMap, s: Setting[T]): ScopedMap =
     m.mapValue[T](s.key, Vector.empty[Setting[T]], ss => append(ss, s))
@@ -399,7 +399,7 @@ trait Init[ScopeType] {
 
     val empty = Map.empty[ScopedKey[_], Flattened]
 
-    val flattenedLocals = (empty /: ordered) { (cmap, c) =>
+    val flattenedLocals = ordered.foldLeft(empty) { (cmap, c) =>
       cmap.updated(c.key, flatten(cmap, c.key, c.dependencies))
     }
 
@@ -859,7 +859,7 @@ trait Init[ScopeType] {
     }
 
     private[sbt] def processAttributes[S](init: S)(f: (S, AttributeMap) => S): S =
-      (init /: alist.toList(inputs)) { (v, i) =>
+      alist.toList(inputs).foldLeft(init) { (v, i) =>
         i.processAttributes(v)(f)
       }
   }

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
@@ -16,7 +16,7 @@ object Util {
     separate(ps)(Types.idFun)
 
   def separate[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
-    val (a, b) = ((Nil: Seq[A], Nil: Seq[B]) /: ps)((xs, y) => prependEither(xs, f(y)))
+    val (a, b) = ps.foldLeft((Nil: Seq[A], Nil: Seq[B]))((xs, y) => prependEither(xs, f(y)))
     (a.reverse, b.reverse)
   }
 

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -81,7 +81,7 @@ object JLineCompletion {
 
   def convertCompletions(cs: Set[Completion]): (Seq[String], Seq[String]) = {
     val (insert, display) =
-      ((Set.empty[String], Set.empty[String]) /: cs) {
+      cs.foldLeft((Set.empty[String], Set.empty[String])) {
         case (t @ (insert, display), comp) =>
           if (comp.isEmpty) t
           else (appendNonEmpty(insert, comp.append), appendNonEmpty(display, comp.display))

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -487,7 +487,7 @@ trait ParserMain {
 
   /** Applies parser `p` to input `s`. */
   def apply[T](p: Parser[T])(s: String): Parser[T] =
-    (p /: s)(derive1)
+    s.foldLeft(p)(derive1)
 
   /** Applies parser `p` to a single character of input. */
   def derive1[T](p: Parser[T], c: Char): Parser[T] =

--- a/internal/util-logic/src/main/scala/sbt/internal/util/logic/Logic.scala
+++ b/internal/util-logic/src/main/scala/sbt/internal/util/logic/Logic.scala
@@ -170,10 +170,10 @@ object Logic {
   }
 
   private[this] def dependencyMap(clauses: Clauses): Map[Atom, Set[Literal]] =
-    (Map.empty[Atom, Set[Literal]] /: clauses.clauses) {
+    clauses.clauses.foldLeft(Map.empty[Atom, Set[Literal]]) {
       case (m, Clause(formula, heads)) =>
         val deps = literals(formula)
-        (m /: heads) { (n, head) =>
+        heads.foldLeft(m) { (n, head) =>
           n.updated(head, n.getOrElse(head, Set.empty) ++ deps)
         }
     }
@@ -305,7 +305,7 @@ object Logic {
       case Clause(formula, head) +: tail =>
         // collect direct positive and negative literals and track them in separate graphs
         val (pos, neg) = directDeps(formula)
-        val (newPos, newNeg) = ((posDeps, negDeps) /: head) {
+        val (newPos, newNeg) = head.foldLeft((posDeps, negDeps)) {
           case ((pdeps, ndeps), d) =>
             (pdeps + (d, pos), ndeps + (d, neg))
         }

--- a/main-actions/src/main/scala/sbt/DotGraph.scala
+++ b/main-actions/src/main/scala/sbt/DotGraph.scala
@@ -85,7 +85,7 @@ object DotGraph {
 
   private def relativized(roots: Iterable[File], path: File): String = {
     val relativized = roots.flatMap(root => IO.relativize(root, path))
-    val shortest = (Int.MaxValue /: relativized)(_ min _.length)
+    val shortest = relativized.foldLeft(Int.MaxValue)(_ min _.length)
     relativized.find(_.length == shortest).getOrElse(path.getName)
   }
 }

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -390,7 +390,7 @@ object Tests {
       }
     }
   def overall(results: Iterable[TestResult]): TestResult =
-    ((TestResult.Passed: TestResult) /: results) { (acc, result) =>
+    results.foldLeft(TestResult.Passed: TestResult) { (acc, result) =>
       if (severity(acc) < severity(result)) result else acc
     }
   def discover(

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -105,7 +105,7 @@ object BasicCommands {
   def help: Command = Command.make(HelpCommand, helpBrief, helpDetailed)(helpParser)
 
   def helpParser(s: State): Parser[() => State] = {
-    val h = (Help.empty /: s.definedCommands)(
+    val h = s.definedCommands.foldLeft(Help.empty)(
       (a, b) =>
         a ++ (try b.help(s)
         catch { case NonFatal(_) => Help.empty })
@@ -319,7 +319,7 @@ object BasicCommands {
           if (cp.isEmpty) parentLoader else toLoader(cp.map(f => new File(f)), parentLoader)
         val loaded =
           args.map(arg => ModuleUtilities.getObject(arg, loader).asInstanceOf[State => State])
-        (state /: loaded)((s, obj) => obj(s))
+        loaded.foldLeft(state)((s, obj) => obj(s))
     }
 
   def callParser: Parser[(Seq[String], Seq[String])] =

--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -151,7 +151,7 @@ object Command {
   def combine(cmds: Seq[Command]): State => Parser[() => State] = {
     val (simple, arbs) = separateCommands(cmds)
     state =>
-      (simpleParser(simple)(state) /: arbs.map(_ parser state))(_ | _)
+      arbs.map(_ parser state).foldLeft(simpleParser(simple)(state))(_ | _)
   }
 
   private[this] def separateCommands(

--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -131,7 +131,7 @@ object Watched {
   def multi(base: Watched, paths: Seq[Watched]): Watched =
     new AWatched {
       override def watchSources(s: State): Seq[Watched.WatchSource] =
-        (base.watchSources(s) /: paths)(_ ++ _.watchSources(s))
+        paths.foldLeft(base.watchSources(s))(_ ++ _.watchSources(s))
       override def terminateWatch(key: Int): Boolean = base.terminateWatch(key)
       override val pollInterval: FiniteDuration = (base +: paths).map(_.pollInterval).min
       override val antiEntropy: FiniteDuration = (base +: paths).map(_.antiEntropy).min

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3365,7 +3365,7 @@ object Classpaths {
   }
 
   def union[A, B](maps: Seq[A => Seq[B]]): A => Seq[B] =
-    a => (Seq[B]() /: maps) { _ ++ _(a) } distinct;
+    a => maps.foldLeft(Seq[B]()) { _ ++ _(a) } distinct;
 
   def parseList(s: String, allConfs: Seq[String]): Seq[String] =
     (trim(s split ",") flatMap replaceWildcard(allConfs)).distinct

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -96,7 +96,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.8"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.10"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -326,7 +326,7 @@ ${listConflicts(conflicting)}""")
   }
   private[sbt] def and(a: Plugins, b: Plugins) = b match {
     case Empty    => a
-    case And(ns)  => (a /: ns)(_ && _)
+    case And(ns)  => ns.foldLeft(a)(_ && _)
     case b: Basic => a && b
   }
   private[sbt] def remove(a: Plugins, del: Set[Basic]): Plugins = a match {

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -706,7 +706,7 @@ object Project extends ProjectExtra {
   ): Relation[ScopedKey[_], ScopedKey[_]] = {
     val cMap = Def.flattenLocals(Def.compiled(settings, actual))
     val emptyRelation = Relation.empty[ScopedKey[_], ScopedKey[_]]
-    (emptyRelation /: cMap) { case (r, (key, value)) => r + (key, value.dependencies) }
+    cMap.foldLeft(emptyRelation) { case (r, (key, value)) => r + (key, value.dependencies) }
   }
 
   def showDefinitions(key: AttributeKey[_], defs: Seq[Scope])(

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -48,7 +48,7 @@ object Tags {
   }
   private[this] final class Sum(tags: Seq[Tag], max: Int) extends Rule {
     checkMax(max)
-    def apply(m: TagMap) = (0 /: tags)((sum, t) => sum + getInt(m, t)) <= max
+    def apply(m: TagMap) = tags.foldLeft(0)((sum, t) => sum + getInt(m, t)) <= max
     override def toString = tags.mkString("Limit sum of ", ", ", " to " + max)
   }
   private[this] final class Or(a: Rule, b: Rule) extends Rule {

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -324,7 +324,7 @@ object BuildStreams {
     resolvePath(projectPath(units, root, scoped, data), nonProjectPath(scoped))
 
   def resolvePath(base: File, components: Seq[String]): File =
-    (base /: components)((b, p) => new File(b, p))
+    components.foldLeft(base)((b, p) => new File(b, p))
 
   def pathComponent[T](axis: ScopeAxis[T], scoped: ScopedKey[_], label: String)(
       show: T => String

--- a/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -65,7 +65,7 @@ private[sbt] object EvaluateConfigurations {
       evaluateSbtFile(eval, src, IO.readLines(src), imports, 0)
     }
     loader =>
-      (LoadedSbtFile.empty /: loadFiles) { (loaded, load) =>
+      loadFiles.foldLeft(LoadedSbtFile.empty) { (loaded, load) =>
         loaded merge load(loader)
       }
   }

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -68,7 +68,7 @@ object IvyConsole {
       unmanaged: Seq[File]
   )
   def parseDependencies(args: Seq[String], log: Logger): Dependencies =
-    (Dependencies(Nil, Nil, Nil) /: args)(parseArgument(log))
+    args.foldLeft(Dependencies(Nil, Nil, Nil))(parseArgument(log))
   def parseArgument(log: Logger)(acc: Dependencies, arg: String): Dependencies =
     arg match {
       case _ if arg contains " at " => acc.copy(resolvers = parseResolver(arg) +: acc.resolvers)

--- a/main/src/main/scala/sbt/internal/KeyIndex.scala
+++ b/main/src/main/scala/sbt/internal/KeyIndex.scala
@@ -22,7 +22,7 @@ object KeyIndex {
       projects: Map[URI, Set[String]],
       configurations: Map[String, Seq[Configuration]]
   ): ExtendableKeyIndex =
-    (base(projects, configurations) /: known) { _ add _ }
+    known.foldLeft(base(projects, configurations)) { _ add _ }
   def aggregate(
       known: Iterable[ScopedKey[_]],
       extra: BuildUtil[_],
@@ -44,7 +44,7 @@ object KeyIndex {
     }
     toAggregate.foldLeft(base(projects, configurations)) {
       case (index, Nil)  => index
-      case (index, keys) => (index /: keys)(_ add _)
+      case (index, keys) => keys.foldLeft(index)(_ add _)
     }
   }
 
@@ -84,7 +84,7 @@ object KeyIndex {
     def keys(proj: Option[ResolvedReference], conf: Option[String], task: Option[AttributeKey[_]]) =
       concat(_.keys(proj, conf, task))
     def concat[T](f: KeyIndex => Set[T]): Set[T] =
-      (Set.empty[T] /: indices)((s, k) => s ++ f(k))
+      indices.foldLeft(Set.empty[T])((s, k) => s ++ f(k))
   }
   private[sbt] def getOr[A, B](m: Map[A, B], key: A, or: B): B = m.getOrElse(key, or)
   private[sbt] def keySet[A, B](m: Map[Option[A], B]): Set[A] = m.keys.flatten.toSet
@@ -241,7 +241,7 @@ private[sbt] final class KeyIndex0(val data: BuildIndex) extends ExtendableKeyIn
       key: String
   ): Set[AttributeKey[_]] = keyIndex(proj, conf).tasks(key)
   def keys(proj: Option[ResolvedReference]): Set[String] =
-    (Set.empty[String] /: optConfigs(proj)) { (s, c) =>
+    optConfigs(proj).foldLeft(Set.empty[String]) { (s, c) =>
       s ++ keys(proj, c)
     }
   def keys(proj: Option[ResolvedReference], conf: Option[String]): Set[String] =
@@ -270,7 +270,7 @@ private[sbt] final class KeyIndex0(val data: BuildIndex) extends ExtendableKeyIn
   def addAggregated(scoped: ScopedKey[_], extra: BuildUtil[_]): ExtendableKeyIndex =
     if (validID(scoped.key.label)) {
       val aggregateProjects = Aggregation.aggregate(scoped, ScopeMask(), extra, reverse = true)
-      ((this: ExtendableKeyIndex) /: aggregateProjects)(_ add _)
+      aggregateProjects.foldLeft(this: ExtendableKeyIndex)(_ add _)
     } else
       this
 

--- a/main/src/main/scala/sbt/internal/KeyIndex.scala
+++ b/main/src/main/scala/sbt/internal/KeyIndex.scala
@@ -42,7 +42,7 @@ object KeyIndex {
         Aggregation.aggregate(key, ScopeMask(), extra, reverse = true)
       case _ => Nil
     }
-    (base(projects, configurations) /: toAggregate) {
+    toAggregate.foldLeft(base(projects, configurations)) {
       case (index, Nil)  => index
       case (index, keys) => (index /: keys)(_ add _)
     }

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -498,7 +498,7 @@ private[sbt] object Load {
     unit.definitions.builds.flatMap(_.buildLoaders).toList match {
       case Nil => loaders
       case x :: xs =>
-        val resolver = (x /: xs) { _ | _ }
+        val resolver = xs.foldLeft(x) { _ | _ }
         if (isRoot) loaders.setRoot(resolver) else loaders.addNonRoot(unit.uri, resolver)
     }
 
@@ -1072,7 +1072,7 @@ private[sbt] object Load {
           case sf: DefaultSbtFiles => settings(defaultSbtFiles.filter(sf.include))
           case p: AutoPlugins      => autoPluginSettings(p)
           case q: Sequence =>
-            (Seq.empty[Setting[_]] /: q.sequence) { (b, add) =>
+            q.sequence.foldLeft(Seq.empty[Setting[_]]) { (b, add) =>
               b ++ expandSettings(add)
             }
         }
@@ -1128,7 +1128,9 @@ private[sbt] object Load {
         0
       )(loader)
     // How to merge SbtFiles we read into one thing
-    def merge(ls: Seq[LoadedSbtFile]): LoadedSbtFile = (LoadedSbtFile.empty /: ls) { _ merge _ }
+    def merge(ls: Seq[LoadedSbtFile]): LoadedSbtFile = ls.foldLeft(LoadedSbtFile.empty) {
+      _ merge _
+    }
     // Loads a given file, or pulls from the cache.
 
     def memoLoadSettingsFile(src: File): LoadedSbtFile =
@@ -1148,7 +1150,7 @@ private[sbt] object Load {
       case sf: SbtFiles        => sf.files.map(f => IO.resolve(projectBase, f)).filterNot(_.isHidden)
       case sf: DefaultSbtFiles => defaultSbtFiles.filter(sf.include).filterNot(_.isHidden)
       case q: Sequence =>
-        (Seq.empty[File] /: q.sequence) { (b, add) =>
+        q.sequence.foldLeft(Seq.empty[File]) { (b, add) =>
           b ++ associatedFiles(add)
         }
       case _ => Seq.empty

--- a/main/src/main/scala/sbt/internal/PluginsDebug.scala
+++ b/main/src/main/scala/sbt/internal/PluginsDebug.scala
@@ -418,7 +418,7 @@ private[sbt] object PluginsDebug {
     def allSettings(p: AutoPlugin): Seq[Setting[_]] =
       p.projectSettings ++ p.buildSettings ++ p.globalSettings
     val empty = Relation.empty[AutoPlugin, AttributeKey[_]]
-    (empty /: available)((r, p) => r + (p, extractDefinedKeys(allSettings(p))))
+    available.foldLeft(empty)((r, p) => r + (p, extractDefinedKeys(allSettings(p))))
   }
 
   private[this] def excludedError(transitive: Boolean, dependencies: List[AutoPlugin]): String =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
   def addSbtZincCompileCore(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierVersion = "2.0.0-RC3-3"
+  val lmCoursierVersion = "2.0.0-RC3-4"
   val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % lmCoursierVersion
 
   val sjsonNewScalaJson = Def.setting {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.8"
+  val scala212 = "2.12.10"
   lazy val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala212
   def nightlyVersion: Option[String] = sys.props.get("sbt.build.version")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
-addSbtPlugin("org.scala-sbt"     % "sbt-houserules"  % "0.3.9")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"    % "2.0.2")
-addSbtPlugin("org.scala-sbt"     % "sbt-contraband"  % "0.4.1")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "3.0.2")
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"   % "0.9.0")
-addSbtPlugin("com.lightbend"     % "sbt-whitesource" % "0.1.14")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.9")
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.9")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.2")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/sbt/src/sbt-test/actions/cross-incremental/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-incremental/build.sbt
@@ -1,5 +1,5 @@
-scalaVersion := "2.12.8"
-crossScalaVersions := List("2.12.8", "2.13.0")
+scalaVersion := "2.12.10"
+crossScalaVersions := List("2.12.10", "2.13.0")
 
 val setLastModified = taskKey[Unit]("Sets the last modified time for classfiles")
 setLastModified := {

--- a/sbt/src/sbt-test/actions/cross-multi-parser/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-multi-parser/build.sbt
@@ -1,1 +1,1 @@
-crossScalaVersions := Seq[String]("2.11.12", "2.12.8")
+crossScalaVersions := Seq[String]("2.11.12", "2.12.10")

--- a/sbt/src/sbt-test/actions/cross-multi-parser/test
+++ b/sbt/src/sbt-test/actions/cross-multi-parser/test
@@ -1,5 +1,5 @@
 > ++2.11.12; compile
 
-> ++ 2.12.8  ; compile;
+> ++ 2.12.10  ; compile;
 
-> ++ 2.12.8  ; compile
+> ++ 2.12.10 ; compile

--- a/sbt/src/sbt-test/actions/cross-multiproject/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-multiproject/build.sbt
@@ -1,4 +1,5 @@
-lazy val scala212 = "2.12.8"
+lazy val scala212 = "2.12.10"
+// keep this at M5 to test full version
 lazy val scala213 = "2.13.0-M5"
 
 ThisBuild / crossScalaVersions := Seq(scala212, scala213)

--- a/sbt/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt/src/sbt-test/actions/cross-multiproject/test
@@ -13,7 +13,7 @@ $ exists lib/target/scala-2.13.0-M5
 
 # test safe switching
 > clean
-> ++ 2.12.8 -v compile
+> ++ 2.12.10 -v compile
 $ exists lib/target/scala-2.12
 -$ exists lib/target/scala-2.13.0-M5
 $ exists sbt-foo/target/scala-2.12
@@ -29,7 +29,7 @@ $ exists sbt-foo/target/scala-2.12
 
 # Test ++ leaves crossScalaVersions unchanged
 > clean
-> ++2.12.8
+> ++2.12.10
 > +extrasProj/compile
 $ exists extras/target/scala-2.13.0-M5
 $ exists extras/target/scala-2.12

--- a/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.8"
+lazy val scala212 = "2.12.10"
 lazy val scala213 = "2.13.0-M5"
 
 ThisBuild / scalaVersion := scala212

--- a/sbt/src/sbt-test/actions/doc-file-options/build.sbt
+++ b/sbt/src/sbt-test/actions/doc-file-options/build.sbt
@@ -2,7 +2,7 @@ val newContents = "bbbbbbbbb"
 
 val rootContentFile = "root.txt"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/actions/external-doc/build.sbt
+++ b/sbt/src/sbt-test/actions/external-doc/build.sbt
@@ -24,7 +24,7 @@ val bResolver = Def.setting {
 
 val apiBaseSetting = apiURL := Some(apiBase(name.value))
 def apiBase(projectName: String) = url(s"http://example.org/${projectName}")
-def scalaLibraryBase(v: String) = url(s"http://www.scala-lang.org/api/$v/")
+def scalaLibraryBase(v: String) = url(s"https://www.scala-lang.org/api/$v/")
 def addDep(projectName: String) =
 	libraryDependencies += organization.value %% projectName % version.value
 

--- a/sbt/src/sbt-test/actions/generator/build.sbt
+++ b/sbt/src/sbt-test/actions/generator/build.sbt
@@ -1,6 +1,6 @@
 val buildInfo = taskKey[Seq[File]]("generates the build info")
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/actions/multi-command/build.sbt
+++ b/sbt/src/sbt-test/actions/multi-command/build.sbt
@@ -19,4 +19,4 @@ val dynamicTask = taskKey[Unit]("dynamic input task")
 
 dynamicTask := { println("not yet et") }
 
-crossScalaVersions := "2.11.12" :: "2.12.8" :: Nil
+crossScalaVersions := "2.11.12" :: "2.12.10" :: Nil

--- a/sbt/src/sbt-test/actions/multi-command/test
+++ b/sbt/src/sbt-test/actions/multi-command/test
@@ -37,4 +37,4 @@
 
 > ++ 2.11.12 compile; setStringValue bar; checkStringValue bar
 
-> ++2.12.8 compile; setStringValue foo; checkStringValue foo
+> ++2.12.10 compile; setStringValue foo; checkStringValue foo

--- a/sbt/src/sbt-test/classloader-cache/akka-actor-system/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/akka-actor-system/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val akkaTest = (project in file(".")).settings(
   name := "akka-test",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.5.16",
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"

--- a/sbt/src/sbt-test/classloader-cache/jni/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/jni/build.sbt
@@ -13,7 +13,7 @@ def wrap(task: InputKey[Unit]): Def.Initialize[Task[Unit]] =
 ThisBuild / turbo := true
 
 val root = (project in file(".")).settings(
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-h",
   sourceDirectory.value.toPath.resolve("main/native/include").toString),
   libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.6" % "test",

--- a/sbt/src/sbt-test/classloader-cache/library-mismatch/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/library-mismatch/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val snapshot = (project in file(".")).settings(
   name := "mismatched-libraries",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   libraryDependencies ++= Seq("com.lihaoyi" %% "utest" % "0.6.6" % "test"),
   testFrameworks := Seq(TestFramework("utest.runner.Framework")),
   resolvers += "Local Maven" at file("libraries/ivy").toURI.toURL.toString,

--- a/sbt/src/sbt-test/classloader-cache/runtime-layers/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/runtime-layers/build.sbt
@@ -1,6 +1,6 @@
 val layeringStrategyTest = (project in file(".")).settings(
   name := "layering-strategy-test",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   organization := "sbt",
   libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.16",
 )

--- a/sbt/src/sbt-test/classloader-cache/snapshot/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/snapshot/build.sbt
@@ -9,7 +9,7 @@ ThisBuild / useCoursier := false
 
 val snapshot = (project in file(".")).settings(
   name := "akka-test",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"
   ),

--- a/sbt/src/sbt-test/classloader-cache/snapshot/libraries/library-1/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
+++ b/sbt/src/sbt-test/classloader-cache/snapshot/libraries/library-1/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.8</version>
+            <version>2.12.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/sbt/src/sbt-test/classloader-cache/snapshot/libraries/library-2/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
+++ b/sbt/src/sbt-test/classloader-cache/snapshot/libraries/library-2/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.8</version>
+            <version>2.12.10</version>
         </dependency>
     </dependencies>
 </project>

--- a/sbt/src/sbt-test/classloader-cache/spark/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/spark/build.sbt
@@ -2,6 +2,6 @@ name := "Simple Project"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3"

--- a/sbt/src/sbt-test/classloader-cache/utest/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/utest/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val utestTest = (project in file(".")).settings(
   name := "utest-test",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"
   ),

--- a/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.8"
+lazy val scala212 = "2.12.10"
 lazy val scala213 = "2.13.0-M5"
 ThisBuild / scalaVersion := scala212
 

--- a/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 // TTL of Coursier is 24h
 ThisBuild / useCoursier := false

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
@@ -3,7 +3,7 @@ lazy val check = taskKey[Unit]("Runs the check")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junit = "junit" % "junit" % "4.11"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(

--- a/sbt/src/sbt-test/dependency-management/compiler-bridge-binary/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/compiler-bridge-binary/build.sbt
@@ -1,9 +1,9 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val check = taskKey[Unit]("")
 
 // We can't use "%%" here without breaking the "== bridgeModule" check below
-val bridgeModule = "org.scala-sbt" % s"compiler-bridge_2.12" % "1.3.0-M3"
+val bridgeModule = "org.scala-sbt" % "compiler-bridge_2.12" % "1.3.0"
 
 libraryDependencies += bridgeModule % Configurations.ScalaTool
 

--- a/sbt/src/sbt-test/dependency-management/conflict-coursier/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/conflict-coursier/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies ++= List(
   "org.webjars.npm" % "randomatic" % "1.1.7",
   "org.webjars.npm" % "is-odd"     % "2.0.0",

--- a/sbt/src/sbt-test/dependency-management/global-plugins/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/global-plugins/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"

--- a/sbt/src/sbt-test/dependency-management/snapshot-local/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/snapshot-local/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 def customIvyPaths: Seq[Def.Setting[_]] = Seq(
   ivyPaths := IvyPaths((baseDirectory in ThisBuild).value, Some((baseDirectory in ThisBuild).value / "ivy-cache"))

--- a/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 // TTL is 24h so we can't detect the change
 ThisBuild / useCoursier := false

--- a/sbt/src/sbt-test/dependency-management/sources/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/sources/build.sbt
@@ -1,5 +1,4 @@
-// ThisBuild / useCoursier := false
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(
@@ -13,15 +12,16 @@ def checkSources(report: UpdateReport): Unit = {
   val srcs = getSources(report).map(_.getName)
   if(srcs.isEmpty)
     sys.error(s"No sources retrieved\n\n$report")
-  else if (srcs.size != 8 || !srcs.exists(_ == "akka-actor_2.12-2.5.22-sources.jar")) {
-    // scala-library-2.12.8-sources.jar
-    // config-1.3.3-sources.jar
-    // akka-actor_2.12-2.5.22-sources.jar
-    // scala-java8-compat_2.12-0.8.0-sources.jar
-    // scala-xml_2.12-1.0.6-sources.jar
-    // scala-compiler-2.12.8-sources.jar
-    // scala-reflect-2.12.8-sources.jar
-    // jline-2.14.6-sources.jar
+  else if (srcs.size != 9 || !srcs.exists(_ == "akka-actor_2.12-2.5.22-sources.jar")) {
+// [info] [error] 	scala-java8-compat_2.12-0.8.0-sources.jar
+// [info] [error] 	scala-library-2.12.10-sources.jar
+// [info] [error] 	config-1.3.3-sources.jar
+// [info] [error] 	akka-actor_2.12-2.5.22-sources.jar
+// [info] [error] 	scala-compiler-2.12.10-sources.jar
+// [info] [error] 	jline-2.14.6-sources.jar
+// [info] [error] 	jansi-1.12-sources.jar
+// [info] [error] 	scala-xml_2.12-1.0.6-sources.jar
+// [info] [error] 	scala-reflect-2.12.10-sources.jar
     sys.error("Incorrect sources retrieved:\n\t" + srcs.mkString("\n\t"))
   } else ()
 }

--- a/sbt/src/sbt-test/plugins/hydra/build.sbt
+++ b/sbt/src/sbt-test/plugins/hydra/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val check = taskKey[Unit]("")
 

--- a/sbt/src/sbt-test/plugins/sbt-native-packager/build.sbt
+++ b/sbt/src/sbt-test/plugins/sbt-native-packager/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 name := "hello"
 enablePlugins(JavaAppPackaging)

--- a/sbt/src/sbt-test/project/aggregate/projA/build.sbt
+++ b/sbt/src/sbt-test/project/aggregate/projA/build.sbt
@@ -1,3 +1,3 @@
 name := "projA"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"

--- a/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
+++ b/sbt/src/sbt-test/project/cross-plugins-defaults/build.sbt
@@ -1,7 +1,7 @@
 val baseSbt = "1."
 
-val buildCrossList = List("2.10.7", "2.11.12", "2.12.8")
-scalaVersion in ThisBuild := "2.12.8"
+val buildCrossList = List("2.10.7", "2.11.12", "2.12.10")
+scalaVersion in ThisBuild := "2.12.10"
 crossScalaVersions in ThisBuild := buildCrossList
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/sbt/src/sbt-test/project/flatten/build.sbt
+++ b/sbt/src/sbt-test/project/flatten/build.sbt
@@ -1,6 +1,6 @@
 val unpackage = TaskKey[Unit]("unpackage")
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/project/internal-tracking/build.sbt
+++ b/sbt/src/sbt-test/project/internal-tracking/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / trackInternalDependencies := TrackLevel.NoTracking
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt/src/sbt-test/project/semanticdb/build.sbt
@@ -1,3 +1,4 @@
+// TODO: bump to 2.12.10 once scalameta is available
 ThisBuild / scalaVersion := "2.12.8"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbIncludeInJar := true

--- a/sbt/src/sbt-test/run/fork-loader/build.sbt
+++ b/sbt/src/sbt-test/run/fork-loader/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/source-dependencies/binary/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/binary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val dep = project
 

--- a/sbt/src/sbt-test/source-dependencies/cross-source/test
+++ b/sbt/src/sbt-test/source-dependencies/cross-source/test
@@ -1,3 +1,3 @@
 # A.scala needs B.scala, it would be in source list
-> ++2.12.8!
+> ++2.12.10!
 > compile

--- a/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-annotation/build.sbt
@@ -1,3 +1,4 @@
+// TODO: bump to 2.12.10 once macro paradise is available
 ThisBuild / scalaVersion := "2.12.8"
 
 val paradiseVersion = "2.1.1"

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/source-dependencies/macro/build.sbt
+++ b/sbt/src/sbt-test/source-dependencies/macro/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt/src/sbt-test/tests/arguments/build.sbt
+++ b/sbt/src/sbt-test/tests/arguments/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/do-not-discover/build.sbt
+++ b/sbt/src/sbt-test/tests/do-not-discover/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/done/build.sbt
+++ b/sbt/src/sbt-test/tests/done/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/fork-async/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-async/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-parallel/build.sbt
@@ -1,7 +1,7 @@
 import Tests._
 import Defaults._
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 val check = taskKey[Unit]("Check that tests are executed in parallel")
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/tests/fork-test-group-parallel/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-test-group-parallel/build.sbt
@@ -1,5 +1,5 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 Global / concurrentRestrictions := Seq(Tags.limitAll(4))
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/fork-uncaught2/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-uncaught2/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
 

--- a/sbt/src/sbt-test/tests/fork/build.sbt
+++ b/sbt/src/sbt-test/tests/fork/build.sbt
@@ -11,7 +11,7 @@ val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 def groupId(idx: Int) = "group_" + (idx + 1)
 def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / organization := "org.example"
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/tests/fork2/build.sbt
+++ b/sbt/src/sbt-test/tests/fork2/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 fork := true
 libraryDependencies += scalatest % Test

--- a/sbt/src/sbt-test/tests/it/build.sbt
+++ b/sbt/src/sbt-test/tests/it/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
 

--- a/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
+++ b/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
@@ -14,7 +14,7 @@ val nestedSuitesReportFile = "target/test-reports/my.scalatest.MyNestedSuites.xm
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-par/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-inproc-seq/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-subproc/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-subproc/build.sbt
@@ -1,7 +1,7 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/nested-tests/build.sbt
+++ b/sbt/src/sbt-test/tests/nested-tests/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / version := "0.0.1" 
 ThisBuild / organization := "org.catastrophe"
 

--- a/sbt/src/sbt-test/tests/one-class-multi-framework/build.sbt
+++ b/sbt/src/sbt-test/tests/one-class-multi-framework/build.sbt
@@ -1,5 +1,5 @@
 val specsJunit = "org.specs2" %% "specs2-junit" % "4.3.4"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies += junitinterface % Test
 libraryDependencies += specsJunit % Test

--- a/sbt/src/sbt-test/tests/order/build.sbt
+++ b/sbt/src/sbt-test/tests/order/build.sbt
@@ -1,5 +1,5 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 Test / parallelExecution := false
 libraryDependencies += scalcheck % Test

--- a/sbt/src/sbt-test/tests/resources/build.sbt
+++ b/sbt/src/sbt-test/tests/resources/build.sbt
@@ -1,3 +1,3 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/scala-instance-classloader/build.sbt
+++ b/sbt/src/sbt-test/tests/scala-instance-classloader/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.ScalaInstance
 lazy val OtherScala = config("other-scala").hide
 lazy val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.5.17"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .configs(OtherScala)
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       val rawJars = (managedClasspath in OtherScala).value.map(_.data)
       val scalaHome = (target.value / "scala-home")
       def removeVersion(name: String): String =
-        name.replaceAll("\\-2.12.8", "")
+        name.replaceAll("\\-2.12.10", "")
       for(jar <- rawJars) {
         val tjar = scalaHome / s"lib/${removeVersion(jar.getName)}"
         IO.copyFile(jar, tjar)

--- a/sbt/src/sbt-test/tests/serial/build.sbt
+++ b/sbt/src/sbt-test/tests/serial/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / organization := "com.example"
 ThisBuild / version      := "0.0.1-SNAPSHOT"
 

--- a/sbt/src/sbt-test/tests/setup-cleanup/base.sbt
+++ b/sbt/src/sbt-test/tests/setup-cleanup/base.sbt
@@ -1,3 +1,3 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies += scalatest

--- a/sbt/src/sbt-test/tests/single-runner/build.sbt
+++ b/sbt/src/sbt-test/tests/single-runner/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/specs-run/build.sbt
+++ b/sbt/src/sbt-test/tests/specs-run/build.sbt
@@ -1,4 +1,4 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 libraryDependencies += specs % Test

--- a/sbt/src/sbt-test/tests/t543/build.sbt
+++ b/sbt/src/sbt-test/tests/t543/build.sbt
@@ -7,7 +7,7 @@ val check = TaskKey[Unit]("check", "Check correct error has been returned.")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt/src/sbt-test/tests/task/build.sbt
+++ b/sbt/src/sbt-test/tests/task/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt/src/sbt-test/tests/test-exclude/build.sbt
+++ b/sbt/src/sbt-test/tests/test-exclude/build.sbt
@@ -1,5 +1,5 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/tests/test-quick/build.sbt
+++ b/sbt/src/sbt-test/tests/test-quick/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/watch/commands/build.sbt
+++ b/sbt/src/sbt-test/watch/commands/build.sbt
@@ -53,4 +53,4 @@ expectFailure / watchOnFileInputEvent := { (_, e) =>
 }
 
 
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+crossScalaVersions := Seq("2.11.12", "2.12.10")

--- a/sbt/src/server-test/handshake/build.sbt
+++ b/sbt/src/server-test/handshake/build.sbt
@@ -1,6 +1,6 @@
 import sbt.internal.server.{ ServerHandler, ServerIntent }
 
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 
 lazy val root = (project in file("."))
   .settings(

--- a/tasks-standard/src/test/scala/Execute.scala
+++ b/tasks-standard/src/test/scala/Execute.scala
@@ -37,7 +37,7 @@ object ExecuteSpec extends Properties("Execute") {
     (i: Int, times: Int, workers: Int) =>
       ("Workers: " + workers) |: ("Value: " + i) |: ("Times: " + times) |: {
         val initial = task(0) map (identity[Int])
-        def t = (initial /: (0 until times))((t, ignore) => t.map(_ + i))
+        def t = (0 until times).foldLeft(initial)((t, ignore) => t.map(_ + i))
         checkResult(tryRun(t, false, workers), i * times)
       }
   }

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -116,7 +116,7 @@ object ConcurrentRestrictions {
     m.updated(a, newb)
   }
   private[this] def merge[A, B](m: Map[A, B], n: Map[A, B])(f: (B, B) => B): Map[A, B] =
-    (m /: n) { case (acc, (a, b)) => update(acc, a, b)(f) }
+    n.foldLeft(m) { case (acc, (a, b)) => update(acc, a, b)(f) }
 
   /**
    * Constructs a CompletionService suitable for backing task execution based on the provided restrictions on concurrent task execution.

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -363,7 +363,7 @@ private[sbt] final class Execute[F[_] <: AnyRef](
     val seen = IDSet.create[F[_]]
     def visit(n: F[_]): List[F[_]] =
       (seen process n)(List[F[_]]()) {
-        node :: (List[F[_]]() /: dependencies(n)) { (ss, dep) =>
+        node :: dependencies(n).foldLeft(List[F[_]]()) { (ss, dep) =>
           visit(dep) ::: ss
         }
       }

--- a/testing/src/main/scala/sbt/TestReportListener.scala
+++ b/testing/src/main/scala/sbt/TestReportListener.scala
@@ -131,7 +131,7 @@ object TestEvent {
     }
 
   private[sbt] def overallResult(events: Seq[TEvent]): TestResult =
-    ((TestResult.Passed: TestResult) /: events) { (sum, event) =>
+    events.foldLeft(TestResult.Passed: TestResult) { (sum, event) =>
       (sum, event.status) match {
         case (TestResult.Error, _)  => TestResult.Error
         case (_, TStatus.Error)     => TestResult.Error


### PR DESCRIPTION
This a backport of https://github.com/sbt/sbt/pull/5072 + #5010 (needed because I deprecated /: in 2.12.10)
