### PR TITLE
Overhaul terminal io

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -94,6 +94,7 @@ private[sbt] object JLine {
   @deprecated("Handled by Terminal.fixTerminalProperty", "1.4.0")
   private[sbt] def fixTerminalProperty(): Unit = ()
 
+  @deprecated("For binary compatibility only", "1.4.0")
   private[sbt] def makeInputStream(injectThreadSleep: Boolean): InputStream =
     if (injectThreadSleep) new InputStreamWrapper(originalIn, 2.milliseconds)
     else originalIn
@@ -176,6 +177,7 @@ final class FullReader(
     val handleCONT: Boolean,
     inputStream: InputStream,
 ) extends JLine {
+  @deprecated("Use the constructor with no injectThreadSleep parameter", "1.4.0")
   def this(
       historyPath: Option[File],
       complete: Parser[_],

--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -33,6 +33,11 @@ abstract class JLine extends LineReader {
         Option("")
     }
 
+  override def redraw(): Unit = {
+    reader.drawLine()
+    reader.flush()
+  }
+
   private[this] def unsynchronizedReadLine(prompt: String, mask: Option[Char]): Option[String] =
     readLineWithHistory(prompt, mask) map { x =>
       x.trim
@@ -169,6 +174,7 @@ private[sbt] class InputStreamWrapper(is: InputStream, val poll: Duration)
 
 trait LineReader {
   def readLine(prompt: String, mask: Option[Char] = None): Option[String]
+  def redraw(): Unit = ()
 }
 
 final class FullReader(

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -106,6 +106,7 @@ object ConsoleAppender {
   private[sbt] def cursorUp(n: Int): String = s"\u001B[${n}A"
   private[sbt] def cursorDown(n: Int): String = s"\u001B[${n}B"
   private[sbt] def scrollUp(n: Int): String = s"\u001B[${n}S"
+  private[sbt] def clearScreen(n: Int): String = s"\u001B[${n}J"
   private[sbt] final val DeleteLine = "\u001B[2K"
   private[sbt] final val CursorLeft1000 = "\u001B[1000D"
   private[sbt] final val CursorDown1 = cursorDown(1)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -113,6 +113,7 @@ object ConsoleAppender {
   private[sbt] def clearScreen(n: Int): String = s"\u001B[${n}J"
   private[sbt] def clearLine(n: Int): String = s"\u001B[${n}K"
   private[sbt] final val DeleteLine = "\u001B[2K"
+  private[sbt] final val ClearScreenAfterCursor = clearScreen(0)
   private[sbt] final val CursorLeft1000 = cursorLeft(1000)
   private[sbt] final val CursorDown1 = cursorDown(1)
   private[this] val showProgressHolder: AtomicBoolean = new AtomicBoolean(false)
@@ -558,7 +559,7 @@ private[sbt] object ProgressState {
     case state =>
       if (state.progressLines.get.nonEmpty) {
         val lines = printProgress(0, 0)
-        printStream.print(ConsoleAppender.clearScreen(0) + "\n" + lines)
+        printStream.print(ClearScreenAfterCursor + "\n" + lines)
       } else printStream.write('\n')
   }
 
@@ -603,7 +604,7 @@ private[sbt] object ProgressState {
         val left = cursorLeft(1000) // resets the position to the left
         val offset = width > 0
         val pad = math.max(state.padding.get - height, 0)
-        val start = clearScreen(0) + (if (offset) "\n" else "")
+        val start = ClearScreenAfterCursor + (if (offset) "\n" else "")
         val totalSize = currentLength + state.blankZone + pad
         val blank = left + s"\n$DeleteLine" * (totalSize - currentLength)
         val lines = previousLines.mkString(DeleteLine, s"\n$DeleteLine", s"\n$DeleteLine")
@@ -612,7 +613,7 @@ private[sbt] object ProgressState {
         val resetCursor = resetCursorUp + resetCursorRight
         start + blank + lines + resetCursor
       } else {
-        clearScreen(0)
+        ClearScreenAfterCursor
       }
   }
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -1,0 +1,210 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import java.io.{ InputStream, OutputStream }
+import java.util.Locale
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+import java.util.concurrent.locks.ReentrantLock
+
+import jline.console.ConsoleReader
+
+import scala.util.control.NonFatal
+
+object Terminal {
+
+  /**
+   * Gets the current width of the terminal. The implementation reads a property from the jline
+   * config which is updated if it has been more than a second since the last update. It is thus
+   * possible for this value to be stale.
+   *
+   * @return the terminal width.
+   */
+  def getWidth: Int = terminal.getWidth
+
+  /**
+   * Gets the current height of the terminal. The implementation reads a property from the jline
+   * config which is updated if it has been more than a second since the last update. It is thus
+   * possible for this value to be stale.
+   *
+   * @return the terminal height.
+   */
+  def getHeight: Int = terminal.getHeight
+
+  /**
+   * Returns true if the current terminal supports ansi characters.
+   *
+   * @return true if the current terminal supports ansi escape codes.
+   */
+  def isAnsiSupported: Boolean =
+    try terminal.isAnsiSupported
+    catch { case NonFatal(_) => !isWindows }
+
+  /**
+   * Returns true if System.in is attached. When sbt is run as a subprocess, like in scripted or
+   * as a server, System.in will not be attached and this method will return false. Otherwise
+   * it will return true.
+   *
+   * @return true if System.in is attached.
+   */
+  def systemInIsAttached: Boolean = attached.get
+
+  /**
+   * Provides a wrapper around System.in. The wrapped stream in will check if the terminal is attached
+   * in available and read. If a read returns -1, it will mark System.in as unattached so that
+   * it can be detected by [[systemInIsAttached]].
+   *
+   * @return the wrapped InputStream
+   */
+  private[sbt] def wrappedSystemIn: InputStream = WrappedSystemIn
+
+  /**
+   * Restore the terminal to its initial state.
+   */
+  private[sbt] def restore(): Unit = terminal.restore()
+
+  /**
+   * Runs a thunk ensuring that the terminal has echo enabled. Most of the time sbt should have
+   * echo mode on except when it is explicitly set to raw mode via [[withRawSystemIn]].
+   *
+   * @param f the thunk to run
+   * @tparam T the result type of the thunk
+   * @return the result of the thunk
+   */
+  private[sbt] def withEcho[T](toggle: Boolean)(f: => T): T = {
+    val previous = terminal.isEchoEnabled
+    terminalLock.lockInterruptibly()
+    try {
+      terminal.setEchoEnabled(toggle)
+      f
+    } finally {
+      terminal.setEchoEnabled(previous)
+      terminalLock.unlock()
+    }
+  }
+
+  /**
+   * Runs a thunk ensuring that the terminal is in canonical mode:
+   * [[https://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html Canonical or Not]].
+   * Most of the time sbt should be in canonical mode except when it is explicitly set to raw mode
+   * via [[withRawSystemIn]].
+   *
+   * @param f the thunk to run
+   * @tparam T the result type of the thunk
+   * @return the result of the thunk
+   */
+  private[sbt] def withCanonicalIn[T](f: => T): T = withTerminal { t =>
+    t.restore()
+    f
+  }
+
+  /**
+   * Runs a thunk ensuring that the terminal is in in non-canonical mode:
+   * [[https://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html Canonical or Not]].
+   * This should be used when sbt is reading user input, e.g. in `shell` or a continuous build.
+   * @param f the thunk to run
+   * @tparam T the result type of the thunk
+   * @return the result of the thunk
+   */
+  private[sbt] def withRawSystemIn[T](f: => T): T = withTerminal { t =>
+    t.init()
+    f
+  }
+
+  private[this] def withTerminal[T](f: jline.Terminal => T): T = {
+    val t = terminal
+    terminalLock.lockInterruptibly()
+    try f(t)
+    finally {
+      t.restore()
+      terminalLock.unlock()
+    }
+  }
+
+  private[this] object WrappedSystemIn extends InputStream {
+    private[this] val in = terminal.wrapInIfNeeded(System.in)
+    override def available(): Int = if (attached.get) in.available else 0
+    override def read(): Int = synchronized {
+      if (attached.get) {
+        val res = in.read
+        if (res == -1) attached.set(false)
+        res
+      } else -1
+    }
+  }
+
+  private[this] val terminalLock = new ReentrantLock()
+  private[this] val attached = new AtomicBoolean(true)
+  private[this] val terminalHolder = new AtomicReference(wrap(jline.TerminalFactory.get))
+  private[this] lazy val isWindows =
+    System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH).indexOf("windows") >= 0
+
+  private[this] def wrap(terminal: jline.Terminal): jline.Terminal = {
+    val term: jline.Terminal = new jline.Terminal {
+      private[this] val hasConsole = System.console != null
+      private[this] def alive = hasConsole && attached.get
+      override def init(): Unit = if (alive) terminal.init()
+      override def restore(): Unit = if (alive) terminal.restore()
+      override def reset(): Unit = if (alive) terminal.reset()
+      override def isSupported: Boolean = terminal.isSupported
+      override def getWidth: Int = terminal.getWidth
+      override def getHeight: Int = terminal.getHeight
+      override def isAnsiSupported: Boolean = terminal.isAnsiSupported
+      override def wrapOutIfNeeded(out: OutputStream): OutputStream = terminal.wrapOutIfNeeded(out)
+      override def wrapInIfNeeded(in: InputStream): InputStream = terminal.wrapInIfNeeded(in)
+      override def hasWeirdWrap: Boolean = terminal.hasWeirdWrap
+      override def isEchoEnabled: Boolean = terminal.isEchoEnabled
+      override def setEchoEnabled(enabled: Boolean): Unit = if (alive) {
+        terminal.setEchoEnabled(enabled)
+      }
+      override def disableInterruptCharacter(): Unit =
+        if (alive) terminal.disableInterruptCharacter()
+      override def enableInterruptCharacter(): Unit =
+        if (alive) terminal.enableInterruptCharacter()
+      override def getOutputEncoding: String = terminal.getOutputEncoding
+    }
+    term.restore()
+    term.setEchoEnabled(true)
+    term
+  }
+
+  private[util] def reset(): Unit = {
+    jline.TerminalFactory.reset()
+    terminalHolder.set(wrap(jline.TerminalFactory.get))
+  }
+
+  // translate explicit class names to type in order to support
+  //  older Scala, since it shaded classes but not the system property
+  private[this] def fixTerminalProperty(): Unit = {
+    val terminalProperty = "jline.terminal"
+    val newValue = System.getProperty(terminalProperty) match {
+      case "jline.UnixTerminal"                             => "unix"
+      case null if System.getProperty("sbt.cygwin") != null => "unix"
+      case "jline.WindowsTerminal"                          => "windows"
+      case "jline.AnsiWindowsTerminal"                      => "windows"
+      case "jline.UnsupportedTerminal"                      => "none"
+      case x                                                => x
+    }
+    if (newValue != null) {
+      System.setProperty(terminalProperty, newValue)
+      ()
+    }
+  }
+  fixTerminalProperty()
+
+  private[sbt] def createReader(in: InputStream): ConsoleReader =
+    new ConsoleReader(in, System.out, terminal)
+
+  private[this] def terminal: jline.Terminal = terminalHolder.get match {
+    case null => throw new IllegalStateException("Uninitialized terminal.")
+    case term => term
+  }
+
+  @deprecated("For compatibility only", "1.4.0")
+  private[sbt] def deprecatedTeminal: jline.Terminal = terminal
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -7,14 +7,17 @@
 
 package sbt.internal.util
 
-import java.io.{ InputStream, OutputStream }
+import java.io.{ InputStream, OutputStream, PrintStream }
 import java.nio.channels.ClosedChannelException
 import java.util.Locale
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import java.util.concurrent.locks.ReentrantLock
 
 import jline.console.ConsoleReader
 
+import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 object Terminal {
@@ -36,6 +39,38 @@ object Terminal {
    * @return the terminal height.
    */
   def getHeight: Int = terminal.getHeight
+
+  /**
+   * Returns the height and width of the current line that is displayed on the terminal. If the
+   * most recently flushed byte is a newline, this will be `(0, 0)`.
+   *
+   * @return the (height, width) pair
+   */
+  def getLineHeightAndWidth: (Int, Int) = currentLine.get.toArray match {
+    case bytes if bytes.isEmpty => (0, 0)
+    case bytes =>
+      val width = getWidth
+      val line = EscHelpers.removeEscapeSequences(new String(bytes))
+      val count = lineCount(line)
+      (count, line.length - ((count - 1) * width))
+  }
+
+  /**
+   * Returns the number of lines that the input string will cover given the current width of the
+   * terminal.
+   *
+   * @param line the input line
+   * @return the number of lines that the line will cover on the terminal
+   */
+  def lineCount(line: String): Int = {
+    val width = getWidth
+    val lines = EscHelpers.removeEscapeSequences(line).split('\n')
+    def count(l: String): Int = {
+      val len = l.length
+      if (width > 0 && len > 0) (len - 1 + width) / width else 0
+    }
+    lines.tail.foldLeft(lines.headOption.fold(0)(count))(_ + count(_))
+  }
 
   /**
    * Returns true if the current terminal supports ansi characters.
@@ -102,6 +137,17 @@ object Terminal {
   }
 
   /**
+   *
+   * @param f the thunk to run
+   * @tparam T the result type of the thunk
+   * @return the result of the thunk
+   */
+  private[sbt] def withStreams[T](f: => T): T =
+    if (System.getProperty("sbt.io.virtual", "true") == "true") {
+      withOut(withIn(f))
+    } else f
+
+  /**
    * Runs a thunk ensuring that the terminal is in canonical mode:
    * [[https://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html Canonical or Not]].
    * Most of the time sbt should be in canonical mode except when it is explicitly set to raw mode
@@ -139,6 +185,79 @@ object Terminal {
     }
   }
 
+  private[this] val originalOut = System.out
+  private[this] val originalIn = System.in
+  private[this] val currentLine = new AtomicReference(new ArrayBuffer[Byte])
+  private[this] val lineBuffer = new LinkedBlockingQueue[Byte]
+  private[this] val flushQueue = new LinkedBlockingQueue[Unit]
+  private[this] val writeLock = new AnyRef
+  private[this] final class WriteThread extends Thread("sbt-stdout-write-thread") {
+    setDaemon(true)
+    start()
+    private[this] val isStopped = new AtomicBoolean(false)
+    def close(): Unit = {
+      isStopped.set(true)
+      flushQueue.put(())
+      ()
+    }
+    @tailrec override def run(): Unit = {
+      try {
+        flushQueue.take()
+        val bytes = new java.util.ArrayList[Byte]
+        writeLock.synchronized {
+          lineBuffer.drainTo(bytes)
+          import scala.collection.JavaConverters._
+          val remaining = bytes.asScala.foldLeft(new ArrayBuffer[Byte]) { (buf, i) =>
+            if (i == 10) {
+              ProgressState.addBytes(buf)
+              ProgressState.clearBytes()
+              buf.foreach(b => originalOut.write(b & 0xFF))
+              ProgressState.reprint(originalOut)
+              currentLine.set(new ArrayBuffer[Byte])
+              new ArrayBuffer[Byte]
+            } else buf += i
+          }
+          if (remaining.nonEmpty) {
+            currentLine.get ++= remaining
+            originalOut.write(remaining.toArray)
+          }
+          originalOut.flush()
+        }
+      } catch { case _: InterruptedException => isStopped.set(true) }
+      if (!isStopped.get) run()
+    }
+  }
+  private[this] def withOut[T](f: => T): T = {
+    val thread = new WriteThread
+    try {
+      System.setOut(SystemPrintStream)
+      scala.Console.withOut(SystemPrintStream)(f)
+    } finally {
+      thread.close()
+      System.setOut(originalOut)
+    }
+  }
+  private[this] def withIn[T](f: => T): T =
+    try {
+      System.setIn(Terminal.wrappedSystemIn)
+      scala.Console.withIn(Terminal.wrappedSystemIn)(f)
+    } finally System.setIn(originalIn)
+
+  private[sbt] def withPrintStream[T](f: PrintStream => T): T = writeLock.synchronized {
+    f(originalOut)
+  }
+  private object SystemOutputStream extends OutputStream {
+    override def write(b: Int): Unit = writeLock.synchronized(lineBuffer.put(b.toByte))
+    override def write(b: Array[Byte]): Unit = writeLock.synchronized(b.foreach(lineBuffer.put))
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = writeLock.synchronized {
+      val lo = math.max(0, off)
+      val hi = math.min(math.max(off + len, 0), b.length)
+      (lo until hi).foreach(i => lineBuffer.put(b(i)))
+    }
+    def write(s: String): Unit = s.getBytes.foreach(lineBuffer.put)
+    override def flush(): Unit = writeLock.synchronized(flushQueue.put(()))
+  }
+  private object SystemPrintStream extends PrintStream(SystemOutputStream, true)
   private[this] object WrappedSystemIn extends InputStream {
     private[this] val in = terminal.wrapInIfNeeded(System.in)
     override def available(): Int = if (attached.get) in.available else 0

--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -9,9 +9,10 @@ package sbt
 
 import java.io.File
 import sbt.internal.inc.{ AnalyzingCompiler, PlainVirtualFile }
-import sbt.internal.util.JLine
+import sbt.internal.util.Terminal
 import sbt.util.Logger
-import xsbti.compile.{ Inputs, Compilers }
+import xsbti.compile.{ Compilers, Inputs }
+
 import scala.util.Try
 
 final class Console(compiler: AnalyzingCompiler) {
@@ -51,10 +52,7 @@ final class Console(compiler: AnalyzingCompiler) {
         loader,
         bindings
       )
-    JLine.usingTerminal { t =>
-      t.init
-      Run.executeTrapExit(console0, log)
-    }
+    Terminal.withRawSystemIn(Run.executeTrapExit(console0, log))
   }
 }
 

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -9,15 +9,15 @@ package sbt
 
 import java.nio.file.Paths
 import sbt.util.Level
-import sbt.internal.util.{ AttributeKey, FullReader }
+import sbt.internal.util.{ AttributeKey, FullReader, JLine, Terminal }
 import sbt.internal.util.complete.{
   Completion,
   Completions,
   DefaultParsers,
-  History => CHistory,
   HistoryCommands,
   Parser,
-  TokenCompletions
+  TokenCompletions,
+  History => CHistory
 }
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util.Util.{ AnyOps, nil, nilSeq, none }
@@ -25,13 +25,14 @@ import sbt.internal.inc.classpath.ClasspathUtil.toLoader
 import sbt.internal.inc.ModuleUtilities
 import sbt.internal.client.NetworkClient
 import DefaultParsers._
+
 import Function.tupled
 import Command.applyEffect
 import BasicCommandStrings._
 import CommandUtil._
 import BasicKeys._
-
 import java.io.File
+
 import sbt.io.IO
 
 import scala.collection.mutable.ListBuffer
@@ -372,7 +373,8 @@ object BasicCommands {
   def oldshell: Command = Command.command(OldShell, Help.more(Shell, OldShellDetailed)) { s =>
     val history = (s get historyPath) getOrElse (new File(s.baseDir, ".history")).some
     val prompt = (s get shellPrompt) match { case Some(pf) => pf(s); case None => "> " }
-    val reader = new FullReader(history, s.combinedParser)
+    val reader =
+      new FullReader(history, s.combinedParser, JLine.HandleCONT, Terminal.wrappedSystemIn)
     val line = reader.readLine(prompt)
     line match {
       case Some(line) =>

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -9,7 +9,7 @@ package sbt
 
 import java.nio.file.Paths
 import sbt.util.Level
-import sbt.internal.util.{ AttributeKey, FullReader, JLine, Terminal }
+import sbt.internal.util.{ AttributeKey, FullReader, LineReader, Terminal }
 import sbt.internal.util.complete.{
   Completion,
   Completions,
@@ -34,7 +34,9 @@ import BasicKeys._
 import java.io.File
 
 import sbt.io.IO
+import sbt.util.Level
 
+import scala.Function.tupled
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
@@ -374,7 +376,7 @@ object BasicCommands {
     val history = (s get historyPath) getOrElse (new File(s.baseDir, ".history")).some
     val prompt = (s get shellPrompt) match { case Some(pf) => pf(s); case None => "> " }
     val reader =
-      new FullReader(history, s.combinedParser, JLine.HandleCONT, Terminal.wrappedSystemIn)
+      new FullReader(history, s.combinedParser, LineReader.HandleCONT, Terminal.wrappedSystemIn)
     val line = reader.readLine(prompt)
     line match {
       case Some(line) =>

--- a/main-command/src/main/scala/sbt/internal/CommandChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/CommandChannel.scala
@@ -62,4 +62,5 @@ case class ConsolePromptEvent(state: State) extends EventMessage
 /*
  * This is a data passed specifically for unprompting local console.
  */
+@deprecated("No longer used", "1.4.0")
 case class ConsoleUnpromptEvent(lastSource: Option[CommandSource]) extends EventMessage

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -51,18 +51,6 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
             askUserThread = Some(x)
             x.start()
         }
-      case e: ConsoleUnpromptEvent =>
-        e.lastSource match {
-          case Some(src) if src.channelName != name =>
-            askUserThread match {
-              case Some(_) =>
-              // keep listening while network-origin command is running
-              // make sure to test Windows and Cygwin, if you uncomment
-              // shutdown()
-              case _ =>
-            }
-          case _ =>
-        }
       case _ => //
     }
 

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -29,7 +29,12 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
     private val history = s.get(historyPath).getOrElse(Some(new File(s.baseDir, ".history")))
     private val prompt = getPrompt(s)
     private val reader =
-      new FullReader(history, s.combinedParser, JLine.HandleCONT, Terminal.throwOnClosedSystemIn)
+      new FullReader(
+        history,
+        s.combinedParser,
+        LineReader.HandleCONT,
+        Terminal.throwOnClosedSystemIn
+      )
     setDaemon(true)
     start()
     override def run(): Unit =

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -23,7 +23,9 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
     val history = (s get historyPath) getOrElse (new File(s.baseDir, ".history")).some
     val prompt = (s get shellPrompt) match {
       case Some(pf) => pf(s)
-      case None     => "> "
+      case None =>
+        def ansi(s: String): String = if (ConsoleAppender.formatEnabledInEnv) s"$s" else ""
+        s"${ansi(ConsoleAppender.DeleteLine)}> ${ansi(ConsoleAppender.clearScreen(0))}"
     }
     val reader =
       new FullReader(history, s.combinedParser, JLine.HandleCONT, Terminal.throwOnClosedSystemIn)

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -10,27 +10,29 @@ package internal
 
 import java.io.File
 import java.nio.channels.ClosedChannelException
+import java.util.concurrent.atomic.AtomicReference
 
 import sbt.BasicKeys._
-import sbt.internal.util.Util.AnyOps
 import sbt.internal.util._
 import sbt.protocol.EventMessage
 import sjsonnew.JsonFormat
 
 private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel {
-  private var askUserThread: Option[Thread] = None
-  def makeAskUserThread(s: State): Thread = new Thread("ask-user-thread") {
-    val history = (s get historyPath) getOrElse (new File(s.baseDir, ".history")).some
-    val prompt = (s get shellPrompt) match {
-      case Some(pf) => pf(s)
-      case None =>
-        def ansi(s: String): String = if (ConsoleAppender.formatEnabledInEnv) s"$s" else ""
-        s"${ansi(ConsoleAppender.DeleteLine)}> ${ansi(ConsoleAppender.clearScreen(0))}"
-    }
-    val reader =
+  private[this] val askUserThread = new AtomicReference[AskUserThread]
+  private[this] def getPrompt(s: State): String = s.get(shellPrompt) match {
+    case Some(pf) => pf(s)
+    case None =>
+      def ansi(s: String): String = if (ConsoleAppender.formatEnabledInEnv) s"$s" else ""
+      s"${ansi(ConsoleAppender.DeleteLine)}> ${ansi(ConsoleAppender.clearScreen(0))}"
+  }
+  private[this] class AskUserThread(s: State) extends Thread("ask-user-thread") {
+    private val history = s.get(historyPath).getOrElse(Some(new File(s.baseDir, ".history")))
+    private val prompt = getPrompt(s)
+    private val reader =
       new FullReader(history, s.combinedParser, JLine.HandleCONT, Terminal.throwOnClosedSystemIn)
-    override def run(): Unit = {
-      // This internally handles thread interruption and returns Some("")
+    setDaemon(true)
+    start()
+    override def run(): Unit =
       try {
         reader.readLine(prompt) match {
           case Some(cmd) => append(Exec(cmd, Some(Exec.newExecId), Some(CommandSource(name))))
@@ -38,12 +40,18 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
             println("") // Prevents server shutdown log lines from appearing on the prompt line
             append(Exec("exit", Some(Exec.newExecId), Some(CommandSource(name))))
         }
+        ()
       } catch {
         case _: ClosedChannelException =>
-      }
-      askUserThread = None
+      } finally askUserThread.synchronized(askUserThread.set(null))
+    def redraw(): Unit = {
+      System.out.print(ConsoleAppender.clearLine(0))
+      reader.redraw()
+      System.out.print(ConsoleAppender.clearScreen(0))
+      System.out.flush()
     }
   }
+  private[this] def makeAskUserThread(s: State): AskUserThread = new AskUserThread(s)
 
   def run(s: State): State = s
 
@@ -54,21 +62,24 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
   def publishEventMessage(event: EventMessage): Unit =
     event match {
       case e: ConsolePromptEvent =>
-        askUserThread match {
-          case Some(_) =>
-          case _ =>
-            val x = makeAskUserThread(e.state)
-            askUserThread = Some(x)
-            x.start()
+        if (Terminal.systemInIsAttached) {
+          askUserThread.synchronized {
+            askUserThread.get match {
+              case null => askUserThread.set(makeAskUserThread(e.state))
+              case t    => t.redraw()
+            }
+          }
         }
       case _ => //
     }
 
-  def shutdown(): Unit =
-    askUserThread match {
-      case Some(x) if x.isAlive =>
-        x.interrupt()
-        askUserThread = None
+  def shutdown(): Unit = askUserThread.synchronized {
+    askUserThread.get match {
+      case null =>
+      case t if t.isAlive =>
+        t.interrupt()
+        askUserThread.set(null)
       case _ => ()
     }
+  }
 }

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -23,7 +23,7 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
     case Some(pf) => pf(s)
     case None =>
       def ansi(s: String): String = if (ConsoleAppender.formatEnabledInEnv) s"$s" else ""
-      s"${ansi(ConsoleAppender.DeleteLine)}> ${ansi(ConsoleAppender.clearScreen(0))}"
+      s"${ansi(ConsoleAppender.DeleteLine)}> ${ansi(ConsoleAppender.ClearScreenAfterCursor)}"
   }
   private[this] class AskUserThread(s: State) extends Thread("ask-user-thread") {
     private val history = s.get(historyPath).getOrElse(Some(new File(s.baseDir, ".history")))
@@ -52,7 +52,7 @@ private[sbt] final class ConsoleChannel(val name: String) extends CommandChannel
     def redraw(): Unit = {
       System.out.print(ConsoleAppender.clearLine(0))
       reader.redraw()
-      System.out.print(ConsoleAppender.clearScreen(0))
+      System.out.print(ConsoleAppender.ClearScreenAfterCursor)
       System.out.flush()
     }
   }

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -12,18 +12,20 @@ package client
 import java.io.{ File, IOException }
 import java.util.UUID
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
-import scala.collection.mutable.ListBuffer
-import scala.util.control.NonFatal
-import scala.util.{ Success, Failure }
-import scala.sys.process.{ BasicIO, Process, ProcessLogger }
-import sbt.protocol._
-import sbt.internal.protocol._
+
 import sbt.internal.langserver.{ LogMessageParams, MessageType, PublishDiagnosticsParams }
-import sbt.internal.util.{ JLine, ConsoleAppender }
-import sbt.util.Level
-import sbt.io.syntax._
+import sbt.internal.protocol._
+import sbt.internal.util.{ ConsoleAppender, JLine }
 import sbt.io.IO
+import sbt.io.syntax._
+import sbt.protocol._
+import sbt.util.Level
 import sjsonnew.support.scalajson.unsafe.Converter
+
+import scala.collection.mutable.ListBuffer
+import scala.sys.process.{ BasicIO, Process, ProcessLogger }
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Success }
 
 class NetworkClient(configuration: xsbti.AppConfiguration, arguments: List[String]) { self =>
   private val channelName = new AtomicReference("_")

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import sbt.internal.langserver.{ LogMessageParams, MessageType, PublishDiagnosticsParams }
 import sbt.internal.protocol._
-import sbt.internal.util.{ ConsoleAppender, JLine }
+import sbt.internal.util.{ ConsoleAppender, LineReader }
 import sbt.io.IO
 import sbt.io.syntax._
 import sbt.protocol._
@@ -216,7 +216,7 @@ class NetworkClient(configuration: xsbti.AppConfiguration, arguments: List[Strin
   }
 
   def shell(): Unit = {
-    val reader = JLine.simple(None, JLine.HandleCONT, injectThreadSleep = true)
+    val reader = LineReader.simple(None, LineReader.HandleCONT, injectThreadSleep = true)
     while (running.get) {
       reader.readLine("> ", None) match {
         case Some("shutdown") =>

--- a/main/src/main/scala/sbt/CommandLineUIService.scala
+++ b/main/src/main/scala/sbt/CommandLineUIService.scala
@@ -7,7 +7,7 @@
 
 package sbt
 
-import sbt.internal.util.{ JLine, SimpleReader }
+import sbt.internal.util.{ SimpleReader, Terminal }
 
 trait CommandLineUIService extends InteractionService {
   override def readLine(prompt: String, mask: Boolean): Option[String] = {
@@ -27,9 +27,9 @@ trait CommandLineUIService extends InteractionService {
     }
   }
 
-  override def terminalWidth: Int = JLine.terminal.getWidth
+  override def terminalWidth: Int = Terminal.getWidth
 
-  override def terminalHeight: Int = JLine.terminal.getHeight
+  override def terminalHeight: Int = Terminal.getHeight
 }
 
 object CommandLineUIService extends CommandLineUIService

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1516,7 +1516,7 @@ object Defaults extends BuildCommon {
     classes match {
       case multiple if multiple.size > 1 && logWarning =>
         val msg =
-          "Multiple main classes detected. Run 'show discoveredMainClasses' to see the list."
+          "multiple main classes detected: run 'show discoveredMainClasses' to see the list"
         logger.warn(msg)
       case _ =>
     }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1486,7 +1486,24 @@ object Defaults extends BuildCommon {
     }
 
   def askForMainClass(classes: Seq[String]): Option[String] =
-    sbt.SelectMainClass(Some(SimpleReader readLine _), classes)
+    sbt.SelectMainClass(
+      if (classes.length >= 10) Some(SimpleReader.readLine(_))
+      else
+        Some(s => {
+          def print(st: String) = { scala.Console.out.print(st); scala.Console.out.flush() }
+          print(s)
+          Terminal.withRawSystemIn {
+            Terminal.wrappedSystemIn.read match {
+              case -1 => None
+              case b =>
+                val res = b.toChar.toString
+                println(res)
+                Some(res)
+            }
+          }
+        }),
+      classes
+    )
 
   def pickMainClass(classes: Seq[String]): Option[String] =
     sbt.SelectMainClass(None, classes)

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -260,10 +260,7 @@ object EvaluateTask {
             ps.reset()
             ConsoleAppender.setShowProgress(true)
             val appender = MainAppender.defaultScreen(StandardMain.console)
-            appender match {
-              case c: ConsoleAppender => c.setProgressState(ps)
-              case _                  =>
-            }
+            ProgressState.set(ps)
             val log = LogManager.progressLogger(appender)
             Some(new TaskProgress(log))
           case _ => None

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -900,6 +900,9 @@ object BuiltinCommands {
       .getOpt(Keys.minForcegcInterval)
       .getOrElse(GCUtil.defaultMinForcegcInterval)
     val exec: Exec = exchange.blockUntilNextExec(minGCInterval, s1.globalLogging.full)
+    if (exec.source.fold(true)(_.channelName != "console0")) {
+      s1.log.info(s"Running remote command: ${exec.commandLine}")
+    }
     val newState = s1
       .copy(
         onFailure = Some(Exec(Shell, None)),

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -9,7 +9,7 @@ package sbt
 
 import java.io.{ File, IOException }
 import java.net.URI
-import java.nio.file.{ FileAlreadyExistsException, Files, FileSystems }
+import java.nio.file.{ FileAlreadyExistsException, FileSystems, Files }
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{ Locale, Properties }
@@ -23,7 +23,7 @@ import sbt.internal._
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util._
-import sbt.internal.util.complete.{ SizeParser, Parser }
+import sbt.internal.util.complete.{ Parser, SizeParser }
 import sbt.io._
 import sbt.io.syntax._
 import sbt.util.{ Level, Logger, Show }
@@ -888,7 +888,7 @@ object BuiltinCommands {
   }
 
   def shell: Command = Command.command(Shell, Help.more(Shell, ShellDetailed)) { s0 =>
-    import sbt.internal.{ ConsolePromptEvent, ConsoleUnpromptEvent }
+    import sbt.internal.ConsolePromptEvent
     val exchange = StandardMain.exchange
     val welcomeState = displayWelcomeBanner(s0)
     val s1 = exchange run welcomeState
@@ -904,7 +904,6 @@ object BuiltinCommands {
         remainingCommands = exec +: Exec(Shell, None) +: s1.remainingCommands
       )
       .setInteractive(true)
-    exchange publishEventMessage ConsoleUnpromptEvent(exec.source)
     if (exec.commandLine.trim.isEmpty) newState
     else newState.clearGlobalLog
   }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -776,11 +776,11 @@ object BuiltinCommands {
 
     result.toChar match {
       case '\n' | '\r' => retry
-      case 'r'         => retry
-      case 'q'         => s.exit(ok = false)
-      case 'i'         => s.log.warn(s"Ignoring load failure: $ignoreMsg."); s
-      case 'l'         => LastCommand :: loadProjectCommand(LoadFailed, loadArg) :: s
-      case _           => println("Invalid response."); doLoadFailed(s, loadArg)
+      case 'r' | 'R'   => retry
+      case 'q' | 'Q'   => s.exit(ok = false)
+      case 'i' | 'I'   => s.log.warn(s"Ignoring load failure: $ignoreMsg."); s
+      case 'l' | 'L'   => LastCommand :: loadProjectCommand(LoadFailed, loadArg) :: s
+      case c           => println(s"Invalid response: '$c'"); doLoadFailed(s, loadArg)
     }
   }
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -900,7 +900,7 @@ object BuiltinCommands {
       .getOrElse(GCUtil.defaultMinForcegcInterval)
     val exec: Exec = exchange.blockUntilNextExec(minGCInterval, s1.globalLogging.full)
     if (exec.source.fold(true)(_.channelName != "console0")) {
-      s1.log.info(s"Running remote command: ${exec.commandLine}")
+      s1.log.info(s"received remote command: ${exec.commandLine}")
     }
     val newState = s1
       .copy(

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -10,12 +10,11 @@ package sbt
 import java.io.PrintWriter
 import java.util.Properties
 
-import jline.TerminalFactory
 import sbt.internal.{ Aggregation, ShutdownHooks }
 import sbt.internal.langserver.ErrorCodes
 import sbt.internal.protocol.JsonRpcResponseError
 import sbt.internal.util.complete.Parser
-import sbt.internal.util.{ ErrorHandling, GlobalLogBacking }
+import sbt.internal.util.{ ErrorHandling, GlobalLogBacking, Terminal }
 import sbt.io.{ IO, Using }
 import sbt.protocol._
 import sbt.util.Logger
@@ -31,7 +30,7 @@ object MainLoop {
     // We've disabled jline shutdown hooks to prevent classloader leaks, and have been careful to always restore
     // the jline terminal in finally blocks, but hitting ctrl+c prevents finally blocks from being executed, in that
     // case the only way to restore the terminal is in a shutdown hook.
-    val shutdownHook = ShutdownHooks.add(() => TerminalFactory.get().restore())
+    val shutdownHook = ShutdownHooks.add(Terminal.restore)
 
     try {
       runLoggedLoop(state, state.globalLogging.backing)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -364,10 +364,6 @@ private[sbt] final class CommandExchange {
         channels collect {
           case c: ConsoleChannel => c.publishEventMessage(entry)
         }
-      case entry: ConsoleUnpromptEvent =>
-        channels collect {
-          case c: ConsoleChannel => c.publishEventMessage(entry)
-        }
       case entry: ExecStatusEvent =>
         channels collect {
           case c: ConsoleChannel =>

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -10,7 +10,7 @@ package internal
 
 import sbt.internal.classpath.AlternativeZincUtil
 import sbt.internal.inc.{ ScalaInstance, ZincLmUtil }
-import sbt.internal.util.JLine
+import sbt.internal.util.Terminal
 import sbt.util.Logger
 import xsbti.compile.ClasspathOptionsUtil
 
@@ -61,7 +61,7 @@ object ConsoleProject {
     val importString = imports.mkString("", ";\n", ";\n\n")
     val initCommands = importString + extra
 
-    JLine.usingTerminal { _ =>
+    Terminal.withCanonicalIn {
       // TODO - Hook up dsl classpath correctly...
       (new Console(compiler))(
         unit.classpath,

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -26,7 +26,7 @@ import sbt.internal.io.WatchState
 import sbt.internal.nio._
 import sbt.internal.util.complete.Parser._
 import sbt.internal.util.complete.{ Parser, Parsers }
-import sbt.internal.util.{ AttributeKey, JLine, Util }
+import sbt.internal.util.{ AttributeKey, Terminal, Util }
 import sbt.nio.Keys.{ fileInputs, _ }
 import sbt.nio.Watch.{ Creation, Deletion, ShowOptions, Update }
 import sbt.nio.file.{ FileAttributes, Glob }
@@ -272,11 +272,8 @@ private[sbt] object Continuous extends DeprecatedContinuous {
     f(s, valid, invalid)
   }
 
-  private[this] def withCharBufferedStdIn[R](f: InputStream => R): R = {
-    val terminal = JLine.terminal
-    terminal.init()
-    terminal.setEchoEnabled(true)
-    val wrapped = terminal.wrapInIfNeeded(System.in)
+  private[this] def withCharBufferedStdIn[R](f: InputStream => R): R = Terminal.withRawSystemIn {
+    val wrapped = Terminal.wrappedSystemIn
     if (Util.isNonCygwinWindows) {
       val inputStream: InputStream with AutoCloseable = new InputStream with AutoCloseable {
         private[this] val buffer = new java.util.LinkedList[Int]

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -288,10 +288,13 @@ private[sbt] object Continuous extends DeprecatedContinuous {
           override def run(): Unit = {
             try {
               if (!closed.get()) {
-                buffer.add(wrapped.read())
+                wrapped.read() match {
+                  case -1 => closed.set(true)
+                  case b  => buffer.add(b)
+                }
               }
             } catch {
-              case _: InterruptedException =>
+              case _: InterruptedException => closed.set(true)
             }
             if (!closed.get()) run()
           }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -9,6 +9,7 @@ package sbt
 package internal
 
 import java.io.PrintWriter
+
 import Def.ScopedKey
 import Scope.GlobalScope
 import Keys.{ logLevel, logManager, persistLogLevel, persistTraceLevel, sLog, traceLevel }
@@ -16,13 +17,14 @@ import sbt.internal.util.{
   AttributeKey,
   ConsoleAppender,
   ConsoleOut,
+  MainAppender,
+  ManagedLogger,
+  ProgressState,
   Settings,
-  SuppressedTraceContext,
-  MainAppender
+  SuppressedTraceContext
 }
 import MainAppender._
-import sbt.util.{ Level, Logger, LogExchange }
-import sbt.internal.util.ManagedLogger
+import sbt.util.{ Level, LogExchange, Logger }
 import org.apache.logging.log4j.core.Appender
 
 sealed abstract class LogManager {
@@ -142,10 +144,7 @@ object LogManager {
     val extraBacked = state.globalLogging.backed :: relay :: Nil
     val ps = Project.extract(state).get(sbt.Keys.progressState in ThisBuild)
     val consoleOpt = consoleLocally(state, console)
-    consoleOpt foreach {
-      case a: ConsoleAppender => ps.foreach(a.setProgressState)
-      case _                  =>
-    }
+    ps.foreach(ProgressState.set)
     val config = MainAppender.MainAppenderConfig(
       consoleOpt,
       backed,

--- a/main/src/main/scala/sbt/internal/SettingGraph.scala
+++ b/main/src/main/scala/sbt/internal/SettingGraph.scala
@@ -8,13 +8,13 @@
 package sbt
 package internal
 
-import sbt.internal.util.{ JLine }
 import sbt.util.Show
-
 import java.io.File
-import Def.{ compiled, flattenLocals, ScopedKey }
-import Predef.{ any2stringadd => _, _ }
 
+import Def.{ ScopedKey, compiled, flattenLocals }
+import sbt.internal.util.Terminal
+
+import Predef.{ any2stringadd => _, _ }
 import sbt.io.IO
 
 object SettingGraph {
@@ -82,7 +82,7 @@ object Graph {
   // [info]   |
   // [info]   +-quux
   def toAscii[A](top: A, children: A => Seq[A], display: A => String, defaultWidth: Int): String = {
-    val maxColumn = math.max(JLine.terminal.getWidth, defaultWidth) - 8
+    val maxColumn = math.max(Terminal.getWidth, defaultWidth) - 8
     val twoSpaces = " " + " " // prevent accidentally being converted into a tab
     def limitLine(s: String): String =
       if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -94,7 +94,7 @@ object SysProp {
   def supershell: Boolean = booleanOpt("sbt.supershell").getOrElse(!dumbTerm && color)
 
   def supershellSleep: Long = long("sbt.supershell.sleep", 100L)
-  def supershellBlankZone: Int = int("sbt.supershell.blankzone", 5)
+  def supershellBlankZone: Int = int("sbt.supershell.blankzone", 1)
 
   def defaultUseCoursier: Boolean = {
     val coursierOpt = booleanOpt("sbt.coursier")

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -90,7 +90,7 @@ object SysProp {
 
   def fileCacheSize: Long =
     SizeParser(System.getProperty("sbt.file.cache.size", "128M")).getOrElse(128L * 1024 * 1024)
-  def dumbTerm: Boolean = sys.env.get("TERM").filter(_ == "dumb").isDefined
+  def dumbTerm: Boolean = sys.env.get("TERM").contains("dumb")
   def supershell: Boolean = booleanOpt("sbt.supershell").getOrElse(!dumbTerm && color)
 
   def supershellSleep: Long = long("sbt.supershell.sleep", 100L)

--- a/run/src/main/scala/sbt/SelectMainClass.scala
+++ b/run/src/main/scala/sbt/SelectMainClass.scala
@@ -7,6 +7,7 @@
 
 package sbt
 
+import sbt.internal.util.ConsoleAppender
 import sbt.internal.util.Util.{ AnyOps, none }
 
 object SelectMainClass {
@@ -19,12 +20,14 @@ object SelectMainClass {
       case Nil         => None
       case head :: Nil => Some(head)
       case multiple =>
-        promptIfMultipleChoices flatMap { prompt =>
-          println("\nMultiple main classes detected, select one to run:\n")
-          for ((className, index) <- multiple.zipWithIndex)
-            println(" [" + (index + 1) + "] " + className)
+        promptIfMultipleChoices.flatMap { prompt =>
+          val header = "\nMultiple main classes detected. Select one to run:\n"
+          val classes = multiple.zipWithIndex
+            .map { case (className, index) => s" [${index + 1}] $className" }
+            .mkString("\n")
+          println(ConsoleAppender.clearScreen(0) + header + classes)
+
           val line = trim(prompt("\nEnter number: "))
-          println("")
           toInt(line, multiple.length) map multiple.apply
         }
     }

--- a/run/src/main/scala/sbt/SelectMainClass.scala
+++ b/run/src/main/scala/sbt/SelectMainClass.scala
@@ -25,7 +25,7 @@ object SelectMainClass {
           val classes = multiple.zipWithIndex
             .map { case (className, index) => s" [${index + 1}] $className" }
             .mkString("\n")
-          println(ConsoleAppender.clearScreen(0) + header + classes)
+          println(ConsoleAppender.ClearScreenAfterCursor + header + classes)
 
           val line = trim(prompt("\nEnter number: "))
           toInt(line, multiple.length) map multiple.apply


### PR DESCRIPTION
This PR makes a number of enhancements to terminal io. Because of how the changes stacked on top of each other, it both was difficult to split this into many smaller PRs. Every individual commit in the PR compiles and should likely pass scripted.

The two main changes are:
1. Adds a new `Terminal` class which is used to do things like switch the tty mode between canonical and raw mode and also access properties like the height and width of the terminal. 
2. Changes the global `java.lang.System.out` and `scala.Console.out` to go through a proxy. This enables us to make supershell work with `println`. It also allows us to make supershell work when output has been printed without a newline by reseting the cursor back to where the previous output left off.

The impact of item 2 can be seen in some recorded terminal sessions. First I made a simple project that ran a task that depended on 8 other tasks that each just print some random lines to System.out. Here is what it looks like with 1.3.5:
[![asciicast](https://asciinema.org/a/bU4QN2jYdeQG10rP67sPiy7mD.svg)](https://asciinema.org/a/bU4QN2jYdeQG10rP67sPiy7mD)
And here is what it looks like with these changes:
[![asciicast](https://asciinema.org/a/GJ3oXZYRps2B2edWsc1c0hKqb.svg)](https://asciinema.org/a/GJ3oXZYRps2B2edWsc1c0hKqb)

The run task didn't really work with supershell before (https://github.com/sbt/sbt/issues/5246):
[![asciicast](https://asciinema.org/a/zGPdHdKXwsT5AQHJ42PkgITWJ.svg)](https://asciinema.org/a/zGPdHdKXwsT5AQHJ42PkgITWJ)
Now the cursor correctly moves back to the right place:
[![asciicast](https://asciinema.org/a/AHp7zyxIWCYD8ia7EOkOSBkr5.svg)](https://asciinema.org/a/AHp7zyxIWCYD8ia7EOkOSBkr5)
I also made it so that if there are fewer than 10 main classes that the user doesn't have to enter a newline to select the class.

I also made some improvements to `ConsoleChannel` and the `CommandExchange` that makes the output more sane when a client connects and runs commands. With 1.3.5, the output could get mixed with the shell prompt and the prompt wasn't restored after the command completed:
[![asciicast](https://asciinema.org/a/UQ3grChhP44mOsIJWQXMMM3W5.svg)](https://asciinema.org/a/UQ3grChhP44mOsIJWQXMMM3W5)
Now the output is saner and sbt logs what command is being invoked by the network client:
[![asciicast](https://asciinema.org/a/UCJO4yA93S6EzrTQLoDHEWTdu.svg)](https://asciinema.org/a/UCJO4yA93S6EzrTQLoDHEWTdu)

Miscellaneous fixes:
* Clear the current line and the screen to the bottom in the shell prompt. This prevents stray supershell lines from ending up stuck at the bottom.
* We no longer poll System.in in `ConsoleChannel` and block instead. As a result the cpu utilization of sbt when idle drops from about 2% to 0% on my computer. Input latency should also be slightly lower.
* In continuous, we stop trying to read from System.in if we read a -1 byte that indicates the channel has closed.

Fixes #5246  
I think should fix #5162 