### PR TITLE
Allow windows console users to exit with ctrl+c

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -108,9 +108,12 @@ private[sbt] object JLine3 {
               }
             case _ => throw new ClosedException
           }
-          if (res == 4 && term.prompt.render().endsWith(term.prompt.mkPrompt()))
-            throw new ClosedException
-          res
+          res match {
+            case 3 /* ctrl+c */ => throw new ClosedException
+            case 4 /* ctrl+d */ if term.prompt.render().endsWith(term.prompt.mkPrompt()) =>
+              throw new ClosedException
+            case r => r
+          }
         }
       }
       override val output: OutputStream = new OutputStream {


### PR DESCRIPTION
On windows with jline3, inputting ctrl+c in the sbt console just causes
the input stream to return -3 unlike mac and linux where ctrl+c always
signals.

Fixes https://github.com/sbt/sbt/issues/5791