### PR TITLE
Remove Util helper function usages

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -7,11 +7,10 @@
 
 package sbt.internal.util
 
-import scala.language.existentials
-
-import Types._
+import sbt.internal.util.Types._
 import sbt.util.Show
-import Util.{ nil, nilSeq }
+
+import scala.language.existentials
 
 sealed trait Settings[ScopeType] {
   def data: Map[ScopeType, AttributeMap]
@@ -385,13 +384,13 @@ trait Init[ScopeType] {
     val locals = compiled flatMap {
       case (key, comp) =>
         if (key.key.isLocal) Seq(comp)
-        else nilSeq[Compiled[_]]
+        else Seq.empty[Compiled[_]]
     }
     val ordered = Dag.topologicalSort(locals)(
       _.dependencies.flatMap(
         dep =>
           if (dep.key.isLocal) Seq[Compiled[_]](compiled(dep))
-          else nilSeq[Compiled[_]]
+          else Seq.empty[Compiled[_]]
       )
     )
     def flatten(
@@ -414,7 +413,7 @@ trait Init[ScopeType] {
 
     compiled flatMap {
       case (key, comp) =>
-        if (key.key.isLocal) nilSeq[(ScopedKey[_], Flattened)]
+        if (key.key.isLocal) Seq.empty[(ScopedKey[_], Flattened)]
         else
           Seq[(ScopedKey[_], Flattened)]((key, flatten(flattenedLocals, key, comp.dependencies)))
     }
@@ -522,9 +521,8 @@ trait Init[ScopeType] {
               val out = local :+ d.setting.setScope(s)
               d.outputs ++= out
               out
-            } else
-              nilSeq
-        } getOrElse nilSeq
+            } else Nil
+        } getOrElse Nil
       }
       derivedForKey.flatMap(localAndDerived)
     }
@@ -535,7 +533,7 @@ trait Init[ScopeType] {
     def process(rem: List[Setting[_]]): Unit = rem match {
       case s :: ss =>
         val sk = s.key
-        val ds = if (processed.add(sk)) deriveFor(sk) else nil
+        val ds = if (processed.add(sk)) deriveFor(sk) else Nil
         addDefs(ds)
         process(ds ::: ss)
       case Nil =>
@@ -547,7 +545,7 @@ trait Init[ScopeType] {
     val allDefs = addLocal(init)(scopeLocal)
     allDefs.flatMap {
       case d: DerivedSetting[_] => (derivedToStruct get d map (_.outputs)).toSeq.flatten
-      case s                    => s :: nil
+      case s                    => s :: Nil
     }
   }
 

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
@@ -55,12 +55,4 @@ object Util {
 
   lazy val isNonCygwinWindows: Boolean = isWindows && !isCygwin
   lazy val isCygwinWindows: Boolean = isWindows && isCygwin
-
-  def nil[A]: List[A] = List.empty[A]
-  def nilSeq[A]: Seq[A] = Seq.empty[A]
-  def none[A]: Option[A] = (None: Option[A])
-
-  implicit class AnyOps[A](private val value: A) extends AnyVal {
-    def some: Option[A] = (Some(value): Option[A])
-  }
 }

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/HistoryCommands.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/HistoryCommands.scala
@@ -9,7 +9,6 @@ package sbt.internal.util
 package complete
 
 import sbt.io.IO
-import Util.{ AnyOps, nil }
 
 object HistoryCommands {
   val Start = "!"
@@ -58,7 +57,7 @@ object HistoryCommands {
   lazy val last = Last ^^^ { execute(_.!!) }
 
   lazy val list = ListCommands ~> (num ?? Int.MaxValue) map { show => (h: History) =>
-    { printHistory(h, MaxLines, show); nil[String].some }
+    { printHistory(h, MaxLines, show); Some(Nil) }
   }
 
   lazy val execStr = flag('?') ~ token(any.+.string, "<string>") map {
@@ -71,7 +70,7 @@ object HistoryCommands {
       execute(h => if (neg) h !- value else h ! value)
   }
 
-  lazy val help = success((h: History) => { printHelp(); nil[String].some })
+  lazy val help = success((h: History) => { printHelp(); Some(Nil) })
 
   def execute(f: History => Option[String]): History => Option[List[String]] = (h: History) => {
     val command = f(h).filterNot(_.startsWith(Start))
@@ -80,7 +79,7 @@ object HistoryCommands {
     h.path foreach { h =>
       IO.writeLines(h, lines)
     }
-    command.toList.some
+    Some(command.toList)
   }
 
   val actionParser: Parser[complete.History => Option[List[String]]] =

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -8,21 +8,13 @@
 package sbt.internal.util
 package complete
 
-import Parser._
 import java.io.File
+import java.lang.Character._
 import java.net.URI
-import java.lang.Character.{
-  CURRENCY_SYMBOL,
-  DASH_PUNCTUATION,
-  MATH_SYMBOL,
-  MODIFIER_SYMBOL,
-  OTHER_PUNCTUATION,
-  OTHER_SYMBOL,
-  getType
-}
+
+import sbt.internal.util.complete.Parser._
 
 import scala.annotation.tailrec
-import sbt.internal.util.Util.nilSeq
 
 /** Provides standard implementations of commonly useful [[Parser]]s. */
 trait Parsers {
@@ -275,7 +267,7 @@ trait Parsers {
    * The result is the (possibly empty) sequence of results from the multiple `rep` applications.  The `sep` results are discarded.
    */
   def repsep[T](rep: Parser[T], sep: Parser[_]): Parser[Seq[T]] =
-    rep1sep(rep, sep) ?? nilSeq[T]
+    rep1sep(rep, sep) ?? Seq.empty[T]
 
   /**
    * Applies `rep` one or more times, separated by `sep`.

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -18,7 +18,6 @@ import sbt.util.Logger
 import sbt.ConcurrentRestrictions.Tag
 import sbt.protocol.testing._
 import sbt.internal.util.ConsoleAppender
-import sbt.internal.util.Util.{ AnyOps, none }
 
 private[sbt] object ForkTests {
   def apply(
@@ -57,8 +56,8 @@ private[sbt] object ForkTests {
     std.TaskExtra.task {
       val server = new ServerSocket(0)
       val testListeners = opts.testListeners flatMap {
-        case tl: TestsListener => tl.some
-        case _                 => none[TestsListener]
+        case tl: TestsListener => Some(tl)
+        case _                 => None
       }
 
       object Acceptor extends Runnable {

--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -8,10 +8,9 @@
 package sbt
 
 import sbt.internal.inc.ReflectUtilities
-import sbt.internal.util.complete.{ DefaultParsers, EditDistance, Parser }
 import sbt.internal.util.Types.const
+import sbt.internal.util.complete.{ DefaultParsers, EditDistance, Parser }
 import sbt.internal.util.{ AttributeKey, AttributeMap, Util }
-import sbt.internal.util.Util.{ nilSeq }
 
 /**
  * An operation that can be executed from the sbt console.
@@ -196,7 +195,7 @@ object Command {
     s"Not a valid $label: $value" + similar(value, allowed)
 
   def similar(value: String, allowed: Iterable[String]): String = {
-    val suggested = if (value.length > 2) suggestions(value, allowed.toSeq) else nilSeq
+    val suggested = if (value.length > 2) suggestions(value, allowed.toSeq) else Nil
     if (suggested.isEmpty) "" else suggested.mkString(" (similar: ", ", ", ")")
   }
 

--- a/main-command/src/main/scala/sbt/CommandUtil.scala
+++ b/main-command/src/main/scala/sbt/CommandUtil.scala
@@ -13,7 +13,6 @@ import java.util.regex.{ Pattern, PatternSyntaxException }
 import sbt.internal.util.AttributeKey
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.DefaultParsers._
-import sbt.internal.util.Util.nilSeq
 
 import sbt.io.IO
 import sbt.io.syntax._
@@ -36,7 +35,7 @@ object CommandUtil {
     catch { case _: NoSuchMethodError => new File(".").getAbsoluteFile }
 
   def aligned(pre: String, sep: String, in: Seq[(String, String)]): Seq[String] =
-    if (in.isEmpty) nilSeq
+    if (in.isEmpty) Nil
     else {
       val width = in.iterator.map(_._1.length).max
       for ((a, b) <- in) yield pre + fill(a, width) + sep + b
@@ -80,10 +79,8 @@ object CommandUtil {
         val keyMatches = Highlight.showMatches(pattern)(k)
         val keyString = Highlight.bold(keyMatches getOrElse k)
         val contentString = contentMatches getOrElse v
-        if (keyMatches.isDefined || contentMatches.isDefined)
-          Seq((keyString, contentString))
-        else
-          nilSeq
+        if (keyMatches.isDefined || contentMatches.isDefined) Seq((keyString, contentString))
+        else Nil
     }
   }
 

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -8,18 +8,18 @@
 package sbt
 package internal
 
-import sbt.internal.util._
-import BasicKeys._
 import java.io.File
+
+import sbt.BasicKeys._
+import sbt.internal.util._
 import sbt.protocol.EventMessage
 import sjsonnew.JsonFormat
-import Util.AnyOps
 
 private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel {
   private var askUserThread: Option[Thread] = None
   def makeAskUserThread(s: State): Thread = new Thread("ask-user-thread") {
-    val history = (s get historyPath) getOrElse (new File(s.baseDir, ".history")).some
-    val prompt = (s get shellPrompt) match {
+    val history = s.get(historyPath).getOrElse(Some(new File(s.baseDir, ".history")))
+    val prompt = s.get(shellPrompt) match {
       case Some(pf) => pf(s)
       case None     => "> "
     }

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -15,7 +15,6 @@ import sbt.Scope.{ GlobalScope, ThisScope }
 import sbt.internal.util.Types.const
 import sbt.internal.util.complete.Parser
 import sbt.internal.util._
-import Util._
 import sbt.util.Show
 
 /** A concrete settings system that uses `sbt.Scope` for the scope type. */
@@ -173,9 +172,8 @@ object Def extends Init[Scope] with TaskMacroExtra {
 
   override def deriveAllowed[T](s: Setting[T], allowDynamic: Boolean): Option[String] =
     super.deriveAllowed(s, allowDynamic) orElse
-      (if (s.key.scope != ThisScope)
-         s"Scope cannot be defined for ${definedSettingString(s)}".some
-       else none) orElse
+      (if (s.key.scope != ThisScope) Some(s"Scope cannot be defined for ${definedSettingString(s)}")
+       else None) orElse
       s.dependencies
         .find(k => k.scope != ThisScope)
         .map(

--- a/main-settings/src/main/scala/sbt/InputTask.scala
+++ b/main-settings/src/main/scala/sbt/InputTask.scala
@@ -7,12 +7,11 @@
 
 package sbt
 
-import sbt.internal.util.complete.Parser
-import Def.{ Initialize, ScopedKey }
-import std.TaskExtra._
-import sbt.internal.util.{ ~>, AttributeKey, Types }
+import sbt.Def.{ Initialize, ScopedKey }
 import sbt.internal.util.Types._
-import sbt.internal.util.Util._
+import sbt.internal.util.complete.Parser
+import sbt.internal.util.{ AttributeKey, Types, ~> }
+import sbt.std.TaskExtra._
 
 /** Parses input and produces a task to run.  Constructed using the companion object. */
 final class InputTask[T] private (val parser: State => Parser[Task[T]]) {
@@ -148,7 +147,7 @@ object InputTask {
     val key = localKey[Option[I]]
     val f: () => I = () =>
       sys.error(s"Internal sbt error: InputTask stub was not substituted properly.")
-    val t: Task[I] = Task(Info[I]().set(key, none), Pure(f, false))
+    val t: Task[I] = Task(Info[I]().set(key, None), Pure(f, false))
     (key, t)
   }
 

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -10,7 +10,6 @@ package sbt
 import java.net.URI
 
 import sbt.internal.util.{ AttributeKey, AttributeMap, Dag }
-import sbt.internal.util.Util._
 
 import sbt.io.IO
 
@@ -214,7 +213,7 @@ object Scope {
       val zeroConfig = if (showZeroConfig) "Zero /" else ""
       val configPrefix = config.foldStrict(display, zeroConfig, "./")
       val taskPrefix = task.foldStrict(_.label + " /", "", "./")
-      val extras = extra.foldStrict(_.entries.map(_.toString).toList, nil, nil)
+      val extras = extra.foldStrict(_.entries.map(_.toString).toList, Nil, Nil)
       val postfix = if (extras.isEmpty) "" else extras.mkString("(", ", ", ")")
       if (scope == GlobalScope) "Global / " + sep + postfix
       else

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -7,8 +7,6 @@
 
 package sbt
 
-import sbt.internal.util.Util._
-
 sealed trait ScopeAxis[+S] {
   def foldStrict[T](f: S => T, ifZero: T, ifThis: T): T = fold(f, ifZero, ifThis)
   def fold[T](f: S => T, ifZero: => T, ifThis: => T): T = this match {
@@ -16,7 +14,7 @@ sealed trait ScopeAxis[+S] {
     case Zero      => ifZero
     case Select(s) => f(s)
   }
-  def toOption: Option[S] = foldStrict(Option(_), none, none)
+  def toOption: Option[S] = foldStrict(Option(_), None, None)
   def map[T](f: S => T): ScopeAxis[T] =
     foldStrict(s => Select(f(s)): ScopeAxis[T], Zero: ScopeAxis[T], This: ScopeAxis[T])
   def isSelect: Boolean = false

--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -9,13 +9,12 @@ package sbt
 
 import java.io.File
 import java.lang.ProcessBuilder.Redirect
+import java.lang.{ ProcessBuilder => JProcessBuilder }
+
+import sbt.OutputStrategy._
+import sbt.internal.util.Util
 
 import scala.sys.process.Process
-import OutputStrategy._
-import sbt.internal.util.Util
-import Util.{ AnyOps, none }
-
-import java.lang.{ ProcessBuilder => JProcessBuilder }
 
 /**
  * Represents a command that can be forked.
@@ -73,9 +72,8 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
       arguments: Seq[String]
   ): Seq[String] = {
     val boot =
-      if (bootJars.isEmpty) none[String]
-      else
-        ("-Xbootclasspath/a:" + bootJars.map(_.getAbsolutePath).mkString(File.pathSeparator)).some
+      if (bootJars.isEmpty) None
+      else Some("-Xbootclasspath/a:" + bootJars.map(_.getAbsolutePath).mkString(File.pathSeparator))
     jvmOptions ++ boot.toList ++ runnerClass.toList ++ arguments
   }
 }

--- a/run/src/main/scala/sbt/SelectMainClass.scala
+++ b/run/src/main/scala/sbt/SelectMainClass.scala
@@ -7,8 +7,6 @@
 
 package sbt
 
-import sbt.internal.util.Util.{ AnyOps, none }
-
 object SelectMainClass {
   // Some(SimpleReader.readLine _)
   def apply(
@@ -29,19 +27,19 @@ object SelectMainClass {
         }
     }
   }
-  private def trim(s: Option[String]) = s.getOrElse("")
+  private def trim(s: Option[String]): String = s.getOrElse("")
   private def toInt(s: String, size: Int): Option[Int] =
     try {
       val i = s.toInt
       if (i > 0 && i <= size)
-        (i - 1).some
+        Some(i - 1)
       else {
         println("Number out of range: was " + i + ", expected number between 1 and " + size)
-        none
+        None
       }
     } catch {
       case nfe: NumberFormatException =>
         println("Invalid number: " + nfe.toString)
-        none
+        None
     }
 }

--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -7,19 +7,18 @@
 
 package sbt
 
-import scala.reflect.Manifest
-import scala.collection.concurrent.TrieMap
+import java.lang.Integer.{ toHexString => hex }
+import java.lang.Thread.currentThread
 import java.lang.ref.WeakReference
-import Thread.currentThread
 import java.security.Permission
 import java.util.concurrent.{ ConcurrentHashMap => CMap }
-import java.lang.Integer.{ toHexString => hex }
 import java.util.function.Supplier
 
-import sbt.util.Logger
-import sbt.util.InterfaceUtil
-import sbt.internal.util.Util.{ AnyOps, none }
-import TrapExit._
+import sbt.TrapExit._
+import sbt.util.{ InterfaceUtil, Logger }
+
+import scala.collection.concurrent.TrieMap
+import scala.reflect.Manifest
 
 /**
  * Provides an approximation to isolated execution within a single JVM.
@@ -295,8 +294,8 @@ private final class TrapExit(delegateManager: SecurityManager) extends SecurityM
     private[this] def setExceptionHandler(t: Thread): Unit = {
       val group = t.getThreadGroup
       val previousHandler = t.getUncaughtExceptionHandler match {
-        case null | `group` | (_: LoggingExceptionHandler) => none[Thread.UncaughtExceptionHandler]
-        case x                                             => x.some // delegate to a custom handler only
+        case null | `group` | (_: LoggingExceptionHandler) => None
+        case x                                             => Some(x) // delegate to a custom handler only
       }
       t.setUncaughtExceptionHandler(new LoggingExceptionHandler(log, previousHandler))
     }

--- a/run/src/test/scala/sbt/ForkTest.scala
+++ b/run/src/test/scala/sbt/ForkTest.scala
@@ -7,15 +7,14 @@
 
 package sbt
 
-import org.scalacheck._
-import Prop.{ Exception => _, _ }
-import Gen.{ alphaNumChar, frequency, nonEmptyListOf }
 import java.io.File
 
+import org.scalacheck.Gen.{ alphaNumChar, frequency, nonEmptyListOf }
+import org.scalacheck.Prop.{ Exception => _, _ }
+import org.scalacheck._
+import sbt.OutputStrategy._
 import sbt.internal.TestLogger
 import sbt.io.{ IO, Path }
-import OutputStrategy._
-import sbt.internal.util.Util._
 
 object ForkTest extends Properties("Fork") {
 
@@ -26,7 +25,7 @@ object ForkTest extends Properties("Fork") {
    */
   final val MaximumClasspathLength = 100000
 
-  lazy val genOptionName = frequency((9, "-cp".some), (9, "-classpath".some), (1, none))
+  lazy val genOptionName = frequency((9, Some("-cp")), (9, Some("-classpath")), (1, None))
   lazy val pathElement = nonEmptyListOf(alphaNumChar).map(_.mkString)
   lazy val path = nonEmptyListOf(pathElement).map(_.mkString(File.separator))
   lazy val genRelClasspath = nonEmptyListOf(path)

--- a/tasks-standard/src/main/scala/sbt/std/Streams.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Streams.scala
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import sbt.internal.io.DeferredWriter
 import sbt.internal.util.ManagedLogger
-import sbt.internal.util.Util.{ nil }
 import sbt.io.IO
 import sbt.io.syntax._
 import sbt.util._
@@ -142,7 +141,7 @@ object Streams {
   ): Streams[Key] = new Streams[Key] {
 
     def apply(a: Key): ManagedStreams[Key] = new ManagedStreams[Key] {
-      private[this] var opened: List[Closeable] = nil
+      private[this] var opened: List[Closeable] = Nil
       private[this] var closed = false
 
       def getInput(a: Key, sid: String = default): Input =

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -12,7 +12,6 @@ import java.util.concurrent.ExecutionException
 import sbt.internal.util.ErrorHandling.wideConvert
 import sbt.internal.util.{ DelegatingPMap, IDSet, PMap, RMap, ~> }
 import sbt.internal.util.Types._
-import sbt.internal.util.Util.nilSeq
 import Execute._
 
 import scala.annotation.tailrec
@@ -324,7 +323,7 @@ private[sbt] final class Execute[F[_] <: AnyRef](
   def runBefore(node: F[_]): Seq[F[_]] = getSeq(triggers.runBefore, node)
   def triggeredBy(node: F[_]): Seq[F[_]] = getSeq(triggers.injectFor, node)
   def getSeq(map: collection.Map[F[_], Seq[F[_]]], node: F[_]): Seq[F[_]] =
-    map.getOrElse(node, nilSeq[F[_]])
+    map.getOrElse(node, Seq.empty[F[_]])
 
   // Contracts
 


### PR DESCRIPTION
These methods make the code less readable in my opinion. This should be
a no-op. In addition to replacing the depreacted apis:
UtilOps.{ AnyOps, nil, nilSeq, none }, I optimized the imports of each
file where I made changes. I also rewrote a few lines that did something
like `foo get bar getOrElse baz` to `foo.get(bar).getOrElse(baz)`.