### PR TITLE
Clear appenders after task evaluation

### DIFF
--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -20,7 +20,7 @@ import sbt.internal._
 import sbt.internal.util._
 import sbt.librarymanagement.{ Resolver, UpdateReport }
 import sbt.std.Transform.DummyTaskMap
-import sbt.util.{ Logger, Show }
+import sbt.util.{ LogExchange, Logger, Show }
 
 import scala.Console.RED
 import scala.concurrent.duration.Duration
@@ -383,11 +383,13 @@ object EvaluateTask {
     streams(ScopedKey(Project.fillTaskAxis(key).scope, Keys.streams.key))
 
   def withStreams[T](structure: BuildStructure, state: State)(f: Streams => T): T = {
-    val str = std.Streams.closeable(structure.streams(state))
+    val logExchange = new LogExchange
+    val str = std.Streams.closeable(structure.streams(state.put(logExchangeAttribute, logExchange)))
     try {
       f(str)
     } finally {
       str.close()
+      logExchange.close()
     }
   }
 

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -35,7 +35,7 @@ import sbt.librarymanagement._
 import sbt.librarymanagement.ivy.{ Credentials, IvyConfiguration, IvyPaths, UpdateOptions }
 import sbt.nio.file.Glob
 import sbt.testing.Framework
-import sbt.util.{ Level, Logger }
+import sbt.util.{ Level, LogExchange, Logger }
 import xsbti.FileConverter
 import xsbti.compile._
 import xsbti.compile.analysis.ReadStamps
@@ -61,6 +61,7 @@ object Keys {
   val timingFormat = settingKey[java.text.DateFormat]("The format used for displaying the completion time.").withRank(CSetting)
   val extraLoggers = settingKey[ScopedKey[_] => Seq[Appender]]("A function that provides additional loggers for a given setting.").withRank(DSetting)
   val logManager = settingKey[LogManager]("The log manager, which creates Loggers for different contexts.").withRank(DSetting)
+  private[sbt] val logExchangeAttribute = AttributeKey[LogExchange]("log-exchange-attribute", "The current log manager", Invisible)
   val logBuffered = settingKey[Boolean]("True if logging should be buffered until work completes.").withRank(CSetting)
   val sLog = settingKey[Logger]("Logger usable by settings during project loading.").withRank(CSetting)
   val serverLog = taskKey[Unit]("A dummy task to set server log level using Global / serverLog / logLevel.").withRank(CTask)

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -19,7 +19,7 @@ import sbt.LocalRootProject
 import sbt.io.syntax._
 import sbt.internal.util.{ AttributeEntry, AttributeKey, AttributeMap, Attributed, Settings }
 import sbt.internal.util.Attributed.data
-import sbt.util.Logger
+import sbt.util.{ LogExchange, Logger }
 import sjsonnew.SupportConverter
 import sjsonnew.shaded.scalajson.ast.unsafe.JValue
 
@@ -316,11 +316,12 @@ object BuildStreams {
         sjsonnew.support.scalajson.unsafe.CompactPrinter.apply,
         sjsonnew.support.scalajson.unsafe.Parser.parseUnsafe
       )
-    (s get Keys.stateStreams) getOrElse {
+    s.get(Keys.stateStreams).getOrElse {
+      val exchange = s.get(Keys.logExchangeAttribute).getOrElse(LogExchange)
       std.Streams(
         path(units, root, data),
         displayFull,
-        LogManager.construct(data, s),
+        LogManager.construct(data, s, exchange),
         sjsonnew.support.scalajson.unsafe.Converter, {
           val factory =
             s.get(Keys.cacheStoreFactoryFactory).getOrElse(InMemoryCacheStore.factory(0))

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -476,9 +476,14 @@ private[sbt] class DefaultBackgroundJobService(private[sbt] val serviceTempDirBa
     extends AbstractBackgroundJobService {
   @deprecated("Use the constructor that specifies the background job temporary directory", "1.4.0")
   def this() = this(IO.createTemporaryDirectory)
+  val logExchange = new LogExchange
   override def makeContext(id: Long, spawningTask: ScopedKey[_], state: State): ManagedLogger = {
     val extracted = Project.extract(state)
-    LogManager.constructBackgroundLog(extracted.structure.data, state)(spawningTask)
+    LogManager.constructBackgroundLog(extracted.structure.data, state, logExchange)(spawningTask)
+  }
+  override def shutdown(): Unit = {
+    super.shutdown()
+    logExchange.close()
   }
 }
 private[sbt] object DefaultBackgroundJobService {


### PR DESCRIPTION
sbt was leaking ConsoleAppenders with each task run. When I looked at a
heap dump after I ran compile 30 times in a project (see below) with
about 20 subprojects, I found the dump filled with leaked
ConsoleAppenders. This can be fixed by removing the loggers created
during task evaluation from log4j. I was concerned about removing
loggers that were still in use so I refactored LogManager so that it now
takes a LogExchange parameter. EvaluateTask can pass in a fresh
LogExchange and clear out all of the loggers when it's done.

Clearing the appenders is not only a memory leak but a performance
improvement as well. Adding a logger requires updating a concurrent hash
map which gets slower as the map size increases. I noticed in a
flamegraph that creating appenders was taking 50% of the total time
which was what motivated this change.

My project was a local clone of the repro project in
https://github.com/sbt/sbt/issues/5508. I was testing sbt overhead by
timing how long it took to run 30 iterations of no-op compile. There is
also a memory leak in TaskProgress that I will resolve separately that
causes degraded performance. With the fix for TaskProgress, the console
appender leaks cause the time for no-op compilation to increase per
iteration by about 100-200ms every 30 iterations. After applying this
change on top, there is no longer a noticeable increase in as the number
of iterations increase. This is very important since if we're planning
to push people towards the thin client, we really need to avoid resource
leaks in sbt.

This is not scientific, but for a sense of the potential impact of these
changes, with 1.3.13, the first 30 no-op compiles took about 390ms per
compile, the second 30 took 460 and the third took about 570. After all
of the fixes were applied in 1.4.0, the first 30 iteration took about
350ms per compile, the second took around 270. Then I ran 300
iterations which almost surely would have caused an OOM and taken
forever with 1.3.13 and the average was 250 (yay, JIT!).

Fixes #4779 https://github.com/sbt/sbt/pull/4779