### PR TITLE
Make IvyXml.writeFiles private[sbt]

### DIFF
--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -180,7 +180,7 @@ object IvyXml {
     </ivy-module>
   }
 
-  private def makeIvyXmlBefore[T](
+  private[sbt] def makeIvyXmlBefore[T](
       task: TaskKey[T],
       shadedConfigOpt: Option[Configuration]
   ): Setting[Task[T]] =


### PR DESCRIPTION
The publishLocalBin doesn't make an ivy.xml file. In order to add that
functionality, we need to make IvyXml.writeFiles available at the
private[sbt] level.