### PR TITLE
Filter out duplicate `TaskDef`s in test agent

### DIFF
--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.concurrent.*;
 
 public final class ForkMain {
@@ -326,7 +327,7 @@ public final class ForkMain {
 
         if (framework == null) continue;
 
-        final ArrayList<TaskDef> filteredTests = new ArrayList<>();
+        final LinkedHashSet<TaskDef> filteredTests = new LinkedHashSet<>();
         for (final Fingerprint testFingerprint : framework.fingerprints()) {
           for (final TaskDef test : tests) {
             // TODO: To pass in correct explicitlySpecified and selectors


### PR DESCRIPTION
When forking, a test could be run as many times as its `TestDef` matched
`Fingerprint`s. When forking is disabled, sbt correctly runs the tests
only once.

I'm happy to add the following reproduction to a scripted test if you think it's necessary:

/build.sbt:
```scala
lazy val test = project
  .in(file("test"))
  .settings(
    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test,
    libraryDependencies += "org.scalameta" % "junit-interface" % "0.7.11" % Test,
    testFrameworks := Seq(TestFramework("munit.internal.junitinterface.PantsFramework")),
    fork := true,
  )
```

/test/src/test/scala/MyTest.scala:
```scala
class MyTest extends org.scalatest.WordSpec {
  "foo" should { "bar" in { () } }
}
```

```
[info] welcome to sbt 1.3.13 (Twitter Java 1.8.0_242)
[info] loading settings for project global-plugins from plugins.sbt ...
[info] loading global plugins from /Users/mduhem/.sbt/1.0/plugins
[info] loading settings for project multi-run-build from metals.sbt ...
[info] loading project definition from /Users/mduhem/Desktop/multi-run/project
[info] loading settings for project multi-run from build.sbt ...
[info] set current project to multi-run (in build file:/Users/mduhem/Desktop/multi-run/)
[info] sbt server started at local:///Users/mduhem/.sbt/1.0/server/76b9f50b136c0afd383f/sock
sbt:multi-run> debug
[debug] Checking for meta build source updates
sbt:multi-run> test
[debug] Checking for meta build source updates
(...)
[debug] Full compilation, no sources in previous analysis.
[debug] Framework implementation 'org.scalacheck.ScalaCheckFramework' not present.
[debug] Framework implementation 'org.specs2.runner.Specs2Framework' not present.
[debug] Framework implementation 'org.specs2.runner.SpecsFramework' not present.
[debug] Framework implementation 'org.specs.runner.SpecsFramework' not present.
[debug] Framework implementation 'org.scalatest.tools.Framework' not present.
[debug] Framework implementation 'org.scalatest.tools.ScalaTestFramework' not present.
[debug] Framework implementation 'com.novocode.junit.JUnitFramework' not present.
[debug] Subclass fingerprints: List()
[debug] Annotation fingerprints: List()
[debug] No changes
[debug] Subclass fingerprints: List((junit.framework.TestCase,false,munit.internal.junitinterface.JUnit3Fingerprint@5bd3fe4b), (org.scalatest.Suite,false,CustomFingerprint{suite='org.scalatest.Suite'}), (org.scalatest.Suite,false,CustomFingerprint{suite='org.scalatest.Suite'}))
[debug] Annotation fingerprints: List((org.junit.runner.RunWith,false,munit.internal.junitinterface.RunWithFingerprint@58dac1eb), (org.junit.Test,false,munit.internal.junitinterface.JUnitFingerprint@438d198a))
[debug] javaOptions: Vector()
[debug] Forking tests - parallelism = false
[debug] Create a single-thread test executor
[debug] Runner for munit.internal.junitinterface.PantsFramework produced 2 initial tasks for 2 tests.
[debug]   Running TaskDef(MyTest, sbt.ForkMain@74953f91, false, [SuiteSelector])
MyTest:
  + foo should bar 0.015s
[debug]     Produced 0 nested tasks and 1 events.
MyTest:
  + foo should bar 0.0s
[debug]   Running TaskDef(MyTest, sbt.ForkMain@74953f91, false, [SuiteSelector])
[debug]     Produced 0 nested tasks and 1 events.
[debug] Summary for JUnit not available.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[debug] Passed tests:
[debug]         MyTest
[success] Total time: 2 s, completed Aug 26, 2020 10:49:50 AM
[debug] Checking for meta build source updates
```

```
sbt:multi-run> set every fork := false
[debug] Checking for meta build source updates
[info] Defining Global / fork, test / fork
[info] The new values will be used by Compile / run / runner, Test / run / runner and 7 others.
[info]  Run `last`  for details.
[info] Reapplying settings...
[info] set current project to multi-run (in build file:/Users/mduhem/Desktop/multi-run/)
[debug] Checking for meta build source updates
sbt:multi-run> test
[debug] Checking for meta build source updates
(...)
[debug] Framework implementation 'org.scalacheck.ScalaCheckFramework' not present.
[debug] Framework implementation 'org.specs2.runner.Specs2Framework' not present.
[debug] Framework implementation 'org.specs2.runner.SpecsFramework' not present.
[debug] Framework implementation 'org.specs.runner.SpecsFramework' not present.
[debug] Framework implementation 'org.scalatest.tools.Framework' not present.
[debug] Framework implementation 'org.scalatest.tools.ScalaTestFramework' not present.
[debug] Framework implementation 'com.novocode.junit.JUnitFramework' not present.
[debug] Subclass fingerprints: List()
[debug] Annotation fingerprints: List()
[debug] Subclass fingerprints: List((junit.framework.TestCase,false,munit.internal.junitinterface.JUnit3Fingerprint@2534041e), (org.scalatest.Suite,false,CustomFingerprint{suite='org.scalatest.Suite'}), (org.scalatest.Suite,false,CustomFingerprint{suite='org.scalatest.Suite'}))
[debug] Annotation fingerprints: List((org.junit.runner.RunWith,false,munit.internal.junitinterface.RunWithFingerprint@726e931f), (org.junit.Test,false,munit.internal.junitinterface.JUnitFingerprint@36669b32))
[debug] Running TaskDef(MyTest, CustomFingerprint{suite='org.scalatest.Suite'}, false, [SuiteSelector])
MyTest:
  + foo should bar 0.01s
[debug] Summary for JUnit not available.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[debug] Passed tests:
[debug]         MyTest
[success] Total time: 0 s, completed Aug 26, 2020 10:51:15 AM
[debug] Checking for meta build source updates
```

In the first run, notice:
> Runner for munit.internal.junitinterface.PantsFramework produced 2 initial tasks for 2 tests.