### PR TITLE
Make virtual file value cache global

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -405,6 +405,8 @@ object Defaults extends BuildCommon {
       )
     },
     fileConverter := MappedFileConverter(rootPaths.value, allowMachinePath.value),
+    // The virtual file value cache needs to be global or sbt will run out of direct byte buffer memory.
+    classpathDefinesClassCache := VirtualFileValueCache.definesClassCache(fileConverter.value),
     fullServerHandlers := {
       Seq(
         LanguageServerProtocol.handler(fileConverter.value),
@@ -788,7 +790,6 @@ object Defaults extends BuildCommon {
       else old
     },
     persistJarClasspath :== true,
-    classpathDefinesClassCache := VirtualFileValueCache.definesClassCache(fileConverter.value),
     classpathEntryDefinesClassVF := {
       (if (persistJarClasspath.value) classpathDefinesClassCache.value
        else VirtualFileValueCache.definesClassCache(fileConverter.value)).get


### PR DESCRIPTION
In 0d2b00c7e9b36930265c37e1fc909a32549836b8, I introduced a setting for
the virtual file defines class cache to avoid ooms coming from zinc
stamping the project jar files. I introduced that cache at the compile
level though rather than global level and crashes were still occurring
in the sbt build. It was very easy to induce a crash on my computer by
running compile a few times, reload and then compile again. After making
the cache global, the crashes went away.