### PR TITLE
Fixes semicolon showing up in parser errors 

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -89,10 +89,7 @@ object JLineCompletion {
     (insert.toSeq, display.toSeq.sorted)
   }
 
-  def appendNonEmpty(set: Set[String], add: String) = {
-    val trimmed = add.trim
-    if (trimmed.isEmpty || trimmed == ";") set else set + add
-  }
+  def appendNonEmpty(set: Set[String], add: String) = if (add.trim.isEmpty) set else set + add
 
   def customCompletor(
       f: (String, Int) => (Seq[String], Seq[String])

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -199,10 +199,12 @@ object BasicCommands {
       else Parser.success(result.toList)
     }
 
-    (cmdParser ~ multiCmdParser.+).flatMap {
-      case ("", rest) => validateCommands(rest)
-      case (p, rest)  => validateCommands(rest).map(p :: _)
-    }
+    (cmdParser ~ multiCmdParser.+)
+      .flatMap {
+        case ("", rest) => validateCommands(rest)
+        case (p, rest)  => validateCommands(rest).map(p :: _)
+      }
+      .examples() // clear out Expected ';' and semicolon in completions
   }
 
   def multiParser(s: State): Parser[List[String]] = multiParserImpl(Some(s))

--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -44,7 +44,11 @@ final case class State(
   private[sbt] lazy val (multiCommands, nonMultiCommands) =
     definedCommands.partition(_.nameOption.contains(BasicCommandStrings.Multi))
   private[sbt] lazy val nonMultiParser = Command.combine(nonMultiCommands)(this)
-  lazy val combinedParser = multiCommands.foldRight(nonMultiParser)(_.parser(this) | _)
+  lazy val combinedParser: Parser[() => State] =
+    multiCommands.headOption match {
+      case Some(multi) => multi.parser(this) | nonMultiParser
+      case _           => nonMultiParser
+    }
 
   def source: Option[CommandSource] =
     currentCommand match {


### PR DESCRIPTION
Fixes #5039
Fixes #4989

This is take 2 on the semicolon fix by emptying out the completion examples in the multi parser.

```
> set scalaV
```

would complete to

```
> set scalaVersion
```