### PR TITLE
Background jobs

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -351,7 +351,7 @@ object Defaults extends BuildCommon {
         sys.env.contains("CI") || SysProp.ci,
       // watch related settings
       pollInterval :== Watch.defaultPollInterval,
-    ) ++ LintUnused.lintSettings
+    ) ++ LintUnused.lintSettings ++ DefaultBackgroundJobService.backgroundJobServiceSettings
   )
 
   def defaultTestTasks(key: Scoped): Seq[Setting[_]] =

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1599,7 +1599,8 @@ object Defaults extends BuildCommon {
   }
 
   def bgWaitForTask: Initialize[InputTask[Unit]] = foreachJobTask { (manager, handle) =>
-    manager.waitFor(handle)
+    manager.waitForTry(handle)
+    ()
   }
 
   def docTaskSettings(key: TaskKey[File] = doc): Seq[Setting[_]] =

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -251,6 +251,7 @@ object Keys {
   val javaOptions = taskKey[Seq[String]]("Options passed to a new JVM when forking.").withRank(BPlusTask)
   val envVars = taskKey[Map[String, String]]("Environment variables used when forking a new JVM").withRank(BTask)
 
+  val bgJobServiceDirectory = settingKey[File]("The directory for temporary files used by background jobs.")
   val bgJobService = settingKey[BackgroundJobService]("Job manager used to run background jobs.")
   val bgList = taskKey[Seq[JobHandle]]("List running background jobs.")
   val ps = taskKey[Seq[JobHandle]]("bgList variant that displays on the log.")

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -130,7 +130,7 @@ object StandardMain {
       try {
         MainLoop.runLogged(s)
       } finally {
-        try DefaultBackgroundJobService.backgroundJobService.shutdown()
+        try DefaultBackgroundJobService.shutdown()
         finally hook.close()
         ()
       }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -126,15 +126,14 @@ object StandardMain {
   def runManaged(s: State): xsbti.MainResult = {
     val previous = TrapExit.installManager()
     try {
+      val hook = ShutdownHooks.add(closeRunnable)
       try {
-        val hook = ShutdownHooks.add(closeRunnable)
-        try {
-          MainLoop.runLogged(s)
-        } finally {
-          hook.close()
-          ()
-        }
-      } finally DefaultBackgroundJobService.backgroundJobService.shutdown()
+        MainLoop.runLogged(s)
+      } finally {
+        try DefaultBackgroundJobService.backgroundJobService.shutdown()
+        finally hook.close()
+        ()
+      }
     } finally TrapExit.uninstallManager(previous)
   }
 

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -372,7 +372,7 @@ private[sbt] class BackgroundThreadPool extends java.io.Closeable {
           list
         }
         listeners.foreach { l =>
-          l.executionContext.execute(new Runnable { override def run = l.callback() })
+          l.executionContext.execute(() => l.callback())
         }
       }
     }

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -130,7 +130,6 @@ private[sbt] object Load {
   def injectGlobal(state: State): Seq[Setting[_]] =
     (appConfiguration in GlobalScope :== state.configuration) +:
       LogManager.settingsLogger(state) +:
-      DefaultBackgroundJobService.backgroundJobServiceSetting +:
       EvaluateTask.injectSettings
 
   def defaultWithGlobal(


### PR DESCRIPTION
This PR makes a number of miscellaneous improvements to the background job service including:
* Shuts down background jobs when an error occurs (which happens when Ctrl+C is inputted and thus should fix https://github.com/sbt/sbt/issues/2274 for non-forked `run` provided the main method handles interrupts)
* Moves the background job service directory from a temp directory specified by java.io.tmpdir (which is /tmp on linux and user specific on mac and windows) to `$PROJECT_BASE_DIR/target/bg-jobs`).