### PR TITLE
Fix output when starting sbt from thin client

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -297,7 +297,7 @@ object Terminal {
       // This approximates that both stdin and stdio are connected,
       // so by default color will be turned off for pipes and redirects.
       val hasConsole = Option(java.lang.System.console).isDefined
-      props.map(_.ansi).getOrElse(true) && hasConsole
+      props.map(_.color).getOrElse(hasConsole)
     }
     sys.props.get("sbt.log.noformat") match {
       case Some(_) => !java.lang.Boolean.getBoolean("sbt.log.noformat")
@@ -852,8 +852,7 @@ object Terminal {
         term.setEchoEnabled(true)
       }
     }
-    override def isColorEnabled: Boolean =
-      props.map(_.color).getOrElse(ConsoleAppender.formatEnabledInEnv)
+    override def isColorEnabled: Boolean = props.map(_.color).getOrElse(formatEnabledInEnv)
 
     override def isSupershellEnabled: Boolean =
       props

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1006,6 +1006,7 @@ object NetworkClient {
       i += 1
     }
     val base = new File("").getCanonicalFile
+    if (!sbtArguments.contains("-Dsbt.io.virtual=true")) sbtArguments += "-Dsbt.io.virtual=true"
     new Arguments(base, sbtArguments, commandArgs, completionArguments, sbtScript)
   }
 


### PR DESCRIPTION
When starting sbt via the thin client with 1.4.0-RC1, there is no output
until sbt finishes booting up which is poor ux. The reason is that sbt
only uses virtual io when sbt.io.virtual == true or formatEnabledInEnv
== true and not ci. The default value for formatEnabledInEnv is set
based on whether color is enabled in the environment. This had copied
old logic that turned on color if ansi was enabled but it makes more
sense to check the color property (which is set by the thin client via
an environment variable when it launches sbt) and fall back to whether
or not java.lang.System.console is defined. We also can explicitly set
"-Dsbt.io.virtual=true" when the thin client launches sbt since the thin
client relies on this behavior. By doing it in both places, the sbtn
for 1.4.0-RC1 will display boot output for newer versions of sbt.

Bonus: don't call ConsoleAppender.formatEnabledInEnv which just calls
back to Terminal.formatEnabledInEnv