### PR TITLE
Delay the initialization of Coursier cache

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -32,10 +32,6 @@ object MainLoop {
   /** Entry point to run the remaining commands in State with managed global logging.*/
   def runLogged(state: State): xsbti.MainResult = {
 
-    // This warns if ~/.coursier/cache is found.
-    // Temporary, remove when updating coursier to 2.0.0 final.
-    lmcoursier.CoursierConfiguration.checkLegacyCache()
-
     // We've disabled jline shutdown hooks to prevent classloader leaks, and have been careful to always restore
     // the jline terminal in finally blocks, but hitting ctrl+c prevents finally blocks from being executed, in that
     // case the only way to restore the terminal is in a shutdown hook.

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -521,7 +521,7 @@ object Project extends ProjectExtra {
     val authentication: Option[Set[ServerAuthentication]] = get(serverAuthentication)
     val connectionType: Option[ConnectionType] = get(serverConnectionType)
     val srvLogLevel: Option[Level.Value] = (logLevel in (ref, serverLog)).get(structure.data)
-    val hs: Option[Seq[ServerHandler]] = get(fullServerHandlers)
+    val hs: Option[Seq[ServerHandler]] = get(fullServerHandlers in ThisBuild)
     val commandDefs = allCommands.distinct.flatten[Command].map(_ tag (projectCommand, true))
     val newDefinedCommands = commandDefs ++ BasicCommands.removeTagged(
       s.definedCommands,

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -37,10 +37,18 @@ object LMCoursier {
   private[this] val credentialRegistry: ConcurrentHashMap[(String, String), IvyCredentials] =
     new ConcurrentHashMap
 
+  private[this] lazy val checkLegacyCache: Unit = {
+    // This warns if ~/.coursier/cache is found.
+    // Temporary, remove when updating coursier to 2.0.0 final.
+    lmcoursier.CoursierConfiguration.checkLegacyCache()
+  }
+
   def defaultCacheLocation: File =
     sys.props.get("sbt.coursier.home") match {
       case Some(home) => new File(home).getAbsoluteFile / "cache"
-      case _          => CoursierDependencyResolution.defaultCacheLocation
+      case _ =>
+        checkLegacyCache
+        CoursierDependencyResolution.defaultCacheLocation
     }
 
   def relaxedForAllModules: Seq[(ModuleMatchers, Reconciliation)] =

--- a/main/src/main/scala/sbt/plugins/IvyPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/IvyPlugin.scala
@@ -26,8 +26,11 @@ object IvyPlugin extends AutoPlugin {
   override def requires = CorePlugin
   override def trigger = allRequirements
 
-  override lazy val projectSettings: Seq[Setting[_]] =
-    Classpaths.ivyPublishSettings ++ Classpaths.ivyBaseSettings
   override lazy val globalSettings: Seq[Setting[_]] =
     Defaults.globalIvyCore
+  override lazy val buildSettings: Seq[Setting[_]] =
+    Defaults.buildLevelIvySettings
+  override lazy val projectSettings: Seq[Setting[_]] =
+    Classpaths.ivyPublishSettings ++ Classpaths.ivyBaseSettings
+
 }

--- a/main/src/main/scala/sbt/plugins/JvmPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JvmPlugin.scala
@@ -30,6 +30,12 @@ object JvmPlugin extends AutoPlugin {
   override def requires = IvyPlugin
   override def trigger = allRequirements
 
+  override lazy val globalSettings: Seq[Setting[_]] =
+    Defaults.globalJvmCore
+
+  override lazy val buildSettings: Seq[Setting[_]] =
+    Defaults.buildLevelJvmSettings
+
   override lazy val projectSettings: Seq[Setting[_]] =
     Defaults.runnerSettings ++
       Defaults.paths ++
@@ -38,8 +44,6 @@ object JvmPlugin extends AutoPlugin {
       Defaults.baseTasks ++
       Defaults.compileBase ++
       Defaults.defaultConfigs
-  override lazy val globalSettings: Seq[Setting[_]] =
-    Defaults.globalJvmCore
 
   override def projectConfigurations: Seq[Configuration] =
     Configurations.default

--- a/sbt/src/sbt-test/dependency-management/artifact/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/artifact/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / scalaVersion     := "2.12.11"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 lazy val Dev = config("dev").extend(Compile)
   .describedAs("Dependencies required for development environments")

--- a/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
@@ -2,6 +2,7 @@ ThisBuild / scalaVersion := "2.12.11"
 
 // TTL of Coursier is 24h
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def localCache =
 	ivyPaths := IvyPaths(baseDirectory.value, Some((baseDirectory in ThisBuild).value / "ivy" / "cache"))

--- a/sbt/src/sbt-test/dependency-management/cache-local/cache.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-local/cache.sbt
@@ -1,1 +1,2 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 ivyPaths := { IvyPaths(baseDirectory.value, Some(target.value / ".ivy2")) }

--- a/sbt/src/sbt-test/dependency-management/cache-resolver/cache.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-resolver/cache.sbt
@@ -1,7 +1,8 @@
-ivyPaths in ThisBuild := {
-	val base = (baseDirectory in ThisBuild).value
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+ThisBuild / ivyPaths := {
+	val base = (ThisBuild / baseDirectory).value
 	IvyPaths(base, Some(base / "ivy-cache"))
 }
-managedScalaInstance in ThisBuild := false
-autoScalaLibrary in ThisBuild := false
-crossPaths in ThisBuild := false
+ThisBuild / managedScalaInstance := false
+ThisBuild / autoScalaLibrary  := false
+ThisBuild / crossPaths := false

--- a/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/cache-update/build.sbt
@@ -1,5 +1,6 @@
-scalaVersion in ThisBuild        := "2.10.4"
-dependencyOverrides in ThisBuild += "com.github.nscala-time" %% "nscala-time" % "1.0.0"
+ThisBuild / scalaVersion        := "2.10.4"
+ThisBuild / dependencyOverrides += "com.github.nscala-time" %% "nscala-time" % "1.0.0"
+ThisBuild / csrCacheDirectory   := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 lazy val root = (project in file("."))
   .dependsOn(p1 % Compile)

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/changes/multi.sbt
@@ -6,6 +6,8 @@ val summingbirdVersion = "0.4.0"
 val luceneVersion = "4.0.0"
 val akkaVersion = "2.3.1"
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-circular/multi.sbt
@@ -6,6 +6,8 @@ val summingbirdVersion = "0.4.0"
 val luceneVersion = "4.0.0"
 val akkaVersion = "2.3.1"
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-classifier/multi.sbt
@@ -2,6 +2,8 @@ ThisBuild / useCoursier := false
 
 lazy val check = taskKey[Unit]("Runs the check")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-configurations/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-configurations/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Vector[Def.Setting[_]] =
   Vector(
     organization := "com.example",

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-conflicts/multi.sbt
@@ -1,6 +1,8 @@
 // https://github.com/sbt/sbt/issues/1710
 // https://github.com/sbt/sbt/issues/1760
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 inThisBuild(Seq(
   organization := "com.example",
   version := "0.1.0",

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-exclude/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-exclude/multi.sbt
@@ -2,6 +2,7 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-force/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-force/multi.sbt
@@ -1,5 +1,7 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
@@ -4,6 +4,7 @@ val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junit = "junit" % "junit" % "4.11"
 
 ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(

--- a/sbt/src/sbt-test/dependency-management/cached-resolution-overrides/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/cached-resolution-overrides/multi.sbt
@@ -1,5 +1,7 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/chainresolver/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/chainresolver/build.sbt
@@ -1,5 +1,7 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/circular-dependency/changes/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/circular-dependency/changes/multi.sbt
@@ -1,4 +1,5 @@
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 lazy val check = taskKey[Unit]("Runs the check")
 

--- a/sbt/src/sbt-test/dependency-management/circular-dependency/multi.sbt
+++ b/sbt/src/sbt-test/dependency-management/circular-dependency/multi.sbt
@@ -1,5 +1,7 @@
 lazy val check = taskKey[Unit]("Runs the check")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((target in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/classifier/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/classifier/build.sbt
@@ -1,3 +1,4 @@
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 libraryDependencies += "org.testng" % "testng" % "5.7" classifier "jdk15"

--- a/sbt/src/sbt-test/dependency-management/credentials/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/credentials/build.sbt
@@ -1,4 +1,5 @@
 ThisBuild / scalaVersion := "2.13.0"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 // don't blow up when credential file doesn't exist

--- a/sbt/src/sbt-test/dependency-management/deliver-artifacts/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/deliver-artifacts/build.sbt
@@ -1,3 +1,7 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+ThisBuild / organization := "org.example"
+ThisBuild / version := "1.0"
+
 lazy val a = project.settings(common: _*).settings(
 	// verifies that a can be published as an ivy.xml file and preserve the extra artifact information,
 	//   such as a classifier
@@ -9,10 +13,6 @@ lazy val a = project.settings(common: _*).settings(
 lazy val b = project.settings(common: _*).settings(
 	libraryDependencies := Seq(organization.value %% "a" % version.value)
 )
-
-organization in ThisBuild := "org.example"
-
-version in ThisBuild := "1.0"
 
 lazy val common = Seq(
 	autoScalaLibrary := false, // avoid downloading fresh scala-library/scala-compiler

--- a/sbt/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
@@ -2,6 +2,7 @@
 ThisBuild / organization := "com.example"
 ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
@@ -9,7 +10,6 @@ def commonSettings: Seq[Def.Setting[_]] =
       (ThisBuild / baseDirectory).value,
       Some((LocalRootProject / target).value / "ivy-cache")
     ),
-    csrCacheDirectory := (LocalRootProject / target).value / "cache",
     fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
     publishTo := Some(MavenCache("local-maven", (LocalRootProject / target).value / "local-maven")),
     resolvers += MavenCache("local-maven", (LocalRootProject / target).value / "local-maven"),

--- a/sbt/src/sbt-test/dependency-management/exclude-transitive/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/exclude-transitive/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   settings(
     ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/exclude-transitive/test
+++ b/sbt/src/sbt-test/dependency-management/exclude-transitive/test
@@ -14,6 +14,7 @@ $ touch transitive
 # load the project definition with transitive dependencies disabled
 # and check that they are not downloaded
 
+$ delete coursier-cache
 $ delete ivy-cache
 $ delete transitive
 > reload

--- a/sbt/src/sbt-test/dependency-management/extra/DefineColor.sbt
+++ b/sbt/src/sbt-test/dependency-management/extra/DefineColor.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file("."))
   .settings(
     organization := "com.example",

--- a/sbt/src/sbt-test/dependency-management/extra/changes/UseColor.sbt
+++ b/sbt/src/sbt-test/dependency-management/extra/changes/UseColor.sbt
@@ -1,4 +1,5 @@
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt/src/sbt-test/dependency-management/force/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/force/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   settings(
     ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/info/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/info/build.sbt
@@ -1,4 +1,5 @@
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 import scala.xml._
 

--- a/sbt/src/sbt-test/dependency-management/inline-dependencies-a/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/inline-dependencies-a/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 libraryDependencies += "org.scalacheck" % "scalacheck" % "1.5"
 
 ivyPaths := baseDirectory( dir => IvyPaths(dir, Some(dir / "ivy-home"))).value

--- a/sbt/src/sbt-test/dependency-management/metadata-only-resolver/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/metadata-only-resolver/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / ".ivy2"))
 
 // not in the default repositories

--- a/sbt/src/sbt-test/dependency-management/module-confs/common.sbt
+++ b/sbt/src/sbt-test/dependency-management/module-confs/common.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 ivyScala ~= { (is: Option[IvyScala]) => is.map(_.copy(checkExplicit = false, overrideScalaVersion = false, filterImplicit = false)) }
 
 ivyPaths := baseDirectory( dir => IvyPaths(dir, Some(dir / "ivy-home"))).value

--- a/sbt/src/sbt-test/dependency-management/mvn-local/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/mvn-local/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
     ivyPaths := IvyPaths( (baseDirectory in ThisBuild).value, Some((baseDirectory in LocalRootProject).value / "ivy-cache")),

--- a/sbt/src/sbt-test/dependency-management/no-file-fails-publish/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/no-file-fails-publish/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 
 organization := "org.example"

--- a/sbt/src/sbt-test/dependency-management/override/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/override/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 autoScalaLibrary := false
 
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))

--- a/sbt/src/sbt-test/dependency-management/pom-advanced/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-advanced/build.sbt
@@ -1,5 +1,7 @@
 import complete.DefaultParsers._
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   settings(
     resolvers ++= Seq(local, Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),

--- a/sbt/src/sbt-test/dependency-management/pom-parent-pom/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/pom-parent-pom/build.sbt
@@ -1,4 +1,5 @@
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 val checkIvyXml = taskKey[Unit]("Checks the ivy.xml transform was correct")
 

--- a/sbt/src/sbt-test/dependency-management/publish-local/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/publish-local/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   dependsOn(sub).
   aggregate(sub).

--- a/sbt/src/sbt-test/dependency-management/publish-local/changes/RetrieveTest.sbt
+++ b/sbt/src/sbt-test/dependency-management/publish-local/changes/RetrieveTest.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   settings(inThisBuild(List(
       organization := "A",

--- a/sbt/src/sbt-test/dependency-management/snapshot-local/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/snapshot-local/build.sbt
@@ -1,5 +1,6 @@
 ThisBuild / organization := "com.example"
 ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def customIvyPaths: Seq[Def.Setting[_]] = Seq(
   ivyPaths := IvyPaths((baseDirectory in ThisBuild).value, Some((baseDirectory in ThisBuild).value / "ivy-cache"))

--- a/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
@@ -3,6 +3,7 @@ ThisBuild / scalaVersion := "2.12.11"
 
 // TTL is 24h so we can't detect the change
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def customIvyPaths: Seq[Def.Setting[_]] = Seq(
   ivyPaths := IvyPaths((baseDirectory in ThisBuild).value, Some((baseDirectory in ThisBuild).value / "ivy-cache"))

--- a/sbt/src/sbt-test/dependency-management/t468/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/t468/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 autoScalaLibrary := false
 
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))

--- a/sbt/src/sbt-test/dependency-management/test-artifact/cache.sbt
+++ b/sbt/src/sbt-test/dependency-management/test-artifact/cache.sbt
@@ -1,4 +1,5 @@
 ThisBuild / useCoursier := false
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 ivyPaths := {
 	val base = baseDirectory.value

--- a/sbt/src/sbt-test/dependency-management/url/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/url/build.sbt
@@ -1,5 +1,7 @@
 import sbt.internal.inc.classpath.ClasspathUtilities
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 lazy val root = (project in file(".")).
   settings(
     ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache")),

--- a/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/build.sbt
+++ b/sbt/src/sbt-test/ivy-deps-management/update-classifiers-snapshot-srcs/build.sbt
@@ -1,6 +1,8 @@
 def ivyHome = Def.setting((target in LocalRootProject).value / "ivy")
 def localRepo = Def.setting((target in LocalRootProject).value / "local-repo")
 
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 val commonSettings = Seq[Def.Setting[_]](
   organization := "org.example",
   version := "1.0-SNAPSHOT",

--- a/sbt/src/sbt-test/project/generated-root-no-publish/build.sbt
+++ b/sbt/src/sbt-test/project/generated-root-no-publish/build.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 val commonSettings = Seq(
   organization := "com.example",
   version := "0.1.0",

--- a/sbt/src/sbt-test/project/generated-root-no-publish/changes/bare.sbt
+++ b/sbt/src/sbt-test/project/generated-root-no-publish/changes/bare.sbt
@@ -1,3 +1,5 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
 organization := "com.example"
 version := "0.1.0"
 ivyPaths := IvyPaths((baseDirectory in LocalRootProject).value, Some((target in LocalRootProject).value / "ivy-cache"))

--- a/sbt/src/sbt-test/project/transitive-plugins/build.sbt
+++ b/sbt/src/sbt-test/project/transitive-plugins/build.sbt
@@ -1,4 +1,5 @@
 ThisBuild / organization := "org.example"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5722

This attempts to delay the initialization of Coursier cache, such that it will no longer trigger Coursier's directory-related code if `ThisBuild / useCoursier` or `-Dsbt.coursier` is set to `false`.