### PR TITLE
Use DumbTerminal if sbt.log.noformat=true

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -75,7 +75,7 @@ private[sbt] object JLine3 {
     }
   }
   private[sbt] def apply(term: Terminal): JTerminal = {
-    if (System.getProperty("jline.terminal", "") == "none")
+    if (System.getProperty("jline.terminal", "") == "none" || !Terminal.formatEnabledInEnv)
       new DumbTerminal(term.inputStream, term.outputStream)
     else wrapTerminal(term)
   }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -768,14 +768,17 @@ object Terminal {
   //  older Scala, since it shaded classes but not the system property
   private[this] def fixTerminalProperty(): Unit = {
     val terminalProperty = "jline.terminal"
-    val newValue = System.getProperty(terminalProperty) match {
-      case "jline.UnixTerminal"                             => "unix"
-      case null if System.getProperty("sbt.cygwin") != null => "unix"
-      case "jline.WindowsTerminal"                          => "windows"
-      case "jline.AnsiWindowsTerminal"                      => "windows"
-      case "jline.UnsupportedTerminal"                      => "none"
-      case x                                                => x
-    }
+    val newValue =
+      if (!formatEnabledInEnv) "none"
+      else
+        System.getProperty(terminalProperty) match {
+          case "jline.UnixTerminal"                             => "unix"
+          case null if System.getProperty("sbt.cygwin") != null => "unix"
+          case "jline.WindowsTerminal"                          => "windows"
+          case "jline.AnsiWindowsTerminal"                      => "windows"
+          case "jline.UnsupportedTerminal"                      => "none"
+          case x                                                => x
+        }
     if (newValue != null) {
       System.setProperty(terminalProperty, newValue)
       ()


### PR DESCRIPTION
When sbt is run with the sbt.log.noformat system property set to true,
no virtual io is used which causes the jline 3 terminal that we creaate
to not work at all. For reasons that I don't understand, it is also
necessary to set the jline.terminal system property to none to make the
dumb terminal work.