### PR TITLE
Fix line reader for jEdit

### DIFF
--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -25,7 +25,6 @@ private[sbt] final class ConsoleChannel(
 
   override val userThread: UserThread = new UserThread(this)
   private[sbt] def terminal = Terminal.console
-  if (System.console == null) terminal.setPrompt(Prompt.NoPrompt)
 }
 private[sbt] object ConsoleChannel {
   private[sbt] def defaultName = "console0"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/5936

There were a few issues with line reading with jEdit. One was the console prompt was not displayed because the console prompt was disabled when `System.console == null`. The other was that we in some cases did not read any input from System.in when `System.console == null`. To fix the latter, I needed to add some explicit handling for dumb terminals. After these changes, the sbt shell worked fine in the jEdit console on my computer.