### PR TITLE
Fix coursierint NPE when credential realm is null

### DIFF
--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -231,7 +231,7 @@ object CoursierInputsTasks {
           .withHost(c.host)
           .withUsername(c.userName)
           .withPassword(c.passwd)
-          .withRealm(Some(c.realm).filter(_.nonEmpty))
+          .withRealm(Option(c.realm).filter(_.nonEmpty))
           .withHttpsOnly(false)
           .withMatchHost(true)
       }


### PR DESCRIPTION
As stated in #5492 and #2366 some artifact hosting services (at least
Azure Artifacts, seems to affect GCP as well) do not offer a stable HTTP
Auth realm that can be safely set in SBT credentials, hence the need to
support null or empty Credentials.

The Ivy (publishing) side of the issue was fixed in sbt/ivy#36

As to the resolving side, This commit is only part of the solution as it
just prevents an NPE and does not consider if coursier itself will fall
back to finding credentials with a null realm that matches the server
hostname.

Related-to: #5492
Related-to: #2366
Signed-off-by: Erwan Queffelec <erwan.queffelec@gmail.com>