### PR TITLE
Bump coursier to v2.0.0-RC6-24

### DIFF
--- a/notes/1.3.0/fix-resource-deadlock-in-lmcoursier.md
+++ b/notes/1.3.0/fix-resource-deadlock-in-lmcoursier.md
@@ -1,0 +1,6 @@
+[#5238]: https://github.com/sbt/sbt/issues/5238
+[#5238]: https://github.com/sbt/sbt/pull/5755
+
+### Bug Fixes
+
+- Update courser to v2.0.0-RC6-24 to fix `IOException: Resource deadlock would occur` [#5238]()/[#5755]().

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0-RC6-8"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0-RC6-24"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.0") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
My builds are intermittently failing due to https://github.com/sbt/sbt/issues/5238.

I see that:
- https://github.com/coursier/coursier/commit/48fd23ab657718528eba28a8bf0ae5eed572606b is meant to fix/workaround the issue.
- That commit is available in coursier `v2.0.0-RC6-24 … v2.0.0-RC6-22`.
- https://github.com/coursier/coursier/releases/tag/v2.0.0-RC6-24 is included in https://github.com/coursier/sbt-coursier/commit/bbbcad02c56b808183da3fa63bdf2bda3e6b3846 lm-coursier-shaded v2.0.0-RC6-8 (confusing).
- lm-coursier-shaded was updated in sbt at https://github.com/sbt/sbt/commit/2bebee4dfe94b23d58b2ee7a7bc6bc879ea591cf does not appear to be present in any sbt release.