### PR TITLE
Use more aggressive strategy to join ui threads

### DIFF
--- a/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
+++ b/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
@@ -1,0 +1,30 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import scala.annotation.tailrec
+import scala.concurrent.duration._
+
+object JoinThread {
+  implicit class ThreadOps(val t: Thread) extends AnyVal {
+    def joinFor(duration: FiniteDuration): Unit = {
+      val deadline = duration.fromNow
+      var exception: Option[InterruptedException] = None
+      @tailrec def impl(): Unit = {
+        try {
+          t.interrupt()
+          t.join(10)
+        } catch { case e: InterruptedException => exception = Some(e) }
+        if (t.isAlive) impl()
+      }
+      impl()
+      if (t.isAlive) System.err.println(s"Unable to join thread $t after $duration")
+      exception.foreach(throw _)
+    }
+  }
+}


### PR DESCRIPTION
There can be race conditions where we try to interrupt and join a ui
thread before it becomes interruptible by blockign on a queue. To
workaround this, we can add the JoinThread class which adds an
extension method Thread.joinFor that takes a FiniteDuration parameter.
This variant of join will repeatedly interrupt and attempt to join the
thread for up to 10 milliseconds before retrying until the limit is
reached. If the limit is reached, we print a noisy error to the console.

I'm not 100% sure if we are leaking threads in the latest sbt version
but this gives me more piece of mind that either we are always
successfully joining the threads or we will be alerted if the joining
fails.