### PR TITLE
Only initialize console terminal streams when used

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -33,7 +33,7 @@ object ConsoleLogger {
   @deprecated("Use EscHelpers.removeEscapeSequences instead", "0.13.x")
   def removeEscapeSequences(s: String): String = EscHelpers.removeEscapeSequences(s)
   @deprecated("Use ConsoleAppender.formatEnabledInEnv instead", "0.13.x")
-  val formatEnabled = ConsoleAppender.formatEnabledInEnv
+  lazy val formatEnabled = ConsoleAppender.formatEnabledInEnv
   @deprecated("Use ConsoleAppender.noSuppressedMessage instead", "0.13.x")
   val noSuppressedMessage = ConsoleAppender.noSuppressedMessage
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -460,7 +460,7 @@ object Terminal {
       ()
     }
   }
-  private[this] val nonBlockingIn: WriteableInputStream =
+  private[this] lazy val nonBlockingIn: WriteableInputStream =
     new WriteableInputStream(jline.TerminalFactory.get.wrapInIfNeeded(originalIn), "console")
 
   private[this] val inputStream = new AtomicReference[InputStream](System.in)


### PR DESCRIPTION
In dogfooding sbt, I found that the WriteableInputStream used by the
console terminal initialized before it was needed. This would lead to
multiple instances of the WriteableInputStream being created, which
could lead to zombie threads reading from stdin. I'm not 100% sure what
the classloading scenario was that caused this to be a problem but in a
few days of using sbt after these changes, I haven't seem zombie
threads.