### PR TITLE
Allow sbt to force flush of remote output

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -163,7 +163,7 @@ trait Terminal extends AutoCloseable {
     if (lines.nonEmpty) lines.tail.foldLeft(lines.headOption.fold(0)(count))(_ + count(_))
     else 0
   }
-
+  private[sbt] def flush(): Unit = printStream.flush()
 }
 
 object Terminal {

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -202,6 +202,10 @@ object MainLoop {
         StandardMain.exchange.setExec(Some(exec))
         StandardMain.exchange.unprompt(ConsoleUnpromptEvent(exec.source))
         val newState = Command.process(exec.commandLine, progressState)
+        // Flush the terminal output after command evaluation to ensure that all output
+        // is displayed in the thin client before we report the command status.
+        val terminal = channelName.flatMap(exchange.channelForName(_).map(_.terminal))
+        terminal.foreach(_.flush())
         if (exec.execId.fold(true)(!_.startsWith(networkExecPrefix)) &&
             !exec.commandLine.startsWith(networkExecPrefix)) {
           val doneEvent = ExecStatusEvent(

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -131,7 +131,7 @@ object Aggregation {
     if (get(showSuccess)) {
       if (get(showTiming)) {
         val msg = timingString(start, stop, structure.data, currentRef)
-        if (success) log.success(msg) else log.error(msg)
+        if (success) log.success(msg) else if (Terminal.get.isSuccessEnabled) log.error(msg)
       } else if (success)
         log.success("")
     }


### PR DESCRIPTION
In eb688c9ecdb942dbf0fa985c0103f6f95f6341c1, we started buffering output
to the remote client to reduce flickering. This was causing problems
with the output for the thin client in batch mode. With the delay, it
was possible for the client to exit before all of its output had been
displayed.

Bonus: only display aggregation error message if terminal has success
enabled (the thin client displays its own timing message so the message
in aggregation ended up being a duplicate).