### PR TITLE
Make IvyXml.writeFiles private[sbt]

### DIFF
--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -47,7 +47,7 @@ object IvyXml {
   }
 
   // These are required for publish to be fine, later on.
-  private def writeFiles(
+  private[sbt] def writeFiles(
       currentProject: Project,
       shadedConfigOpt: Option[Configuration],
       ivySbt: IvySbt,
@@ -180,7 +180,7 @@ object IvyXml {
     </ivy-module>
   }
 
-  private[sbt] def makeIvyXmlBefore[T](
+  private def makeIvyXmlBefore[T](
       task: TaskKey[T],
       shadedConfigOpt: Option[Configuration]
   ): Setting[Task[T]] =


### PR DESCRIPTION
This is a forward port of bb6496daa61a7cfc47e53f914223541ff0566171. Somehow this slipped through the cracks and breaks the development branch from loading (https://github.com/sbt/sbt/issues/5532).