### PR TITLE
Fixes "Could not create directory ...classes.bak"

### DIFF
--- a/sbt/src/sbt-test/tests/bak/build.sbt
+++ b/sbt/src/sbt-test/tests/bak/build.sbt
@@ -1,0 +1,45 @@
+// https://github.com/sbt/sbt/issues/1673#issuecomment-537327439
+
+val Config_0 = config("config-0").extend(Compile)
+val Config_1 = config("config-1").extend(Compile)
+val Config_2 = config("config-2").extend(Compile)
+val Config_3 = config("config-3").extend(Compile)
+val Config_4 = config("config-4").extend(Compile)
+val Config_5 = config("config-5").extend(Compile)
+val Config_6 = config("config-6").extend(Compile)
+val Config_7 = config("config-7").extend(Compile)
+val Config_8 = config("config-8").extend(Compile)
+val Config_9 = config("config-9").extend(Compile)
+val Config_10 = config("config-10").extend(Compile)
+val Config_11 = config("config-11").extend(Compile)
+val Config_12 = config("config-12").extend(Compile)
+val Config_13 = config("config-13").extend(Compile)
+val Config_14 = config("config-14").extend(Compile)
+val Config_15 = config("config-15").extend(Compile)
+
+val CustomConfigs = List(Config_0, Config_1, Config_2, Config_3, Config_4, Config_5, Config_6, Config_7, Config_8, Config_9, Config_10, Config_11, Config_12, Config_13, Config_14, Config_15)
+
+val t = taskKey[Unit]("")
+val p1 = project
+  .configs(CustomConfigs: _*)
+  .settings(
+    t := {
+        (compile in Config_0).value
+        (compile in Config_1).value
+        (compile in Config_2).value
+        (compile in Config_3).value
+        (compile in Config_4).value
+        (compile in Config_5).value
+        (compile in Config_6).value
+        (compile in Config_7).value
+        (compile in Config_8).value
+        (compile in Config_9).value
+        (compile in Config_10).value
+        (compile in Config_11).value
+        (compile in Config_12).value
+        (compile in Config_13).value
+        (compile in Config_14).value
+        (compile in Config_15).value
+    }
+  )
+  .settings(CustomConfigs.flatMap(c => inConfig(c)(Defaults.testSettings)))

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-0/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-0/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-1/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-1/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-10/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-10/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-11/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-11/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-12/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-12/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-13/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-13/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-14/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-14/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-15/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-15/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-2/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-2/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-3/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-3/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-4/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-4/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-5/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-5/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-6/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-6/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-7/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-7/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-8/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-8/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/config-9/scala/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/config-9/scala/A.scala
@@ -1,0 +1,2 @@
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/p1/src/main/java/p1/J.java
+++ b/sbt/src/sbt-test/tests/bak/p1/src/main/java/p1/J.java
@@ -1,0 +1,1 @@
+package p1;

--- a/sbt/src/sbt-test/tests/bak/p1/src/main/scala/p1/A.scala
+++ b/sbt/src/sbt-test/tests/bak/p1/src/main/scala/p1/A.scala
@@ -1,0 +1,4 @@
+package p1
+
+class A
+object A

--- a/sbt/src/sbt-test/tests/bak/test
+++ b/sbt/src/sbt-test/tests/bak/test
@@ -1,0 +1,3 @@
+> p1/t;clean;p1/t;clean;p1/t;clean
+$ sleep 100
+> p1/t;clean;p1/t;clean;p1/t;clean


### PR DESCRIPTION
Fixes #1673

There's been reports of intermittent "Could not create directory" error related to "classes.bak." @retronym identified that all configurations are using the same directory, and that might be the cause of race condition.

This addresses the issue by assigning a unique directory for each configuration.

*This issue was expedited via the Lightbend subscription.*
