### PR TITLE
Don't use last modified time of directories in doc

### DIFF
--- a/main-actions/src/main/scala/sbt/RawCompileLike.scala
+++ b/main-actions/src/main/scala/sbt/RawCompileLike.scala
@@ -56,10 +56,9 @@ object RawCompileLike {
       type Inputs =
         FilesInfo[HashFileInfo] :+: FilesInfo[ModifiedFileInfo] :+: Seq[File] :+: File :+:
           Seq[String] :+: Int :+: HNil
-      val inputs
-          : Inputs = hash(sources.toSet ++ optionFiles(options, fileInputOpts)) :+: lastModified(
-        classpath.toSet
-      ) :+: classpath :+: outputDirectory :+: options :+: maxErrors :+: HNil
+      val inputs: Inputs = hash(sources.toSet ++ optionFiles(options, fileInputOpts)) :+:
+        FilesInfo(classpath.toSet.map(lastModified.fileOrDirectoryMax)) :+: classpath :+:
+        outputDirectory :+: options :+: maxErrors :+: HNil
       val cachedComp = inputChanged(cacheStoreFactory make "inputs") { (inChanged, in: Inputs) =>
         inputChanged(cacheStoreFactory make "output") {
           (outChanged, outputs: FilesInfo[PlainFileInfo]) =>


### PR DESCRIPTION
I noticed that sbt does a _lot_ of no-op docs in the sbt project.
Through some debugging, I determined that this was because the target
directory last modified time of some of the dependent projects would
change between runs. I'm not really sure why that was happening but
instead of computing the last modified time of the directory, we should
be checking the last modified time of the directory contents.

After this change a no-op `doc` in the sbt project returns in less than
one second on my mac. Before, it was more like 25-60 seconds (the upper
bound is one runs `doc` because `sbtRoot/doc` takes about a minute).