### PR TITLE
Fix many instances of server test hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 before_install:
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.0/install.sh | bash && . ~/.jabba/jabba.sh
   - if [ $SBT_LOCAL == true ]; then sbt -Dsbt.io.virtual=false publishLocalBin; fi
+  - rm -r $(find $HOME/.sbt/boot -name "*-SNAPSHOT") || true
 
 install:
   - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
@@ -45,6 +46,7 @@ before_cache:
   - find $HOME/.cache/coursier/v1 -name "ivydata-*.properties" -delete
   - find $HOME/.ivy2              -name "ivydata-*.properties" -delete
   - find $HOME/.sbt               -name "*.lock"               -delete
+  - rm -r $(find $HOME/.sbt/boot -name "*-SNAPSHOT") || true
 
 cache:
   directories:

--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -445,6 +445,7 @@ object State {
     s.fail
   }
   private[sbt] def logFullException(e: Throwable, log: Logger): Unit = {
+    e.printStackTrace(System.err)
     log.trace(e)
     log.error(ErrorHandling reducedToString e)
     log.error("Use 'last' for the full log.")

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -919,7 +919,9 @@ class NetworkClient(
       if (mainThread != null && mainThread != Thread.currentThread) mainThread.interrupt
       connectionHolder.get match {
         case null =>
-        case c    => c.shutdown()
+        case c =>
+          try sendExecCommand("exit")
+          finally c.shutdown()
       }
       Option(inputThread.get).foreach(_.interrupt())
     } catch {

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -799,7 +799,7 @@ class NetworkClient(
       val json = s"""{"query":"$query","level":1}"""
       val execId = sendJson("sbt/completion", json)
       pendingCompletions.put(execId, result.put)
-      val response = result.take
+      val response = result.poll(30, TimeUnit.SECONDS)
       def fillCompletions(label: String, regex: String, command: String): Seq[String] = {
         def updateCompletions(): Seq[String] = {
           errorStream.println()

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -1041,19 +1041,17 @@ object BuiltinCommands {
         .extract(s1)
         .getOpt(Keys.minForcegcInterval)
         .getOrElse(GCUtil.defaultMinForcegcInterval)
-      try {
-        val exec: Exec = getExec(s1, minGCInterval)
-        val newState = s1
-          .copy(
-            onFailure = Some(Exec(Shell, None)),
-            remainingCommands = exec +: Exec(Shell, None) +: s1.remainingCommands
-          )
-          .setInteractive(true)
-        val res =
-          if (exec.commandLine.trim.isEmpty) newState
-          else newState.clearGlobalLog
-        res
-      } catch { case _: InterruptedException => s1.exit(true) }
+      val exec: Exec = getExec(s1, minGCInterval)
+      val newState = s1
+        .copy(
+          onFailure = Some(Exec(Shell, None)),
+          remainingCommands = exec +: Exec(Shell, None) +: s1.remainingCommands
+        )
+        .setInteractive(true)
+      val res =
+        if (exec.commandLine.trim.isEmpty) newState
+        else newState.clearGlobalLog
+      res
     }
   }
 

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -91,7 +91,7 @@ private[sbt] final class CommandExchange {
           case s @ Seq(_, _) => Some(s.min)
           case s             => s.headOption
         }
-        Option(deadline match {
+        try Option(deadline match {
           case Some(d: Deadline) =>
             commandQueue.poll(d.timeLeft.toMillis + 1, TimeUnit.MILLISECONDS) match {
               case null if idleDeadline.fold(false)(_.isOverdue) =>
@@ -106,6 +106,7 @@ private[sbt] final class CommandExchange {
             }
           case _ => commandQueue.take
         })
+        catch { case _: InterruptedException => None }
       }
       poll match {
         case Some(exec) if exec.source.fold(true)(s => channels.exists(_.name == s.channelName)) =>

--- a/sbt/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt/src/test/scala/sbt/RunFromSourceMain.scala
@@ -37,10 +37,10 @@ object RunFromSourceMain {
   ): Process = {
     val fo = fo0
       .withWorkingDirectory(workingDirectory)
-      .withRunJVMOptions(sys.props.get("sbt.ivy.home") match {
+      .withRunJVMOptions((sys.props.get("sbt.ivy.home") match {
         case Some(home) => Vector(s"-Dsbt.ivy.home=$home")
         case _          => Vector()
-      })
+      }) ++ fo0.runJVMOptions)
     implicit val runner = new ForkRun(fo)
     val options =
       Vector(workingDirectory.toString, scalaVersion, sbtVersion, cp.mkString(pathSeparator))

--- a/server-test/src/test/scala/testpkg/EventsTest.scala
+++ b/server-test/src/test/scala/testpkg/EventsTest.scala
@@ -55,6 +55,9 @@ object EventsTest extends AbstractServerTest {
       s"""{ "jsonrpc": "2.0", "id":$id, "method": "sbt/exec", "params": { "commandLine": "run" } }"""
     )
     assert(svr.waitForString(10.seconds) { s =>
+      s contains "Compiled events"
+    })
+    assert(svr.waitForString(10.seconds) { s =>
       s contains "Waiting for"
     })
     val cancelID = currentID.getAndIncrement()
@@ -66,13 +69,15 @@ object EventsTest extends AbstractServerTest {
     })
   }
 
-  /* This test is timing out.
   test("cancel on-going task with string id") { _ =>
     import sbt.Exec
     val id = Exec.newExecId
     svr.sendJsonRpc(
       s"""{ "jsonrpc": "2.0", "id": "$id", "method": "sbt/exec", "params": { "commandLine": "run" } }"""
     )
+    assert(svr.waitForString(10.seconds) { s =>
+      s contains "Compiled events"
+    })
     assert(svr.waitForString(10.seconds) { s =>
       s contains "Waiting for"
     })
@@ -84,5 +89,4 @@ object EventsTest extends AbstractServerTest {
       s contains """"result":{"status":"Task cancelled""""
     })
   }
- */
 }


### PR DESCRIPTION
The server tests often hang or fail in ci. There were a number of small issues that were causing this behavior. What I did to track it down was rewrite .travis.yml so that it ran `serverTestProj/test` 6 times per build. As a result, it would run the server tests 30 times each time I pushed to github. I added lots of println debugging to see what was going on right before and after the hangs. I also added a background thread that would print a stacktrace for all of the threads on the jvm every few minutes. I don't think these changes make the tests 100% reliable, but they are far more reliable than they were before.