### PR TITLE
Set `lineEndings = preserve` in .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,7 @@ edition = 2019-10
 maxColumn = 100
 project.git = true
 project.excludeFilters = [ "\\Wsbt-test\\W", "\\Winput_sources\\W", "\\Wcontraband-scala\\W" ]
+lineEndings = preserve
 
 # https://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala


### PR DESCRIPTION
On windows, scalafmt was rewriting '\n' with '\r\n'.