### PR TITLE
Initialize value before starting thread

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -608,9 +608,9 @@ object Terminal {
      */
     private class ReadThread extends Thread with AutoCloseable {
       val result = new LinkedBlockingQueue[Integer]
+      val running = new AtomicBoolean(true)
       setDaemon(true)
       start()
-      val running = new AtomicBoolean(true)
       override def run(): Unit = while (running.get) {
         bootInputStreamHolder.get match {
           case null =>


### PR DESCRIPTION
Depending on how quickly the thread starts up, this can cause an NPE
(see #5938).