### PR TITLE
Fix getter and setter for virtual terminal attributes

### DIFF
--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -871,7 +871,7 @@ final class NetworkChannel(
           lflag = attributes.getOrElse("lflag", ""),
           cchars = attributes.getOrElse("cchars", ""),
         )
-        val queue = VirtualTerminal.setTerminalAttributes(name, jsonRpcRequest, attrs)
+        val queue = VirtualTerminal.setTerminalAttributesCommand(name, jsonRpcRequest, attrs)
         try queue.take
         catch { case _: InterruptedException => }
       }

--- a/main/src/main/scala/sbt/internal/server/VirtualTerminal.scala
+++ b/main/src/main/scala/sbt/internal/server/VirtualTerminal.scala
@@ -19,6 +19,8 @@ import sbt.internal.protocol.{
 import sbt.protocol.Serialization.{
   attach,
   systemIn,
+  getTerminalAttributes,
+  setTerminalAttributes,
   terminalCapabilities,
   terminalGetSize,
   terminalPropertiesQuery,
@@ -103,10 +105,10 @@ object VirtualTerminal {
     val id = UUID.randomUUID.toString
     val queue = new ArrayBlockingQueue[TerminalAttributesResponse](1)
     pendingTerminalAttributes.put((channelName, id), queue)
-    jsonRpcRequest(id, terminalCapabilities, TerminalAttributesQuery())
+    jsonRpcRequest(id, getTerminalAttributes, TerminalAttributesQuery())
     queue
   }
-  private[sbt] def setTerminalAttributes(
+  private[sbt] def setTerminalAttributesCommand(
       channelName: String,
       jsonRpcRequest: (String, String, TerminalSetAttributesCommand) => Unit,
       query: TerminalSetAttributesCommand
@@ -114,7 +116,7 @@ object VirtualTerminal {
     val id = UUID.randomUUID.toString
     val queue = new ArrayBlockingQueue[Unit](1)
     pendingTerminalSetAttributes.put((channelName, id), queue)
-    jsonRpcRequest(id, terminalCapabilities, query)
+    jsonRpcRequest(id, setTerminalAttributes, query)
     queue
   }
 


### PR DESCRIPTION
Neither NetworkTerminal.getAttributes nor NetworkTerminal.setAttributes
worked correctly because they were sending the wrong json method name.
This wasn't noticeable because neither of these methods had previously
been used by sbt.