### PR TITLE
Improve sbt build load time by 25%

### DIFF
--- a/internal/util-collection/src/main/scala-2.12/sbt/internal/util/WrappedMap.scala
+++ b/internal/util-collection/src/main/scala-2.12/sbt/internal/util/WrappedMap.scala
@@ -1,0 +1,17 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import scala.collection.JavaConverters._
+private[util] class WrappedMap[K, V](val jmap: java.util.Map[K, V]) extends Map[K, V] {
+  def +[V1 >: V](kv: (K, V1)): scala.collection.immutable.Map[K, V1] =
+    jmap.asScala.toMap + kv
+  def -(key: K): scala.collection.immutable.Map[K, V] = jmap.asScala.toMap - key
+  def get(key: K): Option[V] = Option(jmap.get(key))
+  def iterator: Iterator[(K, V)] = jmap.asScala.iterator
+}

--- a/internal/util-collection/src/main/scala-2.13/sbt/internal/util/WrappedMap.scala
+++ b/internal/util-collection/src/main/scala-2.13/sbt/internal/util/WrappedMap.scala
@@ -1,0 +1,18 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import scala.collection.JavaConverters._
+private[util] class WrappedMap[K, V](val jmap: java.util.Map[K, V]) extends Map[K, V] {
+  def removed(key: K): scala.collection.immutable.Map[K, V] = jmap.asScala.toMap.removed(key)
+  def updated[V1 >: V](key: K, value: V1): scala.collection.immutable.Map[K, V1] =
+    jmap.asScala.toMap.updated(key, value)
+
+  def get(key: K): Option[V] = Option(jmap.get(key))
+  def iterator: Iterator[(K, V)] = jmap.asScala.iterator
+}

--- a/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -361,9 +361,12 @@ object Index {
       settings: Set[AttributeKey[_]]
   )(label: AttributeKey[_] => String): Map[String, AttributeKey[_]] = {
     val multiMap = settings.groupBy(label)
-    val duplicates = multiMap collect { case (k, xs) if xs.size > 1 => (k, xs.map(_.manifest)) } collect {
-      case (k, xs) if xs.size > 1                                   => (k, xs)
-    }
+    val duplicates = multiMap.iterator
+      .collect { case (k, xs) if xs.size > 1 => (k, xs.map(_.manifest)) }
+      .collect {
+        case (k, xs) if xs.size > 1 => (k, xs)
+      }
+      .toVector
     if (duplicates.isEmpty)
       multiMap.collect { case (k, v) if validID(k) => (k, v.head) } toMap
     else

--- a/main/src/main/scala/sbt/internal/KeyIndex.scala
+++ b/main/src/main/scala/sbt/internal/KeyIndex.scala
@@ -22,7 +22,7 @@ object KeyIndex {
       projects: Map[URI, Set[String]],
       configurations: Map[String, Seq[Configuration]]
   ): ExtendableKeyIndex =
-    known.foldLeft(base(projects, configurations)) { _ add _ }
+    known.par.foldLeft(base(projects, configurations)) { _ add _ }
   def aggregate(
       known: Iterable[ScopedKey[_]],
       extra: BuildUtil[_],


### PR DESCRIPTION
The sbt project load made a number of relatively inefficient
transformations of scala collecitons. I went through and found the slow
parts during project loading and made my best attempt at fixing them.
The most significant changes I made were in places using IMap. An IMap
is more or less a wrapper around an immutable Map. It can be much faster
to construct an IMap by creating a java mutable hashmap, wrapping it a
scala Map that delegates to the underlying java hashmap (with a copy on
write if the map is modified) and constructing the IMap from the wrapped
map. It was also in many cases to parallelize some transformations
wherever the order didn't matter.

After applying all of these changes, I found that loading the sbt
project took generally between 8.5 and 9 seconds on my laptop. With
1.3.13, it hovered around 11.5 seconds. I saw a similar speedup in zinc.
The biggest specific improvement was that generating the compiled map
dropped from between 3.5-4 seconds to pretty consistently being around
1.5 seconds.