### PR TITLE
Reproduce scaladoc failures

### DIFF
--- a/sbt/src/sbt-test/actions/doc/build.sbt
+++ b/sbt/src/sbt-test/actions/doc/build.sbt
@@ -1,5 +1,19 @@
+import complete.{ Parser, Parsers }
+import Parser._
+import Parsers._
+
 lazy val root = (project in file("."))
   .settings(
     crossPaths := false,
-    Compile / doc / scalacOptions += "-Xfatal-warnings"
+    crossScalaVersions := Seq("2.12.12", "2.13.3"),
+    scalaVersion := "2.12.12",
+    Compile / doc / scalacOptions += "-Xfatal-warnings",
+    commands += Command.command("excludeB") { s =>
+      val impl = """val src = (sources in Compile).value; src.filterNot(_.getName.contains("B"))"""
+      s"set sources in (Compile, doc) := { $impl }" :: s
+    },
+    commands += Command.arb(_ => ("setDocExtension": Parser[String]) ~> " " ~> matched(any.*)) { (s, filter: String) =>
+      val impl = s"""val src = (sources in Compile).value; src.filter(_.getName.endsWith("$filter"))"""
+      s"set sources in (Compile, doc) := { $impl }" :: s
+    },
   )

--- a/sbt/src/sbt-test/actions/doc/changes/B.scala
+++ b/sbt/src/sbt-test/actions/doc/changes/B.scala
@@ -1,0 +1,6 @@
+object B {
+	/**
+	* @param i An argument
+	*/
+	def x(i: Int) = 3
+}

--- a/sbt/src/sbt-test/actions/doc/test
+++ b/sbt/src/sbt-test/actions/doc/test
@@ -1,34 +1,46 @@
-> debug
+-> doc
 
-# -> doc
-
-> set sources in (Compile, doc) := { val src = (sources in Compile).value; src.filterNot(_.getName contains "B") }
+> excludeB
 
 # hybrid project, only scaladoc run
 > doc
 $ exists target/api/index.js
+$ exists target/api/A$.html
 $ absent target/api/scala
 $ absent target/api/java
 
-> set sources in (Compile, doc) := { val src = (sources in (Compile, doc)).value; src.filterNot(_.getName endsWith ".java") }
+> setDocExtension scala
 
+# The original B.scala fails scaladoc
+$ copy-file changes/B.scala B.scala
 # compile task is superfluous. Since doc task preceded by compile task has been problematic due to scala
 # compiler's way of handling empty classpath. We have it here to test that our workaround works.
 > clean ; compile ; doc
 
 # pure scala project, only scaladoc at top level
 $ exists target/api/index.js
+$ exists target/api/A$.html
+$ exists target/api/B$.html
 $ absent target/api/package-list
 $ absent target/api/scala
 $ absent target/api/java
 
-> set sources in (Compile, doc) := { val src = (sources in Compile).value; src.filter(_.getName endsWith ".java") }
+> setDocExtension java
 
 > clean ; doc
 
 # pure java project, only javadoc at top level
 $ exists target/api/index.html
+$ exists target/api/pkg/J.html
 $ absent target/api/index.js
+
+> setDocExtension scala
+> ++2.13.3
+> clean
+$ absent target/api/A$.html
+> doc
+$ exists target/api/A$.html
+$ exists target/api/B$.html
 
 # pending
 # $ absent target/api/scala


### PR DESCRIPTION
This commit adds changes to the actions/doc test that demonstrate that
sbt is failing to actually generate scaladoc for the project classes.
The test passes on the 1.3.x branch.

See https://github.com/sbt/sbt/issues/5798