### PR TITLE
Allow console terminal opt out

### DIFF
--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -57,6 +57,7 @@ object RunFromSourceMain {
       )
     case Array(wd, scalaVersion, sbtVersion, classpath, args @ _*) =>
       System.setProperty("jna.nosys", "true")
+      if (args.exists(_.startsWith("<"))) System.setProperty("sbt.io.virtual", "false")
       val context = LoggerContext(useLog4J = SysProp.useLog4J)
       try run(file(wd), scalaVersion, sbtVersion, classpath, args, context)
       finally context.close()


### PR DESCRIPTION
While running ~scripted that multiple instance of the console terminal
were instantiated which caused problems with reading input. It turned
out that RunFromSourceMain was running in the same jvm process as sbt
and creating a new console terminal in a different classloader. This
both messed up the io of scripted tests when scriptedBufferLog was set
to false but it also made it so that I couldn't exit ~ with <enter>. To
workaround this, I deferred initializaiton of the console terminal to
Terminal.withStreams which is guarded by the sbt.io.virtual system
property.