### PR TITLE
Update semanticdb to work with scala 2.12.11

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -21,7 +21,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := false,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List("-Yrangepos"),
-    semanticdbVersion := "4.2.3"
+    semanticdbVersion := "4.3.7"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(

--- a/sbt/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt/src/sbt-test/project/semanticdb/build.sbt
@@ -1,5 +1,4 @@
-// TODO: bump to 2.12.11 once scalameta is available
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbIncludeInJar := true
 


### PR DESCRIPTION
was planning to do this along with #5474, but the scripted failures threw me off. Hence this PR