### PR TITLE
Monitor project build sources

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -371,13 +371,16 @@ object Defaults extends BuildCommon {
       }).value
   )
 
-  def paths = Seq(
+  // Appended to JvmPlugin.projectSettings
+  def paths: Seq[Setting[_]] = Seq(
     baseDirectory := thisProject.value.base,
     target := baseDirectory.value / "target",
     historyPath := (historyPath or target(t => Option(t / ".history"))).value,
     sourceDirectory := baseDirectory.value / "src",
     sourceManaged := crossTarget.value / "src_managed",
-    resourceManaged := crossTarget.value / "resource_managed"
+    resourceManaged := crossTarget.value / "resource_managed",
+    // Adds subproject build.sbt files to the global list of build files to monitor
+    Scope.Global / checkBuildSources / fileInputs += baseDirectory.value.toGlob / "*.sbt"
   )
 
   lazy val configPaths = sourceConfigPaths ++ resourceConfigPaths ++ outputConfigPaths

--- a/sbt/src/sbt-test/nio/reload/.scalafmt.conf
+++ b/sbt/src/sbt-test/nio/reload/.scalafmt.conf
@@ -1,0 +1,21 @@
+version = 2.0.0
+maxColumn = 100
+project.git = true
+project.excludeFilters = [ "\\Wsbt-test\\W", "\\Winput_sources\\W", "\\Wcontraband-scala\\W" ]
+
+# http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
+# scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
+docstrings = JavaDoc
+
+# This also seems more idiomatic to include whitespace in import x.{ yyy }
+spaces.inImportCurlyBraces = true
+
+# This is more idiomatic Scala.
+# http://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
+align.openParenCallSite = false
+align.openParenDefnSite = false
+
+# For better code clarity
+danglingParentheses = true
+
+trailingCommas = preserve

--- a/sbt/src/sbt-test/nio/reload/build.sbt
+++ b/sbt/src/sbt-test/nio/reload/build.sbt
@@ -11,3 +11,5 @@ exists := {
 }
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+val sub = project

--- a/sbt/src/sbt-test/nio/reload/changes/ScalafmtVersion.scala
+++ b/sbt/src/sbt-test/nio/reload/changes/ScalafmtVersion.scala
@@ -1,0 +1,3 @@
+object ScalafmtVersion {
+  val value = "2.0.4"
+}

--- a/sbt/src/sbt-test/nio/reload/changes/broken.sbt
+++ b/sbt/src/sbt-test/nio/reload/changes/broken.sbt
@@ -8,3 +8,5 @@ exists := {
 }
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+val sub = project

--- a/sbt/src/sbt-test/nio/reload/changes/sub.sbt
+++ b/sbt/src/sbt-test/nio/reload/changes/sub.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scala-sbt" % "sbt" % "1.3.0"

--- a/sbt/src/sbt-test/nio/reload/changes/working.sbt
+++ b/sbt/src/sbt-test/nio/reload/changes/working.sbt
@@ -11,3 +11,5 @@ exists := {
 }
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+val sub = project

--- a/sbt/src/sbt-test/nio/reload/project/plugins.sbt
+++ b/sbt/src/sbt-test/nio/reload/project/plugins.sbt
@@ -1,0 +1,8 @@
+libraryDependencies ++= {
+  if (ScalafmtVersion.value == "2.0.4") {
+    val sbtV = (sbtBinaryVersion in pluginCrossBuild).value
+    val scalaV = (scalaBinaryVersion in update).value
+    val dep = "org.scalameta" % "sbt-scalafmt" % ScalafmtVersion.value
+    sbt.Defaults.sbtPluginExtra(dep, sbtV, scalaV) :: Nil
+  } else Nil
+}

--- a/sbt/src/sbt-test/nio/reload/project/project/ScalafmtVersion.scala
+++ b/sbt/src/sbt-test/nio/reload/project/project/ScalafmtVersion.scala
@@ -1,0 +1,3 @@
+object ScalafmtVersion {
+  val value = "2.0.3"
+}

--- a/sbt/src/sbt-test/nio/reload/sub/src/main/scala/Test.scala
+++ b/sbt/src/sbt-test/nio/reload/sub/src/main/scala/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  val x = sbt.Keys
+}

--- a/sbt/src/sbt-test/nio/reload/test
+++ b/sbt/src/sbt-test/nio/reload/test
@@ -17,3 +17,9 @@ $ copy-file changes/working.sbt build.sbt
 > foo foo; reload
 
 > exists foo
+
+-> compile
+
+$ copy-file changes/sub.sbt sub/build.sbt
+
+> compile

--- a/sbt/src/sbt-test/nio/reload/test
+++ b/sbt/src/sbt-test/nio/reload/test
@@ -23,3 +23,9 @@ $ copy-file changes/working.sbt build.sbt
 $ copy-file changes/sub.sbt sub/build.sbt
 
 > compile
+
+-> scalafmt
+
+$ copy-file changes/ScalafmtVersion.scala project/project/ScalafmtVersion.scala
+
+> scalafmt


### PR DESCRIPTION
In sbt 1.3.0, we only monitor build sources in the root project
directory and the root project meta build directory. This commit adds
these inputs for each project.

Fixes https://github.com/sbt/sbt/issues/5061.