### PR TITLE
Support scala 2.13 console in thin client

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 private[util] object JLine3 {
+  def getJLine3Terminal: JTerminal = apply(Terminal.get)
   private val capabilityMap = Capability
     .values()
     .map { c =>

--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -66,6 +66,7 @@ final class Console(compiler: AnalyzingCompiler) {
     val previous = sys.props.get("scala.color").getOrElse("auto")
     try {
       sys.props("scala.color") = if (terminal.isColorEnabled) "true" else "false"
+      sys.props("scala.jline.terminal.provider") = "sbt.internal.util.JLine3$"
       terminal.withRawOutput {
         terminal.withRawInput(Run.executeTrapExit(console0, log))
       }

--- a/main/src/main/java/sbt/internal/MetaBuildLoader.java
+++ b/main/src/main/java/sbt/internal/MetaBuildLoader.java
@@ -61,9 +61,10 @@ public final class MetaBuildLoader extends URLClassLoader {
    */
   public static MetaBuildLoader makeLoader(final AppProvider appProvider) throws IOException {
     final Pattern pattern =
-        Pattern.compile("^(test-interface-[0-9.]+|jline-[0-9.]+-sbt-.*|jansi-[0-9.]+)\\.jar");
+        Pattern.compile(
+            "^(test-interface-[0-9.]+|jline-3[0-9.]+|jline-[0-9.]+-sbt-.*|jansi-[0-9.]+)\\.jar");
     final File[] cp = appProvider.mainClasspath();
-    final URL[] interfaceURLs = new URL[3];
+    final URL[] interfaceURLs = new URL[4];
     final File[] extra =
         appProvider.id().classpathExtra() == null ? new File[0] : appProvider.id().classpathExtra();
     final Set<File> bottomClasspath = new LinkedHashSet<>();

--- a/main/src/main/scala/sbt/internal/XMainConfiguration.scala
+++ b/main/src/main/scala/sbt/internal/XMainConfiguration.scala
@@ -63,7 +63,7 @@ private[sbt] class XMainConfiguration {
       try {
         val method = topLoader.getClass.getMethod("getEarlyJars")
         val jars = method.invoke(topLoader).asInstanceOf[Array[URL]]
-        var canReuseConfiguration = jars.length == 3
+        var canReuseConfiguration = jars.length == 4
         var j = 0
         while (j < jars.length && canReuseConfiguration) {
           val s = jars(j).toString
@@ -71,7 +71,7 @@ private[sbt] class XMainConfiguration {
             s.contains("jline") || s.contains("test-interface") || s.contains("jansi")
           j += 1
         }
-        if (canReuseConfiguration) configuration else makeConfiguration(configuration)
+        if (canReuseConfiguration && j == 4) configuration else makeConfiguration(configuration)
       } catch {
         case _: NoSuchMethodException => makeConfiguration(configuration)
       }


### PR DESCRIPTION
In order to make the console task work with scala 2.13 and the thin
client, we need to provide a way for the scala repl to use an sbt
provided jline3 terminal instead of the default terminal typically built
by the repl. We also need to put jline 3 higher up in the classloading
hierarchy to ensure that two versions of jline 3 are not loaded (which
makes it impossible to share the sbt terminal with the scala terminal).