### PR TITLE
[1.3.x] lm-coursier-shaded 2.0.0-RC5-2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -271,7 +271,8 @@ val completeProj = (project in file("internal") / "util-complete")
       exclude[DirectMissingMethodProblem]("sbt.internal.util.complete.History.this"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.util.complete.Completion.suggestion"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.util.complete.Completion.token"),
-      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.complete.Completion.displayOnly")
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.complete.Completion.displayOnly"),
+      exclude[IncompatibleSignatureProblem]("sbt.internal.util.complete.*"),
     ),
   )
   .configure(addSbtIO, addSbtUtilControl, addSbtUtilLogging)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
   def addSbtZincCompileCore(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierVersion = "2.0.0-RC3-4"
+  val lmCoursierVersion = "2.0.0-RC5-2"
   val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % lmCoursierVersion
 
   val sjsonNewScalaJson = Def.setting {


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/5240