### PR TITLE
Replaces Apache Log4j with our own logger to avoid Appender leakage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val utilPosition = (project in file("internal") / "util-position")
 
 lazy val utilLogging = (project in file("internal") / "util-logging")
   .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
-  .dependsOn(utilInterface, collectionProj)
+  .dependsOn(utilInterface, collectionProj, coreMacrosProj)
   .settings(
     utilCommonSettings,
     name := "Util Logging",
@@ -781,7 +781,7 @@ lazy val commandProj = (project in file("main-command"))
 lazy val coreMacrosProj = (project in file("core-macros"))
   .dependsOn(collectionProj)
   .settings(
-    baseSettings,
+    baseSettings :+ (crossScalaVersions := (scala212 :: scala213 :: Nil)),
     name := "Core Macros",
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     mimaSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -410,6 +410,16 @@ lazy val utilLogging = (project in file("internal") / "util-logging")
       exclude[InheritedNewAbstractMethodProblem](
         "sbt.internal.util.codec.JsonProtocol.ProgressEventFormat"
       ),
+      exclude[DirectMissingMethodProblem]("sbt.internal.util.MainAppender.*"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.BufferedAppender.*"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.ManagedLogger.this"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.ManagedLogger.this"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.MainAppender*"),
+      exclude[IncompatibleMethTypeProblem]("sbt.internal.util.GlobalLogging.*"),
+      exclude[IncompatibleSignatureProblem]("sbt.internal.util.GlobalLogging.*"),
+      exclude[IncompatibleSignatureProblem]("sbt.internal.util.MainAppender*"),
+      exclude[MissingTypesProblem]("sbt.internal.util.ConsoleAppender"),
+      exclude[MissingTypesProblem]("sbt.internal.util.BufferedAppender"),
     ),
   )
   .configure(addSbtIO)
@@ -1004,6 +1014,9 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.productsTask"),
       exclude[DirectMissingMethodProblem]("sbt.Classpaths.jarProductsTask"),
       exclude[DirectMissingMethodProblem]("sbt.StandardMain.cache"),
+      // internal logging apis,
+      exclude[IncompatibleSignatureProblem]("sbt.internal.LogManager*"),
+      exclude[MissingTypesProblem]("sbt.internal.RelayAppender"),
     )
   )
   .configure(

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
@@ -1,0 +1,27 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util.appmacro
+
+import scala.reflect.macros.blackbox
+
+object StringTypeTag {
+  def impl[A: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
+    import c.universe._
+    val tpe = weakTypeOf[A]
+    def typeToString(tpe: Type): String = tpe match {
+      case TypeRef(_, sym, args) if args.nonEmpty =>
+        val typeCon = tpe.typeSymbol.fullName
+        val typeArgs = args map typeToString
+        s"""$typeCon[${typeArgs.mkString(",")}]"""
+      case _ => tpe.toString
+    }
+
+    val key = Literal(Constant(typeToString(tpe)))
+    q"new sbt.internal.util.StringTypeTag[$tpe]($key)"
+  }
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -13,11 +13,14 @@ import java.nio.channels.ClosedChannelException
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 
 import org.apache.logging.log4j.core.appender.AbstractAppender
-import org.apache.logging.log4j.core.{ LogEvent => XLogEvent }
+import org.apache.logging.log4j.core.{ Appender => XAppender, LogEvent => XLogEvent }
 import org.apache.logging.log4j.message.{ Message, ObjectMessage, ReusableObjectMessage }
 import org.apache.logging.log4j.{ Level => XLevel }
 import sbt.internal.util.ConsoleAppender._
 import sbt.util._
+import org.apache.logging.log4j.core.AbstractLogEvent
+import org.apache.logging.log4j.message.StringFormatterMessageFactory
+import java.util.concurrent.atomic.AtomicReference
 
 object ConsoleLogger {
   // These are provided so other modules do not break immediately.
@@ -80,7 +83,7 @@ class ConsoleLogger private[ConsoleLogger] (
     suppressedMessage: SuppressedTraceContext => Option[String]
 ) extends BasicLogger {
 
-  private[sbt] val appender: ConsoleAppender =
+  private[sbt] val appender: Appender =
     ConsoleAppender(generateName(), out, ansiCodesSupported, useFormat, suppressedMessage)
 
   override def control(event: ControlEvent.Value, message: => String): Unit =
@@ -117,12 +120,12 @@ object ConsoleAppender {
   private[this] val showProgressHolder: AtomicBoolean = new AtomicBoolean(false)
   def setShowProgress(b: Boolean): Unit = showProgressHolder.set(b)
   def showProgress: Boolean = showProgressHolder.get
-  private[ConsoleAppender] trait Properties {
+  private[sbt] trait Properties {
     def isAnsiSupported: Boolean
     def isColorEnabled: Boolean
     def out: ConsoleOut
   }
-  object Properties {
+  private[sbt] object Properties {
     def from(terminal: Terminal): Properties = new Properties {
       override def isAnsiSupported: Boolean = terminal.isAnsiSupported
       override def isColorEnabled: Boolean = terminal.isColorEnabled
@@ -187,7 +190,7 @@ object ConsoleAppender {
    *
    * @return A new `ConsoleAppender` that writes to standard output.
    */
-  def apply(): ConsoleAppender = apply(ConsoleOut.systemOut)
+  def apply(): Appender = apply(ConsoleOut.systemOut)
 
   /**
    * A new `ConsoleAppender` that appends log message to `out`.
@@ -195,7 +198,7 @@ object ConsoleAppender {
    * @param out Where to write messages.
    * @return A new `ConsoleAppender`.
    */
-  def apply(out: PrintStream): ConsoleAppender = apply(ConsoleOut.printStreamOut(out))
+  def apply(out: PrintStream): Appender = apply(ConsoleOut.printStreamOut(out))
 
   /**
    * A new `ConsoleAppender` that appends log messages to `out`.
@@ -203,7 +206,7 @@ object ConsoleAppender {
    * @param out Where to write messages.
    * @return A new `ConsoleAppender`.
    */
-  def apply(out: PrintWriter): ConsoleAppender = apply(ConsoleOut.printWriterOut(out))
+  def apply(out: PrintWriter): Appender = apply(ConsoleOut.printWriterOut(out))
 
   /**
    * A new `ConsoleAppender` that writes to `out`.
@@ -211,7 +214,7 @@ object ConsoleAppender {
    * @param out Where to write messages.
    * @return A new `ConsoleAppender that writes to `out`.
    */
-  def apply(out: ConsoleOut): ConsoleAppender = apply(generateName(), out)
+  def apply(out: ConsoleOut): Appender = apply(generateName(), out)
 
   /**
    * A new `ConsoleAppender` identified by `name`, and that writes to standard output.
@@ -219,7 +222,7 @@ object ConsoleAppender {
    * @param name An identifier for the `ConsoleAppender`.
    * @return A new `ConsoleAppender` that writes to standard output.
    */
-  def apply(name: String): ConsoleAppender = apply(name, ConsoleOut.systemOut)
+  def apply(name: String): Appender = apply(name, ConsoleOut.systemOut)
 
   /**
    * A new `ConsoleAppender` identified by `name`, and that writes to `out`.
@@ -228,7 +231,7 @@ object ConsoleAppender {
    * @param out Where to write messages.
    * @return A new `ConsoleAppender` that writes to `out`.
    */
-  def apply(name: String, out: ConsoleOut): ConsoleAppender = apply(name, out, formatEnabledInEnv)
+  def apply(name: String, out: ConsoleOut): Appender = apply(name, out, formatEnabledInEnv)
 
   /**
    * A new `ConsoleAppender` identified by `name`, and that writes to `out`.
@@ -242,7 +245,7 @@ object ConsoleAppender {
       name: String,
       out: ConsoleOut,
       suppressedMessage: SuppressedTraceContext => Option[String]
-  ): ConsoleAppender =
+  ): Appender =
     apply(name, out, formatEnabledInEnv, formatEnabledInEnv, suppressedMessage)
 
   /**
@@ -253,7 +256,7 @@ object ConsoleAppender {
    * @param useFormat `true` to enable format (color, bold, etc.), `false` to remove formatting.
    * @return A new `ConsoleAppender` that writes to `out`.
    */
-  def apply(name: String, out: ConsoleOut, useFormat: Boolean): ConsoleAppender =
+  def apply(name: String, out: ConsoleOut, useFormat: Boolean): Appender =
     apply(name, out, useFormat || formatEnabledInEnv, useFormat, noSuppressedMessage)
 
   /**
@@ -263,10 +266,8 @@ object ConsoleAppender {
    * @param terminal  The terminal to which this appender corresponds
    * @return A new `ConsoleAppender` that writes to `out`.
    */
-  def apply(name: String, terminal: Terminal): ConsoleAppender = {
-    val appender = new ConsoleAppender(name, Properties.from(terminal), noSuppressedMessage)
-    appender.start()
-    appender
+  def apply(name: String, terminal: Terminal): Appender = {
+    new ConsoleAppender(name, Properties.from(terminal), noSuppressedMessage)
   }
 
   /**
@@ -281,10 +282,8 @@ object ConsoleAppender {
       name: String,
       terminal: Terminal,
       suppressedMessage: SuppressedTraceContext => Option[String]
-  ): ConsoleAppender = {
-    val appender = new ConsoleAppender(name, Properties.from(terminal), suppressedMessage)
-    appender.start()
-    appender
+  ): Appender = {
+    new ConsoleAppender(name, Properties.from(terminal), suppressedMessage)
   }
 
   /**
@@ -303,10 +302,12 @@ object ConsoleAppender {
       ansiCodesSupported: Boolean,
       useFormat: Boolean,
       suppressedMessage: SuppressedTraceContext => Option[String]
-  ): ConsoleAppender = {
-    val appender = new ConsoleAppender(name, out, ansiCodesSupported, useFormat, suppressedMessage)
-    appender.start
-    appender
+  ): Appender = {
+    new ConsoleAppender(
+      name,
+      Properties.from(out, ansiCodesSupported, useFormat),
+      suppressedMessage
+    )
   }
 
   /**
@@ -356,18 +357,38 @@ object ConsoleAppender {
  *
  * This logger is not thread-safe.
  */
-class ConsoleAppender private[ConsoleAppender] (
-    name: String,
-    properties: Properties,
-    suppressedMessage: SuppressedTraceContext => Option[String]
-) extends AbstractAppender(name, null, LogExchange.dummyLayout, true, Array.empty) {
-  def this(
-      name: String,
-      out: ConsoleOut,
-      ansiCodesSupported: Boolean,
-      useFormat: Boolean,
-      suppressedMessage: SuppressedTraceContext => Option[String]
-  ) = this(name, Properties.from(out, ansiCodesSupported, useFormat), suppressedMessage)
+class ConsoleAppender(
+    override private[sbt] val name: String,
+    override private[sbt] val properties: Properties,
+    override private[sbt] val suppressedMessage: SuppressedTraceContext => Option[String]
+) extends Appender {
+  private[this] val log4j = new AtomicReference[XAppender](null)
+  override private[sbt] lazy val toLog4J = log4j.get match {
+    case null =>
+      log4j.synchronized {
+        log4j.get match {
+          case null =>
+            val l = new Log4JConsoleAppender(name, properties, suppressedMessage, { event =>
+              val level = ConsoleAppender.toLevel(event.getLevel)
+              val message = event.getMessage
+              try appendMessage(level, message)
+              catch { case _: ClosedChannelException => }
+            })
+            log4j.set(l)
+            l
+          case l => l
+        }
+      }
+  }
+  override def close(): Unit = log4j.get match {
+    case null =>
+    case a    => a.stop()
+  }
+}
+trait Appender extends AutoCloseable {
+  private[sbt] def name: String
+  private[sbt] def properties: Properties
+  private[sbt] def suppressedMessage: SuppressedTraceContext => Option[String]
   import scala.Console.{ BLUE, GREEN, RED, YELLOW }
 
   private[util] def out: ConsoleOut = properties.out
@@ -392,12 +413,7 @@ class ConsoleAppender private[ConsoleAppender] (
    */
   def getTrace: Int = synchronized { traceEnabledVar }
 
-  override def append(event: XLogEvent): Unit = {
-    val level = ConsoleAppender.toLevel(event.getLevel)
-    val message = event.getMessage
-    try appendMessage(level, message)
-    catch { case _: ClosedChannelException => }
-  }
+  private[sbt] def toLog4J: XAppender
 
   /**
    * Logs the stack trace of `t`, possibly shortening it.
@@ -497,7 +513,7 @@ class ConsoleAppender private[ConsoleAppender] (
     out.println(toWrite)
   }
 
-  private def appendMessage(level: Level.Value, msg: Message): Unit =
+  private[util] def appendMessage(level: Level.Value, msg: Message): Unit =
     msg match {
       case o: ObjectMessage         => appendMessageContent(level, o.getParameter)
       case o: ReusableObjectMessage => appendMessageContent(level, o.getParameter)
@@ -549,6 +565,39 @@ class ConsoleAppender private[ConsoleAppender] (
       case x: ObjectEvent[_] => appendEvent(x)
       case _                 => Vector(o.toString) foreach { appendLog(level, _) }
     }
+  }
+  private[sbt] def appendObjectEvent[T](level: Level.Value, message: => ObjectEvent[T]): Unit =
+    appendMessageContent(level, message)
+
+}
+private[internal] class Log4JConsoleAppender(
+    override private[sbt] val name: String,
+    override private[sbt] val properties: Properties,
+    override private[sbt] val suppressedMessage: SuppressedTraceContext => Option[String],
+    appendEvent: XLogEvent => Unit,
+) extends AbstractAppender(name, null, LogExchange.dummyLayout, true, Array.empty)
+    with Appender {
+  start()
+  override def close(): Unit = stop()
+  override private[sbt] def toLog4J: XAppender = this
+  override def append(event: XLogEvent): Unit = appendEvent(event)
+}
+private[sbt] class ConsoleAppenderFromLog4J(
+    override private[sbt] val name: String,
+    override private[sbt] val properties: Properties,
+    override private[sbt] val suppressedMessage: SuppressedTraceContext => Option[String],
+    val delegate: XAppender,
+) extends Appender {
+  def this(name: String, delegate: XAppender) =
+    this(name, Properties.from(Terminal.get), _ => None, delegate)
+  override def close(): Unit = delegate.stop()
+  private[sbt] def toLog4J: XAppender = delegate
+  override def appendLog(level: sbt.util.Level.Value, message: => String): Unit = {
+    delegate.append(new AbstractLogEvent {
+      override def getLevel(): XLevel = ConsoleAppender.toXLevel(level)
+      override def getMessage(): Message =
+        StringFormatterMessageFactory.INSTANCE.newMessage(message.toString, Array.empty)
+    })
   }
 }
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/GlobalLogging.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/GlobalLogging.scala
@@ -9,7 +9,6 @@ package sbt.internal.util
 
 import sbt.util._
 import java.io.{ File, PrintWriter }
-import org.apache.logging.log4j.core.Appender
 
 /**
  * Provides the current global logging configuration.
@@ -25,7 +24,7 @@ final case class GlobalLogging(
     console: ConsoleOut,
     backed: Appender,
     backing: GlobalLogBacking,
-    newAppender: (ManagedLogger, PrintWriter, GlobalLogBacking) => GlobalLogging
+    newAppender: (ManagedLogger, PrintWriter, GlobalLogBacking, LoggerContext) => GlobalLogging
 )
 
 final case class GlobalLogging1(
@@ -78,14 +77,14 @@ object GlobalLogging {
   }
 
   def initial(
-      newAppender: (ManagedLogger, PrintWriter, GlobalLogBacking) => GlobalLogging,
+      newAppender: (ManagedLogger, PrintWriter, GlobalLogBacking, LoggerContext) => GlobalLogging,
       newBackingFile: => File,
       console: ConsoleOut
   ): GlobalLogging = {
     val loggerName = generateName
-    val log = LogExchange.logger(loggerName)
+    val log = LoggerContext.globalContext.logger(loggerName, None, None)
     val appender = ConsoleAppender(ConsoleAppender.generateName, console)
-    LogExchange.bindLoggerAppenders(loggerName, List(appender -> Level.Info))
+    LoggerContext.globalContext.addAppender(loggerName, appender -> Level.Info)
     GlobalLogging(log, console, appender, GlobalLogBacking(newBackingFile), newAppender)
   }
 }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
@@ -7,6 +7,7 @@
 
 package sbt.internal.util
 
+import scala.language.experimental.macros
 import scala.reflect.runtime.universe._
 
 /** This is used to carry type information in JSON. */
@@ -15,6 +16,10 @@ final case class StringTypeTag[A](key: String) {
 }
 
 object StringTypeTag {
+
+  /** Generates a StringTypeTag for any type at compile time. */
+  implicit def fast[A]: StringTypeTag[A] = macro appmacro.StringTypeTag.impl[A]
+  @deprecated("Prefer macro generated StringTypeTag", "1.4.0")
   def apply[A: TypeTag]: StringTypeTag[A] =
     synchronized {
       def doApply: StringTypeTag[A] = {
@@ -38,6 +43,7 @@ object StringTypeTag {
       retry(3)
     }
 
+  @deprecated("Prefer macro generated StringTypeTag", "1.4.0")
   def typeToString(tpe: Type): String =
     tpe match {
       case TypeRef(_, sym, args) =>

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -174,9 +174,9 @@ object Terminal {
     try Terminal.console.printStream.println(s"[info] $string")
     catch { case _: IOException => }
   }
-  private[sbt] def set(terminal: Terminal) = {
-    activeTerminal.set(terminal)
+  private[sbt] def set(terminal: Terminal): Terminal = {
     jline.TerminalFactory.set(terminal.toJLine)
+    activeTerminal.getAndSet(terminal)
   }
   implicit class TerminalOps(private val term: Terminal) extends AnyVal {
     def ansi(richString: => String, string: => String): String =

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.core.config.{ AppenderRef, LoggerConfig }
 import org.apache.logging.log4j.core.layout.PatternLayout
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
-import scala.reflect.runtime.universe.TypeTag
 import sjsonnew.JsonFormat
 
 // http://logging.apache.org/log4j/2.x/manual/customconfig.html
@@ -114,9 +113,15 @@ sealed abstract class LogExchange {
   def getOrElseUpdateStringCodec[A](tag: String, v: ShowLines[A]): ShowLines[A] =
     stringCodecs.getOrElseUpdate(tag, v).asInstanceOf[ShowLines[A]]
 
-  def registerStringCodec[A: ShowLines: TypeTag]: Unit = {
-    val tag = StringTypeTag[A]
-    registerStringCodecByStringTypeTag(tag)
+  @deprecated("Prefer macro based registerStringCodec", "1.4.0")
+  def registerStringCodec[A](
+      st: ShowLines[A],
+      tt: scala.reflect.runtime.universe.TypeTag[A]
+  ): Unit = {
+    registerStringCodecByStringTypeTag(StringTypeTag.apply[A](tt))(st)
+  }
+  private[sbt] def registerStringCodec[A: ShowLines: StringTypeTag]: Unit = {
+    registerStringCodecByStringTypeTag(implicitly[StringTypeTag[A]])
   }
 
   private[sbt] def registerStringCodecByStringTypeTag[A: ShowLines](tag: StringTypeTag[A]): Unit = {

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -24,7 +24,6 @@ sealed abstract class LogExchange {
   private[sbt] lazy val context: LoggerContext = init()
   private[sbt] lazy val builtInStringCodecs: Unit = initStringCodecs()
   private[sbt] lazy val asyncStdout: AsyncAppender = buildAsyncStdout
-  private[sbt] val jsonCodecs: concurrent.Map[String, JsonFormat[_]] = concurrent.TrieMap()
   private[sbt] val stringCodecs: concurrent.Map[String, ShowLines[_]] = concurrent.TrieMap()
 
   def logger(name: String): ManagedLogger = logger(name, None, None)
@@ -100,12 +99,15 @@ sealed abstract class LogExchange {
     lo
   }
 
-  def jsonCodec[A](tag: String): Option[JsonFormat[A]] =
-    jsonCodecs.get(tag) map { _.asInstanceOf[JsonFormat[A]] }
-  def hasJsonCodec(tag: String): Boolean =
-    jsonCodecs.contains(tag)
-  def getOrElseUpdateJsonCodec[A](tag: String, v: JsonFormat[A]): JsonFormat[A] =
-    jsonCodecs.getOrElseUpdate(tag, v).asInstanceOf[JsonFormat[A]]
+  @deprecated("It is now necessary to provide a json format instance", "1.4.0")
+  def jsonCodec[A](tag: String): Option[JsonFormat[A]] = None
+  @deprecated("Always returns false", "1.4.0")
+  def hasJsonCodec(tag: String): Boolean = false
+  @deprecated("This is a no-op", "1.4.0")
+  def getOrElseUpdateJsonCodec[A](tag: String, v: JsonFormat[A]): JsonFormat[A] = v
+  @deprecated("The log manager no longer caches jsonCodecs", "1.4.0")
+  def jsonCodecs(): concurrent.Map[String, JsonFormat[_]] = concurrent.TrieMap.empty
+
   def stringCodec[A](tag: String): Option[ShowLines[A]] =
     stringCodecs.get(tag) map { _.asInstanceOf[ShowLines[A]] }
   def hasStringCodec(tag: String): Boolean =

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -1,0 +1,189 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.util
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import org.apache.logging.log4j.{ Level => XLevel }
+import org.apache.logging.log4j.core.{ Appender => XAppender, LoggerContext => XLoggerContext }
+import org.apache.logging.log4j.core.config.{ AppenderRef, LoggerConfig }
+import sbt.internal.util._
+import scala.collection.JavaConverters._
+import org.apache.logging.log4j.core.config.AbstractConfiguration
+import org.apache.logging.log4j.message.ObjectMessage
+
+/**
+ * Provides a context for generating loggers during task evaluation. The logger context
+ * can be initialized for a single command evaluation run and all of the resources
+ * created (such as cached logger appenders) can be cleaned up after task evaluation.
+ * This trait evolved out of LogExchange when it became clear that it was very difficult
+ * to manage the loggers and appenders without introducing memory leaks.
+ */
+sealed trait LoggerContext extends AutoCloseable {
+  def logger(name: String, channelName: Option[String], execId: Option[String]): ManagedLogger
+  def clearAppenders(loggerName: String): Unit
+  def addAppender(
+      loggerName: String,
+      appender: (Appender, Level.Value)
+  ): Unit
+  def appenders(loggerName: String): Seq[Appender]
+  def remove(name: String): Unit
+}
+object LoggerContext {
+  private[this] val useLog4J = System.getProperty("sbt.log.uselog4j", "false") == "true"
+  private[this] lazy val global = new LoggerContext.LoggerContextImpl
+  private[this] lazy val globalLog4J = new LoggerContext.Log4JLoggerContext(LogExchange.context)
+  private[sbt] lazy val globalContext = if (useLog4J) globalLog4J else global
+  private[util] class Log4JLoggerContext(val xlc: XLoggerContext) extends LoggerContext {
+    private val config = xlc.getConfiguration match {
+      case a: AbstractConfiguration => a
+      case _                        => throw new IllegalStateException("")
+    }
+    val loggers = new java.util.Vector[String]
+    private[this] val closed = new AtomicBoolean(false)
+    override def logger(
+        name: String,
+        channelName: Option[String],
+        execId: Option[String]
+    ): ManagedLogger = {
+      if (closed.get) {
+        throw new IllegalStateException("Tried to create logger for closed LoggerContext")
+      }
+      val loggerConfig = LoggerConfig.createLogger(
+        false,
+        XLevel.DEBUG,
+        name,
+        // disable the calculation of caller location as it is very expensive
+        // https://issues.apache.org/jira/browse/LOG4J2-153
+        "false",
+        Array[AppenderRef](),
+        null,
+        config,
+        null
+      )
+      config.addLogger(name, loggerConfig)
+      val logger = xlc.getLogger(name)
+      LogExchange.addConfig(name, loggerConfig)
+      loggers.add(name)
+      val xlogger = new MiniLogger {
+        def log(level: Level.Value, message: => String): Unit =
+          logger.log(
+            ConsoleAppender.toXLevel(level),
+            new ObjectMessage(StringEvent(level.toString, message, channelName, execId))
+          )
+        def log[T](level: Level.Value, message: ObjectEvent[T]): Unit =
+          logger.log(ConsoleAppender.toXLevel(level), new ObjectMessage(message))
+      }
+      new ManagedLogger(name, channelName, execId, xlogger, Some(Terminal.get), this)
+    }
+    override def clearAppenders(loggerName: String): Unit = {
+      val lc = config.getLoggerConfig(loggerName)
+      lc.getAppenders.asScala foreach {
+        case (name, a) =>
+          a.stop()
+          lc.removeAppender(name)
+      }
+    }
+    override def addAppender(
+        loggerName: String,
+        appender: (Appender, Level.Value)
+    ): Unit = {
+      val lc = config.getLoggerConfig(loggerName)
+      appender match {
+        case (x: XAppender, lv) => lc.addAppender(x, ConsoleAppender.toXLevel(lv), null)
+        case (x, lv)            => lc.addAppender(x.toLog4J, ConsoleAppender.toXLevel(lv), null)
+      }
+    }
+    override def appenders(loggerName: String): Seq[Appender] = {
+      val lc = config.getLoggerConfig(loggerName)
+      lc.getAppenders.asScala.collect { case (name, ca: ConsoleAppender) => ca }.toVector
+    }
+    override def remove(name: String): Unit = {
+      val lc = config.getLoggerConfig(name)
+      config.removeLogger(name)
+    }
+    def close(): Unit = if (closed.compareAndSet(false, true)) {
+      loggers.forEach(l => remove(l))
+      loggers.clear()
+    }
+  }
+  private[util] class LoggerContextImpl extends LoggerContext {
+    private class Log extends MiniLogger {
+      private val consoleAppenders: java.util.Vector[(Appender, Level.Value)] =
+        new java.util.Vector
+      def log(level: Level.Value, message: => String): Unit =
+        consoleAppenders.forEach {
+          case (a, l) =>
+            if (level.compare(l) >= 0) a.appendLog(level, message)
+        }
+      def log[T](level: Level.Value, message: ObjectEvent[T]): Unit = {
+        consoleAppenders.forEach {
+          case (a, l) =>
+            if (level.compare(l) >= 0) a.appendObjectEvent(level, message)
+        }
+      }
+      def addAppender(newAppender: (Appender, Level.Value)): Unit =
+        Util.ignoreResult(consoleAppenders.add(newAppender))
+      def clearAppenders(): Unit = {
+        consoleAppenders.forEach { case (a, _) => a.close() }
+        consoleAppenders.clear()
+      }
+      def appenders: Seq[Appender] = consoleAppenders.asScala.map(_._1).toVector
+    }
+    private[this] val loggers = new ConcurrentHashMap[String, Log]
+    private[this] val closed = new AtomicBoolean(false)
+    override def logger(
+        name: String,
+        channelName: Option[String],
+        execId: Option[String]
+    ): ManagedLogger = {
+      if (closed.get) {
+        throw new IllegalStateException("Tried to create logger for closed LoggerContext")
+      }
+      val xlogger = new Log
+      loggers.put(name, xlogger)
+      new ManagedLogger(name, channelName, execId, xlogger, Some(Terminal.get), this)
+    }
+    override def clearAppenders(loggerName: String): Unit = {
+      loggers.get(loggerName) match {
+        case null =>
+        case l    => l.clearAppenders()
+      }
+    }
+    override def addAppender(
+        loggerName: String,
+        appender: (Appender, Level.Value)
+    ): Unit = {
+      if (closed.get) {
+        throw new IllegalStateException("Tried to add appender for closed LoggerContext")
+      }
+      loggers.get(loggerName) match {
+        case null =>
+        case l    => l.addAppender(appender)
+      }
+    }
+    override def appenders(loggerName: String): Seq[Appender] = {
+      loggers.get(loggerName) match {
+        case null => Nil
+        case l    => l.appenders
+      }
+    }
+    override def remove(name: String): Unit = {
+      loggers.remove(name) match {
+        case null =>
+        case l    => l.clearAppenders()
+      }
+    }
+    def close(): Unit = {
+      loggers.forEach((name, l) => l.clearAppenders())
+      loggers.clear()
+    }
+  }
+  private[sbt] def apply(useLog4J: Boolean) =
+    if (useLog4J) new Log4JLoggerContext(LogExchange.context) else new LoggerContextImpl
+}

--- a/internal/util-logging/src/test/scala/LogExchangeSpec.scala
+++ b/internal/util-logging/src/test/scala/LogExchangeSpec.scala
@@ -14,9 +14,17 @@ import org.scalatest._
 class LogExchangeSpec extends FlatSpec with Matchers {
   import LogExchange._
 
-  checkTypeTag("stringTypeTagThrowable", stringTypeTagThrowable, StringTypeTag[Throwable])
-  checkTypeTag("stringTypeTagTraceEvent", stringTypeTagTraceEvent, StringTypeTag[TraceEvent])
-  checkTypeTag("stringTypeTagSuccessEvent", stringTypeTagSuccessEvent, StringTypeTag[SuccessEvent])
+  checkTypeTag("stringTypeTagThrowable", stringTypeTagThrowable, StringTypeTag.fast[Throwable])
+  checkTypeTag(
+    "stringTypeTagTraceEvent",
+    stringTypeTagTraceEvent,
+    StringTypeTag.fast[TraceEvent]
+  )
+  checkTypeTag(
+    "stringTypeTagSuccessEvent",
+    stringTypeTagSuccessEvent,
+    StringTypeTag.fast[SuccessEvent]
+  )
 
   private def checkTypeTag[A](name: String, inc: StringTypeTag[A], exp: StringTypeTag[A]): Unit =
     s"LogExchange.$name" should s"match real StringTypeTag[$exp]" in {

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -84,7 +84,7 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
     } {
       pool.submit(new Runnable {
         def run(): Unit = {
-          val stringTypeTag = StringTypeTag[List[Int]]
+          val stringTypeTag = StringTypeTag.fast[List[Int]]
           val log = LogExchange.logger(s"foo$i")
           LogExchange.bindLoggerAppenders(s"foo$i", List(LogExchange.asyncStdout -> Level.Info))
           if (i % 100 == 0) {

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -11,25 +11,30 @@ import org.scalatest._
 import sbt.util._
 import java.io.{ File, PrintWriter }
 import sbt.io.Using
+import com.github.ghik.silencer.silent
 
 class ManagedLoggerSpec extends FlatSpec with Matchers {
+  val context = LoggerContext(useLog4J = true)
+  @silent
+  val asyncStdout = new ConsoleAppenderFromLog4J("asyncStdout", LogExchange.asyncStdout)
+  def newLogger(name: String): ManagedLogger = context.logger(name, None, None)
   "ManagedLogger" should "log to console" in {
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     log.info("test")
     log.debug("test")
   }
 
   it should "support event logging" in {
     import sjsonnew.BasicJsonProtocol._
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     log.infoEvent(1)
   }
 
   it should "validate performance improvement of disabling location calculation for async loggers" in {
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     val before = System.currentTimeMillis()
     1 to 10000 foreach { _ =>
       log.debug("test")
@@ -41,15 +46,15 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
 
   it should "support logging Throwable out of the box" in {
     import sbt.internal.util.codec.JsonProtocol._
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     log.infoEvent(SuccessEvent("yes"))
   }
 
   it should "allow registering Show[Int]" in {
     import sjsonnew.BasicJsonProtocol._
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     implicit val intShow: ShowLines[Int] =
       ShowLines((x: Int) => Vector(s"String representation of $x"))
     log.registerStringCodec[Int]
@@ -58,8 +63,8 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
 
   it should "allow registering Show[Array[Int]]" in {
     import sjsonnew.BasicJsonProtocol._
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     implicit val intArrayShow: ShowLines[Array[Int]] =
       ShowLines((x: Array[Int]) => Vector(s"String representation of ${x.mkString}"))
     log.registerStringCodec[Array[Int]]
@@ -68,8 +73,8 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
 
   it should "allow registering Show[Vector[Vector[Int]]]" in {
     import sjsonnew.BasicJsonProtocol._
-    val log = LogExchange.logger("foo")
-    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val log = newLogger("foo")
+    context.addAppender("foo", asyncStdout -> Level.Info)
     implicit val intVectorShow: ShowLines[Vector[Vector[Int]]] =
       ShowLines((xss: Vector[Vector[Int]]) => Vector(s"String representation of $xss"))
     log.registerStringCodec[Vector[Vector[Int]]]
@@ -85,8 +90,8 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
       pool.submit(new Runnable {
         def run(): Unit = {
           val stringTypeTag = StringTypeTag.fast[List[Int]]
-          val log = LogExchange.logger(s"foo$i")
-          LogExchange.bindLoggerAppenders(s"foo$i", List(LogExchange.asyncStdout -> Level.Info))
+          val log = newLogger(s"foo$i")
+          context.addAppender(s"foo$i", asyncStdout -> Level.Info)
           if (i % 100 == 0) {
             log.info(s"foo$i test $stringTypeTag")
           }
@@ -113,7 +118,7 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
     val logBacking0 = global0.backing
     val global1 = Using.fileWriter(append = true)(logBacking0.file) { writer =>
       val out = new PrintWriter(writer)
-      val g = global0.newAppender(global0.full, out, logBacking0)
+      val g = global0.newAppender(global0.full, out, logBacking0, context)
       val full = g.full
       (1 to 3).toList foreach (x => full.info(s"newAppender $x"))
       assert(logBacking0.file.exists)
@@ -122,7 +127,7 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
     val logBacking1 = global1.backing
     Using.fileWriter(append = true)(logBacking1.file) { writer =>
       val out = new PrintWriter(writer)
-      val g = global1.newAppender(global1.full, out, logBacking1)
+      val g = global1.newAppender(global1.full, out, logBacking1, context)
       val full = g.full
       (1 to 3).toList foreach (x => full.info(s"newAppender $x"))
       // println(logBacking.file)

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -215,7 +215,6 @@ $AliasCommand name=
 
   def FailureWall: String = "resumeFromFailure"
 
-  def SetTerminal = "sbtSetTerminal"
   def ReportResult = "sbtReportResult"
   def CompleteExec = "sbtCompleteExec"
   def MapExec = "sbtMapExec"

--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -21,7 +21,6 @@ import BasicCommandStrings.{
   MapExec,
   PopOnFailure,
   ReportResult,
-  SetTerminal,
   StartServer,
   StashOnFailure,
   networkExecPrefix,
@@ -314,10 +313,8 @@ object State {
               val stash = Exec(StashOnFailure, None)
               val failureWall = Exec(FailureWall, None)
               val pop = Exec(PopOnFailure, None)
-              val setTerm = Exec(s"$SetTerminal ${s.channelName}", None)
-              val setConsole = Exec(s"$SetTerminal console0", None)
-              val remaining = stash :: map :: cmd :: complete :: failureWall :: pop :: setConsole :: report :: xs
-              runCmd(setTerm, remaining)
+              val remaining = map :: cmd :: complete :: failureWall :: pop :: report :: xs
+              runCmd(stash, remaining)
             case _ => runCmd(x, xs)
           }
       }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -15,7 +15,7 @@ import lmcoursier.definitions.{ CacheLogger, ModuleMatchers, Reconciliation }
 import lmcoursier.{ CoursierConfiguration, FallbackDependency }
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor
 import org.apache.ivy.core.module.id.ModuleRevisionId
-import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.{ Appender => XAppender }
 import sbt.BuildSyntax._
 import sbt.Def.ScopedKey
 import sbt.KeyRanks._
@@ -27,7 +27,7 @@ import sbt.internal.io.WatchState
 import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
 import sbt.internal.remotecache.RemoteCacheArtifact
 import sbt.internal.server.ServerHandler
-import sbt.internal.util.{ AttributeKey, ProgressState, SourcePosition }
+import sbt.internal.util.{ Appender, AttributeKey, ProgressState, SourcePosition }
 import sbt.io._
 import sbt.librarymanagement.Configurations.CompilerPlugin
 import sbt.librarymanagement.LibraryManagementCodec._
@@ -35,7 +35,7 @@ import sbt.librarymanagement._
 import sbt.librarymanagement.ivy.{ Credentials, IvyConfiguration, IvyPaths, UpdateOptions }
 import sbt.nio.file.Glob
 import sbt.testing.Framework
-import sbt.util.{ Level, Logger }
+import sbt.util.{ Level, Logger, LoggerContext }
 import xsbti.{ FileConverter, VirtualFile }
 import xsbti.compile._
 import xsbti.compile.analysis.ReadStamps
@@ -59,8 +59,12 @@ object Keys {
   val showSuccess = settingKey[Boolean]("If true, displays a success message after running a command successfully.").withRank(CSetting)
   val showTiming = settingKey[Boolean]("If true, the command success message includes the completion time.").withRank(CSetting)
   val timingFormat = settingKey[java.text.DateFormat]("The format used for displaying the completion time.").withRank(CSetting)
-  val extraLoggers = settingKey[ScopedKey[_] => Seq[Appender]]("A function that provides additional loggers for a given setting.").withRank(DSetting)
+  @deprecated("", "1.4.0")
+  val extraLoggers = settingKey[ScopedKey[_] => Seq[XAppender]]("A function that provides additional loggers for a given setting.").withRank(DSetting)
+  val extraAppenders = settingKey[ScopedKey[_] => Seq[Appender]]("A function that provides additional loggers for a given setting.").withRank(DSetting)
+  val useLog4J = settingKey[Boolean]("Toggles whether or not to use log4j for sbt internal loggers.").withRank(Invisible)
   val logManager = settingKey[LogManager]("The log manager, which creates Loggers for different contexts.").withRank(DSetting)
+  private[sbt] val loggerContext = AttributeKey[LoggerContext]("sbt-logger-context", "The logger config which creates Loggers for different contexts.", Int.MaxValue)
   val logBuffered = settingKey[Boolean]("True if logging should be buffered until work completes.").withRank(CSetting)
   val sLog = settingKey[Logger]("Logger usable by settings during project loading.").withRank(CSetting)
   val serverLog = taskKey[Unit]("A dummy task to set server log level using Global / serverLog / logLevel.").withRank(CTask)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -15,7 +15,7 @@ import java.util.Properties
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.atomic.AtomicBoolean
 
-import sbt.BasicCommandStrings.{ SetTerminal, Shell, Shutdown, TemplateCommand, networkExecPrefix }
+import sbt.BasicCommandStrings.{ Shell, Shutdown, TemplateCommand, networkExecPrefix }
 import sbt.Project.LoadAction
 import sbt.compiler.EvalImports
 import sbt.internal.Aggregation.AnyKeys
@@ -311,7 +311,6 @@ object BuiltinCommands {
       NetworkChannel.disconnect,
       waitCmd,
       promptChannel,
-      setTerminalCommand,
     ) ++ allBasicCommands ++ ContinuousCommands.value
 
   def DefaultBootCommands: Seq[String] =
@@ -958,12 +957,6 @@ object BuiltinCommands {
     val help = Help.more(ClearCaches, ClearCachesDetailed)
     val f: State => State = registerCompilerCache _ andThen (_.initializeClassLoaderCache) andThen addCacheStoreFactoryFactory
     Command.command(ClearCaches, help)(f)
-  }
-
-  def setTerminalCommand = Command.arb(_ => BasicCommands.reportParser(SetTerminal)) {
-    (s, channel) =>
-      StandardMain.exchange.channelForName(channel).foreach(c => Terminal.set(c.terminal))
-      s
   }
 
   private[sbt] def waitCmd: Command =

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -930,8 +930,9 @@ object BuiltinCommands {
     val session = Load.initialSession(structure, eval, s0)
     SessionSettings.checkSession(session, s2)
     val s3 = addCacheStoreFactoryFactory(Project.setProject(session, structure, s2))
-    val s4 = setupGlobalFileTreeRepository(s3)
-    CheckBuildSources.init(LintUnused.lintUnusedFunc(s4))
+    val s4 = s3.put(Keys.useLog4J.key, Project.extract(s3).get(Keys.useLog4J))
+    val s5 = setupGlobalFileTreeRepository(s4)
+    CheckBuildSources.init(LintUnused.lintUnusedFunc(s5))
   }
 
   private val setupGlobalFileTreeRepository: State => State = { state =>

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1210,9 +1210,8 @@ private[sbt] object ContinuousCommands {
     state.get(watchStates).flatMap(_.get(channel)) match {
       case None => state
       case Some(cs) =>
-        val pre = StashOnFailure :: s"$SetTerminal $channel" :: s"$preWatch $channel" :: Nil
-        val post = FailureWall :: PopOnFailure :: s"$SetTerminal ${ConsoleChannel.defaultName}" ::
-          s"$postWatch $channel" :: s"$waitWatch $channel" :: Nil
+        val pre = StashOnFailure :: s"$preWatch $channel" :: Nil
+        val post = FailureWall :: PopOnFailure :: s"$postWatch $channel" :: s"$waitWatch $channel" :: Nil
         pre ::: cs.commands.toList ::: post ::: state
     }
   }
@@ -1251,7 +1250,7 @@ private[sbt] object ContinuousCommands {
         case Watch.Trigger     => Right(s"$runWatch ${channel.name}")
         case Watch.Reload =>
           val rewatch = s"$ContinuousExecutePrefix ${ws.count} ${cs.commands mkString "; "}"
-          stop.map(_ :: s"$SetTerminal ${channel.name}" :: "reload" :: rewatch :: Nil mkString "; ")
+          stop.map(_ :: "reload" :: rewatch :: Nil mkString "; ")
         case Watch.Prompt => stop.map(_ :: s"$PromptChannel ${channel.name}" :: Nil mkString ";")
         case Watch.Run(commands) =>
           stop.map(_ +: commands.map(_.commandLine).filter(_.nonEmpty) mkString "; ")

--- a/main/src/main/scala/sbt/internal/FastTrackCommands.scala
+++ b/main/src/main/scala/sbt/internal/FastTrackCommands.scala
@@ -10,7 +10,7 @@ package internal
 
 import BasicCommandStrings._
 import BasicCommands._
-import BuiltinCommands.{ setTerminalCommand, shell, waitCmd }
+import BuiltinCommands.{ shell, waitCmd }
 import ContinuousCommands._
 
 import sbt.internal.util.complete.Parser
@@ -32,7 +32,6 @@ private[sbt] object FastTrackCommands {
     StashOnFailure -> fromCommand(StashOnFailure, stashOnFailure, arguments = false),
     PopOnFailure -> fromCommand(PopOnFailure, popOnFailure, arguments = false),
     Shell -> fromCommand(Shell, shell),
-    SetTerminal -> fromCommand(SetTerminal, setTerminalCommand),
     failWatch -> fromCommand(failWatch, failWatchCommand),
     preWatch -> fromCommand(preWatch, preWatchCommand),
     postWatch -> fromCommand(postWatch, postWatchCommand),

--- a/main/src/main/scala/sbt/internal/RelayAppender.scala
+++ b/main/src/main/scala/sbt/internal/RelayAppender.scala
@@ -8,45 +8,18 @@
 package sbt
 package internal
 
-import org.apache.logging.log4j.message._
-import org.apache.logging.log4j.core.{ LogEvent => XLogEvent }
-import org.apache.logging.log4j.core.appender.AbstractAppender
-import org.apache.logging.log4j.core.layout.PatternLayout
-import org.apache.logging.log4j.core.async.RingBufferLogEvent
-import org.apache.logging.log4j.core.config.Property
-import sbt.util.Level
 import sbt.internal.util._
 import sbt.protocol.LogEvent
+import sbt.util.Level
 
-class RelayAppender(name: String)
-    extends AbstractAppender(
+class RelayAppender(override val name: String)
+    extends ConsoleAppender(
       name,
-      null,
-      PatternLayout.createDefaultLayout(),
-      true,
-      Property.EMPTY_ARRAY
+      ConsoleAppender.Properties.from(ConsoleOut.globalProxy, true, true),
+      _ => None
     ) {
   lazy val exchange = StandardMain.exchange
-
-  def append(event: XLogEvent): Unit = {
-    val level = ConsoleAppender.toLevel(event.getLevel)
-    val message = event.getMessage
-    message match {
-      case o: ObjectMessage        => appendEvent(o.getParameter)
-      case p: ParameterizedMessage => appendLog(level, p.getFormattedMessage)
-      case r: RingBufferLogEvent   => appendLog(level, r.getFormattedMessage)
-      case _                       => appendLog(level, message.toString)
-    }
+  override def appendLog(level: Level.Value, message: => String): Unit = {
+    exchange.logMessage(LogEvent(level = level.toString, message = message))
   }
-  def appendLog(level: Level.Value, message: => String): Unit = {
-    exchange.logMessage(LogEvent(level.toString, message))
-  }
-  def appendEvent(event: AnyRef): Unit =
-    event match {
-      case x: StringEvent    => exchange.logMessage(LogEvent(level = x.level, message = x.message))
-      case x: ObjectEvent[_] => // ignore object events
-      case _ =>
-        println(s"appendEvent: ${event.getClass}")
-        ()
-    }
 }

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -115,6 +115,7 @@ object SysProp {
 
   def banner: Boolean = getOrTrue("sbt.banner")
 
+  def useLog4J: Boolean = getOrFalse("sbt.log.uselog4j")
   def turbo: Boolean = getOrFalse("sbt.turbo")
   def pipelining: Boolean = getOrFalse("sbt.pipelining")
 

--- a/main/src/main/scala/sbt/internal/XMainConfiguration.scala
+++ b/main/src/main/scala/sbt/internal/XMainConfiguration.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.{ ExecutorService, Executors }
 import ClassLoaderClose.close
 
 import sbt.plugins.{ CorePlugin, IvyPlugin, JvmPlugin }
-import sbt.util.LogExchange
 import xsbti._
 
 private[internal] object ClassLoaderWarmup {
@@ -29,7 +28,6 @@ private[internal] object ClassLoaderWarmup {
         ()
       }
 
-      submit(LogExchange.context)
       submit(Class.forName("sbt.internal.parser.SbtParserInit").getConstructor().newInstance())
       submit(CorePlugin.projectSettings)
       submit(IvyPlugin.projectSettings)

--- a/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
@@ -10,7 +10,7 @@ package internal.nio
 
 import java.nio.file.Path
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
-import sbt.BasicCommandStrings.{ RebootCommand, SetTerminal, Shutdown, TerminateAction }
+import sbt.BasicCommandStrings.{ RebootCommand, Shutdown, TerminateAction }
 import sbt.Keys.{ baseDirectory, pollInterval, state }
 import sbt.Scope.Global
 import sbt.SlashSyntax0._
@@ -108,11 +108,7 @@ private[sbt] class CheckBuildSources extends AutoCloseable {
       state: State,
       exec: Exec
   ): Boolean = {
-    val isSetTerminal = exec.commandLine.startsWith(SetTerminal)
-    val name =
-      if (isSetTerminal)
-        exec.commandLine.split(s"$SetTerminal ").lastOption.filterNot(_.isEmpty)
-      else exec.source.map(_.channelName)
+    val name = exec.source.map(_.channelName)
     val loggerOrTerminal =
       name.flatMap(StandardMain.exchange.channelForName(_).map(_.terminal)) match {
         case Some(t) => Right(t)

--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -11,7 +11,7 @@ import java.io.File
 
 import sbt.StandardMain
 import sbt.internal.bsp._
-import sbt.internal.inc.ManagedLoggedReporter
+import sbt.internal.inc.LoggedReporter
 import sbt.internal.util.ManagedLogger
 import xsbti.{ Problem, Severity, Position => XPosition }
 
@@ -30,7 +30,11 @@ class BuildServerReporter(
     logger: ManagedLogger,
     sourcePositionMapper: XPosition => XPosition = identity[XPosition],
     sources: Seq[File]
-) extends ManagedLoggedReporter(maximumErrors, logger, sourcePositionMapper) {
+) extends LoggedReporter(maximumErrors, logger, sourcePositionMapper) {
+  import LoggedReporter.problemFormats._
+  import LoggedReporter.problemStringFormats._
+  logger.registerStringCodec[Problem]
+
   import sbt.internal.bsp.codec.JsonProtocol._
   import sbt.internal.inc.JavaInterfaceUtil._
 
@@ -55,21 +59,21 @@ class BuildServerReporter(
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logError(problem)
+    logger.errorEvent(problem)
   }
 
   override def logWarning(problem: Problem): Unit = {
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logWarning(problem)
+    logger.warnEvent(problem)
   }
 
   override def logInfo(problem: Problem): Unit = {
     publishDiagnostic(problem)
 
     // console channel can keep using the xsbi.Problem
-    super.logInfo(problem)
+    logger.infoEvent(problem)
   }
 
   private def publishDiagnostic(problem: Problem): Unit = {

--- a/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
+++ b/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
@@ -10,10 +10,9 @@ package internal.testing
 
 import testing.{ Logger => TLogger }
 import sbt.internal.util.{ BufferedAppender, ConsoleAppender, ManagedLogger }
-import sbt.util.{ Level, LogExchange, ShowLines }
+import sbt.util.{ Level, ShowLines }
 import sbt.protocol.testing._
 import java.util.concurrent.atomic.AtomicInteger
-import scala.collection.JavaConverters._
 
 object TestLogger {
   import sbt.protocol.testing.codec.JsonProtocol._
@@ -35,20 +34,28 @@ object TestLogger {
       val buffered: Boolean
   )
 
-  def make(global: ManagedLogger, perTest: TestDefinition => PerTest): TestLogger = {
+  @deprecated("Use make variant that accepts a log level.", "1.4.0")
+  def make(
+      global: ManagedLogger,
+      perTest: TestDefinition => PerTest,
+  ): TestLogger = make(global, perTest, Level.Debug)
+
+  def make(
+      global: ManagedLogger,
+      perTest: TestDefinition => PerTest,
+      level: Level.Value
+  ): TestLogger = {
+    val context = global.context
+    val as = context.appenders(global.name)
     def makePerTest(tdef: TestDefinition): ContentLogger = {
       val per = perTest(tdef)
       val l0 = per.log
-      val config = LogExchange.loggerConfig(l0.name)
-      val as = config.getAppenders.asScala
-      val buffs: List[BufferedAppender] = (as map {
-        case (_, v) => BufferedAppender(generateBufferName, v)
-      }).toList
-      val newLog = LogExchange.logger(generateName, l0.channelName, l0.execId)
-      LogExchange.unbindLoggerAppenders(newLog.name)
-      LogExchange.bindLoggerAppenders(newLog.name, buffs map { x =>
-        (x, Level.Debug)
-      })
+      val buffs = as.map(a => BufferedAppender(generateBufferName, a)).toList
+      val newLog = context.logger(generateName, l0.channelName, l0.execId)
+      context.clearAppenders(newLog.name)
+      buffs.foreach { b =>
+        context.addAppender(newLog.name, b -> level)
+      }
       if (per.buffered) {
         buffs foreach { _.record() }
       }


### PR DESCRIPTION
Prior to these changes, sbt was leaking large amounts of memory via
log4j appenders. sbt has an unusual use case for log4j because it
creates many ephemeral loggers while also having a global logger that is
supposed to work for the duration of the sbt session. There is a lot of
shared global state in log4j and properly cleaning up the ephemeral task
appenders would break global logging. This commit fixes the behavior by
introducing an alternate logging implementation. Users can still use the
old log4j logging implementation but it will be off by default. The
internal implementation is very simple: it just blocks the current
thread and writes to all of the appenders. Nevertheless, I found the
performance to be roughly identical to that of log4j in my sample
project. As an experiment, I did the appending on a thread pool and got
a significant performance improvement but I'll defer that to a later PR
since parallel io is harder to reason about.

Background: I was testing sbt performance in
https://github.com/jtjeferreira/sbt-multi-module-sample and noticed that
performance rapidly degraded after I ran compile a few times. I took a
heap dump and it became obvious that sbt was leaking console appenders.
Further investigation revealed that all of the leaking appenders in the
project were coming from task streams. This made me think that the fix
would be to track what loggers were created during task evaluation and
clear them out when task evaluation completed. That almost worked except
that log4j has an internal append only data structure containing logger
names. Since we create unique logger names for each run, that internal
data structure grew without bound. It looked like this could be worked
around by creating a new log4j Configuration (where that data structure
was stored) but while creating new configurations with each task runs
did fix the leak, it also broke global logging, which was using a
different configuration. At this point, I decided to write an alternate
implementation of the appender api where I could be sure that the
appenders were cleaned up without breaking global logging.

Implementation: I made ConsoleAppender a trait and made it no longer
extends log4j AbstractAppender. To do this, I had to remove the one
log4j specific method, append(LogEvent). ConsoleAppender now has a
method toLog4J that, in most cases, will return a log4j Appender that is
almost identical to the Appenders that we previously used. To manage
the loggers created during task evaluation, I introduce a new class,
LoggerContext. The LoggerContext determines which logging backend to use
and keeps track of what appenders and loggers have been created. We can
create a fresh LoggerContext before each task evaluation and clear it
out, cleaning up all of its resources after task evaluation concludes.

In order to make this work, there were many places where we need to
either pass in a LoggerContext or create a new one. The main magic is
happening in the `next(State)` method in Main. This is where we create a
new LoggerContext prior to command evaluation and clean it up after the
evaluation completes.

Users can toggle log4j using the new useLog4J key. They also can set the
system property, sbt.log.uselog4j. The global logger will use the sbt
internal implementation unless the system property is set.

There are a fairly significant number of mima issues since I changed the
type of ConsoleAppender. All of the mima changes were in the
sbt.internal package so I think this should be ok.

Effects: the memory leaks are gone. I successfully ran 5000 no-op
compiles in the sbt-multi-module-sample above with no degradation of
performace. There was a noticeable degradation after 30 no-op compiles
before.

During the refactor, I had to work on TestLogger and in doing so I also
fixed #4480.

This also should fix #4773