### PR TITLE
Kill external processes on sigint

### DIFF
--- a/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
@@ -1,0 +1,33 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.sys.process.Process
+
+/**
+ * Manages forked processes created by sbt. Any process registered
+ * with RunningProcesses can be killed with the killAll method. In
+ * particular, this can be used in a signal handler to kill these
+ * processes when the user inputs ctrl+c.
+ */
+private[sbt] object RunningProcesses {
+  val active = ConcurrentHashMap.newKeySet[Process]
+  def add(process: Process): Unit = active.synchronized {
+    active.add(process)
+    ()
+  }
+  def remove(process: Process): Unit = active.synchronized {
+    active.remove(process)
+    ()
+  }
+  def killAll(): Unit = active.synchronized {
+    active.forEach(_.destroy())
+    active.clear()
+  }
+}

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -17,8 +17,8 @@ import sbt.io.IO
 import sbt.util.Logger
 import sbt.ConcurrentRestrictions.Tag
 import sbt.protocol.testing._
-import sbt.internal.util.ConsoleAppender
 import sbt.internal.util.Util.{ AnyOps, none }
+import sbt.internal.util.{ ConsoleAppender, RunningProcesses }
 
 private[sbt] object ForkTests {
   def apply(
@@ -147,7 +147,13 @@ private[sbt] object ForkTests {
           classOf[ForkMain].getCanonicalName,
           server.getLocalPort.toString
         )
-        val ec = Fork.java(fork, options)
+        val p = Fork.java.fork(fork, options)
+        RunningProcesses.add(p)
+        val ec = try p.exitValue()
+        finally {
+          if (p.isAlive) p.destroy()
+          RunningProcesses.remove(p)
+        }
         val result =
           if (ec != 0)
             TestOutput(

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -480,6 +480,7 @@ object EvaluateTask {
       def cancelAndShutdown(): Unit = {
         println("")
         log.warn("Canceling execution...")
+        RunningProcesses.killAll()
         ConcurrentRestrictions.cancelAll()
         shutdown()
       }


### PR DESCRIPTION
On linux and mac, entering ctrl+c will automatically kill any forked
processes that were created by the sbt server because sigint is
automatically forwarded to the child process. This is not the case on
windows where it is necessary to forcibly kill these processes.