### PR TITLE
Document parts of AList & components of TupleSyntax

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -223,8 +223,7 @@ object Instance {
     def map[S, T](in: M[S], f: S => T): M[T] = a.map(in, (bv: B[S]) => b.map(bv, f))
     def app[K[L[x]], Z](in: K[M], f: K[Id] => Z)(implicit alist: AList[K]): A[B[Z]] = {
       val g: K[B] => B[Z] = in => b.app[K, Z](in, f)
-      type Split[L[x]] = K[(L ∙ B)#l]
-      a.app[Split, B[Z]](in, g)(AList.asplit(alist))
+      a.app[AList.SplitK[K, B]#l, B[Z]](in, g)(AList.asplit(alist))
     }
   }
 }

--- a/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
@@ -91,9 +91,12 @@ object AList {
     ): N[P[A]] = f(a)
   }
 
-  type ASplit[K[L[x]], B[x]] = AList[λ[L[x] => K[(L ∙ B)#l]]]
+  /** Example: calling `AList.SplitK[K, Task]#l` returns the type lambda `A[x] => K[A[Task[x]]`. */
+  sealed trait SplitK[K[L[x]], B[x]] { type l[A[x]] = K[(A ∙ B)#l] }
 
-  /** AList that operates on the outer type constructor `A` of a composition `[x] A[B[x]]` for type constructors `A` and `B`*/
+  type ASplit[K[L[x]], B[x]] = AList[SplitK[K, B]#l]
+
+  /** AList that operates on the outer type constructor `A` of a composition `[x] A[B[x]]` for type constructors `A` and `B`. */
   def asplit[K[L[x]], B[x]](base: AList[K]): ASplit[K, B] = new ASplit[K, B] {
     type Split[L[x]] = K[(L ∙ B)#l]
 


### PR DESCRIPTION
Also, extract the AList.Split type lambda helper for call-site reuse.