### PR TITLE
Throw error if you run sbt from /

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -69,6 +69,7 @@ object SysProp {
   def traces: Boolean = getOrFalse("sbt.traces")
   def client: Boolean = getOrFalse("sbt.client")
   def ci: Boolean = getOrFalse("sbt.ci")
+  def allowRootDir: Boolean = getOrFalse("sbt.rootdir")
 
   def watchMode: String =
     sys.props.get("sbt.watch.mode").getOrElse("auto")


### PR DESCRIPTION
Fixes #1458

Running sbt from `/` results to sbt getting stuck trying to load the directories recursively, and eventually erroring with a java.lang.OutOfMemoryError (after freezing for a long time) even on an Alpine container.

To prevent it, this adds a check to see if the absolute path is `/` or not.

```
/ $ sbt -Dsbt.version=1.4.0-SNAPSHOT
[error] java.lang.IllegalStateException: cannot run sbt from root directory without -Dsbt.rootdir=true; see sbt/sbt#1458
[error] Use 'last' for the full log.
```

Note: To opt into running sbt at `/`, run with `-Dsbt.rootdir=true`.
