### PR TITLE
Use null ConsoleOut for RelayAppender

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
@@ -21,6 +21,13 @@ sealed trait ConsoleOut {
 
 object ConsoleOut {
   def systemOut: ConsoleOut = terminalOut
+  private[sbt] object NullConsoleOut extends ConsoleOut {
+    override val lockObject: AnyRef = this
+    override def print(s: String): Unit = {}
+    override def println(): Unit = {}
+    override def println(s: String): Unit = {}
+    override def flush(): Unit = {}
+  }
   private[sbt] def globalProxy: ConsoleOut = Proxy
   private[sbt] def setGlobalProxy(out: ConsoleOut): Unit = Proxy.set(out)
   private[sbt] def getGlobalProxy: ConsoleOut = Proxy.proxy.get

--- a/main/src/main/scala/sbt/internal/RelayAppender.scala
+++ b/main/src/main/scala/sbt/internal/RelayAppender.scala
@@ -15,7 +15,7 @@ import sbt.util.Level
 class RelayAppender(override val name: String)
     extends ConsoleAppender(
       name,
-      ConsoleAppender.Properties.from(ConsoleOut.globalProxy, true, true),
+      ConsoleAppender.Properties.from(ConsoleOut.NullConsoleOut, true, true),
       _ => None
     ) {
   lazy val exchange = StandardMain.exchange


### PR DESCRIPTION
The RelayAppender should not log directly to console out since it is
supposed to be relaying json log messages to connected clients. This was
manifesting as double printing on some success messages.