### PR TITLE
Run cross commands (with `+`) in parallel when possible

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -194,7 +194,13 @@ object Cross {
           .sortBy(_._1)
         commandsByVersion.flatMap {
           case (v, commands) =>
-            Seq(s"$SwitchCommand $verbose $v!") ++ commands
+            commands match {
+              case Seq(c) => Seq(s"$SwitchCommand $verbose $v! $c")
+              case Seq()  => Nil // should be unreachable
+              case multi if fullArgs.isEmpty =>
+                Seq(s"$SwitchCommand $verbose $v! all ${multi.mkString(" ")}")
+              case multi => Seq(s"$SwitchCommand $verbose $v!") ++ multi
+            }
         }
     }
     allCommands.toList ::: CrossRestoreSessionCommand :: captureCurrentSession(state, extracted)

--- a/sbt/src/sbt-test/actions/cross-multiproject/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-multiproject/build.sbt
@@ -1,6 +1,6 @@
 lazy val scala212 = "2.12.10"
 // keep this at M5 to test full version
-lazy val scala213 = "2.13.0-M5"
+lazy val scala213 = "2.13.1"
 
 ThisBuild / crossScalaVersions := Seq(scala212, scala213)
 ThisBuild / scalaVersion       := scala212

--- a/sbt/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt/src/sbt-test/actions/cross-multiproject/test
@@ -1,43 +1,43 @@
 > + compile
 $ exists lib/target/scala-2.12
-$ exists lib/target/scala-2.13.0-M5
+$ exists lib/target/scala-2.13
 $ exists sbt-foo/target/scala-2.12
--$ exists sbt-foo/target/scala-2.13.0-M5
+-$ exists sbt-foo/target/scala-2.13
 
 > clean
 > + libProj/compile
 $ exists lib/target/scala-2.12
-$ exists lib/target/scala-2.13.0-M5
+$ exists lib/target/scala-2.13
 -$ exists sbt-foo/target/scala-2.12
--$ exists sbt-foo/target/scala-2.13.0-M5
+-$ exists sbt-foo/target/scala-2.13
 
 # test safe switching
 > clean
 > ++ 2.12.10 -v compile
 $ exists lib/target/scala-2.12
--$ exists lib/target/scala-2.13.0-M5
+-$ exists lib/target/scala-2.13
 $ exists sbt-foo/target/scala-2.12
--$ exists sbt-foo/target/scala-2.13.0-M5
+-$ exists sbt-foo/target/scala-2.13
 
 # Test legacy cross build with command support
 # > clean
 # > + build
 # $ exists lib/target/scala-2.12
-# $ exists lib/target/scala-2.13.0-M5
+# $ exists lib/target/scala-2.13
 # $ exists sbt-foo/target/scala-2.12
-# -$ exists sbt-foo/target/scala-2.13.0-M5
+# -$ exists sbt-foo/target/scala-2.13
 
 # Test ++ leaves crossScalaVersions unchanged
 > clean
 > ++2.12.10
 > +extrasProj/compile
-$ exists extras/target/scala-2.13.0-M5
+$ exists extras/target/scala-2.13
 $ exists extras/target/scala-2.12
 
 # test safe switching
 > clean
-> ++ 2.13.0-M5 -v compile
-$ exists lib/target/scala-2.13.0-M5
+> ++ 2.13.1 -v compile
+$ exists lib/target/scala-2.13
 -$ exists lib/target/scala-2.12
 # -$ exists sbt-foo/target/scala-2.12
--$ exists sbt-foo/target/scala-2.13.0-M5
+-$ exists sbt-foo/target/scala-2.13

--- a/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-strict-aggregation/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala212 = "2.12.10"
-lazy val scala213 = "2.13.0-M5"
+lazy val scala213 = "2.13.1"
 
 ThisBuild / scalaVersion := scala212
 

--- a/sbt/src/sbt-test/actions/cross-strict-aggregation/test
+++ b/sbt/src/sbt-test/actions/cross-strict-aggregation/test
@@ -1,7 +1,7 @@
 -> ++2.12.0-magic
 
-> ++2.13.0-M5 compile
+> ++2.13.1 compile
 
-$ exists core/target/scala-2.13.0-M5
--$ exists module/target/scala-2.13.0-M5
+$ exists core/target/scala-2.13
+-$ exists module/target/scala-2.13
 -$ exists module/target/scala-2.12

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala212 = "2.12.10"
-lazy val scala213 = "2.13.0-M5"
+lazy val scala213 = "2.13.1"
 ThisBuild / scalaVersion := scala212
 
 lazy val root = (project in file("."))

--- a/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/test
+++ b/sbt/src/sbt-test/compiler-project/separate-analysis-per-scala/test
@@ -1,3 +1,3 @@
 > + compile
 $ exists target/scala-2.12
-$ exists target/scala-2.13.0-M5
+$ exists target/scala-2.13


### PR DESCRIPTION
There was a performance regression introduced in #5265 that was reported in #5321. This PR reverts back to the 1.3.4 behavior that uses `all` when possible to run the multi commands in parallel.