### PR TITLE
Selective functor

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Classes.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Classes.scala
@@ -14,6 +14,10 @@ object Classes {
     def map[S, T](f: S => T, v: M[S]): M[T]
   }
 
+  trait Selective[M[_]] extends Applicative[M] {
+    def select[A, B](fab: M[Either[A, B]])(fn: M[A => B]): M[B]
+  }
+
   trait Monad[M[_]] extends Applicative[M] {
     def flatten[T](m: M[M[T]]): M[T]
   }

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -221,6 +221,7 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits {
     inputTaskDynMacroImpl,
     inputTaskMacroImpl,
     taskDynMacroImpl,
+    taskIfMacroImpl,
     taskMacroImpl
   }
   import std._
@@ -234,6 +235,7 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits {
   def inputTask[T](t: T): Def.Initialize[InputTask[T]] = macro inputTaskMacroImpl[T]
   def inputTaskDyn[T](t: Def.Initialize[Task[T]]): Def.Initialize[InputTask[T]] =
     macro inputTaskDynMacroImpl[T]
+  def taskIf[T](a: Def.Initialize[Task[T]]): Def.Initialize[Task[T]] = macro taskIfMacroImpl[T]
 
   private[sbt] def selectITask[A, B](
       fab: Initialize[Task[Either[A, B]]],

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -235,7 +235,7 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits {
   def inputTask[T](t: T): Def.Initialize[InputTask[T]] = macro inputTaskMacroImpl[T]
   def inputTaskDyn[T](t: Def.Initialize[Task[T]]): Def.Initialize[InputTask[T]] =
     macro inputTaskDynMacroImpl[T]
-  def taskIf[T](a: Def.Initialize[Task[T]]): Def.Initialize[Task[T]] = macro taskIfMacroImpl[T]
+  def taskIf[T](a: T): Def.Initialize[Task[T]] = macro taskIfMacroImpl[T]
 
   private[sbt] def selectITask[A, B](
       fab: Initialize[Task[Either[A, B]]],

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -315,6 +315,20 @@ object Scoped {
     final def ??[T >: S](or: => T): Initialize[T] = Def.optional(scopedKey)(_ getOrElse or)
   }
 
+  // Duplicated with ProjectExtra.
+  private[sbt] object syntax {
+    implicit def richInitializeTask[T](init: Initialize[Task[T]]): Scoped.RichInitializeTask[T] =
+      new Scoped.RichInitializeTask(init)
+
+    implicit def richInitializeInputTask[T](
+        init: Initialize[InputTask[T]]
+    ): Scoped.RichInitializeInputTask[T] =
+      new Scoped.RichInitializeInputTask(init)
+
+    implicit def richInitialize[T](i: Initialize[T]): Scoped.RichInitialize[T] =
+      new Scoped.RichInitialize[T](i)
+  }
+
   /**
    * Wraps an [[sbt.Def.Initialize]] instance to provide `map` and `flatMap` semantics.
    */

--- a/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
@@ -211,15 +211,16 @@ object TaskLinterDSLFeedback {
     """.stripMargin
 
   def useOfValueInsideIfExpression(task: String): String =
-    s"""${startBold}The evaluation of `$task` happens always inside a regular task.$reset
+    s"""${startBold}value lookup of `$task` inside an `if` expression$reset
        |
-       |$ProblemHeader: `$task` is inside the if expression of a regular task.
-       |  Regular tasks always evaluate task inside the bodies of if expressions.
+       |$ProblemHeader: `$task.value` is inside an `if` expression of a regular task.
+       |  Regular tasks always evaluate task dependencies (`.value`) regardless of `if` expressions.
        |$SolutionHeader:
-       |  1. If you only want to evaluate it when the if predicate is true or false, use a dynamic task.
-       |  2. Make the static evaluation explicit by evaluating `$task` outside the if expression.
-       |  3. If you still want to force the static evaluation, you may annotate the task evaluation with `@sbtUnchecked`, e.g. `($task.value: @sbtUnchecked)`.
-       |  4. Add `import sbt.dsl.LinterLevel.Ignore` to your build file to disable all task linting.
+       |  1. Use a conditional task `Def.taskIf(...)` to evaluate it when the `if` predicate is true or false.
+       |  2. Or turn the task body into a single `if` expression; the task is then auto-converted to a conditional task. 
+       |  3. Or make the static evaluation explicit by declaring `$task.value` outside the `if` expression.
+       |  4. If you still want to force the static lookup, you may annotate the task lookup with `@sbtUnchecked`, e.g. `($task.value: @sbtUnchecked)`.
+       |  5. Add `import sbt.dsl.LinterLevel.Ignore` to your build file to disable all task linting.
     """.stripMargin
 
   def missingValueForKey(key: String): String =

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -104,11 +104,26 @@ object TaskMacro {
 
   def taskMacroImpl[T: c.WeakTypeTag](
       c: blackbox.Context
-  )(t: c.Expr[T]): c.Expr[Initialize[Task[T]]] =
-    Instance.contImpl[T, Id](c, FullInstance, FullConvert, MixedBuilder, TaskLinterDSL)(
-      Left(t),
-      Instance.idTransform[c.type]
-    )
+  )(t: c.Expr[T]): c.Expr[Initialize[Task[T]]] = {
+    import c.universe._
+    t.tree match {
+      // the tree matches `if` and only `if`
+      case If(cond, thenp, elsep) =>
+        c.Expr[Initialize[Task[T]]](mkIfS(c)(cond, thenp, elsep))
+      case _ =>
+        Instance.contImpl[T, Id](c, FullInstance, FullConvert, MixedBuilder, TaskLinterDSL)(
+          Left(t),
+          Instance.idTransform[c.type]
+        )
+    }
+  }
+
+  def mkIfS(
+      c: blackbox.Context
+  )(cond: c.Tree, thenp: c.Tree, elsep: c.Tree): c.Tree = {
+    import c.universe._
+    q"""Def.ifS(Def.task($cond))(Def.task($thenp))(Def.task($elsep))"""
+  }
 
   def taskDynMacroImpl[T: c.WeakTypeTag](
       c: blackbox.Context
@@ -122,13 +137,11 @@ object TaskMacro {
       c: blackbox.Context
   )(a: c.Expr[A]): c.Expr[Initialize[Task[A]]] = {
     import c.universe._
-    def mkIfS(cond: Tree, thenp: Tree, elsep: Tree): Tree =
-      q"""Def.ifS(Def.task($cond))(Def.task($thenp))(Def.task($elsep))"""
     a.tree match {
       case Block(stat, If(cond, thenp, elsep)) =>
-        c.Expr[Initialize[Task[A]]](mkIfS(Block(stat, cond), thenp, elsep))
+        c.Expr[Initialize[Task[A]]](mkIfS(c)(Block(stat, cond), thenp, elsep))
       case If(cond, thenp, elsep) =>
-        c.Expr[Initialize[Task[A]]](mkIfS(cond, thenp, elsep))
+        c.Expr[Initialize[Task[A]]](mkIfS(c)(cond, thenp, elsep))
       case x => ContextUtil.unexpectedTree(x)
     }
   }

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -118,6 +118,21 @@ object TaskMacro {
       Instance.idTransform[c.type]
     )
 
+  def taskIfMacroImpl[A: c.WeakTypeTag](
+      c: blackbox.Context
+  )(a: c.Expr[Initialize[Task[A]]]): c.Expr[Initialize[Task[A]]] = {
+    import c.universe._
+    def mkIfS(cond: Tree, thenp: Tree, elsep: Tree): Tree =
+      q"""Def.ifS(Def.task($cond))($thenp)($elsep)"""
+    a.tree match {
+      case Block(stat, If(cond, thenp, elsep)) =>
+        c.Expr[Initialize[Task[A]]](mkIfS(Block(stat, cond), thenp, elsep))
+      case If(cond, thenp, elsep) =>
+        c.Expr[Initialize[Task[A]]](mkIfS(cond, thenp, elsep))
+      case x => ContextUtil.unexpectedTree(x)
+    }
+  }
+
   /** Implementation of := macro for settings. */
   def settingAssignMacroImpl[T: c.WeakTypeTag](
       c: blackbox.Context

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -120,10 +120,10 @@ object TaskMacro {
 
   def taskIfMacroImpl[A: c.WeakTypeTag](
       c: blackbox.Context
-  )(a: c.Expr[Initialize[Task[A]]]): c.Expr[Initialize[Task[A]]] = {
+  )(a: c.Expr[A]): c.Expr[Initialize[Task[A]]] = {
     import c.universe._
     def mkIfS(cond: Tree, thenp: Tree, elsep: Tree): Tree =
-      q"""Def.ifS(Def.task($cond))($thenp)($elsep)"""
+      q"""Def.ifS(Def.task($cond))(Def.task($thenp))(Def.task($elsep))"""
     a.tree match {
       case Block(stat, If(cond, thenp, elsep)) =>
         c.Expr[Initialize[Task[A]]](mkIfS(Block(stat, cond), thenp, elsep))

--- a/main-settings/src/test/scala/sbt/std/TaskConfigSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskConfigSpec.scala
@@ -52,6 +52,7 @@ class TaskConfigSpec extends fixture.FunSuite with fixture.TestDataFixture {
        |var condition = true
        |
        |val barNeg = Def.task[String] {
+       |  val s = 1
        |  if (condition) fooNeg.value
        |  else ""
        |}

--- a/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
@@ -8,6 +8,20 @@
 package sbt.std
 
 class TaskPosSpec {
+  // Starting sbt 1.4.0, Def.task can have task value lookups inside
+  // if branches since tasks with single if-expressions are automatically
+  // converted into a conditional task.
+  locally {
+    import sbt._, Def._
+    val foo = taskKey[String]("")
+    val bar = taskKey[String]("")
+    val condition = true
+    Def.task[String] {
+      if (condition) foo.value
+      else bar.value
+    }
+  }
+
   // Dynamic tasks can have task invocations inside if branches
   locally {
     import sbt._, Def._
@@ -147,8 +161,12 @@ class TaskPosSpec {
 
   locally {
     import sbt._, Def._
-    def withKey(foo: => SettingKey[String]) = {
-      Def.task { if (true) foo.value }
+    def withKey(foo: => SettingKey[String]): Def.Initialize[Task[Unit]] = {
+      Def.task {
+        if (true) {
+          foo.value; ()
+        }
+      }
     }
     val foo = settingKey[String]("")
     withKey(foo)

--- a/main-settings/src/test/scala/sbt/std/neg/TaskNegSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/neg/TaskNegSpec.scala
@@ -44,6 +44,7 @@ class TaskNegSpec extends fixture.FunSuite with fixture.TestDataFixture {
         |var condition = true
         |
         |val bazNeg = Def.task[String] {
+        |  val s = 1
         |  if (condition) fooNeg.value
         |  else barNeg.value
         |}
@@ -66,6 +67,7 @@ class TaskNegSpec extends fixture.FunSuite with fixture.TestDataFixture {
         |def bi(s: String) = s + "  "
         |
         |val bazNeg = Def.task[String] {
+        |  val s = 1
         |  if (condition) "" + fooNeg.value
         |  else bi(barNeg.value)
         |}
@@ -87,6 +89,7 @@ class TaskNegSpec extends fixture.FunSuite with fixture.TestDataFixture {
         |val bazNeg = Def.taskDyn[String] {
         |  if (condition) {
         |    Def.task {
+        |      val s = 1
         |      if (condition) {
         |        fooNeg.value
         |      } else ""
@@ -114,6 +117,7 @@ class TaskNegSpec extends fixture.FunSuite with fixture.TestDataFixture {
         |val bazNeg = Def.taskDyn[String] {
         |  if (condition) {
         |    Def.task {
+        |      val s = 1
         |      if (condition) {
         |        val first = if (!condition && condition) {
         |          fooNeg.value
@@ -144,6 +148,7 @@ class TaskNegSpec extends fixture.FunSuite with fixture.TestDataFixture {
         |val bazNeg = Def.taskDyn[String] {
         |  if (condition) {
         |    Def.task {
+        |      val s = 1
         |      if (condition) ""
         |      else barNeg.value
         |    }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2129,8 +2129,8 @@ object Defaults extends BuildCommon {
 
   def dependencyResolutionTask: Def.Initialize[Task[DependencyResolution]] =
     Def.taskIf {
-      if (useCoursier.value) Def.task { CoursierDependencyResolution(csrConfiguration.value) } else
-        Def.task { IvyDependencyResolution(ivyConfiguration.value, CustomHttp.okhttpClient.value) }
+      if (useCoursier.value) CoursierDependencyResolution(csrConfiguration.value)
+      else IvyDependencyResolution(ivyConfiguration.value, CustomHttp.okhttpClient.value)
     }
 }
 
@@ -2949,16 +2949,14 @@ object Classpaths {
 
   def publishTask(config: TaskKey[PublishConfiguration]): Initialize[Task[Unit]] =
     Def.taskIf {
-      if ((publish / skip).value)
-        Def.task {
-          val s = streams.value
-          val ref = thisProjectRef.value
-          s.log.debug(s"Skipping publish* for ${ref.project}")
-        } else
-        Def.task {
-          val s = streams.value
-          IvyActions.publish(ivyModule.value, config.value, s.log)
-        }
+      if ((publish / skip).value) {
+        val s = streams.value
+        val ref = thisProjectRef.value
+        s.log.debug(s"Skipping publish* for ${ref.project}")
+      } else {
+        val s = streams.value
+        IvyActions.publish(ivyModule.value, config.value, s.log)
+      }
     } tag (Tags.Publish, Tags.Network)
 
   val moduleIdJsonKeyFormat: sjsonnew.JsonKeyFormat[ModuleID] =

--- a/sbt/src/sbt-test/actions/ifs/build.sbt
+++ b/sbt/src/sbt-test/actions/ifs/build.sbt
@@ -12,8 +12,8 @@ lazy val root = (project in file("."))
     trueAction := { IO.write(output.value, s"true\n", append = true) },
     falseAction := { IO.write(output.value, s"false\n", append = true) },
     foo := (Def.taskIf {
-      if (condition.value) trueAction
-      else falseAction
+      if (condition.value) trueAction.value
+      else falseAction.value
     }).value,
     TaskKey[Unit]("check") := {
       val lines = IO.read(output.value).linesIterator.toList

--- a/sbt/src/sbt-test/actions/ifs/build.sbt
+++ b/sbt/src/sbt-test/actions/ifs/build.sbt
@@ -1,0 +1,25 @@
+val condition = taskKey[Boolean]("")
+val trueAction = taskKey[Unit]("")
+val falseAction = taskKey[Unit]("")
+val foo = taskKey[Unit]("")
+val output = settingKey[File]("")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "ifs",
+    output := baseDirectory.value / "output.txt",
+    condition := true,
+    trueAction := { IO.write(output.value, s"true\n", append = true) },
+    falseAction := { IO.write(output.value, s"false\n", append = true) },
+    foo := (Def.ifS(condition)(trueAction)(falseAction)).value,
+    TaskKey[Unit]("check") := {
+      val lines = IO.read(output.value).linesIterator.toList
+      assert(lines == List("true"))
+      ()
+    },
+    TaskKey[Unit]("check2") := {
+      val lines = IO.read(output.value).linesIterator.toList
+      assert(lines == List("false"))
+      ()
+    },
+  )

--- a/sbt/src/sbt-test/actions/ifs/build.sbt
+++ b/sbt/src/sbt-test/actions/ifs/build.sbt
@@ -1,7 +1,12 @@
 val condition = taskKey[Boolean]("")
+val number = settingKey[Int]("")
 val trueAction = taskKey[Unit]("")
 val falseAction = taskKey[Unit]("")
+val negAction = taskKey[Unit]("")
+val zeroAction = taskKey[Unit]("")
+val posAction = taskKey[Unit]("")
 val foo = taskKey[Unit]("")
+val bar = taskKey[Unit]("")
 val output = settingKey[File]("")
 
 lazy val root = (project in file("."))
@@ -9,20 +14,35 @@ lazy val root = (project in file("."))
     name := "ifs",
     output := baseDirectory.value / "output.txt",
     condition := true,
-    trueAction := { IO.write(output.value, s"true\n", append = true) },
-    falseAction := { IO.write(output.value, s"false\n", append = true) },
+    number := -1,
+
+    // automatic conversion to Def.ifS
+    bar := {
+      if (number.value < 0) negAction.value
+      else if (number.value == 0) zeroAction.value
+      else posAction.value
+    },
+
+    // explicit call to Def.taskIf
     foo := (Def.taskIf {
       if (condition.value) trueAction.value
       else falseAction.value
     }).value,
-    TaskKey[Unit]("check") := {
-      val lines = IO.read(output.value).linesIterator.toList
-      assert(lines == List("true"))
-      ()
-    },
-    TaskKey[Unit]("check2") := {
-      val lines = IO.read(output.value).linesIterator.toList
-      assert(lines == List("false"))
-      ()
-    },
+
+    trueAction := { IO.write(output.value, s"true\n", append = true) },
+    falseAction := { IO.write(output.value, s"false\n", append = true) },
+    negAction := { IO.write(output.value, s"neg\n", append = true) },
+    zeroAction := { IO.write(output.value, s"zero\n", append = true) },
+    posAction := { IO.write(output.value, s"pos\n", append = true) },
+
+    TaskKey[Unit]("checkTrue") := checkLines("true"),
+    TaskKey[Unit]("checkFalse") := checkLines("false"),
+    TaskKey[Unit]("checkNeg") := checkLines("neg"),
+    TaskKey[Unit]("checkZero") := checkLines("zero"),
   )
+
+def checkLines(content: String) = Def.task {
+  val lines = IO.read(output.value).linesIterator.toList
+  assert(lines == List("true"), s"$content was expected but found: $lines")
+  ()
+}

--- a/sbt/src/sbt-test/actions/ifs/build.sbt
+++ b/sbt/src/sbt-test/actions/ifs/build.sbt
@@ -11,7 +11,10 @@ lazy val root = (project in file("."))
     condition := true,
     trueAction := { IO.write(output.value, s"true\n", append = true) },
     falseAction := { IO.write(output.value, s"false\n", append = true) },
-    foo := (Def.ifS(condition)(trueAction)(falseAction)).value,
+    foo := (Def.taskIf {
+      if (condition.value) trueAction
+      else falseAction
+    }).value,
     TaskKey[Unit]("check") := {
       val lines = IO.read(output.value).linesIterator.toList
       assert(lines == List("true"))

--- a/sbt/src/sbt-test/actions/ifs/test
+++ b/sbt/src/sbt-test/actions/ifs/test
@@ -1,0 +1,7 @@
+> foo
+> check
+
+$ delete output.txt
+> set condition := false
+> foo
+> check2

--- a/sbt/src/sbt-test/actions/ifs/test
+++ b/sbt/src/sbt-test/actions/ifs/test
@@ -1,7 +1,16 @@
 > foo
-> check
+> checkTrue
+
+$ delete output.txt
+> bar
+> checkNeg
 
 $ delete output.txt
 > set condition := false
 > foo
-> check2
+> checkFalse
+
+$ delete output.txt
+> set number := 0
+> bar
+> checkZero

--- a/tasks-standard/src/main/scala/sbt/Action.scala
+++ b/tasks-standard/src/main/scala/sbt/Action.scala
@@ -57,6 +57,31 @@ final case class Join[T, U](in: Seq[Task[U]], f: Seq[Result[U]] => Either[Task[T
     Join[T, U](in.map(g.fn[U]), sr => f(sr).left.map(g.fn[T]))
 }
 
+/**
+ * A computation that conditionally falls back to a second transformation.
+ * This can be used to encode `if` conditions.
+ */
+final case class Selected[A, B](fab: Task[Either[A, B]], fin: Task[A => B]) extends Action[B] {
+  private def ml = AList.single[Either[A, B]]
+  type K[L[x]] = L[Either[A, B]]
+
+  private[sbt] def mapTask(g: Task ~> Task) =
+    Selected[A, B](g(fab), g(fin))
+
+  /**
+   * Encode this computation as a flatMap.
+   */
+  private[sbt] def asFlatMapped: FlatMapped[B, K] = {
+    val f: Either[A, B] => Task[B] = {
+      case Right(b) => std.TaskExtra.task(b)
+      case Left(a)  => std.TaskExtra.singleInputTask(fin).map(_(a))
+    }
+    FlatMapped[B, K](fab, {
+      f compose std.TaskExtra.successM
+    }, ml)
+  }
+}
+
 /** Combines metadata `info` and a computation `work` to define a task. */
 final case class Task[T](info: Info[T], work: Action[T]) {
   override def toString = info.name getOrElse ("Task(" + info + ")")

--- a/tasks-standard/src/main/scala/sbt/std/Transform.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Transform.scala
@@ -46,6 +46,7 @@ object Transform {
       case Pure(eval, _)       => uniform(Nil)(_ => Right(eval()))
       case m: Mapped[t, k]     => toNode[t, k](m.in)(right ∙ m.f)(m.alist)
       case m: FlatMapped[t, k] => toNode[t, k](m.in)(left ∙ m.f)(m.alist)
+      case s: Selected[_, t]   => val m = s.asFlatMapped; toNode(m.in)(left ∙ m.f)(m.alist)
       case DependsOn(in, deps) => uniform(existToAny(deps))(const(Left(in)) compose all)
       case Join(in, f)         => uniform(in)(f)
     }


### PR DESCRIPTION
See details in this blog post - http://eed3si9n.com/selective-functor-in-sbt

This implements Selective functor for `Either[A, B]` "task" (`Initialize[Task[Either[A, B]]]`).
The selective functor allows an encoding of if-expression:

```scala
  def ifS[A](
      x: Def.Initialize[Task[Boolean]]
  )(t: Def.Initialize[Task[A]])(e: Def.Initialize[Task[A]]): Def.Initialize[Task[A]]
```

In addition, this provides `Def.taskIf` macro that accepts an if-expression or a block ending in an if-expression.

This allows rewrite of `publishTask` regaining `inspect tree publish`.

```scala
  def publishTask(config: TaskKey[PublishConfiguration]): Initialize[Task[Unit]] =
    Def.taskIf {
      if ((publish / skip).value) {
        val s = streams.value
        val ref = thisProjectRef.value
        s.log.debug(s"Skipping publish* for ${ref.project}")
      } else {
        val s = streams.value
        IvyActions.publish(ivyModule.value, config.value, s.log)
      }
    } tag (Tags.Publish, Tags.Network)
```

**Update**: I've updated this PR so `Def.task(...)`, `:=` would also auto lift to use `Def.ifS` when the task body consists of a single `if`-expression:

```scala
    // automatic conversion to Def.ifS
    bar := {
      if (number.value < 0) negAction.value
      else if (number.value == 0) zeroAction.value
      else posAction.value
    }
```

