### PR TITLE
Increase length of truncated command

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -139,8 +139,8 @@ private[sbt] final class ProgressState(
 }
 
 private[sbt] object ProgressState {
-  private val MIN_COMMAND_WIDTH = 10
   private val SERVER_IS_RUNNING = "sbt server is running "
+  // the + 2 is for the quotation marks
   private val SERVER_IS_RUNNING_LENGTH = SERVER_IS_RUNNING.length + 2
 
   /**
@@ -179,7 +179,7 @@ private[sbt] object ProgressState {
               val width = terminal.getWidth
               val sanitized = if ((cmd.length + SERVER_IS_RUNNING_LENGTH) > width) {
                 if (SERVER_IS_RUNNING_LENGTH + cmd.length < width) cmd
-                else cmd.take(MIN_COMMAND_WIDTH) + "..."
+                else cmd.take(cmd.length - 3 - SERVER_IS_RUNNING_LENGTH) + "..."
               } else cmd
               val tail = if (isWatch) Nil else "enter 'cancel' to stop evaluation" :: Nil
               s"$SERVER_IS_RUNNING '$sanitized'" :: tail


### PR DESCRIPTION
When the server is running a command with a long name on behalf of a
client, we truncate the command if it exceeds the length of the
terminal. This is because some of the bsp commands are very long.
Nevertheless, only taking 10 characters was a bit too aggressive.