### PR TITLE
Fixes high CPU usage while retrying background job shutdown

### DIFF
--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -421,6 +421,13 @@ private[sbt] class BackgroundThreadPool extends java.io.Closeable {
             status = Stopped(Some(thread))
             thread.interrupt()
           case Stopped(threadOption) =>
+            // sleep to avoid consuming a lot of CPU
+            try {
+              Thread.sleep(10)
+            } catch {
+              case e: InterruptedException =>
+                Thread.currentThread().interrupt();
+            }
             // try to interrupt again! woot!
             threadOption.foreach(_.interrupt())
         }


### PR DESCRIPTION
I have noticed that sometimes an sbt shell process uses 100% CPU for several hours non-stop. After some debugging seems like it is constantly calling `Thread.interrupt`. Here is the loop that keeps the CPU busy. 

https://github.com/sbt/sbt/blob/44cc19e66dd63665ace8320b282387c71f6a9c61/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala#L160-L166

As a quickfix I have added a sleep to be triggered only in case when we are trying to interrupt the thread second (or more) time.