### PR TITLE
[1.3] Fix consoleProject

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -489,6 +489,9 @@ object Defaults extends BuildCommon {
     clean := clean.dependsOn(cleanIvy).value,
     scalaCompilerBridgeBinaryJar := None,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(scalaVersion.value),
+    consoleProject / scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeModule(
+      appConfiguration.value.provider.scalaProvider.version
+    ),
   )
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -25,7 +25,7 @@ object ConsoleProject {
     val (state1, dependencyResolution) =
       extracted.runTask(Keys.dependencyResolution, state)
     val (_, scalaCompilerBridgeBinaryJar) =
-      extracted.runTask(Keys.scalaCompilerBridgeBinaryJar, state1)
+      extracted.runTask(Keys.scalaCompilerBridgeBinaryJar.in(Keys.consoleProject), state1)
     val scalaInstance = {
       val scalaProvider = state.configuration.provider.scalaProvider
       ScalaInstance(scalaProvider.version, scalaProvider.launcher)
@@ -50,7 +50,8 @@ object ConsoleProject {
           componentProvider = app.provider.components,
           secondaryCacheDir = Option(zincDir),
           dependencyResolution = dependencyResolution,
-          compilerBridgeSource = extracted.get(Keys.scalaCompilerBridgeSource),
+          compilerBridgeSource =
+            extracted.get(Keys.scalaCompilerBridgeSource.in(Keys.consoleProject)),
           scalaJarsTarget = zincDir,
           classLoaderCache = state1.get(BasicKeys.classLoaderCache),
           log = log

--- a/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.13.1"
+
+// Send some bogus initial command so that it doesn't get stuck.
+// The task itself will still succeed.
+consoleProject / initialCommands := "bail!"

--- a/sbt/src/sbt-test/console/project-compiler-bridge/project/build.sbt
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/project/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.12.10"

--- a/sbt/src/sbt-test/console/project-compiler-bridge/test
+++ b/sbt/src/sbt-test/console/project-compiler-bridge/test
@@ -1,0 +1,1 @@
+> consoleProject


### PR DESCRIPTION
`scalaCompilerBridgeSource` will use the session's scalaVersion, which
needn't match sbt's.

For example, try running `consoleProject` after running ++2.13.1.