### PR TITLE
Set complete flag in completions

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -57,11 +57,14 @@ object LineReader {
          * `testOnly testOnly\ com.foo.FooSpec` instead of `testOnly com.foo.FooSpec`.
          */
         if (c.append.nonEmpty) {
-          if (!pl.line().endsWith(" ")) {
-            candidates.add(new Candidate(pl.line().split(" ").last + c.append))
-          } else {
-            candidates.add(new Candidate(c.append))
-          }
+          val comp =
+            if (!pl.line().endsWith(" ")) pl.line().split(" ").last + c.append else c.append
+          // tell jline to append a " " if the completion would be valid with a " " appended
+          // which can be the case for input tasks and some commands. We need to exclude
+          // the empty string and ";" which always seem to be present.
+          val complete = (Parser.completions(parser, comp + " ", 10).get.map(_.display) --
+            Set(";", "")).nonEmpty
+          candidates.add(new Candidate(comp, comp, null, null, null, null, complete))
         }
       }
     }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -7,7 +7,7 @@
 
 package sbt.internal.util
 
-import java.io.{ InputStream, InterruptedIOException, OutputStream, PrintStream }
+import java.io.{ InputStream, InterruptedIOException, IOException, OutputStream, PrintStream }
 import java.nio.channels.ClosedChannelException
 import java.util.{ Arrays, Locale }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
@@ -171,7 +171,8 @@ object Terminal {
   if (System.getProperty("sbt.jline.verbose", "false") != "true")
     jline.internal.Log.setOutput(new PrintStream(_ => {}, false))
   def consoleLog(string: String): Unit = {
-    Terminal.console.printStream.println(s"[info] $string")
+    try Terminal.console.printStream.println(s"[info] $string")
+    catch { case _: IOException => }
   }
   private[sbt] def set(terminal: Terminal) = {
     activeTerminal.set(terminal)


### PR DESCRIPTION
JLine 3 automatically appends a space character to the completion
candidate unless you tell it not to by setting its 'complete' parameter.
This behavior is generally nice because it will automatically complete
something like 'foo/testO<TAB>' to 'foo/testOnly ' which allows the user
to start typing the testname without having to enter space. It does,
however, break scripted completions because it will complete
'scripted wat<TAB>' to 'scripted watch/ '

This commit updates the custom completer to append a " " to the initial
completions and check if there are any additional completions available.
If so, we set the complete flag to true and jline will append a space to
the input when the user presses <TAB> or <ENTER>. Otherwise the old
jline2 behavior where no spaces are ever appended is preserved.