### PR TITLE
Use real paths for zinc roots

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -72,7 +72,6 @@ import sbt.librarymanagement.CrossVersion.{ binarySbtVersion, binaryScalaVersion
 import sbt.librarymanagement._
 import sbt.librarymanagement.ivy._
 import sbt.librarymanagement.syntax._
-import sbt.nio.FileStamp.Formats.seqPathFileStampJsonFormatter
 import sbt.nio.Keys._
 import sbt.nio.file.syntax._
 import sbt.nio.file.{ FileTreeView, Glob, RecursiveGlob }
@@ -688,27 +687,6 @@ object Defaults extends BuildCommon {
     },
      */
     externalHooks := IncOptions.defaultExternal,
-    compileSourceFileInputs := {
-      import sjsonnew.BasicJsonProtocol.mapFormat
-      compile.value // ensures the inputFileStamps previous value is only set if compile succeeds.
-      val version = scalaVersion.value
-      val versions = crossScalaVersions.value.toSet + version
-      val prev: Map[String, Seq[(java.nio.file.Path, sbt.nio.FileStamp)]] =
-        compileSourceFileInputs.previous.map(_.filterKeys(versions)).getOrElse(Map.empty)
-      prev + (version ->
-        ((unmanagedSources / inputFileStamps).value ++ (managedSourcePaths / outputFileStamps).value))
-    },
-    compileSourceFileInputs := compileSourceFileInputs.triggeredBy(compile).value,
-    compileBinaryFileInputs := {
-      import sjsonnew.BasicJsonProtocol.mapFormat
-      compile.value // ensures the inputFileStamps previous value is only set if compile succeeds.
-      val version = scalaVersion.value
-      val versions = crossScalaVersions.value.toSet + version
-      val prev: Map[String, Seq[(java.nio.file.Path, sbt.nio.FileStamp)]] =
-        compileBinaryFileInputs.previous.map(_.filterKeys(versions)).getOrElse(Map.empty)
-      prev + (version -> (dependencyClasspathFiles / outputFileStamps).value)
-    },
-    compileBinaryFileInputs := compileBinaryFileInputs.triggeredBy(compile).value,
     incOptions := {
       val old = incOptions.value
       old

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -191,7 +191,7 @@ object Defaults extends BuildCommon {
       allowMachinePath :== true,
       rootPaths := {
         val app = appConfiguration.value
-        val base = app.baseDirectory
+        val base = app.baseDirectory.getCanonicalFile
         val boot = app.provider.scalaProvider.launcher.bootDirectory
         val ih = app.provider.scalaProvider.launcher.ivyHome
         val coursierCache = csrCacheDirectory.value

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -33,6 +33,7 @@ import xsbti.compile.CompilerCache
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
+import xsbti.AppProvider
 
 /** This class is the entry point for sbt. */
 final class xMain extends xsbti.AppMain {
@@ -40,6 +41,16 @@ final class xMain extends xsbti.AppMain {
     new XMainConfiguration().run("xMain", configuration)
 }
 private[sbt] object xMain {
+  private[sbt] def dealiasBaseDirectory(config: xsbti.AppConfiguration): xsbti.AppConfiguration = {
+    val dealiasedBase = config.baseDirectory.getCanonicalFile
+    if (config.baseDirectory == dealiasedBase) config
+    else
+      new xsbti.AppConfiguration {
+        override def arguments: Array[String] = config.arguments()
+        override val baseDirectory: File = dealiasedBase
+        override def provider: AppProvider = config.provider()
+      }
+  }
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult =
     try {
       import BasicCommandStrings.{ DashClient, DashDashClient, runEarly }
@@ -54,16 +65,16 @@ private[sbt] object xMain {
       val isClient: String => Boolean = cmd => (cmd == DashClient) || (cmd == DashDashClient)
       val isBsp: String => Boolean = cmd => (cmd == "-bsp") || (cmd == "--bsp")
       if (userCommands.exists(isBsp)) {
-        BspClient.run(configuration)
+        BspClient.run(dealiasBaseDirectory(configuration))
       } else {
         Terminal.withStreams {
           if (clientModByEnv || userCommands.exists(isClient)) {
             val args = userCommands.toList.filterNot(isClient)
-            NetworkClient.run(configuration, args)
+            NetworkClient.run(dealiasBaseDirectory(configuration), args)
             Exit(0)
           } else {
             val state = StandardMain.initialState(
-              configuration,
+              dealiasBaseDirectory(configuration),
               Seq(defaults, early),
               runEarly(DefaultsCommand) :: runEarly(InitCommand) :: BootCommand :: Nil
             )
@@ -84,7 +95,7 @@ private[sbt] object ScriptMain {
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     import BasicCommandStrings.runEarly
     val state = StandardMain.initialState(
-      configuration,
+      xMain.dealiasBaseDirectory(configuration),
       BuiltinCommands.ScriptCommands,
       runEarly(Level.Error.toString) :: Script.Name :: Nil
     )
@@ -99,7 +110,7 @@ final class ConsoleMain extends xsbti.AppMain {
 private[sbt] object ConsoleMain {
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     val state = StandardMain.initialState(
-      configuration,
+      xMain.dealiasBaseDirectory(configuration),
       BuiltinCommands.ConsoleCommands,
       IvyConsole.Name :: Nil
     )


### PR DESCRIPTION
Not using the real paths can cause issues for certain features if sbt is
run out of a symlinked directory, which is the case in scripted tests
for example.