### PR TITLE
Add reprompt fast track command

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -74,13 +74,13 @@ object LineReader {
       parser: Parser[_],
       terminal: Terminal,
   ): LineReader = {
-    val term = JLine3(terminal)
     // We may want to consider insourcing LineReader.java from jline. We don't otherwise
     // directly need jline3 for sbt.
-    val reader = LineReaderBuilder.builder().terminal(term).completer(completer(parser)).build()
-    historyPath.foreach(f => reader.setVariable(JLineReader.HISTORY_FILE, f))
     new LineReader {
       override def readLine(prompt: String, mask: Option[Char]): Option[String] = {
+        val term = JLine3(terminal)
+        val reader = LineReaderBuilder.builder().terminal(term).completer(completer(parser)).build()
+        historyPath.foreach(f => reader.setVariable(JLineReader.HISTORY_FILE, f))
         try terminal.withRawInput {
           Option(mask.map(reader.readLine(prompt, _)).getOrElse(reader.readLine(prompt)))
         } catch {

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -446,7 +446,7 @@ private[sbt] final class CommandExchange {
           case null =>
           case mt: FastTrackTask =>
             mt.task match {
-              case `attach` => mt.channel.prompt(ConsolePromptEvent(lastState.get))
+              case `attach` | "" => mt.channel.prompt(ConsolePromptEvent(lastState.get))
               case `Cancel` =>
                 Option(currentExecRef.get).foreach(cancel)
                 mt.channel.prompt(ConsolePromptEvent(lastState.get))


### PR DESCRIPTION
With the latest sbt snapshot, the ui would get stuck if the user entered
an empty command. They would be presented with an empty prompt and could
not input any commands. This was caused by the change in
d569abe70ae9b5e95fb0d699fb01ffd492d9345e that reset the prompt after a
line was read. I had tried to optimize line reading by ignoring empty
commands in UITask.readline so we wouldn't have to make a new thread.
This optimization wasn't really buying much since it only affects how
quickly the user is reprompted after entering an empty command. Unless a
user is spamming the <enter> key, they shouldn't notice a difference.