### PR TITLE
Fix consoleProject for scala 2.13

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -488,6 +488,9 @@ object Defaults extends BuildCommon {
     clean := clean.dependsOn(cleanIvy).value,
     scalaCompilerBridgeBinaryJar := None,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(scalaVersion.value),
+    consoleProject / scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(
+      appConfiguration.value.provider.scalaProvider.version
+    ),
   )
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -25,7 +25,7 @@ object ConsoleProject {
     val (state1, dependencyResolution) =
       extracted.runTask(Keys.dependencyResolution, state)
     val (_, scalaCompilerBridgeBinaryJar) =
-      extracted.runTask(Keys.scalaCompilerBridgeBinaryJar, state1)
+      extracted.runTask(Keys.scalaCompilerBridgeBinaryJar.in(Keys.consoleProject), state1)
     val scalaInstance = {
       val scalaProvider = state.configuration.provider.scalaProvider
       ScalaInstance(scalaProvider.version, scalaProvider.launcher)
@@ -50,7 +50,8 @@ object ConsoleProject {
           componentProvider = app.provider.components,
           secondaryCacheDir = Option(zincDir),
           dependencyResolution = dependencyResolution,
-          compilerBridgeSource = extracted.get(Keys.scalaCompilerBridgeSource),
+          compilerBridgeSource =
+            extracted.get(Keys.scalaCompilerBridgeSource.in(Keys.consoleProject)),
           scalaJarsTarget = zincDir,
           classLoaderCache = state1.get(BasicKeys.classLoaderCache),
           log = log

--- a/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
@@ -2,4 +2,4 @@ scalaVersion := "2.13.1"
 
 // Send some bogus initial command so that it doesn't get stuck.
 // The task itself will still succeed.
-Compile / consoleProject / initialCommands := "bail!"
+consoleProject / initialCommands := "bail!"

--- a/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.13.1"
+
+// Send some bogus initial command so that it doesn't get stuck.
+// The task itself will still succeed.
+Compile / consoleProject / initialCommands := "bail!"

--- a/sbt/src/sbt-test/console/project-compiler-bridge/project/build.sbt
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/project/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.12.10"

--- a/sbt/src/sbt-test/console/project-compiler-bridge/test
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/test
@@ -1,0 +1,1 @@
+> consoleProject


### PR DESCRIPTION
Scopes `scalaCompilerBridgeSource` to `consoleProject` and sets the default to use:
```
ZincLmUtil.getDefaultBridgeModule(
      appConfiguration.value.provider.scalaProvider.version
    )
```
instead of:
```
ZincLmUtil.getDefaultBridgeModule(scalaVersion.value)
```

I didn't add any notes, I wasn't sure where to put them. There weren't as many as I was expecting.

I considered adding some validation to check whether the bridge matches the scala version but it didn't really seem worth it.

Fixes #5250.