### PR TITLE
Improve ServerSpec feedback

### DIFF
--- a/sbt/src/test/scala/testpkg/ServerSpec.scala
+++ b/sbt/src/test/scala/testpkg/ServerSpec.scala
@@ -166,7 +166,7 @@ object TestServer {
     val init =
       Try {
         testServer.waitForString(30.seconds) { s =>
-          println(s)
+          if (s.nonEmpty) println(s)
           s contains """"message":"Done""""
         }
       }
@@ -292,7 +292,7 @@ case class TestServer(baseDirectory: File) {
     val deadline = duration.fromNow
     @tailrec
     def impl(): Boolean = {
-      if (deadline.isOverdue) false
+      if (deadline.isOverdue || !process.isAlive) false
       else readFrame.fold(false)(f) || impl
     }
     impl()


### PR DESCRIPTION
In some cases if sbt is broken in the right way (for example if the
process dies), the ServerSpec will spam the console by printing empty
lines. This commit prevents it from printing empty lines and also stops
waiting for a server response if the process has died.