### PR TITLE
introduce SysProp sbt.testing.legacyreport

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -70,6 +70,7 @@ object SysProp {
   def client: Boolean = getOrFalse("sbt.client")
   def ci: Boolean = getOrFalse("sbt.ci")
   def allowRootDir: Boolean = getOrFalse("sbt.rootdir")
+  def legacyTestReport: Boolean = getOrFalse("sbt.testing.legacyreport")
 
   def watchMode: String =
     sys.props.get("sbt.watch.mode").getOrElse("auto")

--- a/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
@@ -10,6 +10,7 @@ package plugins
 
 import Def.Setting
 import Keys._
+import sbt.internal.SysProp
 
 /**
  * An experimental plugin that adds the ability for junit-xml to be generated.
@@ -30,6 +31,10 @@ object JUnitXmlReportPlugin extends AutoPlugin {
   // It might be a good idea to derive this setting into specific test scopes.
   override lazy val projectSettings: Seq[Setting[_]] =
     Seq(
-      testListeners += new JUnitXmlTestsListener(target.value.getAbsolutePath, streams.value.log)
+      testListeners += new JUnitXmlTestsListener(
+        target.value.getAbsolutePath,
+        streams.value.log,
+        SysProp.legacyTestReport
+      )
     )
 }

--- a/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
@@ -33,8 +33,8 @@ object JUnitXmlReportPlugin extends AutoPlugin {
     Seq(
       testListeners += new JUnitXmlTestsListener(
         target.value.getAbsolutePath,
-        streams.value.log,
-        SysProp.legacyTestReport
+        SysProp.legacyTestReport,
+        streams.value.log
       )
     )
 }

--- a/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
+++ b/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
@@ -5,11 +5,11 @@ import Defaults._
 val checkReport = taskKey[Unit]("Check the test reports")
 val checkNoReport = taskKey[Unit]("Check that no reports are present")
 
-val oneSecondReportFile = "target/test-reports/a.pkg.OneSecondTest.xml"
-val failingReportFile = "target/test-reports/another.pkg.FailingTest.xml"
+val oneSecondReportFile = "target/test-reports/TEST-a.pkg.OneSecondTest.xml"
+val failingReportFile = "target/test-reports/TEST-another.pkg.FailingTest.xml"
 
-val flatSuiteReportFile = "target/test-reports/my.scalatest.MyFlatSuite.xml"
-val nestedSuitesReportFile = "target/test-reports/my.scalatest.MyNestedSuites.xml"
+val flatSuiteReportFile = "target/test-reports/TEST-my.scalatest.MyFlatSuite.xml"
+val nestedSuitesReportFile = "target/test-reports/TEST-my.scalatest.MyNestedSuites.xml"
 
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -33,9 +33,10 @@ import sbt.protocol.testing.TestResult
  * report format.
  * @param outputDir path to the dir in which a folder with results is generated
  */
-class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends TestsListener {
+class JUnitXmlTestsListener(val outputDir: String, logger: Logger, legacyTestReport: Boolean)
+    extends TestsListener {
   // This constructor is for binary compatibility with older versions of sbt.
-  def this(outputDir: String) = this(outputDir, null)
+  def this(outputDir: String) = this(outputDir, null, false)
 
   /**Current hostname so we know which machine executed the tests*/
   val hostname: String = {
@@ -248,14 +249,14 @@ class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends Tests
     d.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
   private def writeSuite(): Unit = {
-    val legacyFile =
+    val file = if (legacyTestReport) {
       new File(targetDir, s"${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
-    val file =
+    } else {
       new File(targetDir, s"TEST-${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
+    }
     // TODO would be nice to have a logger and log this with level debug
     // System.err.println("Writing JUnit XML test report: " + file)
     val testSuiteResult = withTestSuite(_.stop())
-    XML.save(legacyFile, testSuiteResult, "UTF-8", xmlDecl = true, null)
     XML.save(file, testSuiteResult, "UTF-8", xmlDecl = true, null)
     testSuite.remove()
   }

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -33,10 +33,11 @@ import sbt.protocol.testing.TestResult
  * report format.
  * @param outputDir path to the dir in which a folder with results is generated
  */
-class JUnitXmlTestsListener(val outputDir: String, logger: Logger, legacyTestReport: Boolean)
+class JUnitXmlTestsListener(val outputDir: String, legacyTestReport: Boolean, logger: Logger)
     extends TestsListener {
-  // This constructor is for binary compatibility with older versions of sbt.
-  def this(outputDir: String) = this(outputDir, null, false)
+  // These constructors are for binary compatibility with older versions of sbt.
+  def this(outputDir: String, logger: Logger) = this(outputDir, false, logger)
+  def this(outputDir: String) = this(outputDir, false, null)
 
   /**Current hostname so we know which machine executed the tests*/
   val hostname: String = {


### PR DESCRIPTION
either create test reports with legacy file names (legacyreport=true) or with standard file names (legacyreport=false or omitted) but not both as suggested in #4451