### PR TITLE
Add pseudo --server command

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -200,6 +200,10 @@ $AliasCommand name=
 	Starts the server if it has not been started. This is intended to be used with
 	-Dsbt.server.autostart=false."""
 
+  def ServerDetailed: String =
+    "--server always runs sbt in not-daemon mode."
+  def DashDashServer: String = "--server"
+
   def OldShell: String = "oldshell"
   def OldShellDetailed = "Provides an interactive prompt from which commands can be run."
 

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -212,7 +212,7 @@ $AliasCommand name=
     "Provides an interactive prompt from which commands can be run on a server."
   def DashClient: String = "-client"
   def DashDashClient: String = "--client"
-  def CloseIOStreams: String = "--close-io-streams"
+  def DashDashDetachStdio: String = "--detach-stdio"
 
   def StashOnFailure: String = "sbtStashOnFailure"
   def PopOnFailure: String = "sbtPopOnFailure"

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -129,8 +129,8 @@ object BasicKeys {
     "List of template resolver infos.",
     1000
   )
-  private[sbt] val closeIOStreams = AttributeKey[Boolean](
-    "close-io-streams",
+  private[sbt] val detachStdio = AttributeKey[Boolean](
+    "detach-stdio",
     "Toggles wheter or not to close system in, out and error when the server starts.",
     1000
   )

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -298,7 +298,8 @@ class NetworkClient(
             term.isSupershellEnabled
           ).mkString(",")
 
-        val cmd = arguments.sbtScript +: arguments.sbtArguments :+ BasicCommandStrings.CloseIOStreams
+        val cmd = List(arguments.sbtScript) ++ arguments.sbtArguments ++
+          List(BasicCommandStrings.CloseIOStreams, BasicCommandStrings.DashDashServer)
         val processBuilder =
           new ProcessBuilder(cmd: _*)
             .directory(arguments.baseDirectory)

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -299,7 +299,7 @@ class NetworkClient(
           ).mkString(",")
 
         val cmd = List(arguments.sbtScript) ++ arguments.sbtArguments ++
-          List(BasicCommandStrings.CloseIOStreams, BasicCommandStrings.DashDashServer)
+          List(BasicCommandStrings.DashDashDetachStdio, BasicCommandStrings.DashDashServer)
         val processBuilder =
           new ProcessBuilder(cmd: _*)
             .directory(arguments.baseDirectory)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -59,7 +59,7 @@ private[sbt] object xMain {
   }
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     try {
-      import BasicCommandStrings.{ DashClient, DashDashClient, runEarly }
+      import BasicCommandStrings.{ DashClient, DashDashClient, DashDashServer, runEarly }
       import BasicCommands.early
       import BuiltinCommands.defaults
       import sbt.internal.CommandStrings.{ BootCommand, DefaultsCommand, InitCommand }
@@ -71,7 +71,9 @@ private[sbt] object xMain {
       }
       // if we detect -Dsbt.client=true or -client, run thin client.
       val clientModByEnv = SysProp.client
-      val userCommands = configuration.arguments.map(_.trim)
+      val userCommands = configuration.arguments
+        .map(_.trim)
+        .filterNot(_ == DashDashServer)
       val isClient: String => Boolean = cmd => (cmd == DashClient) || (cmd == DashDashClient)
       val isBsp: String => Boolean = cmd => (cmd == "-bsp") || (cmd == "--bsp")
       if (userCommands.exists(isBsp)) {

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -86,14 +86,14 @@ private[sbt] object xMain {
             NetworkClient.run(dealiasBaseDirectory(configuration), args)
             Exit(0)
           } else {
-            val closeStreams = userCommands.exists(_ == BasicCommandStrings.CloseIOStreams)
+            val detachStdio = userCommands.exists(_ == BasicCommandStrings.DashDashDetachStdio)
             val state0 = StandardMain
               .initialState(
                 dealiasBaseDirectory(configuration),
                 Seq(defaults, early),
                 runEarly(DefaultsCommand) :: runEarly(InitCommand) :: BootCommand :: Nil
               )
-              .put(BasicKeys.closeIOStreams, closeStreams)
+              .put(BasicKeys.detachStdio, detachStdio)
             val state = bootServerSocket match {
               case Some(l) => state0.put(Keys.bootServerSocket, l)
               case _       => state0
@@ -230,7 +230,9 @@ object StandardMain {
 
     import BasicCommandStrings.isEarlyCommand
     val userCommands =
-      configuration.arguments.map(_.trim).filterNot(_ == BasicCommandStrings.CloseIOStreams)
+      configuration.arguments
+        .map(_.trim)
+        .filterNot(_ == BasicCommandStrings.DashDashDetachStdio)
     val (earlyCommands, normalCommands) = (preCommands ++ userCommands).partition(isEarlyCommand)
     val commands = (earlyCommands ++ normalCommands).toList map { x =>
       Exec(x, None)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -246,7 +246,11 @@ private[sbt] final class CommandExchange {
           firstInstance.set(false)
       }
       Terminal.setBootStreams(null, null)
-      if (s.get(BasicKeys.closeIOStreams).getOrElse(false)) Terminal.close()
+
+      if (s.get(BasicKeys.detachStdio).getOrElse(false)) {
+        Terminal.close()
+      }
+
       s.get(Keys.bootServerSocket).foreach(_.close())
     }
     s.remove(Keys.bootServerSocket)


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/5665

This adds `--server` command that is immediately filtered out in Main.scala.
The purpose of `--server` is so we can invoke thin client from `sbt` script at some point in the future when Bash script can parse `project/build.properties`.

`sbtn` would need to call `sbt` again to start the server, and at that point the shell script would need to actually invoke the server. The intent of `--server` is to be used as the tie breaker.

Also build users may want to sometimes call `sbt --server`.