### PR TITLE
Switch to xenial image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: false
-dist: trusty
-group: stable
+dist: xenial
 
 language: scala
 


### PR DESCRIPTION
The majority of Travis CI builds have probalby migrated to using Xenial now; it's better to migrate with the pack to get better hardware support etc.