### PR TITLE
Reduce sbt memory utilization

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -195,13 +195,10 @@ private[sbt] final class CommandExchange {
         new NetworkChannel(
           name,
           socket,
-          Project structure s,
           auth,
           instance,
           handlers,
-          s.log,
           mkAskUser(name),
-          Option(lastState.get),
         )
       subscribe(channel)
     }


### PR DESCRIPTION
The sbt Server is initialized with a callback onIncomingSocket. That
callback was created in CommandExchange and held references to a build
structure and a state. Neither the state nor structure would ever go out
of scope so they effectively leaked. It is possible for each
NetworkChannel to access a recent instance of state through the
CommandExchange.withState method. Using this, we can eliminate the
references to state and build structure in the onIncomingSocket
callback. In the sbt project, this reduced the memory utilization by
about 50mb on startup.