### PR TITLE
Add explicit return type to plugin settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -750,6 +750,8 @@ lazy val mainProj = (project in file("main"))
       exclude[IncompatibleSignatureProblem]("sbt.internal.server.LanguageServerReporter.*"),
       exclude[VirtualStaticMemberProblem]("sbt.internal.server.LanguageServerProtocol.*"),
       exclude[IncompatibleSignatureProblem]("sbt.internal.librarymanagement.IvyXml.*"),
+      exclude[IncompatibleSignatureProblem]("sbt.ScriptedPlugin.*Settings"),
+      exclude[IncompatibleSignatureProblem]("sbt.plugins.SbtPlugin.*Settings"),
       // Removed private internal classes
       exclude[MissingClassProblem]("sbt.internal.ReverseLookupClassLoaderHolder$BottomClassLoader"),
       exclude[MissingClassProblem]("sbt.internal.ReverseLookupClassLoaderHolder$ReverseLookupClassLoader$ResourceLoader"),

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -51,12 +51,12 @@ object ScriptedPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override lazy val globalSettings = Seq(
+  override lazy val globalSettings: Seq[Setting[_]] = Seq(
     scriptedBufferLog := true,
     scriptedLaunchOpts := Seq(),
   )
 
-  override lazy val projectSettings = Seq(
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
     ivyConfigurations ++= Seq(ScriptedConf, ScriptedLaunchConf),
     scriptedSbt := (sbtVersion in pluginCrossBuild).value,
     sbtLauncher := getJars(ScriptedLaunchConf).map(_.get.head).value,

--- a/main/src/main/scala/sbt/plugins/SbtPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SbtPlugin.scala
@@ -9,11 +9,12 @@ package sbt
 package plugins
 
 import Keys._
+import Def.Setting
 
 object SbtPlugin extends AutoPlugin {
   override def requires = ScriptedPlugin
 
-  override lazy val projectSettings = Seq(
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
     sbtPlugin := true
   )
 }


### PR DESCRIPTION
This will avoid triggering `IncompatibleSignatureProblem` when updating settings.

#