### PR TITLE
Replace -jar with -classpath in BSPConnectionDetails

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -202,8 +202,8 @@ private[sbt] object Server {
       private[this] def writeBspConnectionDetails(): Unit = {
         import bsp.codec.JsonProtocol._
         val sbtVersion = appConfiguration.provider.id.version
-        val launcherJar = ManagementFactory.getRuntimeMXBean.getClassPath
-        val details = BuildServerConnection.details(sbtVersion, launcherJar)
+        val launcherClassPath = ManagementFactory.getRuntimeMXBean.getClassPath
+        val details = BuildServerConnection.details(sbtVersion, launcherClassPath)
         val json = Converter.toJson(details).get
         IO.write(bspConnectionFile, CompactPrinter(json), append = false)
       }

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -12,8 +12,17 @@ object BuildServerConnection {
   final val bspVersion = "2.0.0-M5"
   final val languages = Vector("scala")
 
-  def details(sbtVersion: String, launcherJar: String): BspConnectionDetails = {
-    val argv = Vector("java", "-Xms100m", "-Xmx100m", "-jar", launcherJar, "-bsp")
+  def details(sbtVersion: String, launcherClassPath: String): BspConnectionDetails = {
+    val argv =
+      Vector(
+        "java",
+        "-Xms100m",
+        "-Xmx100m",
+        "-classpath",
+        launcherClassPath,
+        "xsbt.boot.Boot",
+        "-bsp"
+      )
     BspConnectionDetails(name, sbtVersion, bspVersion, languages, argv)
   }
 }


### PR DESCRIPTION
Using `-classpath` rather then `-jar` is more robust. This is working even with using the Coursier `sbt` command to launch the sbt server (which will create the bsp connection details file).