### PR TITLE
Use jline2 for raw mode

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -785,10 +785,13 @@ object Terminal {
       system.setSize(new org.jline.terminal.Size(width, height))
 
     override def withRawInput[T](f: => T): T = term.synchronized {
-      val prev = JLine3.enterRawMode(system)
-      try f
-      catch { case _: InterruptedIOException => throw new InterruptedException } finally {
-        setAttributes(prev)
+      try {
+        term.init()
+        term.setEchoEnabled(false)
+        f
+      } catch { case _: InterruptedIOException => throw new InterruptedException } finally {
+        term.restore()
+        term.setEchoEnabled(true)
       }
     }
     override def isColorEnabled: Boolean =


### PR DESCRIPTION
Using the JLine3 implementation of raw mode breaks the scala console for
the console channel.