### PR TITLE
Use java caffeine library rather than scalacache

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -873,7 +873,7 @@ lazy val mainProj = (project in file("main"))
         sys.error(s"PluginCross.scala does not match up with the scalaVersion $sv")
     },
     libraryDependencies ++=
-      (Seq(scalaXml, launcherInterface, scalaCacheCaffeine, lmCoursierShaded) ++ log4jModules),
+      (Seq(scalaXml, launcherInterface, caffeine, lmCoursierShaded) ++ log4jModules),
     libraryDependencies ++= (scalaVersion.value match {
       case v if v.startsWith("2.12.") => List(compilerPlugin(silencerPlugin))
       case _                          => List()
@@ -985,6 +985,7 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.interDependencies"),
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.productsTask"),
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.jarProductsTask"),
+      exclude[DirectMissingMethodProblem]("sbt.StandardMain.cache"),
     )
   )
   .configure(

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -161,8 +161,6 @@ private[sbt] object ConsoleMain {
 
 object StandardMain {
   private[sbt] lazy val exchange = new CommandExchange()
-  import scalacache.caffeine._
-  private[sbt] lazy val cache: scalacache.Cache[Any] = CaffeineCache[Any]
   // The access to the pool should be thread safe because lazy val instantiation is thread safe
   // and pool is only referenced directly in closeRunnable after the executionContext is sure
   // to have been instantiated
@@ -174,8 +172,6 @@ object StandardMain {
   })
 
   private[this] val closeRunnable = () => {
-    cache.close()(scalacache.modes.sync.mode)
-    cache.close()(scalacache.modes.scalaFuture.mode(executionContext))
     exchange.shutdown()
     pool.foreach(_.shutdownNow())
   }

--- a/main/src/test/scala/sbt/internal/server/DefinitionTest.scala
+++ b/main/src/test/scala/sbt/internal/server/DefinitionTest.scala
@@ -9,6 +9,8 @@ package sbt
 package internal
 package server
 
+import com.github.benmanes.caffeine.cache.Caffeine
+
 class DefinitionTest extends org.specs2.mutable.Specification {
   import Definition.textProcessor
 
@@ -132,11 +134,8 @@ class DefinitionTest extends org.specs2.mutable.Specification {
 
   "definition" should {
 
-    import scalacache.caffeine._
-    import scalacache.modes.sync._
-
     "cache data in cache" in {
-      val cache = CaffeineCache[Any]
+      val cache = Caffeine.newBuilder().build[String, Definition.Analyses]()
       val cacheFile = "Test.scala"
       val useBinary = true
 
@@ -148,7 +147,7 @@ class DefinitionTest extends org.specs2.mutable.Specification {
     }
 
     "replace cache data in cache" in {
-      val cache = CaffeineCache[Any]
+      val cache = Caffeine.newBuilder().build[String, Definition.Analyses]()
       val cacheFile = "Test.scala"
       val useBinary = true
       val falseUseBinary = false
@@ -162,7 +161,7 @@ class DefinitionTest extends org.specs2.mutable.Specification {
     }
 
     "cache more data in cache" in {
-      val cache = CaffeineCache[Any]
+      val cache = Caffeine.newBuilder().build[String, Definition.Analyses]()
       val cacheFile = "Test.scala"
       val useBinary = true
       val otherCacheFile = "OtherTest.scala"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,7 +105,7 @@ object Dependencies {
   val log4jSlf4jImpl = log4jModule("log4j-slf4j-impl")
   val log4jModules = Vector(log4jApi, log4jCore, log4jSlf4jImpl)
 
-  val scalaCacheCaffeine = "com.github.cb372" %% "scalacache-caffeine" % "0.20.0"
+  val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"
 
   val hedgehog = "hedgehog" %% "hedgehog-sbt" % "0.1.0"
   val disruptor = "com.lmax" % "disruptor" % "3.4.2"


### PR DESCRIPTION
sbt depends on scalacache (which hasn't been updated in about a year)
and we really don't need the functionality provided by scalacache. In
fact, the java api is somewhat easier to work with for our use case. The
motivation is that scalacache uses slf4j for logging which meant that it
was implicitly loading log4j. This caused some noisy logs during
shutdown when the previously unused cache was initialized just to be
cleaned up.

This commit also upgrades caffeine and moving forward we can always
upgrade caffeine (and potentially shade it) without any conflict with
the scalacache version.