### PR TITLE
Add BSP workspace/reload

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -23,9 +23,8 @@ import sbt.internal.CommandStrings.BootCommand
 import sbt.internal._
 import sbt.internal.client.BspClient
 import sbt.internal.inc.ScalaInstance
-import sbt.internal.io.Retry
 import sbt.internal.nio.{ CheckBuildSources, FileTreeRepository }
-import sbt.internal.server.NetworkChannel
+import sbt.internal.server.{ BuildServerProtocol, NetworkChannel }
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util._
 import sbt.internal.util.complete.{ Parser, SizeParser }
@@ -317,7 +316,10 @@ object BuiltinCommands {
       NetworkChannel.disconnect,
       waitCmd,
       promptChannel,
-    ) ++ allBasicCommands ++ ContinuousCommands.value
+    ) ++
+      allBasicCommands ++
+      ContinuousCommands.value ++
+      BuildServerProtocol.commands
 
   def DefaultBootCommands: Seq[String] =
     WriteSbtVersion :: LoadProject :: NotifyUsersAboutShell :: s"$IfLast $Shell" :: Nil

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
@@ -8,25 +8,27 @@ package sbt.internal.bsp
  * @param compileProvider The languages the server supports compilation via method buildTarget/compile.
  * @param dependencySourcesProvider The server provides sources for library dependencies
                                     via method buildTarget/dependencySources
+ * @param canReload Reloading the workspace state through workspace/reload is supported
  */
 final class BuildServerCapabilities private (
   val compileProvider: Option[sbt.internal.bsp.CompileProvider],
-  val dependencySourcesProvider: Option[Boolean]) extends Serializable {
+  val dependencySourcesProvider: Option[Boolean],
+  val canReload: Option[Boolean]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = o match {
-    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider)
+    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.canReload == x.canReload)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + dependencySourcesProvider.##)
+    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + dependencySourcesProvider.##) + canReload.##)
   }
   override def toString: String = {
-    "BuildServerCapabilities(" + compileProvider + ", " + dependencySourcesProvider + ")"
+    "BuildServerCapabilities(" + compileProvider + ", " + dependencySourcesProvider + ", " + canReload + ")"
   }
-  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider): BuildServerCapabilities = {
-    new BuildServerCapabilities(compileProvider, dependencySourcesProvider)
+  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, canReload: Option[Boolean] = canReload): BuildServerCapabilities = {
+    new BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
   }
   def withCompileProvider(compileProvider: Option[sbt.internal.bsp.CompileProvider]): BuildServerCapabilities = {
     copy(compileProvider = compileProvider)
@@ -40,9 +42,15 @@ final class BuildServerCapabilities private (
   def withDependencySourcesProvider(dependencySourcesProvider: Boolean): BuildServerCapabilities = {
     copy(dependencySourcesProvider = Option(dependencySourcesProvider))
   }
+  def withCanReload(canReload: Option[Boolean]): BuildServerCapabilities = {
+    copy(canReload = canReload)
+  }
+  def withCanReload(canReload: Boolean): BuildServerCapabilities = {
+    copy(canReload = Option(canReload))
+  }
 }
 object BuildServerCapabilities {
   
-  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], dependencySourcesProvider: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, dependencySourcesProvider)
-  def apply(compileProvider: sbt.internal.bsp.CompileProvider, dependencySourcesProvider: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(dependencySourcesProvider))
+  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], dependencySourcesProvider: Option[Boolean], canReload: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
+  def apply(compileProvider: sbt.internal.bsp.CompileProvider, dependencySourcesProvider: Boolean, canReload: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(dependencySourcesProvider), Option(canReload))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
@@ -13,8 +13,9 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
       unbuilder.beginObject(__js)
       val compileProvider = unbuilder.readField[Option[sbt.internal.bsp.CompileProvider]]("compileProvider")
       val dependencySourcesProvider = unbuilder.readField[Option[Boolean]]("dependencySourcesProvider")
+      val canReload = unbuilder.readField[Option[Boolean]]("canReload")
       unbuilder.endObject()
-      sbt.internal.bsp.BuildServerCapabilities(compileProvider, dependencySourcesProvider)
+      sbt.internal.bsp.BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -23,6 +24,7 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
     builder.beginObject()
     builder.addField("compileProvider", obj.compileProvider)
     builder.addField("dependencySourcesProvider", obj.dependencySourcesProvider)
+    builder.addField("canReload", obj.canReload)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -186,6 +186,9 @@ type BuildServerCapabilities {
   # via method buildTarget/resources
   # resourcesProvider: Boolean
 
+  ## Reloading the workspace state through workspace/reload is supported
+  canReload: Boolean
+
   # The server sends notifications to the client on build
   # target change events via buildTarget/didChange
   # buildTargetChangedProvider: Boolean

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -74,6 +74,17 @@ object BuildServerTest extends AbstractServerTest {
     })
   }
 
+  test("workspace/reload") { _ =>
+    svr.sendJsonRpc(
+      """{ "jsonrpc": "2.0", "id": "15", "method": "workspace/reload"}"""
+    )
+    assert(svr.waitForString(10.seconds) { s =>
+      println(s)
+      (s contains """"id":"15"""") &&
+      (s contains """"result":null""")
+    })
+  }
+
   def initializeRequest(): Unit = {
     svr.sendJsonRpc(
       """{ "jsonrpc": "2.0", "id": "10", "method": "build/initialize",


### PR DESCRIPTION
Fixes #5783 

Give BSP clients the ability to trigger a reload by sending a `workspace/reload` request.

According to the specifiaction in https://github.com/build-server-protocol/build-server-protocol/pull/135, the reload is ignored in case of failure, ie the state of sbt stays the same as before.