### PR TITLE
Avoid call to Path.toUri

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -14,6 +14,7 @@ import sbt.internal.util.ManagedLogger
 import xsbti.compile.CompileAnalysis
 import xsbti.{ BasicVirtualFileRef, FileConverter, Problem, Severity, Position => XPosition }
 
+import java.net.URI
 import scala.collection.mutable
 
 /**
@@ -80,7 +81,7 @@ class BuildServerReporter(
     val files = analysis.readSourceInfos.getAllSourceInfos.keySet.asScala
     files foreach { file =>
       val params = PublishDiagnosticsParams(
-        TextDocumentIdentifier(converter.toPath(file).toUri),
+        TextDocumentIdentifier(new URI("file", "", converter.toPath(file).toString, null)),
         buildTarget,
         None,
         diagnostics = Vector(),


### PR DESCRIPTION
I noticed in flamegraphs that a nontrivial amount of time was being
spent in the toUri function when I ran a no-op compile in a project with
5000 source files. My assumption is that since these paths will always
be regular files, we can just construct the URI manually to avoid the
performance hit.