### PR TITLE
Prevent RejectedExecutionException during BackgroundRunnable.cleanup

### DIFF
--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -100,9 +100,12 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
       val workingDirectory: File,
       val job: BackgroundJob
   ) extends AbstractJobHandle {
-    implicit val executionContext: ExecutionContext = StandardMain.executionContext
-    def humanReadableName: String = job.humanReadableName
     // EC for onStop handler below
+    implicit val executionContext: ExecutionContext =
+      ExecutionContext.fromExecutor(pool.executor)
+
+    def humanReadableName: String = job.humanReadableName
+
     job.onStop { () =>
       // TODO: Fix this
       // logger.close()
@@ -305,7 +308,7 @@ private[sbt] class BackgroundThreadPool extends java.io.Closeable {
     }
   }
 
-  private val executor = new java.util.concurrent.ThreadPoolExecutor(
+  private[internal] val executor = new java.util.concurrent.ThreadPoolExecutor(
     0, /* corePoolSize */
     32, /* maxPoolSize, max # of bg tasks */
     2,


### PR DESCRIPTION
As described in https://github.com/sbt/sbt/issues/5226#issuecomment-588986231,  `job.onStop ` callbacks can't be executed on `StandardMain.executionContext` because by the time they are invoked the underlying pool has already been shut down. This leads to an indefinite loop in `AbstractBackgroundJobService.shutdown` that waits for all background jobs to be removed by their `job.onStop` callbacks from `jobSet`.

This PR re-uses the executor of `BackgroundThreadPool` which lives long enough to execute the `job.onStop` callbacks.