### PR TITLE
[1.3.x] Coursier 2.0.0-RC6-4 + lm 1.3.3

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -27,6 +27,11 @@ object MainLoop {
 
   /** Entry point to run the remaining commands in State with managed global logging.*/
   def runLogged(state: State): xsbti.MainResult = {
+
+    // This warns if ~/.coursier/cache is found.
+    // Temporary, remove when updating coursier to 2.0.0 final.
+    lmcoursier.CoursierConfiguration.checkLegacyCache()
+
     // We've disabled jline shutdown hooks to prevent classloader leaks, and have been careful to always restore
     // the jline terminal in finally blocks, but hitting ctrl+c prevents finally blocks from being executed, in that
     // case the only way to restore the terminal is in a shutdown hook.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   private val lmVersion =
     sys.props.get("sbt.build.lm.version") match {
       case Some(version) => version
-      case _             => nightlyVersion.getOrElse("1.3.2")
+      case _             => nightlyVersion.getOrElse("1.3.3")
     }
   val zincVersion = nightlyVersion.getOrElse("1.3.5")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
   def addSbtZincCompileCore(p: Project): Project =
     addSbtModule(p, sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierVersion = "2.0.0-RC6-2"
+  val lmCoursierVersion = "2.0.0-RC6-4"
   val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % lmCoursierVersion
 
   val sjsonNewScalaJson = Def.setting {


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/5555

And warn at start-up if `~/.coursier/cache` is found (see the discussion in https://github.com/coursier/coursier/pull/1691 and https://github.com/coursier/sbt-coursier/pull/222).

https://github.com/coursier/sbt-coursier/releases/tag/v2.0.0-RC6-4

- Deprecate cache directory `~/.coursier/cache`
- missingOk
- HTTP header-based authentication https://github.com/coursier/sbt-coursier/pull/220

This PR also brings in lm 1.3.3 with newly patched Ivy with redirect support.