### PR TITLE
Don't stop watch input thread on bad input

### DIFF
--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -788,7 +788,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
           try {
             interrupted.set(false)
             terminal.inputStream.read match {
-              case -1   => Watch.Ignore
+              case -1   => throw new InterruptedException
               case 3    => Watch.CancelWatch // ctrl+c on windows
               case byte => inputHandler(byte.toChar.toString)
             }
@@ -800,7 +800,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
         action match {
           case Watch.Ignore =>
             val stop = interrupted.get || Thread.interrupted
-            if ((!Terminal.systemInIsAttached || alternative.isDefined) && !stop) impl()
+            if (!stop) impl()
             else None
           case r => Some(r)
         }


### PR DESCRIPTION
In a continuous build in sbt 1.4.0-RC1, if the user enters an invalid
option, it causes the input thread to exit which means the watch would
no longer accept input commands (including <enter> to exit). This fixes
that behavior.