### PR TITLE
Clarify message on sbt.version mismatch

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -827,8 +827,8 @@ object BuiltinCommands {
     sbtVersionOpt.foreach(
       version =>
         if (version != app.id.version()) {
-          state.log.warn(s"""sbt version mismatch, current: ${app.id
-            .version()}, in build.properties: "$version", use 'reboot' to use the new value.""")
+          state.log.warn(s"""sbt version mismatch, using: ${app.id
+            .version()}, in build.properties: "$version".""")
         }
     )
   }

--- a/sbt/src/sbt-test/project/sbt-version-change/build.sbt
+++ b/sbt/src/sbt-test/project/sbt-version-change/build.sbt
@@ -3,6 +3,6 @@ TaskKey[Unit]("checkSbtVersionWarning") := {
 	val logging = state.globalLogging
 	val currVersion = state.configuration.provider.id.version()
 	val contents = IO.read(logging.backing.file)
-	assert(contents.contains(s"""sbt version mismatch, current: $currVersion, in build.properties: "1.1.1", use 'reboot' to use the new value."""))
+	assert(contents.contains(s"""sbt version mismatch, using: $currVersion, in build.properties: "1.1.1"."""))
 	()
 }


### PR DESCRIPTION
Fixes #4291

I removed the metion to `reboot` as it's not working. 
I also don't think this is something that needs to be fixed. If someone wants to use the version in `build.properties`, then better to restart sbt again without passing `-Dsbt.version`.