### PR TITLE
[1.3.x] Use project resolvers before dependency resolvers in coursier

### DIFF
--- a/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
@@ -135,9 +135,11 @@ object CoursierRepositoriesTasks {
     Def.taskDyn {
       val s = state.value
       val projectRef = thisProjectRef.value
-      val projects = Project.transitiveInterDependencies(s, projectRef)
+      val dependencyRefs = Project.transitiveInterDependencies(s, projectRef)
       Def.task {
-        csrResolvers.all(ScopeFilter(inProjects(projectRef +: projects: _*))).value.flatten
+        val resolvers = csrResolvers.all(ScopeFilter(inProjects(projectRef))).value ++
+          csrResolvers.all(ScopeFilter(inProjects(dependencyRefs: _*))).value
+        resolvers.flatten
       }
     }
 }


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/5413

csrResolvers.all evaluates all possible scopes in arbitrary order. This change
makes sure at least the project resolvers are placed before any resolvers from
dependency projects.