### PR TITLE
Handle interrupted exceptions in thin client reader

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -905,7 +905,7 @@ class NetworkClient(
         }
       }
       try Terminal.console.withRawInput(read())
-      catch { case NonFatal(_) => stopped.set(true) }
+      catch { case _: InterruptedException | NonFatal(_) => stopped.set(true) }
     }
 
     def drain(): Unit = inLock.synchronized {


### PR DESCRIPTION
When exiting the thin client, an interrupted exception stack trace ends
up being printed because NonFatal doesn't include interrupted
exceptions.

Fixes https://github.com/sbt/sbt/issues/5759