### PR TITLE
Upgrade scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-version = 2.2.1
+version = 2.3.2
+edition = 2019-10
 maxColumn = 100
 project.git = true
 project.excludeFilters = [ "\\Wsbt-test\\W", "\\Winput_sources\\W", "\\Wcontraband-scala\\W" ]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ scalacOptions ++= Seq("-feature", "-language:postfixOps", "-Ywarn-unused:_,-impo
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.4.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Upgrade scalafmt

Intellij has problems with older versions of scalafmt (see
https://github.com/scalameta/scalafmt/issues/1630). Not sure if this a
scalafmt issue or an intellij issue. I pinned the edition to October
2019 to avoid reformatting tons of files. Once development stabilizes,
we may wish to drop the edition but, for now, it's disruptive to change
the formatting.