### PR TITLE
Don't emit timestamps when packaging to jar

### DIFF
--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -70,7 +70,7 @@ object Package {
       val options: Seq[PackageOption]
   )
 
-  @deprecated("Please specify whether to use a static timestamp", "1.3.4")
+  @deprecated("Please specify whether to use a static timestamp", "1.4.0")
   def apply(conf: Configuration, cacheStoreFactory: CacheStoreFactory, log: Logger): Unit =
     apply(conf, cacheStoreFactory, log, None)
 

--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -163,7 +163,7 @@ object Package {
       homepage map (h => (IMPLEMENTATION_URL, h.toString))
     }: _*)
   }
-  @deprecated("Please specify whether to use a static timestamp", "1.3.4")
+  @deprecated("Please specify whether to use a static timestamp", "1.4.0")
   def makeJar(sources: Seq[(File, String)], jar: File, manifest: Manifest, log: Logger): Unit =
     makeJar(sources, jar, manifest, log, None)
 

--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -70,13 +70,23 @@ object Package {
       val options: Seq[PackageOption]
   )
 
+  @deprecated("Please specify whether to use a static timestamp", "1.3.4")
+  def apply(conf: Configuration, cacheStoreFactory: CacheStoreFactory, log: Logger): Unit =
+    apply(conf, cacheStoreFactory, log, None)
+
   /**
    *
    * @param conf the package configuration that should be build
    * @param cacheStoreFactory used for jar caching. We try to avoid rebuilds as much as possible
    * @param log feedback for the user
+   * @param time static timestamp to use for all entries, if any.
    */
-  def apply(conf: Configuration, cacheStoreFactory: CacheStoreFactory, log: Logger): Unit = {
+  def apply(
+      conf: Configuration,
+      cacheStoreFactory: CacheStoreFactory,
+      log: Logger,
+      time: Option[Long]
+  ): Unit = {
     val manifest = new Manifest
     val main = manifest.getMainAttributes
     for (option <- conf.options) {
@@ -96,7 +106,7 @@ object Package {
         val sources :+: _ :+: manifest :+: HNil = inputs
         outputChanged(cacheStoreFactory make "output") { (outChanged, jar: PlainFileInfo) =>
           if (inChanged || outChanged) {
-            makeJar(sources, jar.file, manifest, log)
+            makeJar(sources, jar.file, manifest, log, time)
             jar.file
             ()
           } else
@@ -153,7 +163,17 @@ object Package {
       homepage map (h => (IMPLEMENTATION_URL, h.toString))
     }: _*)
   }
-  def makeJar(sources: Seq[(File, String)], jar: File, manifest: Manifest, log: Logger): Unit = {
+  @deprecated("Please specify whether to use a static timestamp", "1.3.4")
+  def makeJar(sources: Seq[(File, String)], jar: File, manifest: Manifest, log: Logger): Unit =
+    makeJar(sources, jar, manifest, log, None)
+
+  def makeJar(
+      sources: Seq[(File, String)],
+      jar: File,
+      manifest: Manifest,
+      log: Logger,
+      time: Option[Long]
+  ): Unit = {
     val path = jar.getAbsolutePath
     log.debug("Packaging " + path + " ...")
     if (jar.exists)
@@ -162,7 +182,7 @@ object Package {
       else
         sys.error(path + " exists, but is not a regular file")
     log.debug(sourcesDebugString(sources))
-    IO.jar(sources, jar, manifest)
+    IO.jar(sources, jar, manifest, time)
     log.debug("Done packaging.")
   }
   def sourcesDebugString(sources: Seq[(File, String)]): String =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1409,7 +1409,7 @@ object Defaults extends BuildCommon {
     Def.task {
       val config = packageConfiguration.value
       val s = streams.value
-      Package(config, s.cacheStoreFactory, s.log)
+      Package(config, s.cacheStoreFactory, s.log, Some(0))
       config.jar
     }
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1413,7 +1413,7 @@ object Defaults extends BuildCommon {
         config,
         s.cacheStoreFactory,
         s.log,
-        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong).orElse(Some(0L))
+        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong * 1000).orElse(Some(0L))
       )
       config.jar
     }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1409,7 +1409,12 @@ object Defaults extends BuildCommon {
     Def.task {
       val config = packageConfiguration.value
       val s = streams.value
-      Package(config, s.cacheStoreFactory, s.log, Some(0))
+      Package(
+        config,
+        s.cacheStoreFactory,
+        s.log,
+        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong).orElse(Some(0L))
+      )
       config.jar
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   def nightlyVersion: Option[String] = sys.props.get("sbt.build.version")
 
   // sbt modules
-  private val ioVersion = nightlyVersion.getOrElse("1.3.1")
+  private val ioVersion = nightlyVersion.getOrElse("1.4.0-M1")
   private val lmVersion =
     sys.props.get("sbt.build.lm.version") match {
       case Some(version) => version


### PR DESCRIPTION
This makes the build more deterministic.

This is a continuation of the work in https://github.com/sbt/io/pull/58 , which I decided to get back into partly because Maven has been adding features to the core plugins, and it would be good to be on par :).

As discussed in https://github.com/sbt/io/pull/58, we should be careful about the risk of breaking incremental builds - I haven't found any such issues yet though. Note that this PR only affects the timestamps of entries in jars: timestamps of classes on the filesystem and the filesystem timestamp of the jar itself are not affected.

Discussing this with @eed3si9n, there could be special-purposes build configurations that (for example in order to avoid deleting/creating many files) compile classes directly into a jar rather than first to individual files. I haven't seen this configuration yet, but I suspect it wouldn't use `Defaults.packageTask`, but a custom `Package`/`IO` invocation. Any custom build configuration that requires non-static timestamps can pass `None` as the `time` parameter to keep the original behavior.

This PR requires https://github.com/sbt/io/pull/279