### PR TITLE
Include description and homepage in ivy.xml files

### DIFF
--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -45,6 +45,8 @@ object CoursierInputsTasks {
       sv: String,
       sbv: String,
       auOpt: Option[URL],
+      description: String,
+      homepage: Option[URL],
       log: Logger
   ): CProject = {
 
@@ -63,12 +65,15 @@ object CoursierInputsTasks {
       case (config, dep) =>
         (config, dep.withExclusions(dep.exclusions ++ exclusions0))
     })
-    auOpt match {
+    val proj2 = auOpt match {
       case Some(au) =>
         val props = proj1.properties :+ ("info.apiURL" -> au.toString)
         proj1.withProperties(props)
       case _ => proj1
     }
+    proj2.withInfo(
+      proj2.info.withDescription(description).withHomePage(homepage.fold("")(_.toString))
+    )
   }
 
   def coursierProjectTask: Def.Initialize[sbt.Task[CProject]] =
@@ -81,6 +86,8 @@ object CoursierInputsTasks {
         scalaVersion.value,
         scalaBinaryVersion.value,
         apiURL.value,
+        description.value,
+        homepage.value,
         streams.value.log
       )
     }

--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -104,6 +104,14 @@ object IvyXml {
         }
     }
 
+    val descriptionElem = {
+      val n = <description>{project.info.description}</description>
+      if (project.info.homePage.nonEmpty)
+        n % <x homepage={project.info.homePage} />.attributes
+      else
+        n
+    }
+
     val infoElem = {
       <info
         organisation={project.module.organization.value}
@@ -111,7 +119,7 @@ object IvyXml {
         revision={project.version}
       >
         {licenseElems}
-        <description>{project.info.description}</description>
+        {descriptionElem}
       </info>
     } % infoAttrs
 

--- a/sbt/src/sbt-test/dependency-management/make-ivy-xml/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/make-ivy-xml/build.sbt
@@ -1,0 +1,24 @@
+import scala.xml.XML
+
+val descriptionValue = "This is just a test"
+val homepageValue = "http://example.com"
+
+lazy val root = (project in file(".")) settings(
+  name := "ivy-xml-test",
+  description := descriptionValue,
+  homepage := Some(url(homepageValue)),
+
+  TaskKey[Unit]("checkIvyXml") := {
+    val ivyXml = XML.loadFile(makeIvyXml.value)
+    val description = (ivyXml \ "info" \ "description").head
+    val homepage = (description \ "@homepage").head
+
+    if (description.text != descriptionValue)
+      sys.error(s"Unexpected description: ${description.text}")
+
+    if (homepage.text != homepageValue)
+      sys.error(s"Unexpected homepage: ${homepage.text}")
+
+    ()
+  }
+)

--- a/sbt/src/sbt-test/dependency-management/make-ivy-xml/test
+++ b/sbt/src/sbt-test/dependency-management/make-ivy-xml/test
@@ -1,0 +1,1 @@
+> checkIvyXml


### PR DESCRIPTION
This PR includes the values of the `description` and `homepage`
settings into the `ivy.xml` files generated by the `makeIvyXml`
task. It restores the behaviour of sbt 1.2.8 and if `useCoursier`
is set to `false`.

Two things are changed in this PR:
 * `IvyXml.content` now adds the `homepage` attribute to the
   `description` element if `project.info.homePage` is not empty.
 * `CoursierInputsTasks.coursierProject0` now fills the previous
   empty `CProject.info` field with the description and homepage.

Closes: #5234