### PR TITLE
Progress improvements

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -482,6 +482,7 @@ object Keys {
   object TaskProgress {
     def apply(progress: ExecuteProgress[Task]): TaskProgress = new TaskProgress(progress)
   }
+  private[sbt] val currentTaskProgress = AttributeKey[TaskProgress]("current-task-progress")
   val useSuperShell = settingKey[Boolean]("Enables (true) or disables the super shell.")
   val turbo = settingKey[Boolean]("Enables (true) or disables optional performance features.")
   // This key can be used to add custom ExecuteProgress instances

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -73,7 +73,7 @@ private[sbt] final class TaskProgress(log: ManagedLogger)
   private[this] val skipReportTasks =
     Set("run", "bgRun", "fgRun", "scala", "console", "consoleProject", "consoleQuick", "state")
   private[this] def report(): Unit = {
-    val currentTasks = activeTasks.toVector
+    val currentTasks = activeTasks.toVector.filterNot(Def.isDummy)
     val ltc = lastTaskCount.get
     val currentTasksCount = currentTasks.size
     def report0(): Unit = {


### PR DESCRIPTION
This PR makes a few improvements to task progress rendering. It complements https://github.com/sbt/util/pull/223. After https://github.com/sbt/util/pull/223, progress lines take terminal width into account, but there is some flickering if a dynamic task is used, which might create a new task progress thread:
![util-bump](https://user-images.githubusercontent.com/2658825/65537903-096e8780-debb-11e9-964e-d7667ec03224.gif)
The first change limits sbt to having a single progress thread in most cases, which eliminates the flickering in my example:
![one-thread](https://user-images.githubusercontent.com/2658825/65537938-2014de80-debb-11e9-89eb-6e8247d3a24d.gif)
It also doesn't really make sense to have dummy tasks like `streams-manager` appearing in the task progress, so I filter them out in the second commit:
![no-dummy](https://user-images.githubusercontent.com/2658825/65537983-34f17200-debb-11e9-9264-773049993277.gif)
