### PR TITLE
Add lintUnusedKeysOnLoad to lint ignore keys

### DIFF
--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -31,6 +31,7 @@ object LintUnused {
       commands,
       crossScalaVersions,
       initialize,
+      lintUnusedKeysOnLoad,
       onLoad,
       onLoadMessage,
       onUnload,


### PR DESCRIPTION
I noticed that if lintUnusedKeysOnLoad := true is set, it emits a lint
warning.

As a side note, Project linting takes about 300-400ms in the sbt project
so we might want to consider disabling it by default in batch mode at
least.