### PR TITLE
Fixes semicolon showing up in parser errors

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -89,10 +89,7 @@ object JLineCompletion {
     (insert.toSeq, display.toSeq.sorted)
   }
 
-  def appendNonEmpty(set: Set[String], add: String) = {
-    val trimmed = add.trim
-    if (trimmed.isEmpty || trimmed == ";") set else set + add
-  }
+  def appendNonEmpty(set: Set[String], add: String) = if (add.trim.isEmpty) set else set + add
 
   def customCompletor(
       f: (String, Int) => (Seq[String], Seq[String])

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -208,10 +208,11 @@ object BasicCommands {
       else Parser.success(result.toList)
     }
 
-    (cmdParser ~ multiCmdParser.+).flatMap {
-      case ("", rest) => validateCommands(rest)
-      case (p, rest)  => validateCommands(rest).map(p :: _)
-    }
+    (cmdParser ~ multiCmdParser.+)
+      .flatMap {
+        case ("", rest) => validateCommands(rest)
+        case (p, rest)  => validateCommands(rest).map(p :: _)
+      }
   }
 
   def multiParser(s: State): Parser[List[String]] = multiParserImpl(Some(s))

--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -184,7 +184,8 @@ object Command {
     )
 
   def process(command: String, state: State): State = {
-    parse(command, state.combinedParser) match {
+    (if (command.contains(";")) parse(command, state.combinedParser)
+    else parse(command, state.nonMultiParser)) match {
       case Right(s) => s() // apply command.  command side effects happen here
       case Left(errMsg) =>
         state.log error errMsg

--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -53,7 +53,11 @@ final case class State(
   private[sbt] lazy val (multiCommands, nonMultiCommands) =
     definedCommands.partition(_.nameOption.contains(BasicCommandStrings.Multi))
   private[sbt] lazy val nonMultiParser = Command.combine(nonMultiCommands)(this)
-  lazy val combinedParser = multiCommands.foldRight(nonMultiParser)(_.parser(this) | _)
+  lazy val combinedParser: Parser[() => State] =
+    multiCommands.headOption match {
+      case Some(multi) => multi.parser(this) | nonMultiParser
+      case _           => nonMultiParser
+    }
 
   def source: Option[CommandSource] =
     currentCommand match {

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -14,7 +14,10 @@ import sbt.internal.util.complete.Parser
 object MultiParserSpec {
   val parser: Parser[Seq[String]] = BasicCommands.multiParserImpl(None)
   implicit class StringOps(val s: String) {
-    def parse: Seq[String] = Parser.parse(s, parser).right.get
+    def parse: Seq[String] = Parser.parse(s, parser) match {
+      case Right(x) => x
+      case Left(x)  => sys.error(s)
+    }
     def parseEither: Either[String, Seq[String]] = Parser.parse(s, parser)
   }
 }


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/pull/4990
Fixes #5039
Fixes #4989

This is take 2 on the semicolon fix by emptying out the completion examples in the multi parser.

```
> set scalaV
```

would complete to

```
> set scalaVersion
```

and more importantly

```
coursierUseSbtCredentials := true
```

errors to

```
sbt:hello> coursierUseSbtCredentials := true
[error] Expected ID character
[error] Not a valid command: coursierUseSbtCredentials
[error] Expected project ID
[error] Expected configuration
[error] Expected ':'
[error] Expected key
[error] Not a valid key: coursierUseSbtCredentials (similar: csrExtraCredentials, credentials)
[error] coursierUseSbtCredentials := true
[error]                          ^
```