### PR TITLE
Add retries to BspCompileTask.compute

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -9,6 +9,7 @@ package sbt.internal.server
 
 import sbt._
 import sbt.internal.bsp._
+import sbt.internal.io.Retry
 import sbt.librarymanagement.Configuration
 import sjsonnew.support.scalajson.unsafe.Converter
 import xsbti.compile.CompileResult
@@ -27,7 +28,7 @@ object BspCompileTask {
     val task = BspCompileTask(targetId, project, config)
     try {
       notifyStart(task)
-      val result = compile
+      val result = Retry(compile)
       notifySuccess(task, result)
       result
     } catch {


### PR DESCRIPTION
There have been occasional failures on appveyor where an AccessDeniedException was thrown at this point. AccessDeniedExceptions thrown during scripted tests can often by resolved with a Retry.