### PR TITLE
Banner for 1.4.0 beta 

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -15,7 +15,8 @@ import sbt.internal.util.ConsoleAppender.{
   ClearScreenAfterCursor,
   CursorLeft1000,
   DeleteLine,
-  cursorUp
+  cursorUp,
+  setShowProgress,
 }
 
 import scala.collection.mutable.ArrayBuffer
@@ -160,6 +161,7 @@ private[sbt] object ProgressState {
     val isWatch = terminal.prompt == Prompt.Watch
     val noPrompt = terminal.prompt == Prompt.NoPrompt
     if (terminal.isSupershellEnabled) {
+      setShowProgress(true) // used by Zinc to not show "done compiling"
       if (!pe.skipIfActive.getOrElse(false) || (!isRunning && !isBatch)) {
         terminal.withPrintStream { ps =>
           val commandFromThisTerminal = pe.channelName.fold(true)(_ == terminal.name)

--- a/main/src/main/scala/sbt/internal/Banner.scala
+++ b/main/src/main/scala/sbt/internal/Banner.scala
@@ -10,6 +10,16 @@ package sbt.internal
 private[sbt] object Banner {
   def apply(version: String): Option[String] =
     version match {
+      case v if v.startsWith("1.4.0") =>
+        Some(s"""
+                |Here are some highlights of this release:
+                |  - Build server protocol (BSP) support
+                |  - sbtn: a native thin client for sbt
+                |  - VirtualFile + RemoteCache: caches build artifacts across different machines
+                |  - Incremental build pipelining. Try it using `ThisBuild / usePipelining := true`.
+                |See http://eed3si9n.com/sbt-1.4.0-beta for full release notes.
+                |Hide the banner for this release by running `skipBanner`.
+                |""".stripMargin.linesIterator.mkString("\n"))
       case "1.3.0" =>
         Some(s"""
                 |Welcome to sbt $version.


### PR DESCRIPTION
```
[info] welcome to sbt 1.4.0-SNAPSHOT (AdoptOpenJDK Java 1.8.0_232)
[info] loading settings for project global-plugins from ...
[info] loading global plugins from ...
[info] loading project definition from /private/tmp/hello/project
[info] loading settings for project root from build.sbt ...
[info] set current project to hello (in build file:/private/tmp/hello/)
[info]
[info] Here are some highlights of this release:
[info]   - Build server protocol (BSP) support
[info]   - sbtn: a thin client for sbt built as GraalVM native image
[info]   - VirtualFile + RemoteCache: caches build artifacts across different machines
[info]   - Incremental build pipelining. Try it using `ThisBuild / usePipelining := true`.
[info] See http://eed3si9n.com/sbt-1.4.0-beta for full release notes.
[info] Hide the banner for this release by running `skipBanner`.
[info] sbt server started at local:///Users/eed3si9n/.sbt/1.0/server/478e6db75688771ddcf1/soc
```