### PR TITLE
Remove ! which forces version

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -159,7 +159,7 @@ object Cross {
         // Execute using a blanket switch
         projCrossVersions.toMap.apply(extracted.currentRef).flatMap { version =>
           // Force scala version
-          Seq(s"$SwitchCommand $verbose $version!", aggCommand)
+          Seq(s"$SwitchCommand $verbose $version", aggCommand)
         }
       case Right((keys, taskArgs)) =>
         def project(key: ScopedKey[_]): Option[ProjectRef] = key.scope.project.toOption match {
@@ -195,11 +195,11 @@ object Cross {
         commandsByVersion.flatMap {
           case (v, commands) =>
             commands match {
-              case Seq(c) => Seq(s"$SwitchCommand $verbose $v! $c")
+              case Seq(c) => Seq(s"$SwitchCommand $verbose $v $c")
               case Seq()  => Nil // should be unreachable
               case multi if fullArgs.isEmpty =>
-                Seq(s"$SwitchCommand $verbose $v! all ${multi.mkString(" ")}")
-              case multi => Seq(s"$SwitchCommand $verbose $v!") ++ multi
+                Seq(s"$SwitchCommand $verbose $v all ${multi.mkString(" ")}")
+              case multi => Seq(s"$SwitchCommand $verbose $v") ++ multi
             }
         }
     }
@@ -323,7 +323,7 @@ object Cross {
         if (included.isEmpty) {
           sys.error(
             s"""Switch failed: no subprojects list "$version" (or compatible version) in crossScalaVersions setting.
-               |If you want to force it regardless, call ++ $version!""".stripMargin
+               |If you want to force it regardless, call ++ $version""".stripMargin
           )
         }
         logSwitchInfo(included, excluded)


### PR DESCRIPTION
Commit 53788ba3561a4e79bc9c36c329f43540ad48814e (and related) started using `$version` with `!` when running a task for multiple versions.

See https://github.com/akka/akka-grpc/pull/907 for a reproducer.

Please note that in this PR I blindly removed all usages of `!` and I should probably have done that in a more selective way. This is why I'm keeping this `DRAFT`.