### PR TITLE
Specify full java path in BSP connection details

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -10,7 +10,6 @@ package internal
 package server
 
 import java.io.{ File, IOException }
-import java.lang.management.ManagementFactory
 import java.net.{ InetAddress, ServerSocket, Socket, SocketTimeoutException }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import java.nio.file.attribute.{ AclEntry, AclEntryPermission, AclEntryType, UserPrincipal }
@@ -219,8 +218,7 @@ private[sbt] object Server {
       private[this] def writeBspConnectionDetails(): Unit = {
         import bsp.codec.JsonProtocol._
         val sbtVersion = appConfiguration.provider.id.version
-        val launcherClassPath = ManagementFactory.getRuntimeMXBean.getClassPath
-        val details = BuildServerConnection.details(sbtVersion, launcherClassPath)
+        val details = BuildServerConnection.details(sbtVersion)
         val json = Converter.toJson(details).get
         IO.write(bspConnectionFile, CompactPrinter(json), append = false)
       }

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -170,7 +170,6 @@ object BuildServerProtocol {
 
         case r if r.method == "buildTarget/compile" =>
           val param = Converter.fromJson[CompileParams](json(r)).get
-          callback.log.info(param.toString)
           val targets = param.targets.map(_.uri).mkString(" ")
           val command = Keys.bspBuildTargetCompile.key
           val _ = callback.appendExec(s"$command $targets", Some(r.id))

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -12,14 +12,16 @@ object BuildServerConnection {
   final val bspVersion = "2.0.0-M5"
   final val languages = Vector("scala")
 
-  def details(sbtVersion: String, launcherClassPath: String): BspConnectionDetails = {
+  private[sbt] def details(sbtVersion: String): BspConnectionDetails = {
+    val javaHome = System.getProperty("java.home")
+    val classPath = System.getProperty("java.class.path")
     val argv =
       Vector(
-        "java",
+        s"$javaHome/bin/java",
         "-Xms100m",
         "-Xmx100m",
         "-classpath",
-        launcherClassPath,
+        classPath,
         "xsbt.boot.Boot",
         "-bsp"
       )


### PR DESCRIPTION
Fixes #5623 

Use System properties to add java path and classpath to BSP connection details.