### PR TITLE
implement Def.promise

### DIFF
--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -235,6 +235,12 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits {
   def inputTaskDyn[T](t: Def.Initialize[Task[T]]): Def.Initialize[InputTask[T]] =
     macro inputTaskDynMacroImpl[T]
 
+  /** Returns `PromiseWrap[A]`, which is a wrapper around `scala.concurrent.Promise`.
+   * When a task is typed promise (e.g. `Def.Initialize[Task[PromiseWrap[A]]]`),an implicit
+   * method called `await` is injected which will run in a thread outside of concurrent restriction budget.
+   */
+  def promise[A]: PromiseWrap[A] = new PromiseWrap[A]()
+
   // The following conversions enable the types Initialize[T], Initialize[Task[T]], and Task[T] to
   //  be used in task and setting macros as inputs with an ultimate result of type T
 

--- a/main-settings/src/main/scala/sbt/PromiseWrap.scala
+++ b/main-settings/src/main/scala/sbt/PromiseWrap.scala
@@ -1,0 +1,21 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import scala.concurrent.{ Promise => XPromise }
+
+final class PromiseWrap[A] {
+  private[sbt] val underlying: XPromise[A] = XPromise()
+  def complete(result: Result[A]): Unit =
+    result match {
+      case Inc(cause)   => underlying.failure(cause)
+      case Value(value) => underlying.success(value)
+    }
+  def success(value: A): Unit = underlying.success(value)
+  def failure(cause: Throwable): Unit = underlying.failure(cause)
+}

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -865,14 +865,19 @@ object Project extends ProjectExtra {
     }
   }
 
+  /** implicitly injected to tasks that return PromiseWrap.
+   */
   final class RichTaskPromise[A](i: Def.Initialize[Task[PromiseWrap[A]]]) {
     import scala.concurrent.Await
     import scala.concurrent.duration._
-    def await: Def.Initialize[Task[A]] =
+
+    def await: Def.Initialize[Task[A]] = await(Duration.Inf)
+
+    def await(atMost: Duration): Def.Initialize[Task[A]] =
       (Def
         .task {
           val p = i.value
-          val result: A = Await.result(p.underlying.future, Duration.Inf)
+          val result: A = Await.result(p.underlying.future, atMost)
           result
         })
         .tag(Tags.Sentinel)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -865,6 +865,19 @@ object Project extends ProjectExtra {
     }
   }
 
+  final class RichTaskPromise[A](i: Def.Initialize[Task[PromiseWrap[A]]]) {
+    import scala.concurrent.Await
+    import scala.concurrent.duration._
+    def await: Def.Initialize[Task[A]] =
+      (Def
+        .task {
+          val p = i.value
+          val result: A = Await.result(p.underlying.future, Duration.Inf)
+          result
+        })
+        .tag(Tags.Sentinel)
+  }
+
   import scala.reflect.macros._
 
   def projectMacroImpl(c: blackbox.Context): c.Expr[Project] = {
@@ -906,6 +919,11 @@ trait ProjectExtra {
 
   implicit def richTaskSessionVar[T](init: Initialize[Task[T]]): Project.RichTaskSessionVar[T] =
     new Project.RichTaskSessionVar(init)
+
+  implicit def sbtRichTaskPromise[A](
+      i: Initialize[Task[PromiseWrap[A]]]
+  ): Project.RichTaskPromise[A] =
+    new Project.RichTaskPromise(i)
 
   def inThisBuild(ss: Seq[Setting[_]]): Seq[Setting[_]] =
     inScope(ThisScope.copy(project = Select(ThisBuild)))(ss)

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -21,6 +21,8 @@ object Tags {
   val Update = Tag("update")
   val Publish = Tag("publish")
   val Clean = Tag("clean")
+  // special tag for waiting on a promise
+  val Sentinel = Tag("sentinel")
 
   val CPU = Tag("cpu")
   val Network = Tag("network")

--- a/sbt/src/sbt-test/actions/promise/build.sbt
+++ b/sbt/src/sbt-test/actions/promise/build.sbt
@@ -1,0 +1,40 @@
+val midpoint = taskKey[PromiseWrap[Int]]("")
+val longRunning = taskKey[Unit]("")
+val midTask = taskKey[Unit]("")
+val joinTwo = taskKey[Unit]("")
+val output = settingKey[File]("")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "promise",
+    output := baseDirectory.value / "output.txt",
+    midpoint := Def.promise[Int],
+    longRunning := {
+      val p = midpoint.value
+      val st = streams.value
+      IO.write(output.value, "start\n", append = true)
+      Thread.sleep(100)
+      p.success(5)
+      Thread.sleep(100)
+      IO.write(output.value, "end\n", append = true)
+    },
+    midTask := {
+      val st = streams.value
+      val x = midpoint.await.value
+      IO.write(output.value, s"$x in the middle\n", append = true)
+    },
+    joinTwo := {
+      val x = longRunning.value
+      val y = midTask.value
+    },
+    TaskKey[Unit]("check") := {
+      val lines = IO.read(output.value).linesIterator.toList
+      assert(lines == List("start", "5 in the middle", "end"))
+      ()
+    },
+    TaskKey[Unit]("check2") := {
+      val lines = IO.read(output.value).linesIterator.toList
+      assert(lines == List("start", "end", "5 in the middle"))
+      ()
+    },
+  )

--- a/sbt/src/sbt-test/actions/promise/test
+++ b/sbt/src/sbt-test/actions/promise/test
@@ -1,0 +1,8 @@
+> joinTwo
+> check
+
+$ delete output.txt
+# check that we won't thread starve
+> set Global / concurrentRestrictions := Seq(Tags.limitAll(1))
+> joinTwo
+> check2

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -8,7 +8,18 @@
 package sbt
 
 trait CompletionService[A, R] {
+
+  /**
+   * Submits a work node A with work that returns R.
+   * In Execute this is used for tasks returning sbt.Completed.
+   */
   def submit(node: A, work: () => R): Unit
+
+  /**
+   * Retrieves and removes the result from the next completed task,
+   * waiting if none are yet present.
+   * In Execute this is used for tasks returning sbt.Completed.
+   */
   def take(): R
 }
 


### PR DESCRIPTION
See http://eed3si9n.com/promise-in-sbt for details.

This adds `Def.promise` a facility that wraps `scala.concurrent.Promise`. Project layer, there's an implicit for task-that-returns-promise (`Def.Initialize[Task[PromiseWrap[A]]]`) that would inject `await` method, which returns a task. This is a special task that is tagged with `Tags.Sentinel` so that it will bypass the concurrent restrictions. Since there's no CPU- or IO-bound work, this should be ok.

The purpose of this promise for long-running task to communicate with another task midway.