### PR TITLE
Fixes sbt new by restoring the terminal

### DIFF
--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -49,7 +49,7 @@ private[sbt] final class TaskProgress(log: ManagedLogger)
     }
   }
 
-  override def initial(): Unit = ConsoleAppender.setTerminalWidth(JLine.terminal.getWidth)
+  override def initial(): Unit = ()
 
   override def beforeWork(task: Task[_]): Unit = {
     super.beforeWork(task)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5063

This fixes "sbt new" on Ubuntu by restoring the terminal state after supershell querying for the terminal width.