### PR TITLE
Fix checkbuild sources for projects with meta-meta-build

### DIFF
--- a/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
@@ -67,14 +67,14 @@ private[sbt] object CheckBuildSources {
       @tailrec
       def projectGlobs(projectDir: File, globs: Seq[Glob]): Seq[Glob] = {
         val glob = projectDir.toGlob
-        val base = Seq(
+        val updatedGlobs = globs ++ Seq(
           glob / "*.{sbt,scala,java}",
           // We only want to recursively look in source because otherwise we have to search
           // the project target directories which is expensive.
           glob / "src" / ** / "*.{scala,java}"
         )
         val nextLevel = projectDir / "project"
-        if (nextLevel.exists) projectGlobs(nextLevel, base) else base
+        if (nextLevel.exists) projectGlobs(nextLevel, updatedGlobs) else updatedGlobs
       }
       projectGlobs(projectDir, baseDir.toGlob / "*.sbt" :: Nil)
     } else Nil

--- a/sbt/src/sbt-test/nio/reload/test
+++ b/sbt/src/sbt-test/nio/reload/test
@@ -29,3 +29,7 @@ $ copy-file changes/sub.sbt sub/build.sbt
 $ copy-file changes/ScalafmtVersion.scala project/project/ScalafmtVersion.scala
 
 > scalafmt
+
+$ delete project/plugins.sbt
+
+-> scalafmt


### PR DESCRIPTION
If a project had a meta-meta build (project/project), the build sources
in the project directory were ignored. This was because the projectGlobs
method did not correctly handle recursion. It inadvertently
discarded the accumulator globs and only returned the most recently
generated globs. This commit fixes that and adds a regression test to
the nio/reload scripted test.