### PR TITLE
Add user defined tags to Tests.Group to allow for better concurrency control

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -28,7 +28,7 @@ private[sbt] object ForkTests {
       classpath: Seq[File],
       fork: ForkOptions,
       log: Logger,
-      tag: Tag
+      tags: (Tag, Int)*
   ): Task[TestOutput] = {
     val opts = processOptions(config, tests, log)
 
@@ -41,7 +41,7 @@ private[sbt] object ForkTests {
         constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
       else
         mainTestTask(runners, opts, classpath, fork, log, config.parallel).tagw(config.tags: _*)
-    main.tag(tag).dependsOn(all(opts.setup): _*) flatMap { results =>
+    main.tagw(tags: _*).dependsOn(all(opts.setup): _*) flatMap { results =>
       all(opts.cleanup).join.map(_ => results)
     }
   }

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -46,6 +46,18 @@ private[sbt] object ForkTests {
     }
   }
 
+  def apply(
+      runners: Map[TestFramework, Runner],
+      tests: Vector[TestDefinition],
+      config: Execution,
+      classpath: Seq[File],
+      fork: ForkOptions,
+      log: Logger,
+      tag: Tag
+  ): Task[TestOutput] = {
+    apply(runners, tests, config, classpath, fork, log, tag -> 1)
+  }
+
   private[this] def mainTestTask(
       runners: Map[TestFramework, Runner],
       opts: ProcessedOptions,

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -133,7 +133,12 @@ object Tests {
   final case class SubProcess(config: ForkOptions) extends TestRunPolicy
 
   /** A named group of tests configured to run in the same JVM or be forked. */
-  final case class Group(name: String, tests: Seq[TestDefinition], runPolicy: TestRunPolicy)
+  final case class Group(
+      name: String,
+      tests: Seq[TestDefinition],
+      runPolicy: TestRunPolicy,
+      tags: Seq[(Tag, Int)] = Seq.empty
+  )
 
   private[sbt] final class ProcessedOptions(
       val tests: Vector[TestDefinition],

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -16,23 +16,24 @@ import xsbti.api.Definition
 import xsbti.api.ClassLike
 import xsbti.compile.CompileAnalysis
 import ConcurrentRestrictions.Tag
-
 import testing.{
   AnnotatedFingerprint,
   Fingerprint,
   Framework,
-  SubclassFingerprint,
   Runner,
-  TaskDef,
   Selector,
+  SubclassFingerprint,
   SuiteSelector,
+  TaskDef,
   Task => TestTask
 }
-import scala.annotation.tailrec
 
+import scala.annotation.tailrec
 import sbt.internal.util.ManagedLogger
 import sbt.util.Logger
 import sbt.protocol.testing.TestResult
+
+import scala.runtime.AbstractFunction3
 
 sealed trait TestOption
 
@@ -133,12 +134,113 @@ object Tests {
   final case class SubProcess(config: ForkOptions) extends TestRunPolicy
 
   /** A named group of tests configured to run in the same JVM or be forked. */
-  final case class Group(
-      name: String,
-      tests: Seq[TestDefinition],
-      runPolicy: TestRunPolicy,
-      tags: Seq[(Tag, Int)] = Seq.empty
-  )
+  final class Group(
+      val name: String,
+      val tests: Seq[TestDefinition],
+      val runPolicy: TestRunPolicy,
+      val tags: Seq[(Tag, Int)]
+  ) extends Product
+      with Serializable {
+
+    def this(name: String, tests: Seq[TestDefinition], runPolicy: TestRunPolicy) = {
+      this(name, tests, runPolicy, Seq.empty)
+    }
+
+    def withName(name: String): Group = {
+      new Group(name, tests, runPolicy, tags)
+    }
+
+    def withTests(tests: Seq[TestDefinition]): Group = {
+      new Group(name, tests, runPolicy, tags)
+    }
+
+    def withRunPolicy(runPolicy: TestRunPolicy): Group = {
+      new Group(name, tests, runPolicy, tags)
+    }
+
+    def withTags(tags: Seq[(Tag, Int)]): Group = {
+      new Group(name, tests, runPolicy, tags)
+    }
+
+    //- EXPANDED CASE CLASS METHOD BEGIN -//
+    @deprecated("Methods generated for case class will be removed in the future.", "1.4.0")
+    def copy(
+        name: String = this.name,
+        tests: Seq[TestDefinition] = this.tests,
+        runPolicy: TestRunPolicy = this.runPolicy
+    ): Group = {
+      new Group(name, tests, runPolicy, this.tags)
+    }
+
+    @deprecated("Methods generated for case class will be removed in the future.", "1.4.0")
+    override def productElement(x$1: Int): Any = x$1 match {
+      case 0 => Group.this.name
+      case 1 => Group.this.tests
+      case 2 => Group.this.runPolicy
+      case 3 => Group.this.tags
+    }
+
+    @deprecated("Methods generated for case class will be removed in the future.", "1.4.0")
+    override def productArity: Int = 4
+
+    @deprecated("Methods generated for case class will be removed in the future.", "1.4.0")
+    def canEqual(x$1: Any): Boolean = x$1.isInstanceOf[Group]
+
+    override def hashCode(): Int = {
+      scala.runtime.ScalaRunTime._hashCode(Group.this)
+    }
+
+    override def toString(): String = scala.runtime.ScalaRunTime._toString(Group.this)
+
+    override def equals(x$1: Any): Boolean = {
+      this.eq(x$1.asInstanceOf[Object]) || (x$1.isInstanceOf[Group] && ({
+        val Group$1: Group = x$1.asInstanceOf[Group]
+        name == Group$1.name && tests == Group$1.tests &&
+        runPolicy == Group$1.runPolicy && tags == Group$1.tags
+      }))
+    }
+    //- EXPANDED CASE CLASS METHOD END -//
+  }
+
+  object Group
+      extends AbstractFunction3[String, Seq[TestDefinition], TestRunPolicy, Group]
+      with Serializable {
+    //- EXPANDED CASE CLASS METHOD BEGIN -//
+    final override def toString(): String = "Group"
+    def apply(
+        name: String,
+        tests: Seq[TestDefinition],
+        runPolicy: TestRunPolicy
+    ): Group = {
+      new Group(name, tests, runPolicy, Seq.empty)
+    }
+
+    def apply(
+        name: String,
+        tests: Seq[TestDefinition],
+        runPolicy: TestRunPolicy,
+        tags: Seq[(Tag, Int)]
+    ): Group = {
+      new Group(name, tests, runPolicy, tags)
+    }
+
+    @deprecated("Methods generated for case class will be removed in the future.", "1.4.0")
+    def unapply(
+        x$0: Group
+    ): Option[(String, Seq[TestDefinition], TestRunPolicy)] = {
+      if (x$0 == null) None
+      else
+        Some.apply[(String, Seq[TestDefinition], TestRunPolicy)](
+          Tuple3.apply[String, Seq[TestDefinition], TestRunPolicy](
+            x$0.name,
+            x$0.tests,
+            x$0.runPolicy
+          )
+        )
+    }
+    private def readResolve(): Object = Group
+    //- EXPANDED CASE CLASS METHOD END -//
+  }
 
   private[sbt] final class ProcessedOptions(
       val tests: Vector[TestDefinition],

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1208,7 +1208,7 @@ object Defaults extends BuildCommon {
   ): Initialize[Task[Tests.Output]] = {
     val runners = createTestRunners(frameworks, loader, config)
     val groupTasks = groups map {
-      case Tests.Group(_, tests, runPolicy, tags) =>
+      case Tests.Group(_, tests, runPolicy, groupTags) =>
         runPolicy match {
           case Tests.SubProcess(opts) =>
             s.log.debug(s"javaOptions: ${opts.runJVMOptions}")
@@ -1221,13 +1221,20 @@ object Defaults extends BuildCommon {
               cp.files,
               opts,
               s.log,
-              (Tags.ForkedTestGroup, 1) +: tags: _*
+              (Tags.ForkedTestGroup, 1) +: groupTags: _*
             )
           case Tests.InProcess =>
             if (javaOptions.nonEmpty) {
               s.log.warn("javaOptions will be ignored, fork is set to false")
             }
-            Tests(frameworks, loader, runners, tests.toVector, config, s.log)
+            Tests(
+              frameworks,
+              loader,
+              runners,
+              tests.toVector,
+              config.copy(tags = config.tags ++ groupTags),
+              s.log
+            )
         }
     }
     val output = Tests.foldTasks(groupTasks, config.parallel)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1208,7 +1208,7 @@ object Defaults extends BuildCommon {
   ): Initialize[Task[Tests.Output]] = {
     val runners = createTestRunners(frameworks, loader, config)
     val groupTasks = groups map {
-      case Tests.Group(_, tests, runPolicy) =>
+      case Tests.Group(_, tests, runPolicy, tags) =>
         runPolicy match {
           case Tests.SubProcess(opts) =>
             s.log.debug(s"javaOptions: ${opts.runJVMOptions}")
@@ -1221,7 +1221,7 @@ object Defaults extends BuildCommon {
               cp.files,
               opts,
               s.log,
-              Tags.ForkedTestGroup
+              (Tags.ForkedTestGroup, 1) +: tags: _*
             )
           case Tests.InProcess =>
             if (javaOptions.nonEmpty) {

--- a/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/build.sbt
+++ b/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/build.sbt
@@ -1,0 +1,33 @@
+val specs = "org.specs2" %% "specs2-core" % "4.3.4"
+ThisBuild / scalaVersion := "2.12.11"
+
+val TestATypeTag = Tags.Tag("TestA")
+val TestBTypeTag = Tags.Tag("TestB")
+
+Global / concurrentRestrictions := Seq(Tags.limit(TestATypeTag, 1), Tags.limit(TestBTypeTag, 1))
+
+libraryDependencies += specs % Test
+inConfig(Test)(Seq(
+  testGrouping := {
+    val home = javaHome.value
+    val strategy = outputStrategy.value
+    val baseDir = baseDirectory.value
+    val options = javaOptions.value
+    val connect = connectInput.value
+    val vars = envVars.value
+
+    definedTests.value.map { test => new Tests.Group(test.name, Seq(test), Tests.SubProcess(
+      ForkOptions(
+        javaHome = home,
+        outputStrategy = strategy,
+        bootJars = Vector(),
+        workingDirectory = Some(baseDir),
+        runJVMOptions = options.toVector,
+        connectInput = connect,
+        envVars = vars
+      )
+    ), Seq((if (test.name.contains("TestA")) TestATypeTag else TestBTypeTag) -> 1))
+    }
+  },
+  TaskKey[Unit]("test-failure") := test.failure.value
+))

--- a/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/src/test/scala/example/Test.scala
+++ b/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/src/test/scala/example/Test.scala
@@ -1,0 +1,33 @@
+package example
+
+import java.io.File
+import org.specs2.mutable.Specification
+
+trait Test extends Specification {
+  def testType: String
+  "spec" should {
+    "be run one at time" in {
+      val lock = new File(s"lock${testType}")
+      println(lock)
+      lock.mkdir() should beTrue
+      Thread.sleep(2000)
+      lock.delete() should beTrue
+    }
+  }
+}
+
+class TestA0 extends Test {
+  override def testType: String = "A"
+}
+
+class TestA1 extends Test {
+  override def testType: String = "A"
+}
+
+class TestB0 extends Test {
+  override def testType: String = "B"
+}
+
+class TestB1 extends Test {
+  override def testType: String = "B"
+}

--- a/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/test
+++ b/sbt/src/sbt-test/tests/fork-test-group-parallel-custom-tags/test
@@ -1,0 +1,3 @@
+> test
+> set concurrentRestrictions in Global := Seq(Tags.limitAll(4))
+> testFailure


### PR DESCRIPTION
Thanks in advance for taking the time to consider and review this PR!

This work adds the ability to custom tag a test Group so that different limitations can be set for different forked jvms. 
Currently, if one wants to provide different forked JVMs with different amounts of memory and also limit the total memory allocated at any one time, you have to resort to [different configurations](https://www.scala-sbt.org/1.x/docs/Testing.html#Additional+test+configurations+with+shared+sources). With this PR the following can instead be done:

```sbt

val ForkedMemory = Tags.Tag("ForkedMem")
val MaxForkedMemory = 12 // Max amount of memory available in the container
Global / concurrentRestrictions := Seq(
  Tags.limit(ForkedMemory, MaxForkMemory)
)

Test / testGrouping := {
  Test / definedTests.value.map { test =>

    val testMem = if (test.name.contains("BigTest")) 4 else 2

    Tests.Group(
        name  = test.name,
        tests = Seq(test),
        runPolicy = Tests.SubProcess(
          ForkOptions()
            .withWorkingDirectory(baseDirectory.value)
            .withRunJVMOptions(
              Vector(s"-XX:MaxRAM=${testMem}g")
            )
        ),
        tags = Seq(ForkedMemory -> testMem)
    )
  }
}
```


Note, the scripted tests are very similar to the [currently disabled `fork-test-group-parallel`](https://github.com/sbt/sbt/pull/3456) and may therefore suffer from the same problem in CI. However, they both pass locally. 