### PR TITLE
Make publishLocalBin work without prior publishLocal

### DIFF
--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -180,7 +180,7 @@ object IvyXml {
     </ivy-module>
   }
 
-  private def makeIvyXmlBefore[T](
+  private[sbt] def makeIvyXmlBefore[T](
       task: TaskKey[T],
       shadedConfigOpt: Option[Configuration]
   ): Setting[Task[T]] =

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -1,7 +1,11 @@
-import sbt._, Keys._
+package sbt
 
-import sbt.librarymanagement.PublishConfiguration
-import sbt.librarymanagement.ConfigRef
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{ FileAlreadyExistsException, Files }
+
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import sbt.Keys._
+import sbt.internal.librarymanagement.{ IvySbt, IvyXml }
 
 /** This local plugin provides ways of publishing just the binary jar. */
 object PublishBinPlugin extends AutoPlugin {
@@ -13,22 +17,51 @@ object PublishBinPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def globalSettings = Seq(publishLocalBin := (()))
+  private val dummyDoc = taskKey[File]("").withRank(Int.MaxValue)
+  override val globalSettings = Seq(publishLocalBin := (()))
 
-  override def projectSettings = Def settings (
+  override val projectSettings: Seq[Def.Setting[_]] = Def settings (
     publishLocalBin := Classpaths.publishTask(publishLocalBinConfig).value,
-    publishLocalBinConfig := {
-      Classpaths.publishConfig(
-        false, // publishMavenStyle.value,
-        Classpaths.deliverPattern(crossTarget.value),
-        if (isSnapshot.value) "integration" else "release",
-        ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
-        (packagedArtifacts in publishLocalBin).value.toVector,
-        (checksums in publishLocalBin).value.toVector,
-        logging = ivyLoggingLevel.value,
-        overwrite = isSnapshot.value
+    publishLocalBinConfig := Classpaths.publishConfig(
+      false, // publishMavenStyle.value,
+      Classpaths.deliverPattern(crossTarget.value),
+      if (isSnapshot.value) "integration" else "release",
+      ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+      (packagedArtifacts in publishLocalBin).value.toVector,
+      (checksums in publishLocalBin).value.toVector,
+      logging = ivyLoggingLevel.value,
+      overwrite = isSnapshot.value
+    ),
+    publishLocalBinConfig := publishLocalBinConfig
+      .dependsOn(
+        // Copied from sbt.internal.
+        Def.taskDyn {
+          val doGen = useCoursier.value
+          if (doGen)
+            Def.task {
+              val currentProject = {
+                val proj = csrProject.value
+                val publications = csrPublications.value
+                proj.withPublications(publications)
+              }
+              IvyXml.writeFiles(currentProject, None, ivySbt.value, streams.value.log)
+            } else
+            Def.task(())
+        }
       )
+      .value,
+    dummyDoc := {
+      val dummyFile = streams.value.cacheDirectory / "doc.jar"
+      try {
+        Files.createDirectories(dummyFile.toPath.getParent)
+        Files.createFile(dummyFile.toPath)
+      } catch { case _: FileAlreadyExistsException => }
+      dummyFile
     },
-    packagedArtifacts in publishLocalBin := Classpaths.packaged(Seq(packageBin in Compile)).value
+    dummyDoc / packagedArtifact := (Compile / packageDoc / artifact).value -> dummyDoc.value,
+    packagedArtifacts in publishLocalBin :=
+      Classpaths
+        .packaged(Seq(packageBin in Compile, packageSrc in Compile, makePom, dummyDoc))
+        .value
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.7


### PR DESCRIPTION
The publish and publishLocal tasks are wired in IvyXml.scala to create
an ivy.xml file before running publish. This wasn't done with
publishLocalBin which made it not work when no ivy.xml file was already
present (which was the case after running clean). To fix this, I had to
copy the logic from IvyXml.scala because there was a bootstrapping
problem. As soon as we publish a version of sbt that has made
makeIvyXmlBefore private[sbt], we can remove all of the duplicated code
in PublishBinPlugin.

I was previously unaware of publishLocalBin, but it's useful for testing
sbt manually because the unneeded `doc` can be quite slow. A clean build
with publishLocalBin on my mac took 45 seconds after this change
compared to 75 seconds for publishLocal. Incremental publishLocalBin
when a single simple file in main is modified takes about 2 seconds
compared to about 30 seconds for publishLocal.