### PR TITLE
Allow classloaders to be used after close

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -672,12 +672,14 @@ lazy val mainProj = (project in file("main"))
       exclude[ReversedMissingMethodProblem]("sbt.internal.KeyIndex.*"),
       // internal
       exclude[IncompatibleMethTypeProblem]("sbt.internal.server.LanguageServerReporter.*"),
+
       // Changed signature or removed private[sbt] methods
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.unmanagedLibs0"),
       exclude[DirectMissingMethodProblem]("sbt.Defaults.allTestGroupsTask"),
       exclude[DirectMissingMethodProblem]("sbt.Plugins.topologicalSort"),
       exclude[IncompatibleMethTypeProblem]("sbt.Defaults.allTestGroupsTask"),
-      exclude[DirectMissingMethodProblem]("sbt.StandardMain.shutdownHook")
+      exclude[DirectMissingMethodProblem]("sbt.StandardMain.shutdownHook"),
+      exclude[MissingClassProblem]("sbt.internal.ResourceLoaderImpl"),
     )
   )
   .configure(

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ def sbt10Plus =
     "1.2.7",
     "1.2.8",
   ) ++ sbt13Plus
-def sbt13Plus = Seq() // Add sbt 1.3+ stable versions when released
+def sbt13Plus = Seq("1.3.0")
 
 def mimaSettings = mimaSettingsSince(sbt10Plus)
 def mimaSettingsSince(versions: Seq[String]) = Def settings (

--- a/main/src/main/java/sbt/internal/FlatLoader.java
+++ b/main/src/main/java/sbt/internal/FlatLoader.java
@@ -7,17 +7,23 @@
 
 package sbt.internal;
 
-import java.io.IOException;
+import java.io.File;
 import java.net.URL;
-import java.net.URLClassLoader;
+import sbt.util.Logger;
+import scala.collection.Seq;
 
-final class FlatLoader extends URLClassLoader {
+final class FlatLoader extends LayeredClassLoaderImpl {
   static {
     ClassLoader.registerAsParallelCapable();
   }
 
-  FlatLoader(final URL[] urls, final ClassLoader parent) {
-    super(urls, parent);
+  FlatLoader(
+      final Seq<File> files,
+      final ClassLoader parent,
+      final File file,
+      final boolean allowZombies,
+      final Logger logger) {
+    super(files, parent, file, allowZombies, logger);
   }
 
   @Override
@@ -29,10 +35,5 @@ final class FlatLoader extends URLClassLoader {
       jars.append("\n");
     }
     return "FlatLoader(\n  parent = " + getParent() + "\n  jars = " + jars.toString() + ")";
-  }
-
-  @Override
-  public void close() throws IOException {
-    if (SysProp.closeClassLoaders()) super.close();
   }
 }

--- a/main/src/main/java/sbt/internal/LayeredClassLoader.java
+++ b/main/src/main/java/sbt/internal/LayeredClassLoader.java
@@ -8,14 +8,13 @@
 package sbt.internal;
 
 import java.io.File;
+import sbt.util.Logger;
 import scala.collection.Seq;
 
 final class LayeredClassLoader extends LayeredClassLoaderImpl {
-  LayeredClassLoader(
-      final Seq<File> classpath,
-      final ClassLoader parent,
-      final File tempDir) {
-    super(classpath, parent, tempDir);
+  LayeredClassLoader(final Seq<File> classpath, final ClassLoader parent, final File tempDir, final
+      boolean allowZombies, final Logger logger) {
+    super(classpath, parent, tempDir, allowZombies, logger);
   }
 
   static {

--- a/main/src/main/java/sbt/internal/ScalaLibraryClassLoader.java
+++ b/main/src/main/java/sbt/internal/ScalaLibraryClassLoader.java
@@ -7,7 +7,6 @@
 
 package sbt.internal;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -31,10 +30,5 @@ final class ScalaLibraryClassLoader extends URLClassLoader {
       if (i < jars.length - 2) builder.append(", ");
     }
     return "ScalaLibraryClassLoader(" + builder + " parent = " + getParent() + ")";
-  }
-
-  @Override
-  public void close() throws IOException {
-    if (SysProp.closeClassLoaders()) super.close();
   }
 }

--- a/main/src/main/java/sbt/internal/ScalaReflectClassLoader.java
+++ b/main/src/main/java/sbt/internal/ScalaReflectClassLoader.java
@@ -7,7 +7,6 @@
 
 package sbt.internal;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -26,10 +25,5 @@ final class ScalaReflectClassLoader extends URLClassLoader {
   @Override
   public String toString() {
     return "ScalaReflectClassLoader(" + jar + " parent = " + getParent() + ")";
-  }
-
-  @Override
-  public void close() throws IOException {
-    if (SysProp.closeClassLoaders()) super.close();
   }
 }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -325,7 +325,7 @@ object Keys {
   val dependencyClasspathAsJars = taskKey[Classpath]("The classpath consisting of internal and external, managed and unmanaged dependencies, all as JARs.")
   val fullClasspathAsJars = taskKey[Classpath]("The exported classpath, consisting of build products and unmanaged and managed, internal and external dependencies, all as JARs.")
   val internalDependencyConfigurations = settingKey[Seq[(ProjectRef, Set[String])]]("The project configurations that this configuration depends on")
-  private[sbt] val allowZombieClassLoaders = settingKey[Boolean]("Allow a classloader that has previously been closed by `run` or `test` to continue loading classes.")
+  val allowZombieClassLoaders = settingKey[Boolean]("Allow a classloader that has previously been closed by `run` or `test` to continue loading classes.")
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -325,6 +325,7 @@ object Keys {
   val dependencyClasspathAsJars = taskKey[Classpath]("The classpath consisting of internal and external, managed and unmanaged dependencies, all as JARs.")
   val fullClasspathAsJars = taskKey[Classpath]("The exported classpath, consisting of build products and unmanaged and managed, internal and external dependencies, all as JARs.")
   val internalDependencyConfigurations = settingKey[Seq[(ProjectRef, Set[String])]]("The project configurations that this configuration depends on")
+  private[sbt] val allowZombieClassLoaders = settingKey[Boolean]("Allow a classloader that has previously been closed by `run` or `test` to continue loading classes.")
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)


### PR DESCRIPTION
There have been a number of complaints about the new classloader closing
behavior. It is too aggressive about closing classloaders after test and
run. This commit softens the behavior by allowing a classloader to be
resurrected after close by creating a new zombie classloader that has
the same urls as the original classloader. After this commit, we always
close the classloaders when we are done, but they can still leak
file descriptors if a zombie is created.

To configure the behavior, I added a new comfiguration class:
ClassLoaderCloseMode. It has three options:
1) Ignore -- Do not emit a warning if a zombie is created
2) Warn -- Emit a warning if a zombie is created (default)
3) Strict -- Do not allow zombies to be created and throw an exception
if the loader is used after close.

I verified after this change that I could add a shutdown hook in `run`
and it would be evaluated so long as I set `bgCopyClasspath := false`.
Otherwise the needed jars were deleted before the hooks could run.