### PR TITLE
Split to MiniDependencyTreePlugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix:
     - SBT_CMD="mimaReportBinaryIssues ; javafmtCheck ; Test / javafmtCheck; scalafmtCheckAll ; scalafmtSbtCheck; serverTestProj/scalafmtCheckAll; headerCheck ;test:headerCheck ;whitesourceOnPush ;test:compile; publishLocal; test; serverTestProj/test; doc; $UTIL_TESTS; ++$SCALA_213; $UTIL_TESTS"
     - SBT_CMD="scripted actions/* apiinfo/* compiler-project/* ivy-deps-management/* reporter/* tests/* watch/* classloader-cache/* package/*"
-    - SBT_CMD="scripted dependency-graph/* dependency-management/* plugins/* project-load/* java/* run/* nio/*"
+    - SBT_CMD="dependencyTreeProj/publishLocal; scripted dependency-graph/* dependency-management/* plugins/* project-load/* java/* run/* nio/*"
     - SBT_CMD="repoOverrideTest:scripted dependency-management/*; scripted source-dependencies/* project/*"
 
 matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -648,6 +648,15 @@ lazy val scriptedPluginProj = (project in file("scripted-plugin"))
     ),
   )
 
+lazy val dependencyTreeProj = (project in file("dependency-tree"))
+  .dependsOn(sbtProj)
+  .settings(
+    sbtPlugin := true,
+    baseSettings,
+    name := "sbt-dependency-tree",
+    // mimaSettings,
+  )
+
 // Implementation and support code for defining actions.
 lazy val actionsProj = (project in file("main-actions"))
   .dependsOn(
@@ -1361,6 +1370,7 @@ def allProjects =
     scriptedSbtReduxProj,
     scriptedSbtOldProj,
     scriptedPluginProj,
+    dependencyTreeProj,
     protocolProj,
     actionsProj,
     commandProj,

--- a/build.sbt
+++ b/build.sbt
@@ -655,6 +655,7 @@ lazy val dependencyTreeProj = (project in file("dependency-tree"))
     baseSettings,
     name := "sbt-dependency-tree",
     // mimaSettings,
+    mimaPreviousArtifacts := Set.empty,
   )
 
 // Implementation and support code for defining actions.

--- a/dependency-tree/src/main/scala/sbt/plugins/DependencyTreePlugin.scala
+++ b/dependency-tree/src/main/scala/sbt/plugins/DependencyTreePlugin.scala
@@ -1,0 +1,26 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+object DependencyTreePlugin extends AutoPlugin {
+  object autoImport extends DependencyTreeKeys
+  override def trigger = AllRequirements
+  override def requires = MiniDependencyTreePlugin
+
+  val configurations = Vector(Compile, Test, IntegrationTest, Runtime, Provided, Optional)
+
+  // MiniDependencyTreePlugin provides baseBasicReportingSettings for Compile and Test
+  override def projectSettings: Seq[Def.Setting[_]] =
+    ((configurations diff Vector(Compile, Test)) flatMap { config =>
+      inConfig(config)(DependencyTreeSettings.baseBasicReportingSettings)
+    }) ++
+      (configurations flatMap { config =>
+        inConfig(config)(DependencyTreeSettings.baseFullReportingSettings)
+      })
+}

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3986,6 +3986,16 @@ trait BuildExtra extends BuildCommon with DefExtra {
   /**
    * Adds Maven resolver plugin.
    */
+  def addDependencyTreePlugin: Setting[Seq[ModuleID]] =
+    libraryDependencies += sbtPluginExtra(
+      ModuleID("org.scala-sbt", "sbt-dependency-tree", sbtVersion.value),
+      sbtBinaryVersion.value,
+      scalaBinaryVersion.value
+    )
+
+  /**
+   * Adds Maven resolver plugin.
+   */
   def addMavenResolverPlugin: Setting[Seq[ModuleID]] =
     libraryDependencies += sbtPluginExtra(
       ModuleID("org.scala-sbt", "sbt-maven-resolver", sbtVersion.value),

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -52,7 +52,7 @@ object PluginDiscovery {
       "sbt.plugins.SemanticdbPlugin" -> sbt.plugins.SemanticdbPlugin,
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
       "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin,
-      "sbt.plugins.DependencyGraphPlugin" -> sbt.plugins.DependencyGraphPlugin,
+      "sbt.plugins.MiniDependencyTreePlugin" -> sbt.plugins.MiniDependencyTreePlugin,
     )
     val detectedAutoPlugins = discover[AutoPlugin](AutoPlugins)
     val allAutoPlugins = (defaultAutoPlugins ++ detectedAutoPlugins.modules) map {

--- a/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
@@ -6,23 +6,36 @@
  */
 
 package sbt
-package internal
-package graph
+package plugins
 
 import java.io.File
 import java.net.URI
+import sbt.internal.graph._
 import sbt.BuildSyntax._
 import sbt.librarymanagement.{ ModuleID, UpdateReport }
 
-trait DependencyGraphKeys {
+trait MiniDependencyTreeKeys {
+  val dependencyTreeIncludeScalaLibrary = settingKey[Boolean](
+    "Specifies if scala dependency should be included in dependencyTree output"
+  )
+  val dependencyTree = taskKey[Unit]("Prints an ascii tree of all the dependencies to the console")
   val asString = taskKey[String]("Provides the string value for the task it is scoped for")
   // val printToConsole = TaskKey[Unit]("printToConsole", "Prints the tasks value to the console")
   val toFile = inputKey[File]("Writes the task value to the given file")
 
-  val dependencyTreeIncludeScalaLibrary = settingKey[Boolean](
-    "Specifies if scala dependency should be included in dependencyTree output"
-  )
+  // internal
+  private[sbt] val ignoreMissingUpdate =
+    TaskKey[UpdateReport]("dependencyUpdate", "sbt-dependency-graph version of update")
+  private[sbt] val moduleGraphStore =
+    TaskKey[ModuleGraph]("module-graph-store", "The stored module-graph from the last run")
+  val whatDependsOn =
+    InputKey[String]("what-depends-on", "Shows information about what depends on the given module")
+  private[sbt] val crossProjectId = SettingKey[ModuleID]("dependency-graph-cross-project-id")
+}
 
+object MiniDependencyTreeKeys extends MiniDependencyTreeKeys
+
+abstract class DependencyTreeKeys {
   val dependencyGraphMLFile =
     settingKey[File]("The location the graphml file should be generated at")
   val dependencyGraphML =
@@ -59,37 +72,15 @@ trait DependencyGraphKeys {
   val dependencyBrowseTree = taskKey[URI](
     "Opens an HTML page that can be used to view the dependency tree"
   )
-  val moduleGraph = taskKey[ModuleGraph]("The dependency graph for a project")
-  val moduleGraphIvyReport = taskKey[ModuleGraph](
-    "The dependency graph for a project as generated from an Ivy Report XML"
-  )
-  val moduleGraphSbt = taskKey[ModuleGraph](
-    "The dependency graph for a project as generated from SBT data structures."
-  )
-  val dependencyGraph = inputKey[Unit]("Prints the ascii graph to the console")
-  val dependencyTree = taskKey[Unit]("Prints an ascii tree of all the dependencies to the console")
+  val dependencyTreeModuleGraph = taskKey[ModuleGraph]("The dependency graph for a project")
+
   val dependencyList =
     taskKey[Unit]("Prints a list of all dependencies to the console")
   val dependencyStats =
     taskKey[Unit]("Prints statistics for all dependencies to the console")
-  val ivyReportFunction = taskKey[String => File](
-    "A function which returns the file containing the ivy report from the ivy cache for a given configuration"
-  )
-  val ivyReport = taskKey[File](
-    "A task which returns the location of the ivy report file for a given configuration (default `compile`)."
-  )
   val dependencyLicenseInfo = taskKey[Unit](
     "Aggregates and shows information about the licenses of dependencies"
   )
-
-  // internal
-  private[sbt] val ignoreMissingUpdate =
-    TaskKey[UpdateReport]("dependencyUpdate", "sbt-dependency-graph version of update")
-  private[sbt] val moduleGraphStore =
-    TaskKey[ModuleGraph]("module-graph-store", "The stored module-graph from the last run")
-  val whatDependsOn =
-    InputKey[String]("what-depends-on", "Shows information about what depends on the given module")
-  private[sbt] val crossProjectId = SettingKey[ModuleID]("dependency-graph-cross-project-id")
 }
 
-object DependencyGraphKeys extends DependencyGraphKeys
+object DependencyTreeKeys extends DependencyTreeKeys

--- a/main/src/main/scala/sbt/plugins/MiniDependencyTreePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/MiniDependencyTreePlugin.scala
@@ -1,0 +1,27 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+import sbt.PluginTrigger.AllRequirements
+import sbt.Project._
+import sbt.librarymanagement.Configurations.{ Compile, Test }
+
+object MiniDependencyTreePlugin extends AutoPlugin {
+  object autoImport extends MiniDependencyTreeKeys
+
+  import autoImport._
+  override def trigger: PluginTrigger = AllRequirements
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    dependencyTreeIncludeScalaLibrary := false
+  )
+  override def projectSettings: Seq[Def.Setting[_]] =
+    DependencyTreeSettings.coreSettings ++
+      inConfig(Compile)(DependencyTreeSettings.baseBasicReportingSettings) ++
+      inConfig(Test)(DependencyTreeSettings.baseBasicReportingSettings)
+}

--- a/sbt/src/sbt-test/dependency-graph/cachedResolution/build.sbt
+++ b/sbt/src/sbt-test/dependency-graph/cachedResolution/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.28"
 updateOptions := updateOptions.value.withCachedResolution(true)
 
 TaskKey[Unit]("check") := {
-  val report = (Test / ivyReport).value
+  val report = (Test / updateFull).value
   val graph = (Test / dependencyTree / asString).value
 
   def sanitize(str: String): String = str.split('\n').drop(1).mkString("\n")

--- a/sbt/src/sbt-test/dependency-graph/testDotFileGeneration/project/plugins.sbt
+++ b/sbt/src/sbt-test/dependency-graph/testDotFileGeneration/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/sbt/src/sbt-test/dependency-graph/toFileSubTask/project/plugins.sbt
+++ b/sbt/src/sbt-test/dependency-graph/toFileSubTask/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/sbt/src/sbt-test/dependency-graph/whatDependsOn-without-previous-initialization/project/plugins.sbt
+++ b/sbt/src/sbt-test/dependency-graph/whatDependsOn-without-previous-initialization/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/sbt/src/sbt-test/dependency-graph/whatDependsOn/project/plugins.sbt
+++ b/sbt/src/sbt-test/dependency-graph/whatDependsOn/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/sbt/src/sbt-test/dependency-graph/whatDependsOn/test
+++ b/sbt/src/sbt-test/dependency-graph/whatDependsOn/test
@@ -1,3 +1,3 @@
 # to initialize parser with deps
-> compile:moduleGraph
+> Compile/dependencyTreeModuleGraph
 > check


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/pull/5880

This split the dependency-graph plugin into MiniDependencyTreePlugin and DependencyTreePlugin.

Build users can opt-in to maximum strength dependeny-tree plugin using `project/plugins.sbt`:

```scala
addDependencyTreePlugin
```
