### PR TITLE
Call info before scripted tests

### DIFF
--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -216,7 +216,8 @@ final class ScriptedTests(
             // Reload and initialize (to reload contents of .sbtrc files)
             def sbtHandlerError = sys error "Missing sbt handler. Scripted is misconfigured."
             val sbtHandler = handlers.getOrElse('>', sbtHandlerError)
-            val statement = Statement("reload;initialize", Nil, successExpected = true, line = -1)
+            val statement =
+              Statement("info;reload;initialize", Nil, successExpected = true, line = -1)
 
             // Run reload inside the hook to reuse error handling for pending tests
             val wrapHook = (file: File) => {


### PR DESCRIPTION
If one scripted test calls debug, all subsequent tests will be in debug
mode until another test calls info. We can just call info before each
test run to fix that behavior.