### PR TITLE
[1.3.x] enable ServiceLoader discovery across classloader layers

### DIFF
--- a/sbt/src/sbt-test/classloader-cache/service-loader/build.sbt
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/build.sbt
@@ -1,0 +1,4 @@
+val dependency = project.settings(exportJars := true)
+val descendant = project.dependsOn(dependency).settings(
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+)

--- a/sbt/src/sbt-test/classloader-cache/service-loader/dependency/src/main/java/dependency/Runnable.java
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/dependency/src/main/java/dependency/Runnable.java
@@ -1,0 +1,6 @@
+package dependency;
+
+public class Runnable implements java.lang.Runnable {
+    public void run() {}
+}
+

--- a/sbt/src/sbt-test/classloader-cache/service-loader/dependency/src/main/resources/META-INF/services/java.lang.Runnable
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/dependency/src/main/resources/META-INF/services/java.lang.Runnable
@@ -1,0 +1,1 @@
+dependency.Runnable

--- a/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/main/resources/META-INF/services/java.lang.Runnable
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/main/resources/META-INF/services/java.lang.Runnable
@@ -1,0 +1,1 @@
+descendant.Runnable

--- a/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/main/scala/test/Runnable.scala
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/main/scala/test/Runnable.scala
@@ -1,0 +1,6 @@
+package descendant
+
+class Runnable extends java.lang.Runnable {
+  override def run(): Unit = ()
+}
+

--- a/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/test/scala/test/ServiceLoaderTest.scala
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/descendant/src/test/scala/test/ServiceLoaderTest.scala
@@ -1,0 +1,20 @@
+package test
+
+import collection.JavaConverters._
+import org.scalatest._
+
+class ServiceLoaderTest extends FlatSpec {
+  val expected = Set(classOf[dependency.Runnable], classOf[descendant.Runnable])
+
+  val descendantClassLoader = classOf[descendant.Runnable].getClassLoader
+  val descendantRunnableLoader = java.util.ServiceLoader.load(classOf[java.lang.Runnable], descendantClassLoader)
+  val descendantLoadedClasses = descendantRunnableLoader.iterator().asScala.map(_.getClass).toSet
+  assert(descendantLoadedClasses == expected)
+
+  // this was the actual problem, when classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars
+  val dependencyClassLoader = classOf[dependency.Runnable].getClassLoader
+  val dependencyRunnableLoader = java.util.ServiceLoader.load(classOf[java.lang.Runnable], dependencyClassLoader)
+  val dependencyLoadedClasses = dependencyRunnableLoader.iterator().asScala.map(_.getClass).toSet
+  assert(dependencyLoadedClasses == expected)
+}
+

--- a/sbt/src/sbt-test/classloader-cache/service-loader/test
+++ b/sbt/src/sbt-test/classloader-cache/service-loader/test
@@ -1,0 +1,7 @@
+> set descendant / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars
+
+> test
+
+> set descendant / Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary
+
+> test


### PR DESCRIPTION
Backport of #5540 

Since the cherry-pick applies easily, I was wondering if we could backport this?