### PR TITLE
Make ConsoleReader creation lazy

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -316,7 +316,7 @@ class SimpleReader private[sbt] (
 ) extends JLine {
   def this(historyPath: Option[File], handleCONT: Boolean, injectThreadSleep: Boolean) =
     this(historyPath, handleCONT, Terminal.console)
-  protected[this] val reader: ConsoleReader =
+  protected[this] lazy val reader: ConsoleReader =
     LineReader.createJLine2Reader(historyPath, terminal)
 }
 


### PR DESCRIPTION
I noticed while debugging a jline 2 issue that the SimpleReader was
creating a ConsoleReader on startup even if it was never used.