### PR TITLE
Don't enter raw mode preemptively

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -786,7 +786,6 @@ object Terminal {
       private[util] val system: org.jline.terminal.Terminal,
   ) extends TerminalImpl(in, out, originalErr, "console0") {
     private[this] val rawMode = new AtomicBoolean(false)
-    if (hasConsole) enterRawMode()
     override private[sbt] def getSizeImpl: (Int, Int) = {
       val size = system.getSize
       (size.getColumns, size.getRows)


### PR DESCRIPTION
The user input is not echoed in sbt new because we were switching to raw
mode when creating the console terminal. I can't quite remember why I
was entering raw mode preemptively but it doesn't seem like the best
idea.