### PR TITLE
Allow using a projectref across scala versions with cross building

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -158,8 +158,8 @@ object Cross {
 
         // Execute using a blanket switch
         projCrossVersions.toMap.apply(extracted.currentRef).flatMap { version =>
-          // Force scala version
-          Seq(s"$SwitchCommand $verbose $version!", aggCommand)
+          // Set scala version
+          Seq(s"$SwitchCommand $verbose $version", aggCommand)
         }
       case Right((keys, taskArgs)) =>
         def project(key: ScopedKey[_]): Option[ProjectRef] = key.scope.project.toOption match {
@@ -195,11 +195,11 @@ object Cross {
         commandsByVersion.flatMap {
           case (v, commands) =>
             commands match {
-              case Seq(c) => Seq(s"$SwitchCommand $verbose $v! $c")
+              case Seq(c) => Seq(s"$SwitchCommand $verbose $v $c")
               case Seq()  => Nil // should be unreachable
               case multi if fullArgs.isEmpty =>
                 Seq(s"$SwitchCommand $verbose $v! all ${multi.mkString(" ")}")
-              case multi => Seq(s"$SwitchCommand $verbose $v!") ++ multi
+              case multi => Seq(s"$SwitchCommand $verbose $v") ++ multi
             }
         }
     }

--- a/sbt/src/sbt-test/actions/cross-build-with-projectref/build.sbt
+++ b/sbt/src/sbt-test/actions/cross-build-with-projectref/build.sbt
@@ -1,0 +1,25 @@
+val b = Project("b", file("b"))
+  .settings(
+    crossScalaVersions := Seq("2.12.10", "2.13.1"),
+    compile in Compile := {
+      // We'd like to be able to inspect to this 2.12-only project
+      // even while compiling the 2.13 version of 'b'
+      (fullClasspath in Compile in ProjectRef(file("."), "c")).value
+      (compile in Compile).value
+    }
+  )
+
+val c = Project("c", file("c"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    crossScalaVersions := Seq("2.12.10"),
+    libraryDependencies += 
+      // Some library that is not available on 2.13
+      "com.typesafe.akka" %% "akka-actor" % "2.5.0"
+  )
+
+val root = Project("reproduce-5497", file("."))
+  .aggregate(b, c)
+  .settings(
+    crossScalaVersions := Nil
+  )

--- a/sbt/src/sbt-test/actions/cross-build-with-projectref/test
+++ b/sbt/src/sbt-test/actions/cross-build-with-projectref/test
@@ -1,0 +1,1 @@
+> +compile


### PR DESCRIPTION
Reproduces #5497 and contains the fix by @ignasi35 from #5494 - I'm not seeing
actions/cross-test-only fail here