### PR TITLE
Ability to disable legacy JUnit report filenames

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -131,4 +131,6 @@ object SysProp {
           case None       => true
         }
     }
+  
+  def legacyTestingReport: Booelan = getOrFalse("sbt.testing.legacyreport")
 }

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -132,5 +132,5 @@ object SysProp {
         }
     }
   
-  def legacyTestingReport: Booelan = getOrFalse("sbt.testing.legacyreport")
+  def legacyTestingReport: Boolean = getOrTrue("sbt.testing.legacyreport")
 }


### PR DESCRIPTION
Addresses suggestion in #4451