### PR TITLE
Fix a message about an undefined setting

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -347,7 +347,7 @@ trait Init[ScopeType] {
       extends RuntimeException("References to undefined settings at runtime.") {
     override def getMessage =
       super.getMessage + undefined.map { u =>
-        "\n" + u.defining + " referenced from " + u.referencedKey
+        "\n" + u.referencedKey + " referenced from " + u.defining
       }.mkString
   }
 


### PR DESCRIPTION
`defining` seems to be a setting or a task that references `referencedKey`, not the other way around.