### PR TITLE
Restore bindLoggerAppenders source compatibility

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -49,6 +49,11 @@ sealed abstract class LogExchange {
           .addAppender(loggerName, new ConsoleAppenderFromLog4J(loggerName, a) -> l)
     }
   }
+  @deprecated("Use LoggerContext to bind appenders", "1.4.0")
+  def bindLoggerAppenders(
+      loggerName: String,
+      appenders: Seq[(Appender, Level.Value)]
+  ): Unit = bindLoggerAppenders(loggerName, appenders.map { case (a, l) => a.toLog4J -> l }.toList)
   @deprecated("unused", "1.4.0")
   def loggerConfig(loggerName: String): LoggerConfig = configs.get(loggerName)
 


### PR DESCRIPTION
The akka-http project doesn't load because it gets an Appender with
MainAppender.defaultBacked which returns an sbt Appender rather than a
log4j appender now. It then passes that appender into
bindLoggerAppenders which doesn't work because bindLoggerAppenders was
expecting a log4j appender rather than an sbt Appender..