### PR TITLE
Optimize task progress performance

### DIFF
--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -128,6 +128,16 @@ private[sbt] final class TaskProgress(log: ManagedLogger)
     }
   }
 
-  private[this] def containsSkipTasks(tasks: Vector[Task[_]]): Boolean =
-    tasks.map(taskName).exists(n => skipReportTasks.exists(m => m == n || n.endsWith("/ " + m)))
+  private[this] def containsSkipTasks(tasks: Vector[Task[_]]): Boolean = {
+    tasks.map(taskName).exists { n =>
+      val shortName = n.lastIndexOf('/') match {
+        case -1 => n
+        case i =>
+          var j = i + 1
+          while (n(j) == ' ') j += 1
+          n.substring(j)
+      }
+      skipReportTasks.contains(shortName)
+    }
+  }
 }


### PR DESCRIPTION
This PR makes a few small changes to reduce the overhead of TaskProgress. This turns out to matter because TaskProgress is in the hot path of enqueuing tasks to the CompletionService. These changes had a very similar performance impact to my crude benchmark in #5530. When combined with #5530, my crude benchmark ran about 20% faster (~45seconds vs ~55seconds). Each were about 50 seconds on their own.