### PR TITLE
Cancel all promises if one fails

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2039,6 +2039,7 @@ object Defaults extends BuildCommon {
     } catch {
       case e: Throwable if !promise.isCompleted =>
         promise.failure(e)
+        ConcurrentRestrictions.cancelAllSentinels()
         throw e
     } finally {
       i.setup.reporter match {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5822

Currently the entire shell gets stuck when there's a compilation error with pipelining.
This at least returns to sbt shell.