### PR TITLE
Fixes IntelliJ import for 1.4.x

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -275,17 +275,58 @@ object Terminal {
 
   private[this] val hasProgress: AtomicBoolean = new AtomicBoolean(false)
 
+  private[sbt] def parseLogOption(s: String): LogOption =
+    s.toLowerCase match {
+      case "always" => LogOption.Always
+      case "auto"   => LogOption.Auto
+      case "never"  => LogOption.Never
+      case "true"   => LogOption.Always
+      case "false"  => LogOption.Never
+      case _        => LogOption.Auto
+    }
+
+  /**
+   * Indicates whether formatting has been disabled in environment variables.
+   * 1. -Dsbt.log.noformat=true means no formatting.
+   * 2. -Dsbt.color=always/auto/never/true/false
+   * 3. -Dsbt.colour=always/auto/never/true/false
+   * 4. -Dsbt.log.format=always/auto/never/true/false
+   */
+  private[sbt] lazy val formatEnabledInEnv: Boolean = {
+    def useColorDefault: Boolean = {
+      // This approximates that both stdin and stdio are connected,
+      // so by default color will be turned off for pipes and redirects.
+      val hasConsole = Option(java.lang.System.console).isDefined
+      props.map(_.ansi).getOrElse(true) && hasConsole
+    }
+    sys.props.get("sbt.log.noformat") match {
+      case Some(_) => !java.lang.Boolean.getBoolean("sbt.log.noformat")
+      case _ =>
+        sys.props
+          .get("sbt.color")
+          .orElse(sys.props.get("sbt.colour"))
+          .orElse(sys.props.get("sbt.log.format"))
+          .flatMap({ s =>
+            parseLogOption(s) match {
+              case LogOption.Always => Some(true)
+              case LogOption.Never  => Some(false)
+              case _                => None
+            }
+          })
+          .getOrElse(useColorDefault)
+    }
+  }
+
   /**
    *
-   * @param progress toggles whether or not the console terminal has progress
+   * @param isServer toggles whether or not this is a server of client process
    * @param f the thunk to run
    * @tparam T the result type of the thunk
    * @return the result of the thunk
    */
   private[sbt] def withStreams[T](isServer: Boolean)(f: => T): T =
     // In ci environments, don't touch the io streams unless run with -Dsbt.io.virtual=true
-    if (isCI && System.getProperty("sbt.io.virtual", "") != "true") f
-    else {
+    if (System.getProperty("sbt.io.virtual", "") == "true" || (formatEnabledInEnv && !isCI)) {
       hasProgress.set(isServer)
       consoleTerminalHolder.set(wrap(jline.TerminalFactory.get))
       activeTerminal.set(consoleTerminalHolder.get)
@@ -317,7 +358,7 @@ object Terminal {
           console.close()
         }
       }
-    }
+    } else f
 
   private[this] object ProxyTerminal extends Terminal {
     private def t: Terminal = activeTerminal.get
@@ -693,7 +734,7 @@ object Terminal {
       override def isSupported: Boolean = terminal.isSupported
       override def getWidth: Int = props.map(_.width).getOrElse(terminal.getWidth)
       override def getHeight: Int = props.map(_.height).getOrElse(terminal.getHeight)
-      override def isAnsiSupported: Boolean = props.map(_.ansi).getOrElse(terminal.isAnsiSupported)
+      override def isAnsiSupported: Boolean = formatEnabledInEnv
       override def wrapOutIfNeeded(out: OutputStream): OutputStream = terminal.wrapOutIfNeeded(out)
       override def wrapInIfNeeded(in: InputStream): InputStream = terminal.wrapInIfNeeded(in)
       override def hasWeirdWrap: Boolean = terminal.hasWeirdWrap

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -993,6 +993,7 @@ object Terminal {
   }
   private[sbt] object NullTerminal extends DefaultTerminal
   private[sbt] object SimpleTerminal extends DefaultTerminal {
+    override lazy val inputStream: InputStream = nonBlockingIn
     override lazy val outputStream: OutputStream = originalOut
     override lazy val errorStream: OutputStream = originalErr
   }

--- a/main-command/src/main/scala/sbt/internal/ui/UserThread.scala
+++ b/main-command/src/main/scala/sbt/internal/ui/UserThread.scala
@@ -75,9 +75,11 @@ private[sbt] class UserThread(val channel: CommandChannel) extends AutoCloseable
     // synchronize to ensure that the state isn't modified during the call to reset
     // at the bottom
     synchronized {
-      channel.terminal.withPrintStream { ps =>
-        ps.print(ConsoleAppender.ClearScreenAfterCursor)
-        ps.flush()
+      if (terminal.isAnsiSupported) {
+        channel.terminal.withPrintStream { ps =>
+          ps.print(ConsoleAppender.ClearScreenAfterCursor)
+          ps.flush()
+        }
       }
       val state = consolePromptEvent.state
       terminal.prompt match {

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -104,8 +104,10 @@ private[sbt] object xMain {
     } finally {
       // Clear any stray progress lines
       ShutdownHooks.close()
-      System.out.print(ConsoleAppender.ClearScreenAfterCursor)
-      System.out.flush()
+      if (Terminal.formatEnabledInEnv) {
+        System.out.print(ConsoleAppender.ClearScreenAfterCursor)
+        System.out.flush()
+      }
     }
   }
 


### PR DESCRIPTION
@jastice reported in https://github.com/sbt/sbt/issues/5784 that intellij import is broken with 1.4.0-M2. While debugging this, I found that the jline3 line reader was causing problems for this use case. It was fixable by reverting back to jline 2 when `System.console == null`. My thinking is that we are using jline3 solely for the enhanced tab completions so if `System.console == null` we can assume that we don't need to support enhanced tab completions for that use case. If this assumption is violated, I added an explicit opt in for jline 3 by setting `-Dsbt.jline.version=3`.