### PR TITLE
Fix: Trim internal dependency configs in BSP

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -331,7 +331,7 @@ object BuildServerProtocol {
   private def internalDependencyConfigurationsSetting = Def.settingDyn {
     val directDependencies = Keys.internalDependencyConfigurations.value.map {
       case (project, rawConfigs) =>
-        val configs = rawConfigs.flatMap(_.split(",")).map(ConfigKey.apply)
+        val configs = rawConfigs.flatMap(_.split(",")).map(name => ConfigKey(name.trim))
         (project, configs)
     }
     val ref = Keys.thisProjectRef.value


### PR DESCRIPTION
Fix #5626 

Allow `bspInternalDependencyConfigurations` setting to handle whitespaces.

Example:
```.dependsOn(core % "compile -> compile; test -> test; it -> it, test")```