### PR TITLE
Don't display progress in skip tasks in batch mode

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -142,7 +142,7 @@ trait Terminal extends AutoCloseable {
   private[sbt] def withRawOutput[R](f: => R): R
   private[sbt] def restore(): Unit = {}
   private[sbt] def progressState: ProgressState
-  private[this] val promptHolder: AtomicReference[Prompt] = new AtomicReference(Prompt.Pending)
+  private[this] val promptHolder: AtomicReference[Prompt] = new AtomicReference(Prompt.Batch)
   private[sbt] final def prompt: Prompt = promptHolder.get
   private[sbt] final def setPrompt(newPrompt: Prompt): Unit =
     if (prompt != Prompt.NoPrompt) promptHolder.set(newPrompt)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -1035,6 +1035,7 @@ object BuiltinCommands {
     if (Terminal.startedByRemoteClient && !exchange.hasServer) {
       Exec(Shutdown, None) +: s1
     } else {
+      if (Terminal.console.prompt == Prompt.Batch) Terminal.console.setPrompt(Prompt.Pending)
       exchange prompt ConsolePromptEvent(s0)
       val minGCInterval = Project
         .extract(s1)

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -97,7 +97,7 @@ final class NetworkChannel(
       case t    => t.close()
     }
     interactive.set(value)
-    if (!isInteractive) terminal.setPrompt(Prompt.Batch)
+    if (isInteractive) terminal.setPrompt(Prompt.Pending)
     attached.set(true)
     pendingRequests.remove(id)
     jsonRpcRespond("", id)


### PR DESCRIPTION
In sbt 1.4.0-RC1, if a user ran `sbt console`, the progress lines would
be printed after they had entered the console. This was because the
prompt state was incorrect. To get the prompt in the correct state, we
initialize the prompt to batch and then switch to pending when either
sbt enters the shell or the network client attaches in interactive mode.
We also will now immediately print progress as soon as we enter a skip
task to clear out the progress lines and display the warning about a
running task if there is another client connected while the task is
running.