### PR TITLE
Fix typo in windows end key capability

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
@@ -97,7 +97,7 @@ private[util] class WindowsInputStream(term: org.jline.terminal.Terminal, in: In
                 // VK_END, VK_INSERT and VK_DELETE are not in the ansi key bindings so we
                 // have to manually apply the the sequences here and in JLine3.wrap
                 case 0x23 /* VK_END */ =>
-                  Option(getCapability(Capability.key_end)).getOrElse("\u001B[4!")
+                  Option(getCapability(Capability.key_end)).getOrElse("\u001B[4~")
                 case 0x2D /* VK_INSERT */ =>
                   Option(getCapability(Capability.key_ic)).getOrElse("\u001B[2~")
                 case 0x2E /* VK_DELETE */ =>


### PR DESCRIPTION
The normal ansi escape sequence for the end key is \u001B[4~ not
\u001B[4!. This didn't seem to matter in terms of whether or not the
end key worked but it still is worth changing for consistency. Pointed
out in an issue comment in jline 3
(https://github.com/jline/jline3/issues/578#issuecomment-699834705).