### PR TITLE
Clean ivy resolution cache before regular clean

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -484,10 +484,8 @@ object Defaults extends BuildCommon {
       sbtPlugin.value,
       crossPaths.value
     ),
-    clean := {
-      val _ = clean.value
-      IvyActions.cleanCachedResolutionCache(ivyModule.value, streams.value.log)
-    },
+    cleanIvy := IvyActions.cleanCachedResolutionCache(ivyModule.value, streams.value.log),
+    clean := clean.dependsOn(cleanIvy).value,
     scalaCompilerBridgeBinaryJar := None,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(scalaVersion.value),
   )

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -195,6 +195,7 @@ object Keys {
   val semanticdbOptions = settingKey[Seq[String]]("The Scalac options introduced for SemanticDB").withRank(CSetting)
 
   val clean = taskKey[Unit]("Deletes files produced by the build, such as generated sources, compiled classes, and task caches.").withRank(APlusTask)
+  private[sbt] val cleanIvy = taskKey[Unit]("Deletes the ivy cached resolution")
   val console = taskKey[Unit]("Starts the Scala interpreter with the project classes on the classpath.").withRank(APlusTask)
   val consoleQuick = TaskKey[Unit]("consoleQuick", "Starts the Scala interpreter with the project dependencies on the classpath.", ATask, console)
   val consoleProject = taskKey[Unit]("Starts the Scala interpreter with the sbt and the build definition on the classpath and useful imports.").withRank(AMinusTask)


### PR DESCRIPTION
The way clean was implemented, it was running `clean`, `ivyModule` and
`streams` concurrently. This was problematic because clean could blow
away files needed by `ivyModule` and `streams`. To fix this, move the
cleanCachedResolutionCache into a separate task and run that before the
normal clean.

Should fix https://github.com/sbt/sbt/issues/5067.