### PR TITLE
Remove lint warnings in sbt build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,13 @@ ThisBuild / scalafmtOnCompile := !(Global / insideCI).value
 ThisBuild / Test / scalafmtOnCompile := !(Global / insideCI).value
 ThisBuild / turbo := true
 
+val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
+Global / excludeLint := (Global / excludeLint).?.value.getOrElse(Set.empty)
+Global / excludeLint += componentID
+Global / excludeLint += whitesourceIgnoredScopes
+Global / excludeLint += scriptedBufferLog
+Global / excludeLint += checkPluginCross
+
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 def buildLevelSettings: Seq[Setting[_]] =
@@ -103,8 +110,7 @@ def commonBaseSettings: Seq[Setting[_]] = Def.settings(
   bintrayPackage := (bintrayPackage in ThisBuild).value,
   bintrayRepository := (bintrayRepository in ThisBuild).value,
   publishArtifact in Test := false,
-  fork in compile := true,
-  fork in run := true
+  fork in run := true,
 )
 def commonSettings: Seq[Setting[_]] =
   commonBaseSettings :+

--- a/project/NightlyPlugin.scala
+++ b/project/NightlyPlugin.scala
@@ -29,7 +29,6 @@ object NightlyPlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    crossVersion in update := CrossVersion.full,
     resolvers += Resolver.typesafeIvyRepo("releases").withName("typesafe-alt-project-releases")
   )
 }


### PR DESCRIPTION
There were a number of unused key lint warnings when loading the sbt
build. In the case of `fork in compile` and `crossVersion in update`, it
wasn't clear that these were actually used, so I removed those settings.
The others seemed to be used so I just added them to the exclude list.

Side note: ++= does not work with excludeLintKeys which is why I used +=
for the excludes.