### PR TITLE
Add warning if old launcher is used

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -64,6 +64,11 @@ private[sbt] object xMain {
           Seq(defaults, early),
           runEarly(DefaultsCommand) :: runEarly(InitCommand) :: BootCommand :: Nil
         )
+        if (xMain.getClass.getClassLoader.toString == "SbtMetaBuildClassLoader") {
+          val msg = s"sbt was launched with an old version of sbt-launcher. Please upgrade the " +
+            "launcher version (see https://www.scala-sbt.org/1.x/docs/Setup.html for instructions)."
+          state.globalLogging.full.warn(msg)
+        }
         StandardMain.runManaged(state)
       }
     } finally {


### PR DESCRIPTION
In order to isolate the sbt test launcher interface jar so that the run
and test classpaths don't get contaminated with the sbt build jars, sbt
1.3.0 creates a new classloader from the loader that is passed in by the
launcher unless the launcher provided classloader has a specific format.
Most things work with the old launcher, but there was a report that
consoleProject did not work. To try and ward off similar obscure bugs,
we will now issue a warning if a pre 1.3.0 launcher is used to launch
sbt >= 1.3.0.