### PR TITLE
Add default log4j2.xml

### DIFF
--- a/sbt/src/main/resources/log4j2.xml
+++ b/sbt/src/main/resources/log4j2.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration/>


### PR DESCRIPTION
This should fix the errors that are sometimes seen with abrupt sbt
shutdowns:
```
2020-06-22 12:46:33,475 shutdown-hooks-run-all ERROR No Log4j 2
configuration file found. Using default configuration (logging only
errors to the console), or user programmatically provided
configurations. Set system property 'log4j2.debug' to show Log4j 2
internal initialization logging. See
https://logging.apache.org/log4j/2.x/manual/configuration.html for
instructions on how to configure Log4j 2
```

Should hopefully fix https://github.com/sbt/sbt/issues/4588