### PR TITLE
Fix minor supershell performance regression

### DIFF
--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -48,8 +48,9 @@ private[sbt] class TaskProgress(
       val delay = duration.toMillis
       try {
         val future =
-          if (recurring) scheduler.schedule(runnable, delay, TimeUnit.MILLISECONDS)
-          else scheduler.scheduleAtFixedRate(runnable, delay, delay, TimeUnit.MILLISECONDS)
+          if (recurring)
+            scheduler.scheduleAtFixedRate(runnable, delay, delay, TimeUnit.MILLISECONDS)
+          else scheduler.schedule(runnable, delay, TimeUnit.MILLISECONDS)
         pending.add(future)
         () => Util.ignoreResult(future.cancel(true))
       } catch {


### PR DESCRIPTION
I noticed that no-op compile was a bit slower in this project https://github.com/jtjeferreira/sbt-multi-module-sample with 1.4.0-RC2 compared to 1.4.0-RC1 and tracked it down to a small performance regression that I introduced in 41afe9fbdb0e311e35e3f7d9af225e65901a488b. I also found a logical bug in scheduling progress reports that didn't really seem to affect the ux.