### PR TITLE
Fix echo setting for scala 2.12 thin client console

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -293,4 +293,7 @@ private[sbt] object JLine3 {
     }
     attributes
   }
+  private[sbt] def isEchoEnabled(map: Map[String, String]): Boolean = {
+    attributesFromMap(map).getLocalFlag(LocalFlag.ECHO)
+  }
 }

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -805,7 +805,7 @@ final class NetworkChannel(
     override def getWidth: Int = getProperty(_.width, 0).getOrElse(0)
     override def getHeight: Int = getProperty(_.height, 0).getOrElse(0)
     override def isAnsiSupported: Boolean = getProperty(_.isAnsiSupported, false).getOrElse(false)
-    override def isEchoEnabled: Boolean = waitForPending(_.isEchoEnabled)
+    override def isEchoEnabled: Boolean = sbt.internal.util.JLine3.isEchoEnabled(getAttributes)
     override def isSuccessEnabled: Boolean =
       interactive.get ||
         StandardMain.exchange.withState(ContinuousCommands.isInWatch(_, NetworkChannel.this))


### PR DESCRIPTION
I noticed that when using the scala 2.12 console with the thin client
that there was weird behavior for the first few seconds of the session.
When prompted with 'scala> ' I would type a letter, say v, and the
output would be 'scala>v' instead of 'scala> v'. It turned out that this
was because the NetworkChannel was returning a stale value for
isEchoEnabled. This happened because NetworkChannel has a method
getProperties that is rate limited under the assumption that the
properties rarely change. This made sense for things like
isAnsiSupported or isSuperShellEnabled but not isEchoEnabled. It is
straightforward to fix this by actually getting the terminal attributes
and checking if the echo flag is set.