### PR TITLE
Use dumb terminal when specified by property

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -15,7 +15,7 @@ import org.jline.utils.InfoCmp.Capability
 import org.jline.utils.{ ClosedException, NonBlockingReader, OSUtils }
 import org.jline.terminal.{ Attributes, Size, Terminal => JTerminal }
 import org.jline.terminal.Terminal.SignalHandler
-import org.jline.terminal.impl.AbstractTerminal
+import org.jline.terminal.impl.{ AbstractTerminal, DumbTerminal }
 import org.jline.terminal.impl.jansi.JansiSupportImpl
 import org.jline.terminal.impl.jansi.win.JansiWinSysTerminal
 import scala.collection.JavaConverters._
@@ -75,6 +75,11 @@ private[sbt] object JLine3 {
     }
   }
   private[sbt] def apply(term: Terminal): JTerminal = {
+    if (System.getProperty("jline.terminal", "") == "none")
+      new DumbTerminal(term.inputStream, term.outputStream)
+    else wrapTerminal(term)
+  }
+  private[this] def wrapTerminal(term: Terminal): JTerminal = {
     new AbstractTerminal(term.name, "ansi", Charset.forName("UTF-8"), SignalHandler.SIG_DFL) {
       val closed = new AtomicBoolean(false)
       setOnClose { () =>


### PR DESCRIPTION
Intellij invokes sbt with "-Djline.terminal=jline.UnsupportedTerminal"
which Terminal rewrites to the value none. When that property is set, we
should be using a jline dumb terminal. While
https://github.com/sbt/sbt/pull/5788 did fix the import functionality,
jline 3 was still emitting some ansi characters to the intellij console.
When we feed a dumb terminal to the jline 3 line reader, the ansi
control characters go away.