### PR TITLE
[BSP] Add buildTarget/scalaMainClasses and buildTarget/run endpoints

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -412,8 +412,13 @@ object Defaults extends BuildCommon {
     fullServerHandlers := {
       Seq(
         LanguageServerProtocol.handler(fileConverter.value),
-        BuildServerProtocol
-          .handler(sbtVersion.value, semanticdbEnabled.value, semanticdbVersion.value),
+        BuildServerProtocol.handler(
+          loadedBuild.value,
+          bspWorkspace.value,
+          sbtVersion.value,
+          semanticdbEnabled.value,
+          semanticdbVersion.value
+        ),
         VirtualTerminal.handler,
       ) ++ serverHandlers.value :+ ServerHandler.fallback
     },

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -398,6 +398,7 @@ object Keys {
   val bspBuildTargetDependencySourcesItem = taskKey[DependencySourcesItem]("").withRank(DTask)
   val bspBuildTargetCompile = inputKey[Unit]("").withRank(DTask)
   val bspBuildTargetCompileItem = taskKey[Int]("").withRank(DTask)
+  val bspBuildTargetRun = inputKey[Unit]("Corresponds to buildTarget/run request").withRank(DTask)
   val bspBuildTargetScalacOptions = inputKey[Unit]("").withRank(DTask)
   val bspBuildTargetScalacOptionsItem = taskKey[ScalacOptionsItem]("").withRank(DTask)
   val bspScalaMainClasses = inputKey[Unit]("Corresponds to buildTarget/scalaMainClasses request").withRank(DTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -400,6 +400,8 @@ object Keys {
   val bspBuildTargetCompileItem = taskKey[Int]("").withRank(DTask)
   val bspBuildTargetScalacOptions = inputKey[Unit]("").withRank(DTask)
   val bspBuildTargetScalacOptionsItem = taskKey[ScalacOptionsItem]("").withRank(DTask)
+  val bspScalaMainClasses = inputKey[Unit]("Corresponds to buildTarget/scalaMainClasses request").withRank(DTask)
+  val bspScalaMainClassesItem = taskKey[ScalaMainClassesItem]("").withRank(DTask)
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -21,12 +21,14 @@ import sbt.StandardMain.exchange
 import sbt.internal.bsp._
 import sbt.internal.langserver.ErrorCodes
 import sbt.internal.protocol.JsonRpcRequestMessage
+import sbt.internal.util.Attributed
+import sbt.internal.util.complete.{ Parser, Parsers }
 import sbt.librarymanagement.Configuration
 import sbt.util.Logger
-import sjsonnew.shaded.scalajson.ast.unsafe.JNull
-import sjsonnew.shaded.scalajson.ast.unsafe.JValue
-import sjsonnew.support.scalajson.unsafe.Converter
+import sjsonnew.shaded.scalajson.ast.unsafe.{ JNull, JValue }
+import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser => JsonParser }
 
+import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
 object BuildServerProtocol {
@@ -34,6 +36,7 @@ object BuildServerProtocol {
 
   private val capabilities = BuildServerCapabilities(
     CompileProvider(BuildServerConnection.languages),
+    RunProvider(BuildServerConnection.languages),
     dependencySourcesProvider = true,
     canReload = true
   )
@@ -174,76 +177,106 @@ object BuildServerProtocol {
     },
     bspBuildTargetDependencySourcesItem := dependencySourcesItemTask.value,
     bspBuildTargetCompileItem := bspCompileTask.value,
+    bspBuildTargetRun := bspRunTask.evaluated,
     bspBuildTargetScalacOptionsItem := scalacOptionsTask.value,
     bspInternalDependencyConfigurations := internalDependencyConfigurationsSetting.value,
     bspScalaMainClassesItem := scalaMainClassesTask.value
   )
 
   def handler(
+      loadedBuild: LoadedBuild,
+      workspace: Map[BuildTargetIdentifier, Scope],
       sbtVersion: String,
       semanticdbEnabled: Boolean,
       semanticdbVersion: String
-  ): ServerHandler = ServerHandler { callback =>
-    ServerIntent(
-      onRequest = {
-        case r: JsonRpcRequestMessage if r.method == "build/initialize" =>
-          val params = Converter.fromJson[InitializeBuildParams](json(r)).get
-          checkMetalsCompatibility(semanticdbEnabled, semanticdbVersion, params, callback.log)
+  ): ServerHandler = {
+    val configurationMap: Map[ConfigKey, Configuration] =
+      loadedBuild.allProjectRefs
+        .flatMap { case (_, p) => p.configurations }
+        .distinct
+        .map(c => ConfigKey(c.name) -> c)
+        .toMap
+    ServerHandler { callback =>
+      ServerIntent(
+        onRequest = {
+          case r: JsonRpcRequestMessage if r.method == "build/initialize" =>
+            val params = Converter.fromJson[InitializeBuildParams](json(r)).get
+            checkMetalsCompatibility(semanticdbEnabled, semanticdbVersion, params, callback.log)
 
-          val response = InitializeBuildResult(
-            "sbt",
-            sbtVersion,
-            BuildServerConnection.bspVersion,
-            capabilities,
-            None
-          )
-          callback.jsonRpcRespond(response, Some(r.id)); ()
+            val response = InitializeBuildResult(
+              "sbt",
+              sbtVersion,
+              BuildServerConnection.bspVersion,
+              capabilities,
+              None
+            )
+            callback.jsonRpcRespond(response, Some(r.id)); ()
 
-        case r: JsonRpcRequestMessage if r.method == "workspace/buildTargets" =>
-          val _ = callback.appendExec(Keys.bspWorkspaceBuildTargets.key.toString, Some(r.id))
+          case r: JsonRpcRequestMessage if r.method == "workspace/buildTargets" =>
+            val _ = callback.appendExec(Keys.bspWorkspaceBuildTargets.key.toString, Some(r.id))
 
-        case r: JsonRpcRequestMessage if r.method == "workspace/reload" =>
-          val _ = callback.appendExec(s"$bspReload ${r.id}", None)
+          case r: JsonRpcRequestMessage if r.method == "workspace/reload" =>
+            val _ = callback.appendExec(s"$bspReload ${r.id}", None)
 
-        case r: JsonRpcRequestMessage if r.method == "build/shutdown" =>
-          ()
+          case r: JsonRpcRequestMessage if r.method == "build/shutdown" =>
+            ()
 
-        case r: JsonRpcRequestMessage if r.method == "build/exit" =>
-          val _ = callback.appendExec(Shutdown, Some(r.id))
+          case r: JsonRpcRequestMessage if r.method == "build/exit" =>
+            val _ = callback.appendExec(Shutdown, Some(r.id))
 
-        case r: JsonRpcRequestMessage if r.method == "buildTarget/sources" =>
-          val param = Converter.fromJson[SourcesParams](json(r)).get
-          val targets = param.targets.map(_.uri).mkString(" ")
-          val command = Keys.bspBuildTargetSources.key
-          val _ = callback.appendExec(s"$command $targets", Some(r.id))
+          case r: JsonRpcRequestMessage if r.method == "buildTarget/sources" =>
+            val param = Converter.fromJson[SourcesParams](json(r)).get
+            val targets = param.targets.map(_.uri).mkString(" ")
+            val command = Keys.bspBuildTargetSources.key
+            val _ = callback.appendExec(s"$command $targets", Some(r.id))
 
-        case r if r.method == "buildTarget/dependencySources" =>
-          val param = Converter.fromJson[DependencySourcesParams](json(r)).get
-          val targets = param.targets.map(_.uri).mkString(" ")
-          val command = Keys.bspBuildTargetDependencySources.key
-          val _ = callback.appendExec(s"$command $targets", Some(r.id))
+          case r if r.method == "buildTarget/dependencySources" =>
+            val param = Converter.fromJson[DependencySourcesParams](json(r)).get
+            val targets = param.targets.map(_.uri).mkString(" ")
+            val command = Keys.bspBuildTargetDependencySources.key
+            val _ = callback.appendExec(s"$command $targets", Some(r.id))
 
-        case r if r.method == "buildTarget/compile" =>
-          val param = Converter.fromJson[CompileParams](json(r)).get
-          val targets = param.targets.map(_.uri).mkString(" ")
-          val command = Keys.bspBuildTargetCompile.key
-          val _ = callback.appendExec(s"$command $targets", Some(r.id))
+          case r if r.method == "buildTarget/compile" =>
+            val param = Converter.fromJson[CompileParams](json(r)).get
+            val targets = param.targets.map(_.uri).mkString(" ")
+            val command = Keys.bspBuildTargetCompile.key
+            val _ = callback.appendExec(s"$command $targets", Some(r.id))
 
-        case r: JsonRpcRequestMessage if r.method == "buildTarget/scalacOptions" =>
-          val param = Converter.fromJson[ScalacOptionsParams](json(r)).get
-          val targets = param.targets.map(_.uri).mkString(" ")
-          val command = Keys.bspBuildTargetScalacOptions.key
-          val _ = callback.appendExec(s"$command $targets", Some(r.id))
+          case r if r.method == "buildTarget/run" =>
+            val paramJson = json(r)
+            val param = Converter.fromJson[RunParams](json(r)).get
+            val scope = workspace.getOrElse(
+              param.target,
+              throw LangServerError(
+                ErrorCodes.InvalidParams,
+                s"'${param.target}' is not a valid build target identifier"
+              )
+            )
+            val project = scope.project.toOption.get.asInstanceOf[ProjectRef].project
+            val config = configurationMap(scope.config.toOption.get).id
+            val task = bspBuildTargetRun.key
+            val paramStr = CompactPrinter(paramJson)
+            val _ = callback.appendExec(
+              s"$project / $config / $task $paramStr",
+              Some(r.id)
+            )
 
-        case r: JsonRpcRequestMessage if r.method == "buildTarget/scalaMainClasses" =>
-          val param = Converter.fromJson[ScalacOptionsParams](json(r)).get
-          val targets = param.targets.map(_.uri).mkString(" ")
-          val command = Keys.bspScalaMainClasses.key
-          val _ = callback.appendExec(s"$command $targets", Some(r.id))
-      },
-      onResponse = PartialFunction.empty,
-      onNotification = PartialFunction.empty,
-    )
+          case r: JsonRpcRequestMessage if r.method == "buildTarget/scalacOptions" =>
+            val param = Converter.fromJson[ScalacOptionsParams](json(r)).get
+            val targets = param.targets.map(_.uri).mkString(" ")
+            val command = Keys.bspBuildTargetScalacOptions.key
+            val _ = callback.appendExec(s"$command $targets", Some(r.id))
+
+          case r: JsonRpcRequestMessage if r.method == "buildTarget/scalaMainClasses" =>
+            val param = Converter.fromJson[ScalaMainClassesParams](json(r)).get
+            val targets = param.targets.map(_.uri).mkString(" ")
+            val command = Keys.bspScalaMainClasses.key
+            val _ = callback.appendExec(s"$command $targets", Some(r.id))
+        },
+        onResponse = PartialFunction.empty,
+        onNotification = PartialFunction.empty,
+      )
+    }
   }
 
   private def checkMetalsCompatibility(
@@ -396,6 +429,73 @@ object BuildServerProtocol {
         // Cancellation is not yet implemented
         StatusCode.Error
     }
+  }
+
+  private val jsonParser: Parser[JValue] = (Parsers.any *)
+    .map(_.mkString)
+    .map(JsonParser.parseUnsafe)
+
+  private def bspRunTask: Def.Initialize[InputTask[Unit]] = Def.inputTaskDyn {
+    val runParams = jsonParser.map(json => Converter.fromJson[RunParams](json).get).parsed
+    val defaultClass = Keys.mainClass.value
+    val defaultJvmOptions = Keys.javaOptions.value
+
+    val mainClass = runParams.dataKind match {
+      case Some("scala-main-class") =>
+        val data = runParams.data.getOrElse(JNull)
+        Converter.fromJson[ScalaMainClass](data) match {
+          case Failure(e) =>
+            throw LangServerError(
+              ErrorCodes.ParseError,
+              e.getMessage
+            )
+          case Success(value) => value
+        }
+
+      case Some(dataKind) =>
+        throw LangServerError(
+          ErrorCodes.InvalidParams,
+          s"Unexpected data of kind '$dataKind', 'scala-main-class' is expected"
+        )
+
+      case None =>
+        ScalaMainClass(
+          defaultClass.getOrElse(
+            throw LangServerError(
+              ErrorCodes.InvalidParams,
+              "No default main class is defined"
+            )
+          ),
+          runParams.arguments,
+          defaultJvmOptions.toVector
+        )
+    }
+
+    runMainClassTask(mainClass, runParams.originId)
+  }
+
+  private def runMainClassTask(mainClass: ScalaMainClass, originId: Option[String]) = Def.task {
+    val state = Keys.state.value
+    val logger = Keys.streams.value.log
+    val classpath = Attributed.data(fullClasspath.value)
+    val forkOpts = ForkOptions(
+      javaHome = javaHome.value,
+      outputStrategy = outputStrategy.value,
+      // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
+      bootJars = Vector(),
+      workingDirectory = Some(baseDirectory.value),
+      runJVMOptions = mainClass.jvmOptions,
+      connectInput = connectInput.value,
+      envVars = envVars.value
+    )
+    val runner = new ForkRun(forkOpts)
+    val statusCode = runner
+      .run(mainClass.`class`, classpath, mainClass.arguments, logger)
+      .fold(
+        _ => StatusCode.Error,
+        _ => StatusCode.Success
+      )
+    state.respondEvent(RunResult(originId, statusCode))
   }
 
   private def internalDependencyConfigurationsSetting = Def.settingDyn {

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
@@ -12,29 +12,36 @@ package sbt.internal.bsp
  */
 final class BuildServerCapabilities private (
   val compileProvider: Option[sbt.internal.bsp.CompileProvider],
+  val runProvider: Option[sbt.internal.bsp.RunProvider],
   val dependencySourcesProvider: Option[Boolean],
   val canReload: Option[Boolean]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = o match {
-    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.canReload == x.canReload)
+    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.runProvider == x.runProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.canReload == x.canReload)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + dependencySourcesProvider.##) + canReload.##)
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + runProvider.##) + dependencySourcesProvider.##) + canReload.##)
   }
   override def toString: String = {
-    "BuildServerCapabilities(" + compileProvider + ", " + dependencySourcesProvider + ", " + canReload + ")"
+    "BuildServerCapabilities(" + compileProvider + ", " + runProvider + ", " + dependencySourcesProvider + ", " + canReload + ")"
   }
-  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, canReload: Option[Boolean] = canReload): BuildServerCapabilities = {
-    new BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
+  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, runProvider: Option[sbt.internal.bsp.RunProvider] = runProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, canReload: Option[Boolean] = canReload): BuildServerCapabilities = {
+    new BuildServerCapabilities(compileProvider, runProvider, dependencySourcesProvider, canReload)
   }
   def withCompileProvider(compileProvider: Option[sbt.internal.bsp.CompileProvider]): BuildServerCapabilities = {
     copy(compileProvider = compileProvider)
   }
   def withCompileProvider(compileProvider: sbt.internal.bsp.CompileProvider): BuildServerCapabilities = {
     copy(compileProvider = Option(compileProvider))
+  }
+  def withRunProvider(runProvider: Option[sbt.internal.bsp.RunProvider]): BuildServerCapabilities = {
+    copy(runProvider = runProvider)
+  }
+  def withRunProvider(runProvider: sbt.internal.bsp.RunProvider): BuildServerCapabilities = {
+    copy(runProvider = Option(runProvider))
   }
   def withDependencySourcesProvider(dependencySourcesProvider: Option[Boolean]): BuildServerCapabilities = {
     copy(dependencySourcesProvider = dependencySourcesProvider)
@@ -51,6 +58,6 @@ final class BuildServerCapabilities private (
 }
 object BuildServerCapabilities {
   
-  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], dependencySourcesProvider: Option[Boolean], canReload: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
-  def apply(compileProvider: sbt.internal.bsp.CompileProvider, dependencySourcesProvider: Boolean, canReload: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(dependencySourcesProvider), Option(canReload))
+  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], runProvider: Option[sbt.internal.bsp.RunProvider], dependencySourcesProvider: Option[Boolean], canReload: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, runProvider, dependencySourcesProvider, canReload)
+  def apply(compileProvider: sbt.internal.bsp.CompileProvider, runProvider: sbt.internal.bsp.RunProvider, dependencySourcesProvider: Boolean, canReload: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(runProvider), Option(dependencySourcesProvider), Option(canReload))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/RunParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/RunParams.scala
@@ -1,0 +1,71 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * Run Request
+ * The run request is sent from the client to the server to run a build target.
+ * The server communicates during the initialize handshake whether this method is supported or not.
+ * An empty run request is valid.
+ * @param target The build target to run.
+ * @param originId An option identifier gnerated by the client to identify this request.
+                   The server may include this id in triggered notifications or responses.
+ * @param arguments Optional arguments to the executed application.
+ * @param dataKind Kind of data to expect in the data field.
+                   If this field is not set, the kind of data is not specified.
+ * @param data Language-specific metadata for this execution.
+ */
+final class RunParams private (
+  val target: sbt.internal.bsp.BuildTargetIdentifier,
+  val originId: Option[String],
+  val arguments: Vector[String],
+  val dataKind: Option[String],
+  val data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: RunParams => (this.target == x.target) && (this.originId == x.originId) && (this.arguments == x.arguments) && (this.dataKind == x.dataKind) && (this.data == x.data)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.RunParams".##) + target.##) + originId.##) + arguments.##) + dataKind.##) + data.##)
+  }
+  override def toString: String = {
+    "RunParams(" + target + ", " + originId + ", " + arguments + ", " + dataKind + ", " + data + ")"
+  }
+  private[this] def copy(target: sbt.internal.bsp.BuildTargetIdentifier = target, originId: Option[String] = originId, arguments: Vector[String] = arguments, dataKind: Option[String] = dataKind, data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue] = data): RunParams = {
+    new RunParams(target, originId, arguments, dataKind, data)
+  }
+  def withTarget(target: sbt.internal.bsp.BuildTargetIdentifier): RunParams = {
+    copy(target = target)
+  }
+  def withOriginId(originId: Option[String]): RunParams = {
+    copy(originId = originId)
+  }
+  def withOriginId(originId: String): RunParams = {
+    copy(originId = Option(originId))
+  }
+  def withArguments(arguments: Vector[String]): RunParams = {
+    copy(arguments = arguments)
+  }
+  def withDataKind(dataKind: Option[String]): RunParams = {
+    copy(dataKind = dataKind)
+  }
+  def withDataKind(dataKind: String): RunParams = {
+    copy(dataKind = Option(dataKind))
+  }
+  def withData(data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): RunParams = {
+    copy(data = data)
+  }
+  def withData(data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): RunParams = {
+    copy(data = Option(data))
+  }
+}
+object RunParams {
+  
+  def apply(target: sbt.internal.bsp.BuildTargetIdentifier, originId: Option[String], arguments: Vector[String], dataKind: Option[String], data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): RunParams = new RunParams(target, originId, arguments, dataKind, data)
+  def apply(target: sbt.internal.bsp.BuildTargetIdentifier, originId: String, arguments: Vector[String], dataKind: String, data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): RunParams = new RunParams(target, Option(originId), arguments, Option(dataKind), Option(data))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/RunProvider.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/RunProvider.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+final class RunProvider private (
+  val languageIds: Vector[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: RunProvider => (this.languageIds == x.languageIds)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.bsp.RunProvider".##) + languageIds.##)
+  }
+  override def toString: String = {
+    "RunProvider(" + languageIds + ")"
+  }
+  private[this] def copy(languageIds: Vector[String] = languageIds): RunProvider = {
+    new RunProvider(languageIds)
+  }
+  def withLanguageIds(languageIds: Vector[String]): RunProvider = {
+    copy(languageIds = languageIds)
+  }
+}
+object RunProvider {
+  
+  def apply(languageIds: Vector[String]): RunProvider = new RunProvider(languageIds)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/RunResult.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/RunResult.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * Run Result
+ * @param originId An optional request id to know the origin of this report.
+ * @param statusCode A status code fore the execution.
+ */
+final class RunResult private (
+  val originId: Option[String],
+  val statusCode: Int) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: RunResult => (this.originId == x.originId) && (this.statusCode == x.statusCode)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.bsp.RunResult".##) + originId.##) + statusCode.##)
+  }
+  override def toString: String = {
+    "RunResult(" + originId + ", " + statusCode + ")"
+  }
+  private[this] def copy(originId: Option[String] = originId, statusCode: Int = statusCode): RunResult = {
+    new RunResult(originId, statusCode)
+  }
+  def withOriginId(originId: Option[String]): RunResult = {
+    copy(originId = originId)
+  }
+  def withOriginId(originId: String): RunResult = {
+    copy(originId = Option(originId))
+  }
+  def withStatusCode(statusCode: Int): RunResult = {
+    copy(statusCode = statusCode)
+  }
+}
+object RunResult {
+  
+  def apply(originId: Option[String], statusCode: Int): RunResult = new RunResult(originId, statusCode)
+  def apply(originId: String, statusCode: Int): RunResult = new RunResult(Option(originId), statusCode)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClass.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClass.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * @param class The main class to run.
+ * @param arguments The user arguments to the main entrypoint.
+ * @param jvmOptions The jvm options for the application.
+ */
+final class ScalaMainClass private (
+  val `class`: String,
+  val arguments: Vector[String],
+  val jvmOptions: Vector[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: ScalaMainClass => (this.`class` == x.`class`) && (this.arguments == x.arguments) && (this.jvmOptions == x.jvmOptions)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClass".##) + `class`.##) + arguments.##) + jvmOptions.##)
+  }
+  override def toString: String = {
+    "ScalaMainClass(" + `class` + ", " + arguments + ", " + jvmOptions + ")"
+  }
+  private[this] def copy(`class`: String = `class`, arguments: Vector[String] = arguments, jvmOptions: Vector[String] = jvmOptions): ScalaMainClass = {
+    new ScalaMainClass(`class`, arguments, jvmOptions)
+  }
+  def withClass(`class`: String): ScalaMainClass = {
+    copy(`class` = `class`)
+  }
+  def withArguments(arguments: Vector[String]): ScalaMainClass = {
+    copy(arguments = arguments)
+  }
+  def withJvmOptions(jvmOptions: Vector[String]): ScalaMainClass = {
+    copy(jvmOptions = jvmOptions)
+  }
+}
+object ScalaMainClass {
+  
+  def apply(`class`: String, arguments: Vector[String], jvmOptions: Vector[String]): ScalaMainClass = new ScalaMainClass(`class`, arguments, jvmOptions)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesItem.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesItem.scala
@@ -1,0 +1,40 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * @param target The build target that contains the test classes.
+ * @param classes The main class items
+ */
+final class ScalaMainClassesItem private (
+  val target: sbt.internal.bsp.BuildTargetIdentifier,
+  val classes: Vector[sbt.internal.bsp.ScalaMainClass]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: ScalaMainClassesItem => (this.target == x.target) && (this.classes == x.classes)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClassesItem".##) + target.##) + classes.##)
+  }
+  override def toString: String = {
+    "ScalaMainClassesItem(" + target + ", " + classes + ")"
+  }
+  private[this] def copy(target: sbt.internal.bsp.BuildTargetIdentifier = target, classes: Vector[sbt.internal.bsp.ScalaMainClass] = classes): ScalaMainClassesItem = {
+    new ScalaMainClassesItem(target, classes)
+  }
+  def withTarget(target: sbt.internal.bsp.BuildTargetIdentifier): ScalaMainClassesItem = {
+    copy(target = target)
+  }
+  def withClasses(classes: Vector[sbt.internal.bsp.ScalaMainClass]): ScalaMainClassesItem = {
+    copy(classes = classes)
+  }
+}
+object ScalaMainClassesItem {
+  
+  def apply(target: sbt.internal.bsp.BuildTargetIdentifier, classes: Vector[sbt.internal.bsp.ScalaMainClass]): ScalaMainClassesItem = new ScalaMainClassesItem(target, classes)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesParams.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * The build target main classes request is sent from the client to the server
+ * to query for the list of main classes that can be fed as arguments to buildTarget/run.
+ * @param originId An optional number uniquely identifying a client request.
+ */
+final class ScalaMainClassesParams private (
+  val targets: Vector[sbt.internal.bsp.BuildTargetIdentifier],
+  val originId: Option[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: ScalaMainClassesParams => (this.targets == x.targets) && (this.originId == x.originId)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClassesParams".##) + targets.##) + originId.##)
+  }
+  override def toString: String = {
+    "ScalaMainClassesParams(" + targets + ", " + originId + ")"
+  }
+  private[this] def copy(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier] = targets, originId: Option[String] = originId): ScalaMainClassesParams = {
+    new ScalaMainClassesParams(targets, originId)
+  }
+  def withTargets(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier]): ScalaMainClassesParams = {
+    copy(targets = targets)
+  }
+  def withOriginId(originId: Option[String]): ScalaMainClassesParams = {
+    copy(originId = originId)
+  }
+  def withOriginId(originId: String): ScalaMainClassesParams = {
+    copy(originId = Option(originId))
+  }
+}
+object ScalaMainClassesParams {
+  
+  def apply(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier], originId: Option[String]): ScalaMainClassesParams = new ScalaMainClassesParams(targets, originId)
+  def apply(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier], originId: String): ScalaMainClassesParams = new ScalaMainClassesParams(targets, Option(originId))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesResult.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClassesResult.scala
@@ -1,0 +1,41 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/** @param originId An optional id of the request that triggered this result. */
+final class ScalaMainClassesResult private (
+  val items: Vector[sbt.internal.bsp.ScalaMainClassesItem],
+  val originId: Option[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: ScalaMainClassesResult => (this.items == x.items) && (this.originId == x.originId)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClassesResult".##) + items.##) + originId.##)
+  }
+  override def toString: String = {
+    "ScalaMainClassesResult(" + items + ", " + originId + ")"
+  }
+  private[this] def copy(items: Vector[sbt.internal.bsp.ScalaMainClassesItem] = items, originId: Option[String] = originId): ScalaMainClassesResult = {
+    new ScalaMainClassesResult(items, originId)
+  }
+  def withItems(items: Vector[sbt.internal.bsp.ScalaMainClassesItem]): ScalaMainClassesResult = {
+    copy(items = items)
+  }
+  def withOriginId(originId: Option[String]): ScalaMainClassesResult = {
+    copy(originId = originId)
+  }
+  def withOriginId(originId: String): ScalaMainClassesResult = {
+    copy(originId = Option(originId))
+  }
+}
+object ScalaMainClassesResult {
+  
+  def apply(items: Vector[sbt.internal.bsp.ScalaMainClassesItem], originId: Option[String]): ScalaMainClassesResult = new ScalaMainClassesResult(items, originId)
+  def apply(items: Vector[sbt.internal.bsp.ScalaMainClassesItem], originId: String): ScalaMainClassesResult = new ScalaMainClassesResult(items, Option(originId))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
@@ -5,17 +5,18 @@
 // DO NOT EDIT MANUALLY
 package sbt.internal.bsp.codec
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait BuildServerCapabilitiesFormats { self: sbt.internal.bsp.codec.CompileProviderFormats with sjsonnew.BasicJsonProtocol =>
+trait BuildServerCapabilitiesFormats { self: sbt.internal.bsp.codec.CompileProviderFormats with sbt.internal.bsp.codec.RunProviderFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.BuildServerCapabilities] = new JsonFormat[sbt.internal.bsp.BuildServerCapabilities] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.BuildServerCapabilities = {
     __jsOpt match {
       case Some(__js) =>
       unbuilder.beginObject(__js)
       val compileProvider = unbuilder.readField[Option[sbt.internal.bsp.CompileProvider]]("compileProvider")
+      val runProvider = unbuilder.readField[Option[sbt.internal.bsp.RunProvider]]("runProvider")
       val dependencySourcesProvider = unbuilder.readField[Option[Boolean]]("dependencySourcesProvider")
       val canReload = unbuilder.readField[Option[Boolean]]("canReload")
       unbuilder.endObject()
-      sbt.internal.bsp.BuildServerCapabilities(compileProvider, dependencySourcesProvider, canReload)
+      sbt.internal.bsp.BuildServerCapabilities(compileProvider, runProvider, dependencySourcesProvider, canReload)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -23,6 +24,7 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
   override def write[J](obj: sbt.internal.bsp.BuildServerCapabilities, builder: Builder[J]): Unit = {
     builder.beginObject()
     builder.addField("compileProvider", obj.compileProvider)
+    builder.addField("runProvider", obj.runProvider)
     builder.addField("dependencySourcesProvider", obj.dependencySourcesProvider)
     builder.addField("canReload", obj.canReload)
     builder.endObject()

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
@@ -41,4 +41,8 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.ScalacOptionsResultFormats
   with sbt.internal.bsp.codec.BspConnectionDetailsFormats
   with sbt.internal.bsp.codec.MetalsMetadataFormats
+  with sbt.internal.bsp.codec.ScalaMainClassesParamsFormats
+  with sbt.internal.bsp.codec.ScalaMainClassFormats
+  with sbt.internal.bsp.codec.ScalaMainClassesItemFormats
+  with sbt.internal.bsp.codec.ScalaMainClassesResultFormats
 object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
@@ -17,6 +17,7 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.BuildClientCapabilitiesFormats
   with sbt.internal.bsp.codec.InitializeBuildParamsFormats
   with sbt.internal.bsp.codec.CompileProviderFormats
+  with sbt.internal.bsp.codec.RunProviderFormats
   with sbt.internal.bsp.codec.BuildServerCapabilitiesFormats
   with sbt.internal.bsp.codec.InitializeBuildResultFormats
   with sbt.internal.bsp.codec.PublishDiagnosticsParamsFormats
@@ -34,6 +35,8 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.BspCompileResultFormats
   with sbt.internal.bsp.codec.CompileTaskFormats
   with sbt.internal.bsp.codec.CompileReportFormats
+  with sbt.internal.bsp.codec.RunParamsFormats
+  with sbt.internal.bsp.codec.RunResultFormats
   with sbt.internal.bsp.codec.ScalaBuildTargetFormats
   with sbt.internal.bsp.codec.SbtBuildTargetFormats
   with sbt.internal.bsp.codec.ScalacOptionsParamsFormats

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunParamsFormats.scala
@@ -1,0 +1,35 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait RunParamsFormats { self: sbt.internal.bsp.codec.BuildTargetIdentifierFormats with sbt.internal.util.codec.JValueFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val RunParamsFormat: JsonFormat[sbt.internal.bsp.RunParams] = new JsonFormat[sbt.internal.bsp.RunParams] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.RunParams = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val target = unbuilder.readField[sbt.internal.bsp.BuildTargetIdentifier]("target")
+      val originId = unbuilder.readField[Option[String]]("originId")
+      val arguments = unbuilder.readField[Vector[String]]("arguments")
+      val dataKind = unbuilder.readField[Option[String]]("dataKind")
+      val data = unbuilder.readField[Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]]("data")
+      unbuilder.endObject()
+      sbt.internal.bsp.RunParams(target, originId, arguments, dataKind, data)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.RunParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("target", obj.target)
+    builder.addField("originId", obj.originId)
+    builder.addField("arguments", obj.arguments)
+    builder.addField("dataKind", obj.dataKind)
+    builder.addField("data", obj.data)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunProviderFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunProviderFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait RunProviderFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val RunProviderFormat: JsonFormat[sbt.internal.bsp.RunProvider] = new JsonFormat[sbt.internal.bsp.RunProvider] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.RunProvider = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val languageIds = unbuilder.readField[Vector[String]]("languageIds")
+      unbuilder.endObject()
+      sbt.internal.bsp.RunProvider(languageIds)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.RunProvider, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("languageIds", obj.languageIds)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunResultFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/RunResultFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait RunResultFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val RunResultFormat: JsonFormat[sbt.internal.bsp.RunResult] = new JsonFormat[sbt.internal.bsp.RunResult] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.RunResult = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val originId = unbuilder.readField[Option[String]]("originId")
+      val statusCode = unbuilder.readField[Int]("statusCode")
+      unbuilder.endObject()
+      sbt.internal.bsp.RunResult(originId, statusCode)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.RunResult, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("originId", obj.originId)
+    builder.addField("statusCode", obj.statusCode)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassFormats.scala
@@ -1,0 +1,31 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaMainClassFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val ScalaMainClassFormat: JsonFormat[sbt.internal.bsp.ScalaMainClass] = new JsonFormat[sbt.internal.bsp.ScalaMainClass] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.ScalaMainClass = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val `class` = unbuilder.readField[String]("class")
+      val arguments = unbuilder.readField[Vector[String]]("arguments")
+      val jvmOptions = unbuilder.readField[Vector[String]]("jvmOptions")
+      unbuilder.endObject()
+      sbt.internal.bsp.ScalaMainClass(`class`, arguments, jvmOptions)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.ScalaMainClass, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("class", obj.`class`)
+    builder.addField("arguments", obj.arguments)
+    builder.addField("jvmOptions", obj.jvmOptions)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesItemFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesItemFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaMainClassesItemFormats { self: sbt.internal.bsp.codec.BuildTargetIdentifierFormats with sbt.internal.bsp.codec.ScalaMainClassFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val ScalaMainClassesItemFormat: JsonFormat[sbt.internal.bsp.ScalaMainClassesItem] = new JsonFormat[sbt.internal.bsp.ScalaMainClassesItem] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.ScalaMainClassesItem = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val target = unbuilder.readField[sbt.internal.bsp.BuildTargetIdentifier]("target")
+      val classes = unbuilder.readField[Vector[sbt.internal.bsp.ScalaMainClass]]("classes")
+      unbuilder.endObject()
+      sbt.internal.bsp.ScalaMainClassesItem(target, classes)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.ScalaMainClassesItem, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("target", obj.target)
+    builder.addField("classes", obj.classes)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesParamsFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaMainClassesParamsFormats { self: sbt.internal.bsp.codec.BuildTargetIdentifierFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val ScalaMainClassesParamsFormat: JsonFormat[sbt.internal.bsp.ScalaMainClassesParams] = new JsonFormat[sbt.internal.bsp.ScalaMainClassesParams] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.ScalaMainClassesParams = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val targets = unbuilder.readField[Vector[sbt.internal.bsp.BuildTargetIdentifier]]("targets")
+      val originId = unbuilder.readField[Option[String]]("originId")
+      unbuilder.endObject()
+      sbt.internal.bsp.ScalaMainClassesParams(targets, originId)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.ScalaMainClassesParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("targets", obj.targets)
+    builder.addField("originId", obj.originId)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesResultFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassesResultFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaMainClassesResultFormats { self: sbt.internal.bsp.codec.ScalaMainClassesItemFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val ScalaMainClassesResultFormat: JsonFormat[sbt.internal.bsp.ScalaMainClassesResult] = new JsonFormat[sbt.internal.bsp.ScalaMainClassesResult] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.ScalaMainClassesResult = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val items = unbuilder.readField[Vector[sbt.internal.bsp.ScalaMainClassesItem]]("items")
+      val originId = unbuilder.readField[Option[String]]("originId")
+      unbuilder.endObject()
+      sbt.internal.bsp.ScalaMainClassesResult(items, originId)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.ScalaMainClassesResult, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("items", obj.items)
+    builder.addField("originId", obj.originId)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -469,3 +469,38 @@ type MetalsMetadata {
   ## The list of scala versions that are supported by Metals
   supportedScalaVersions: [String]
 }
+
+## The build target main classes request is sent from the client to the server
+## to query for the list of main classes that can be fed as arguments to buildTarget/run.
+type ScalaMainClassesParams {
+  targets: [sbt.internal.bsp.BuildTargetIdentifier]
+
+  ## An optional number uniquely identifying a client request.
+  originId: String
+}
+
+type ScalaMainClassesResult {
+  items: [sbt.internal.bsp.ScalaMainClassesItem]
+
+  ## An optional id of the request that triggered this result.
+  originId: String
+}
+
+type ScalaMainClassesItem {
+  ## The build target that contains the test classes.
+  target: sbt.internal.bsp.BuildTargetIdentifier!
+
+  ## The main class items
+  classes: [sbt.internal.bsp.ScalaMainClass]
+}
+
+type ScalaMainClass {
+  ## The main class to run.
+  class: String!
+
+  ## The user arguments to the main entrypoint.
+  arguments: [String]
+
+  ## The jvm options for the application.
+  jvmOptions: [String]
+}

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -172,7 +172,7 @@ type BuildServerCapabilities {
   # testProvider: TestProvider
 
   # The languages the server supports run via method buildTarget/run
-  # runProvider: RunProvider
+  runProvider: sbt.internal.bsp.RunProvider
 
   # The server can provide a list of targets that contain a
   # single text document via the method buildTarget/inverseSources
@@ -195,6 +195,10 @@ type BuildServerCapabilities {
 }
 
 type CompileProvider {
+  languageIds: [String]
+}
+
+type RunProvider {
   languageIds: [String]
 }
 
@@ -366,6 +370,39 @@ type CompileReport {
   ## The total number of milliseconds it took to compile the target.
   time: Int
 }
+
+## Run Request
+## The run request is sent from the client to the server to run a build target.
+## The server communicates during the initialize handshake whether this method is supported or not.
+## An empty run request is valid.
+type RunParams {
+  ## The build target to run.
+  target: sbt.internal.bsp.BuildTargetIdentifier!
+
+  ## An option identifier gnerated by the client to identify this request.
+  ## The server may include this id in triggered notifications or responses.
+  originId: String
+
+  ## Optional arguments to the executed application.
+  arguments: [String]
+
+  ## Kind of data to expect in the data field.
+  ## If this field is not set, the kind of data is not specified.
+  dataKind: String
+
+  ## Language-specific metadata for this execution.
+  data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
+}
+
+## Run Result
+type RunResult {
+  ## An optional request id to know the origin of this report.
+  originId: String
+
+  ## A status code fore the execution.
+  statusCode: Int!
+}
+
 
 # Scala Extension
 

--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -5,7 +5,7 @@ Global / serverLog / logLevel := Level.Debug
 lazy val root = (project in file("."))
   .aggregate(foo, util)
 
-lazy val foo = project
+lazy val foo = project.in(file("foo"))
   .dependsOn(util)
 
 lazy val util = project

--- a/server-test/src/server-test/buildserver/foo/src/main/scala/foo/FooMain.scala
+++ b/server-test/src/server-test/buildserver/foo/src/main/scala/foo/FooMain.scala
@@ -1,0 +1,3 @@
+package foo
+
+object FooMain extends App

--- a/server-test/src/server-test/buildserver/foo/src/main/scala/foo/FooMain.scala
+++ b/server-test/src/server-test/buildserver/foo/src/main/scala/foo/FooMain.scala
@@ -1,3 +1,5 @@
 package foo
 
-object FooMain extends App
+object FooMain extends App {
+  println("Hello World!")
+}

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -92,7 +92,7 @@ object BuildServerTest extends AbstractServerTest {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
-    assert(svr.waitForString(10.seconds) { s =>
+    assert(svr.waitForString(30.seconds) { s =>
       println(s)
       (s contains """"id":"16"""") &&
       (s contains """"class":"foo.FooMain"""")

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -85,6 +85,20 @@ object BuildServerTest extends AbstractServerTest {
     })
   }
 
+  test("buildTarget/scalaMainClasses") { _ =>
+    val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#foo/Compile"
+    svr.sendJsonRpc(
+      s"""{ "jsonrpc": "2.0", "id": "16", "method": "buildTarget/scalaMainClasses", "params": {
+         |  "targets": [{ "uri": "$x" }]
+         |} }""".stripMargin
+    )
+    assert(svr.waitForString(10.seconds) { s =>
+      println(s)
+      (s contains """"id":"16"""") &&
+      (s contains """"class":"foo.FooMain"""")
+    })
+  }
+
   def initializeRequest(): Unit = {
     svr.sendJsonRpc(
       """{ "jsonrpc": "2.0", "id": "10", "method": "build/initialize",

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -99,6 +99,27 @@ object BuildServerTest extends AbstractServerTest {
     })
   }
 
+  test("buildTarget/run") { _ =>
+    val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#foo/Compile"
+    svr.sendJsonRpc(
+      s"""{ "jsonrpc": "2.0", "id": "17", "method": "buildTarget/run", "params": {
+         |  "target": { "uri": "$x" },
+         |  "dataKind": "scala-main-class",
+         |  "data": { "class": "foo.FooMain" }
+         |} }""".stripMargin
+    )
+    assert(svr.waitForString(10.seconds) { s =>
+      println(s)
+      (s contains "build/logMessage") &&
+      (s contains """"message":"Hello World!"""")
+    })
+    assert(svr.waitForString(10.seconds) { s =>
+      println(s)
+      (s contains """"id":"17"""") &&
+      (s contains """"statusCode":1""")
+    })
+  }
+
   def initializeRequest(): Unit = {
     svr.sendJsonRpc(
       """{ "jsonrpc": "2.0", "id": "10", "method": "build/initialize",

--- a/server-test/src/test/scala/testpkg/ServerCompletionsTest.scala
+++ b/server-test/src/test/scala/testpkg/ServerCompletionsTest.scala
@@ -19,6 +19,7 @@ object ServerCompletionsTest extends AbstractServerTest {
       s"""{ "jsonrpc": "2.0", "id": 15, "method": "sbt/completion", "params": $completionStr }"""
     )
     assert(svr.waitForString(10.seconds) { s =>
+      println(s)
       s contains """"result":{"items":["""
     })
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5770

The `buildTarget/scalaMainClasses` request queries the list of main classes that can be found in a build target.

Metals uses this endpoint to annotate those classes with the `run | debug` buttons.

![mainClasses](https://user-images.githubusercontent.com/13123162/93607649-e7262180-f9c9-11ea-8fa1-2542d5467616.png)

The `buildTarget/run` endpoint runs a specified main class and return the status code of the execution. It is blocking.

Metals does not use this endpoint because it prefers the `debugSession/start` endpoint that starts a [DAP](https://microsoft.github.io/debug-adapter-protocol/) server. 