### PR TITLE
Introduce a Submission class for submitted works.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,10 @@ def mimaSettingsSince(versions: Seq[String]) = Def settings (
   },
   mimaBinaryIssueFilters ++= Seq(
     // Changes in the internal package
+    exclude[DirectMissingMethodProblem]("sbt.ConcurrentRestrictions.*"),
+    exclude[IncompatibleMethTypeProblem]("sbt.CompletionService.submit"),
+    exclude[DirectMissingMethodProblem]("sbt.CompletionService.*"),
+    exclude[ReversedMissingMethodProblem]("sbt.CompletionService.submit"),
     exclude[DirectMissingMethodProblem]("sbt.internal.*"),
     exclude[FinalClassProblem]("sbt.internal.*"),
     exclude[FinalMethodProblem]("sbt.internal.*"),

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -8,8 +8,16 @@
 package sbt
 
 trait CompletionService[A, R] {
-  def submit(node: A, work: () => R): Unit
+  def submit(submission: Submission[A, R]): Unit
   def take(): R
+}
+
+trait Submission[+A, +R] {
+  def node: A
+  def work(): R
+}
+abstract class NodeSubmission[+A, +R](val node: A) {
+  def work(): R
 }
 
 import java.util.concurrent.{
@@ -30,11 +38,14 @@ object CompletionService {
     apply(new ExecutorCompletionService[T](x))
   def apply[A, T](completion: JCompletionService[T]): CompletionService[A, T] =
     new CompletionService[A, T] {
-      def submit(node: A, work: () => T) = { CompletionService.submit(work, completion); () }
+      def submit(submission: Submission[A, T]) = {
+        CompletionService.submit(submission, completion)
+        ()
+      }
       def take() = completion.take().get()
     }
-  def submit[T](work: () => T, completion: JCompletionService[T]): () => T = {
-    val future = try completion.submit { new Callable[T] { def call = work() } } catch {
+  def submit[T](submission: Submission[_, T], completion: JCompletionService[T]): () => T = {
+    val future = try completion.submit { new Callable[T] { def call = submission.work() } } catch {
       case _: RejectedExecutionException => throw Incomplete(None, message = Some("cancelled"))
     }
     () => future.get()
@@ -42,19 +53,28 @@ object CompletionService {
   def manage[A, T](
       service: CompletionService[A, T]
   )(setup: A => Unit, cleanup: A => Unit): CompletionService[A, T] =
-    wrap(service) { (node, work) => () =>
-      setup(node)
-      try {
-        work()
-      } finally {
-        cleanup(node)
+    new Wrapping[A, T](service) {
+      override protected def wrap(submission: Submission[A, T]): T = {
+        setup(submission.node)
+        try {
+          submission.work()
+        } finally {
+          cleanup(submission.node)
+        }
       }
     }
-  def wrap[A, T](
-      service: CompletionService[A, T]
-  )(w: (A, () => T) => (() => T)): CompletionService[A, T] =
-    new CompletionService[A, T] {
-      def submit(node: A, work: () => T) = service.submit(node, w(node, work))
-      def take() = service.take()
+
+  abstract class Wrapping[A, T](service: CompletionService[A, T]) extends CompletionService[A, T] {
+    protected def wrap(submission: Submission[A, T]): T
+
+    def submit(submission: Submission[A, T]) =
+      service.submit(new WrappedSubmission(submission))
+
+    override def take(): T = service.take()
+
+    private class WrappedSubmission(submission: Submission[A, T]) extends Submission[A, T] {
+      override def node: A = submission.node
+      override def work(): T = wrap(submission)
     }
+  }
 }


### PR DESCRIPTION
Replace the use of too many lambdas (difficult to debug and profile):

- We add a an abstract `Submission` class, to represent some work to be done. The work is represented as the method of this class, not a lambda.
- This class replaces the `Enqueue` inside `ConcurrentRestrictions`.
- Extract the big anonymous class in `ConcurrentRestrictions` as a class.


### Motivations. 

I recently run and profiled a compilation (with several iterations of warmup) of the `http4s-core` package, using Scala 2.13.2 on Sbt 1.3.10. It recorded over 40 MiB of allocations of a Lambda, related to this area of SBT. I had some difficulty to follow the call stack, but using classes instead of `() => T` continuations could help.  

![sbt_lambda_profile](https://user-images.githubusercontent.com/1764610/82730533-d2c66680-9d00-11ea-8c53-cb95cec146bd.png)
