### PR TITLE
Improve progress display with limit + 1 tasks

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -171,7 +171,7 @@ private[sbt] object ProgressState {
               s"  | => ${item.name} ${elapsed}s"
             }
             val limit = state.maxItems
-            if (base.size > limit)
+            if (base.size > limit + 1)
               s"  | ... (${base.size - limit} other tasks)" +: base.takeRight(limit)
             else base
           } else {


### PR DESCRIPTION
When the number of tasks running exceeds the limit for the number of
progress tasks to display by 1. Say the limit is 2 and there are three
tasks running, then we display

  | ... (1 other tasks)
  | => foo 2s
  | => bar 3s

This looks bad considering we could just display what the task actually is.