### PR TITLE
Give a more precise type to mkIvyConfiguration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -800,6 +800,11 @@ lazy val mainProj = (project in file("main"))
       exclude[IncompatibleSignatureProblem]("sbt.ProjectExtra.inScope"),
       exclude[MissingTypesProblem]("sbt.internal.Load*"),
       exclude[IncompatibleSignatureProblem]("sbt.internal.Load*"),
+      // IvyConfiguration was replaced by InlineIvyConfiguration in the generic
+      // signature, this does not break compatibility regardless of what
+      // cast a compiler might have inserted based on the old signature
+      // since we're returning the same values as before.
+      exclude[IncompatibleSignatureProblem]("sbt.Classpaths.mkIvyConfiguration")
     )
   )
   .configure(

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3252,7 +3252,7 @@ object Classpaths {
         buildDependencies.value
       )
     }
-  def mkIvyConfiguration: Initialize[Task[IvyConfiguration]] =
+  def mkIvyConfiguration: Initialize[Task[InlineIvyConfiguration]] =
     Def.task {
       val (rs, other) = (fullResolvers.value.toVector, otherResolvers.value.toVector)
       val s = streams.value


### PR DESCRIPTION
This makes it possible to do mkIvyConfiguration.value.withXXX(...) for
all the methods in InlineIvyConfiguration. (I need this to remove
inter-project resolvers when fetching dotty from sbt-dotty to avoid
accidentally fetching a local project in the build of dotty itself).