### PR TITLE
Demote [sig files written]

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -70,10 +70,16 @@ class BuildServerReporter(
   }
 
   override def logInfo(problem: Problem): Unit = {
-    publishDiagnostic(problem)
+    // demote this message https://github.com/scala/bug/issues/12097
+    val sigFilesWritten = "[sig files written]"
+    if (problem.message == sigFilesWritten) {
+      logger.debug(sigFilesWritten)
+    } else {
+      publishDiagnostic(problem)
 
-    // console channel can keep using the xsbi.Problem
-    logger.infoEvent(problem)
+      // console channel can keep using the xsbi.Problem
+      logger.infoEvent(problem)
+    }
   }
 
   private def publishDiagnostic(problem: Problem): Unit = {


### PR DESCRIPTION
This is a workaround for https://github.com/scala/bug/issues/12097

It gets ridiculous seeing the screen fill up with [sig files written] after a while.
Here's a quick hack to demote that stuff.

## before

```
sbt:sbtRoot> compile
[info] compiling 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] compiling 1 Java source to /private/tmp/sbt/client/target/classes ...
[info] [sig files written]
[info] compiling 2 Scala sources and 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] [sig files written]
[info] [sig files written]
```

## after

```
sbt:sbtRoot> compile
[info] compiling 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
[info] compiling 1 Java source to /private/tmp/sbt/client/target/classes ...
[info] compiling 2 Scala sources and 1 Java source to /private/tmp/sbt/internal/util-scripted/target/scala-2.12/classes ...
```
