### PR TITLE
Remove .sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,0 @@
--J-Xms2048M
--J-Xmx2048M
--J-Xss2M


### PR DESCRIPTION
These prevent sbt from loading the sbt project with the windows batch script. I think
it's better for each developer to manually decide how much ram they want
to devote to sbt anyway.