### PR TITLE
Set isSuccessEnabled on SimpleTerminal

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -978,7 +978,7 @@ object Terminal {
     override def isAnsiSupported: Boolean = false
     override def isColorEnabled: Boolean = false
     override def isEchoEnabled: Boolean = false
-    override def isSuccessEnabled: Boolean = false
+    override def isSuccessEnabled: Boolean = true
     override def isSupershellEnabled: Boolean = false
     override def outputStream: OutputStream = _ => {}
     override def errorStream: OutputStream = _ => {}


### PR DESCRIPTION
The SimpleTerminal is used when sbt is run with -Dsbt.log.noformat=true.
There is no reason to disable success messages by default.

Fixes https://github.com/sbt/sbt/issues/5861