### PR TITLE
Remove HTTP support without explicit opt-in

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -951,7 +951,9 @@ lazy val mainProj = (project in file("main"))
       // since we're returning the same values as before.
       exclude[IncompatibleSignatureProblem]("sbt.Classpaths.mkIvyConfiguration"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.server.Definition*"),
-      exclude[IncompatibleTemplateDefProblem]("sbt.internal.server.LanguageServerProtocol")
+      exclude[IncompatibleTemplateDefProblem]("sbt.internal.server.LanguageServerProtocol"),
+      exclude[DirectMissingMethodProblem]("sbt.Classpaths.warnInsecureProtocol"),
+      exclude[DirectMissingMethodProblem]("sbt.Classpaths.warnInsecureProtocolInModules"),
     )
   )
   .configure(

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -91,7 +91,7 @@ object LMCoursier {
     val sbtScalaOrganization = "org.scala-lang" // always assuming sbt uses mainline scala
     val userForceVersions = Inputs.forceVersions(depsOverrides, scalaVer, scalaBinaryVer)
     Classpaths.warnResolversConflict(rs, log)
-    Classpaths.warnInsecureProtocol(rs, log)
+    Classpaths.errorInsecureProtocol(rs, log)
     CoursierConfiguration()
       .withResolvers(rs.toVector)
       .withInterProjectDependencies(interProjectDependencies.toVector)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.4.0-M6")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.3.0")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.4.0-M1")
   val zincVersion = nightlyVersion.getOrElse("1.4.0-M5")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/sbt/src/sbt-test/dependency-management/default-resolvers/test
+++ b/sbt/src/sbt-test/dependency-management/default-resolvers/test
@@ -9,3 +9,7 @@
 > set resolvers += Resolver.jcenterRepo
 
 > check2
+
+## HTTP
+> set resolvers += ("old_typesafe" at "http://repo.typesafe.com/typesafe/")
+-> update

--- a/sbt/src/sbt-test/dependency-management/exclude-bundle/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-bundle/build.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.vaadin" % "dontpush-addon-ozonelayer" % "0.4.6"
 
-resolvers += "asdf" at "http://maven.vaadin.com/vaadin-addons"
+resolvers += "asdf" at "https://maven.vaadin.com/vaadin-addons"

--- a/sbt/src/sbt-test/dependency-management/exclude-bundle/changes/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-bundle/changes/build.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.vaadin" % "dontpush-addon-ozonelayer" % "0.4.6" exclude("org.atmosphere", "atmosphere-compat-jetty")
 
-resolvers += "asdf" at "http://maven.vaadin.com/vaadin-addons"
+resolvers += "asdf" at "https://maven.vaadin.com/vaadin-addons"

--- a/sbt/src/sbt-test/dependency-management/url/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/url/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.classpath.ClasspathUtilities
 lazy val root = (project in file(".")).
   settings(
     ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),
-    libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1" % Test from "http://jsoup.org/packages/jsoup-1.9.1.jar",
+    libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1" % Test from "https://jsoup.org/packages/jsoup-1.9.1.jar",
     ivyLoggingLevel := UpdateLogging.Full,
     TaskKey[Unit]("checkInTest") := checkClasspath(Test).value,
     TaskKey[Unit]("checkInCompile") := checkClasspath(Compile).value


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4905

### Additional resolvers

To add an additional HTTP resolver, use `.withAllowInsecureProtocol(true)` as follows:

```scala
resolvers += ("example-releases" at "http://repo.example.com/releases/").withAllowInsecureProtocol(true)
```

### Proxy repositories

Make sure to update the `sbt` script and launcher to sbt 1.3.12 or above. There's now a new option `allowInsecureProtocol`, which can be used as follows:

```
[repositories]
  local
  my-ivy-proxy-releases: http://repo.company.com/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], allowInsecureProtocol
  my-maven-proxy-releases: http://repo.company.com/maven-releases/, allowInsecureProtocol
```

See [Proxy Repositories](https://www.scala-sbt.org/1.x/docs/Proxy-Repositories.html) and [sbt Launcher Configuration](https://www.scala-sbt.org/1.x/docs/Launcher-Configuration.html) guide for details.

### Lightbend to require HTTPS on repos starting August 5, 2020

See [Lightbend to require HTTPS on repos starting August 5, 2020](https://www.lightbend.com/blog/lightbend-to-require-https-on-repos-starting-august-5-2020). If your corporate proxy contains the following repositories, make sure to use HTTPS endpoints:

1. https://repo.scala-sbt.org/
2. https://repo.lightbend.com/
3. https://repo.typesafe.com/


