### PR TITLE
Update coursier to 2.0.0-RC6-4

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -26,6 +26,11 @@ object MainLoop {
 
   /** Entry point to run the remaining commands in State with managed global logging.*/
   def runLogged(state: State): xsbti.MainResult = {
+
+    // This warns if ~/.coursier/cache is found.
+    // Temporary, remove when updating coursier to 2.0.0 final.
+    lmcoursier.CoursierConfiguration.checkLegacyCache()
+
     // We've disabled jline shutdown hooks to prevent classloader leaks, and have been careful to always restore
     // the jline terminal in finally blocks, but hitting ctrl+c prevents finally blocks from being executed, in that
     // case the only way to restore the terminal is in a shutdown hook.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0-RC6-2"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0-RC6-4"
 
   def sjsonNew(n: String) = Def.setting("com.eed3si9n" %% n % contrabandSjsonNewVersion.value)
   val sjsonNewScalaJson = sjsonNew("sjson-new-scalajson")


### PR DESCRIPTION
And warn at start-up if `~/.coursier/cache` is found (see the discussion in https://github.com/coursier/coursier/pull/1691 and https://github.com/coursier/sbt-coursier/pull/222).