### PR TITLE
Do not use temporary directories in java.io.tmpdir

### DIFF
--- a/main/src/main/scala/sbt/BuildPaths.scala
+++ b/main/src/main/scala/sbt/BuildPaths.scala
@@ -121,6 +121,10 @@ object BuildPaths {
   def outputDirectory(base: File) = base / DefaultTargetName
 
   def projectStandard(base: File) = base / "project"
+  def globalLoggingStandard(base: File): File =
+    base.getCanonicalFile / DefaultTargetName / GlobalLogging
+  def globalTaskDirectoryStandard(base: File): File =
+    base.getCanonicalFile / DefaultTargetName / TaskTempDirectory
 
   final val PluginsDirectoryName = "plugins"
   final val DefaultTargetName = "target"
@@ -131,6 +135,8 @@ object BuildPaths {
   final val GlobalSettingsProperty = "sbt.global.settings"
   final val DependencyBaseProperty = "sbt.dependency.base"
   final val GlobalZincProperty = "sbt.global.zinc"
+  final val GlobalLogging = "global-logging"
+  final val TaskTempDirectory = "task-temp-directory"
 
   def crossPath(base: File, instance: xsbti.compile.ScalaInstance): File =
     base / ("scala_" + instance.version)


### PR DESCRIPTION
sbt should not by default create files in the location specified by
java.io.tmpdir (which is the default behavior of apis like
IO.createTemporaryDirectory or Files.createTempFile) because they have a
tendency to leak and it also isn't even guaranteed that the user has
write permissions there (though this is unlikely). Doing so creates the
possibility for leaks

I git grepped for `createTemp` and found these apis. After this change,
the files created by sbt should largely be localized to the project and
sbt global base directories.