### PR TITLE
workaround client / clean problem

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -183,7 +183,7 @@ object Cross {
                     val parts = project(k).map(_.project) ++ k.scope.config.toOption.map {
                       case ConfigKey(n) => n.head.toUpper + n.tail
                     } ++ k.scope.task.toOption.map(_.label) ++ Some(k.key.label)
-                    Some(v -> parts.mkString("", " / ", fullArgs))
+                    Some(v -> parts.mkString("", "/", fullArgs))
                   } else None
                 }
               }

--- a/sbt/src/sbt-test/actions/cross-test-only/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-test-only/build.sbt
@@ -1,2 +1,16 @@
-val foo = project
-val root = (project in file(".")).aggregate(foo)
+lazy val root = (project in file("."))
+  .aggregate(foo, client)
+  .settings(
+    crossScalaVersions := Nil
+  )
+
+lazy val foo = project
+  .settings(
+    crossScalaVersions := Seq("2.12.10", "2.13.1"),
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0",
+  )
+
+lazy val client = project
+  .settings(
+    crossScalaVersions := Seq("2.12.10", "2.13.1"),
+  )

--- a/sbt/src/sbt-test/actions/cross-test-only/foo/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-test-only/foo/build.sbt
@@ -1,3 +1,0 @@
-crossScalaVersions := Seq("2.12.10", "2.13.1")
-
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0"

--- a/sbt/src/sbt-test/actions/cross-test-only/test
+++ b/sbt/src/sbt-test/actions/cross-test-only/test
@@ -1,3 +1,5 @@
+> + clean
+
 > + foo / testOnly foo.FooSpec
 
 > + testOnly foo.FooSpec


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5314
Ref https://github.com/sbt/sbt/pull/5265

In sbt 1.3.4, it's possible to define a subproject named `client`.
The current parser behaves differently whether we calll `client/clean` or `client / clean` with whitespaces. The one with the whitespace invokes `client` command (as in thin client). This gets triggered by `+clean` because the new implementation uses whitespace.