### PR TITLE
Add fast path for parsing commands

### DIFF
--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1297,7 +1297,7 @@ private[sbt] object ContinuousCommands {
       case _ => state
     }
   }
-  private[this] val failWatchCommand = watchCommand(failWatch) { (channel, state) =>
+  private[sbt] val failWatchCommand = watchCommand(failWatch) { (channel, state) =>
     state.fail
   }
   /*

--- a/main/src/main/scala/sbt/internal/FastTrackCommands.scala
+++ b/main/src/main/scala/sbt/internal/FastTrackCommands.scala
@@ -1,0 +1,53 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import BasicCommandStrings._
+import BasicCommands._
+import BuiltinCommands.{ setTerminalCommand, shell, waitCmd }
+import ContinuousCommands._
+
+import sbt.internal.util.complete.Parser
+
+/** This is used to speed up command parsing. */
+private[sbt] object FastTrackCommands {
+  private def fromCommand(
+      cmd: String,
+      command: Command,
+      arguments: Boolean = true,
+  ): (State, String) => Option[State] =
+    (s, c) =>
+      Parser.parse(if (arguments) c else "", command.parser(s)) match {
+        case Right(newState) => Some(newState())
+        case l               => None
+      }
+  private val commands = Map[String, (State, String) => Option[State]](
+    FailureWall -> { case (s, c) => if (c == FailureWall) Some(s) else None },
+    StashOnFailure -> fromCommand(StashOnFailure, stashOnFailure, arguments = false),
+    PopOnFailure -> fromCommand(PopOnFailure, popOnFailure, arguments = false),
+    Shell -> fromCommand(Shell, shell),
+    SetTerminal -> fromCommand(SetTerminal, setTerminalCommand),
+    failWatch -> fromCommand(failWatch, failWatchCommand),
+    preWatch -> fromCommand(preWatch, preWatchCommand),
+    postWatch -> fromCommand(postWatch, postWatchCommand),
+    runWatch -> fromCommand(runWatch, runWatchCommand),
+    stopWatch -> fromCommand(stopWatch, stopWatchCommand),
+    waitWatch -> fromCommand(waitWatch, waitCmd),
+  )
+  private[sbt] def evaluate(state: State, cmd: String): Option[State] = {
+    cmd.trim.split(" ") match {
+      case Array(h, _*) =>
+        commands.get(h) match {
+          case Some(command) => command(state, cmd)
+          case _             => None
+        }
+      case _ => None
+    }
+  }
+}


### PR DESCRIPTION
It can easily take 2ms or more to parse a command depending on state's
combined parser. There are some commands that sbt requires to work that
we can handle in microseconds instead of milliseconds by special casing
them.

After this change, I saw the performance of
https://github.com/eatkins/scala-build-watch-performance improve by
a consistent 4-5ms in the 3 source file example which was a drop from
120ms to 115ms. While not necessarily earth shattering, this difference
could theoretically be much worse in other projects that have a lot of
plugins and custom tasks/commands. I think it's worth the modest
maintenance cost.