### PR TITLE
Reduce overhead of some logging apis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -341,7 +341,7 @@ lazy val utilPosition = (project in file("internal") / "util-position")
 
 lazy val utilLogging = (project in file("internal") / "util-logging")
   .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
-  .dependsOn(utilInterface, collectionProj)
+  .dependsOn(utilInterface, collectionProj, coreMacrosProj)
   .settings(
     utilCommonSettings,
     name := "Util Logging",
@@ -763,7 +763,7 @@ lazy val commandProj = (project in file("main-command"))
 lazy val coreMacrosProj = (project in file("core-macros"))
   .dependsOn(collectionProj)
   .settings(
-    baseSettings,
+    baseSettings :+ (crossScalaVersions := (scala212 :: scala213 :: Nil)),
     name := "Core Macros",
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     mimaSettings,

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
@@ -1,0 +1,27 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util.appmacro
+
+import scala.reflect.macros.blackbox
+
+object StringTypeTag {
+  def impl[A: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
+    import c.universe._
+    val tpe = weakTypeOf[A]
+    def typeToString(tpe: Type): String = tpe match {
+      case TypeRef(_, sym, args) if args.nonEmpty =>
+        val typeCon = tpe.typeSymbol.fullName
+        val typeArgs = args map typeToString
+        s"""$typeCon[${typeArgs.mkString(",")}]"""
+      case _ => tpe.toString
+    }
+
+    val key = Literal(Constant(typeToString(tpe)))
+    q"new sbt.internal.util.StringTypeTag[$tpe]($key)"
+  }
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
@@ -7,6 +7,7 @@
 
 package sbt.internal.util
 
+import scala.language.experimental.macros
 import scala.reflect.runtime.universe._
 
 /** This is used to carry type information in JSON. */
@@ -15,6 +16,10 @@ final case class StringTypeTag[A](key: String) {
 }
 
 object StringTypeTag {
+
+  /** Generates a StringTypeTag for any type at compile time. */
+  implicit def fast[A]: StringTypeTag[A] = macro appmacro.StringTypeTag.impl[A]
+  @deprecated("Prefer macro generated StringTypeTag", "1.4.0")
   def apply[A: TypeTag]: StringTypeTag[A] =
     synchronized {
       def doApply: StringTypeTag[A] = {
@@ -38,6 +43,7 @@ object StringTypeTag {
       retry(3)
     }
 
+  @deprecated("Prefer macro generated StringTypeTag", "1.4.0")
   def typeToString(tpe: Type): String =
     tpe match {
       case TypeRef(_, sym, args) =>

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.core.config.{ AppenderRef, LoggerConfig }
 import org.apache.logging.log4j.core.layout.PatternLayout
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
-import scala.reflect.runtime.universe.TypeTag
 import sjsonnew.JsonFormat
 
 // http://logging.apache.org/log4j/2.x/manual/customconfig.html
@@ -114,9 +113,15 @@ sealed abstract class LogExchange {
   def getOrElseUpdateStringCodec[A](tag: String, v: ShowLines[A]): ShowLines[A] =
     stringCodecs.getOrElseUpdate(tag, v).asInstanceOf[ShowLines[A]]
 
-  def registerStringCodec[A: ShowLines: TypeTag]: Unit = {
-    val tag = StringTypeTag[A]
-    registerStringCodecByStringTypeTag(tag)
+  @deprecated("Prefer macro based registerStringCodec", "1.4.0")
+  def registerStringCodec[A](
+      st: ShowLines[A],
+      tt: scala.reflect.runtime.universe.TypeTag[A]
+  ): Unit = {
+    registerStringCodecByStringTypeTag(StringTypeTag.apply[A](tt))(st)
+  }
+  private[sbt] def registerStringCodec[A: ShowLines: StringTypeTag]: Unit = {
+    registerStringCodecByStringTypeTag(implicitly[StringTypeTag[A]])
   }
 
   private[sbt] def registerStringCodecByStringTypeTag[A: ShowLines](tag: StringTypeTag[A]): Unit = {

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -24,7 +24,6 @@ sealed abstract class LogExchange {
   private[sbt] lazy val context: LoggerContext = init()
   private[sbt] lazy val builtInStringCodecs: Unit = initStringCodecs()
   private[sbt] lazy val asyncStdout: AsyncAppender = buildAsyncStdout
-  private[sbt] val jsonCodecs: concurrent.Map[String, JsonFormat[_]] = concurrent.TrieMap()
   private[sbt] val stringCodecs: concurrent.Map[String, ShowLines[_]] = concurrent.TrieMap()
 
   def logger(name: String): ManagedLogger = logger(name, None, None)
@@ -100,12 +99,15 @@ sealed abstract class LogExchange {
     lo
   }
 
-  def jsonCodec[A](tag: String): Option[JsonFormat[A]] =
-    jsonCodecs.get(tag) map { _.asInstanceOf[JsonFormat[A]] }
-  def hasJsonCodec(tag: String): Boolean =
-    jsonCodecs.contains(tag)
-  def getOrElseUpdateJsonCodec[A](tag: String, v: JsonFormat[A]): JsonFormat[A] =
-    jsonCodecs.getOrElseUpdate(tag, v).asInstanceOf[JsonFormat[A]]
+  @deprecated("It is now necessary to provide a json format instance", "1.4.0")
+  def jsonCodec[A](tag: String): Option[JsonFormat[A]] = None
+  @deprecated("Always returns false", "1.4.0")
+  def hasJsonCodec(tag: String): Boolean = false
+  @deprecated("This is a no-op", "1.4.0")
+  def getOrElseUpdateJsonCodec[A](tag: String, v: JsonFormat[A]): JsonFormat[A] = v
+  @deprecated("The log manager no longer caches jsonCodecs", "1.4.0")
+  def jsonCodecs(): concurrent.Map[String, JsonFormat[_]] = concurrent.TrieMap.empty
+
   def stringCodec[A](tag: String): Option[ShowLines[A]] =
     stringCodecs.get(tag) map { _.asInstanceOf[ShowLines[A]] }
   def hasStringCodec(tag: String): Boolean =

--- a/internal/util-logging/src/test/scala/LogExchangeSpec.scala
+++ b/internal/util-logging/src/test/scala/LogExchangeSpec.scala
@@ -14,9 +14,17 @@ import org.scalatest._
 class LogExchangeSpec extends FlatSpec with Matchers {
   import LogExchange._
 
-  checkTypeTag("stringTypeTagThrowable", stringTypeTagThrowable, StringTypeTag[Throwable])
-  checkTypeTag("stringTypeTagTraceEvent", stringTypeTagTraceEvent, StringTypeTag[TraceEvent])
-  checkTypeTag("stringTypeTagSuccessEvent", stringTypeTagSuccessEvent, StringTypeTag[SuccessEvent])
+  checkTypeTag("stringTypeTagThrowable", stringTypeTagThrowable, StringTypeTag.fast[Throwable])
+  checkTypeTag(
+    "stringTypeTagTraceEvent",
+    stringTypeTagTraceEvent,
+    StringTypeTag.fast[TraceEvent]
+  )
+  checkTypeTag(
+    "stringTypeTagSuccessEvent",
+    stringTypeTagSuccessEvent,
+    StringTypeTag.fast[SuccessEvent]
+  )
 
   private def checkTypeTag[A](name: String, inc: StringTypeTag[A], exp: StringTypeTag[A]): Unit =
     s"LogExchange.$name" should s"match real StringTypeTag[$exp]" in {

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -84,7 +84,7 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
     } {
       pool.submit(new Runnable {
         def run(): Unit = {
-          val stringTypeTag = StringTypeTag[List[Int]]
+          val stringTypeTag = StringTypeTag.fast[List[Int]]
           val log = LogExchange.logger(s"foo$i")
           LogExchange.bindLoggerAppenders(s"foo$i", List(LogExchange.asyncStdout -> Level.Info))
           if (i % 100 == 0) {

--- a/main/src/main/scala/sbt/internal/XMainConfiguration.scala
+++ b/main/src/main/scala/sbt/internal/XMainConfiguration.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.{ ExecutorService, Executors }
 import ClassLoaderClose.close
 
 import sbt.plugins.{ CorePlugin, IvyPlugin, JvmPlugin }
-import sbt.util.LogExchange
 import xsbti._
 
 private[internal] object ClassLoaderWarmup {
@@ -29,7 +28,6 @@ private[internal] object ClassLoaderWarmup {
         ()
       }
 
-      submit(LogExchange.context)
       submit(Class.forName("sbt.internal.parser.SbtParserInit").getConstructor().newInstance())
       submit(CorePlugin.projectSettings)
       submit(IvyPlugin.projectSettings)

--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -11,7 +11,7 @@ import java.io.File
 
 import sbt.StandardMain
 import sbt.internal.bsp._
-import sbt.internal.inc.ManagedLoggedReporter
+import sbt.internal.inc.LoggedReporter
 import sbt.internal.util.ManagedLogger
 import xsbti.{ Problem, Severity, Position => XPosition }
 
@@ -30,7 +30,11 @@ class BuildServerReporter(
     logger: ManagedLogger,
     sourcePositionMapper: XPosition => XPosition = identity[XPosition],
     sources: Seq[File]
-) extends ManagedLoggedReporter(maximumErrors, logger, sourcePositionMapper) {
+) extends LoggedReporter(maximumErrors, logger, sourcePositionMapper) {
+  import LoggedReporter.problemFormats._
+  import LoggedReporter.problemStringFormats._
+  logger.registerStringCodec[Problem]
+
   import sbt.internal.bsp.codec.JsonProtocol._
   import sbt.internal.inc.JavaInterfaceUtil._
 
@@ -55,21 +59,21 @@ class BuildServerReporter(
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logError(problem)
+    logger.errorEvent(problem)
   }
 
   override def logWarning(problem: Problem): Unit = {
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logWarning(problem)
+    logger.warnEvent(problem)
   }
 
   override def logInfo(problem: Problem): Unit = {
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logInfo(problem)
+    logger.infoEvent(problem)
   }
 
   private def publishDiagnostic(problem: Problem): Unit = {


### PR DESCRIPTION
I've found that log4j is actually a significant source of cpu performance and memory overhead so I'm working on improving our interactions with logging. These changes aren't directly log4j related but they came up while I was tracking down the performance issues.