### PR TITLE
Don't print stack trace for pending tests

### DIFF
--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -417,7 +417,7 @@ final class ScriptedTests(
       if (t.isInstanceOf[TestException]) {
         t.getCause match {
           case null | _: SocketException => log.error(s" Cause of test exception: ${t.getMessage}")
-          case _                         => t.printStackTrace()
+          case _                         => if (!pending) t.printStackTrace()
         }
         log.play()
       }


### PR DESCRIPTION
This can be very noisy, especially for tests that are marked pending
because they fail to load the build. These induce a lengthy and largely
unhelpful "Reload for batch scripted failed..." error message.