### PR TITLE
Fix DefinesClass implementation for jdk > 8

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -179,7 +179,8 @@ object Defaults extends BuildCommon {
       classpathEntryDefinesClass := {
         val converter = fileConverter.value
         val f = FileValueCache({ x: NioPath =>
-          Locate.definesClass(converter.toVirtualFile(x))
+          if (x.getFileName.toString != "rt.jar") Locate.definesClass(converter.toVirtualFile(x))
+          else ((_: String) => false): DefinesClass
         }).get;
         { (x: File) =>
           f(x.toPath)


### PR DESCRIPTION
When trying to use any jdk > 8 with the latest sbt, sbt will die in some
projects because it tries to call Locate.defineClass on rt.jar, which
is represented with a DummyVirtualFile and causes a crash.