### PR TITLE
Attempt to make CI less flaky

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -155,4 +155,6 @@ for:
     - '%USERPROFILE%\.sbt'
 
   test_script:
-    - sbt "scripted actions/* classloader-cache/* nio/* watch/*" "serverTestProj/test"
+    # The server tests often fail in CI when run together so just run a single test to ensure
+    # that the thin client works on windows
+    - sbt "scripted actions/* classloader-cache/* nio/* watch/*" "serverTestProj/testOnly testpkg.ClientTest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     # WHITESOURCE_PASSWORD=
     - secure: d3bu2KNwsVHwfhbGgO+gmRfDKBJhfICdCJFGWKf2w3Gv86AJZX9nuTYRxz0KtdvEHO5Xw8WTBZLPb2thSJqhw9OCm4J8TBAVqCP0ruUj4+aqBUFy4bVexQ6WKE6nWHs4JPzPk8c6uC1LG3hMuzlC8RGETXtL/n81Ef1u7NjyXjs=
   matrix:
-    - SBT_CMD="mimaReportBinaryIssues ; javafmtCheck ; Test / javafmtCheck; scalafmtCheckAll ; scalafmtSbtCheck; headerCheck ;test:headerCheck ;whitesourceOnPush ;test:compile; publishLocal; test; serverTestProj/test; doc; $UTIL_TESTS; ++$SCALA_213; $UTIL_TESTS"
+    - SBT_CMD="mimaReportBinaryIssues ; javafmtCheck ; Test / javafmtCheck; scalafmtCheckAll ; scalafmtSbtCheck; serverTestProj/scalafmtCheckAll; headerCheck ;test:headerCheck ;whitesourceOnPush ;test:compile; publishLocal; test; serverTestProj/test; doc; $UTIL_TESTS; ++$SCALA_213; $UTIL_TESTS"
     - SBT_CMD="scripted actions/* apiinfo/* compiler-project/* ivy-deps-management/* reporter/* tests/* watch/* classloader-cache/* package/*"
     - SBT_CMD="scripted dependency-management/* plugins/* project-load/* java/* run/* nio/*"
     - SBT_CMD="repoOverrideTest:scripted dependency-management/*; scripted source-dependencies/* project/*"


### PR DESCRIPTION
These are two small changes to make CI less flaky. The first disables most of the server tests on windows because they seem to fail pretty often. We still will run the client test to ensure that the thin client is still working on windows (and that the server protocol is working in general) but not run all of the tests. I also switched scripted to use `shutdown` rather than `exit` to terminate sbt. I'm not sure if that change will help or not but it shouldn't hurt.