### PR TITLE
[1.3.x] Fix for JUnitXmlTestsListener that is removing part of test name when it contains a dot

### DIFF
--- a/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
+++ b/sbt/src/sbt-test/tests/junit-xml-report/build.sbt
@@ -26,7 +26,16 @@ lazy val root = (project in file(".")).
       if( oneSecondReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
       // somehow the 'success' event doesn't go through... TODO investigate
 //      if( (oneSecondReport \ "@time").text.toFloat < 1f ) sys.error("expected test to take at least 1 sec")
+      if( (oneSecondReport \ "@tests").text != "1" ) sys.error("expected 1 tests")
+      if( (oneSecondReport \ "@failures").text != "0" ) sys.error("expected 0 failures")
       if( (oneSecondReport \ "@name").text != "a.pkg.OneSecondTest" ) sys.error("wrong fixture name: " + (oneSecondReport \ "@name").text)
+      oneSecondReport foreach { testsuite =>
+        val className = testsuite \ "testcase" \@ "classname"
+        if( className != "a.pkg.OneSecondTest" ) sys.error(s"wrong class name: $className")
+
+        val actualTestName = testsuite \ "testcase" \@ "name"
+        if( actualTestName != "oneSecond") sys.error(s"wrong test names: $actualTestName")
+      }
       // TODO more checks
 
       val failingReport = XML.loadFile(failingReportFile)
@@ -37,17 +46,36 @@ lazy val root = (project in file(".")).
 
       val scalaTestFlatReport = XML.loadFile(flatSuiteReportFile)
       if( scalaTestFlatReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
-      if( (scalaTestFlatReport \ "@tests").text != "2" ) sys.error("expected 2 tests")
+      if( (scalaTestFlatReport \ "@tests").text != "3" ) sys.error("expected 3 tests")
       if( (scalaTestFlatReport \ "@failures").text != "1" ) sys.error("expected 1 failures")
       if( (scalaTestFlatReport \ "@name").text != "my.scalatest.MyFlatSuite" ) sys.error("wrong fixture name: " + (scalaTestFlatReport \ "@name").text)
+      scalaTestFlatReport foreach { testsuite =>
+        val classNames = (testsuite \ "testcase").map(_ \@ "classname")
+        if( classNames.length != 3 ) sys.error(s"expected 3 classname's, actual result: " + classNames.length)
+        if( classNames.toSet != Set("my.scalatest.MyFlatSuite") ) sys.error(s"wrong class names: ${classNames.mkString(", ")}")
+
+        val expectedTestNames = Set(
+          "Passing test should pass",
+          "Passing test should also pass with file.extension",
+          "Failing test should fail"
+        )
+        val actualTestName = (testsuite \ "testcase").map(_ \@ "name")
+        if( actualTestName.toSet != expectedTestNames) sys.error(s"wrong test names: ${actualTestName.mkString(", ")}")
+      }
 
       val nestedSuitesReport = XML.loadFile(nestedSuitesReportFile)
       if( nestedSuitesReport.label != "testsuite" ) sys.error("Report should have a root <testsuite> element.")
       if( (nestedSuitesReport \ "@tests").text != "2" ) sys.error("expected 2 tests")
       if( (nestedSuitesReport \ "@failures").text != "1" ) sys.error("expected 1 failures")
       if( (nestedSuitesReport \ "@name").text != "my.scalatest.MyNestedSuites" ) sys.error("wrong fixture name: " + (nestedSuitesReport \ "@name").text)
-      val actualTestName = (nestedSuitesReport \ "testcase").map(t => (t \ "@name").text)
-      if( actualTestName.toSet != Set("MyInnerSuite.Inner passing test should pass", "MyInnerSuite.Inner failing test should fail")) sys.error(s"wrong test names: ${actualTestName.mkString(", ")}")
+      nestedSuitesReport foreach { testsuite =>
+        val classNames = (testsuite \ "testcase").map(_ \@ "classname")
+        if( classNames.length != 2 ) sys.error(s"expected 2 classname's, actual result: " + classNames.length)
+        if( classNames.toSet != Set("my.scalatest.MyInnerSuite") ) sys.error(s"wrong class names: ${classNames.mkString(", ")}")
+
+        val actualTestName = (testsuite \ "testcase").map(_ \@ "name")
+        if( actualTestName.toSet != Set("Inner passing test should pass", "Inner failing test should fail")) sys.error(s"wrong test names: ${actualTestName.mkString(", ")}")
+      }
 
       // TODO check console output is in the report
     },

--- a/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/scala-tests.scala
+++ b/sbt/src/sbt-test/tests/junit-xml-report/src/test/scala/scala-tests.scala
@@ -6,11 +6,16 @@ package my.scalatest {
 
     }
 
+    it should "also pass with file.extension" in {
+
+    }
+
     "Failing test" should "fail" in {
       sys.error("wah wah")
     }
   }
 
+  @DoNotDiscover
   class MyInnerSuite(arg: String) extends FlatSpec {
     "Inner passing test" should "pass" in {
 


### PR DESCRIPTION
This is a backport of #5139

Fix for JUnitXmlTestsListener removing part of test when it contains dot
Fixes https://github.com/sbt/sbt/issues/5114
Fixes https://github.com/sbt/sbt/issues/2949