### PR TITLE
Fix #5935: Introduce bspReporter key

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -26,7 +26,7 @@ import sbt.internal.inc.ScalaInstance
 import sbt.internal.io.WatchState
 import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
 import sbt.internal.remotecache.RemoteCacheArtifact
-import sbt.internal.server.ServerHandler
+import sbt.internal.server.{ BuildServerReporter, ServerHandler }
 import sbt.internal.util.{ AttributeKey, ProgressState, SourcePosition }
 import sbt.io._
 import sbt.librarymanagement.Configurations.CompilerPlugin
@@ -411,6 +411,7 @@ object Keys {
   val bspScalaTestClassesItem = taskKey[ScalaTestClassesItem]("").withRank(DTask)
   val bspScalaMainClasses = inputKey[Unit]("Corresponds to buildTarget/scalaMainClasses request").withRank(DTask)
   val bspScalaMainClassesItem = taskKey[ScalaMainClassesItem]("").withRank(DTask)
+  val bspReporter = taskKey[BuildServerReporter]("").withRank(DTask)
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)


### PR DESCRIPTION
Fixes #5935 

I introduce the `bspReporter` key that is typed to `BuildServerReporter`.

The `bspReporter` encapsulates the `compilerReporter`. It sends the compiler diagnostics to the BSP client and then forward them to the `compilerReporter`. In case `bspEnabled` is set to false, the `bspReporter` would only forward the logs to the `compilerReporter`, so that the overhead is minimal.

A user can override the `compilerReporter` as usual. It should not need to override the `bspReporter` which is internal.