### PR TITLE
Add bspEnabled setting

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -386,7 +386,8 @@ object Keys {
   val exportPipelining = settingKey[Boolean]("Product early output so downstream subprojects can do pipelining.").withRank(BSetting)
 
   val bspConfig = taskKey[Unit]("Create or update the BSP connection files").withRank(DSetting)
-  val bspTargetIdentifier = settingKey[BuildTargetIdentifier]("Id for BSP build target.").withRank(DSetting)
+  val bspEnabled = settingKey[Boolean]("Enable/Disable BSP for this build, project or configuration")
+  val bspTargetIdentifier = settingKey[BuildTargetIdentifier]("Build target identifier of a project and configuration.").withRank(DSetting)
   val bspWorkspace = settingKey[Map[BuildTargetIdentifier, Scope]]("Mapping of BSP build targets to sbt scopes").withRank(DSetting)
   val bspInternalDependencyConfigurations = settingKey[Seq[(ProjectRef, Set[ConfigKey])]]("The project configurations that this configuration depends on, possibly transitivly").withRank(DSetting)
   val bspWorkspaceBuildTargets = taskKey[Seq[BuildTarget]]("List all the BSP build targets").withRank(DTask)

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -39,6 +39,7 @@ object BuildServerProtocol {
       sbtVersion.value,
       (ThisBuild / baseDirectory).value
     ),
+    bspEnabled := true,
     bspWorkspace := bspWorkspaceSetting.value,
     bspWorkspaceBuildTargets := Def.taskDyn {
       val workspace = Keys.bspWorkspace.value
@@ -246,7 +247,15 @@ object BuildServerProtocol {
           .map(_ / Keys.bspTargetIdentifier)
           .join
           .value
-        targetIds.zip(scopes).toMap
+        val bspEnabled = scopes
+          .map(_ / Keys.bspEnabled)
+          .join
+          .value
+        val result = for {
+          (targetId, scope, bspEnabled) <- (targetIds, scopes, bspEnabled).zipped
+          if bspEnabled
+        } yield targetId -> scope
+        result.toMap
       }
     }
 


### PR DESCRIPTION
Fixes #5675

We have `Global / bspEnabled := true` by default.

One can set `<project> / <config> / bspEnabled := false` to disable BSP on a specific project and configuration. It makes the corresponding target out of the BSP workspace and thus unknown by the BSP client.

This can be handy if the project is very resource consuming or very involved in some way.