### PR TITLE
Fix #5950: Better BSP reporting

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -26,7 +26,7 @@ import sbt.internal.inc.ScalaInstance
 import sbt.internal.io.WatchState
 import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
 import sbt.internal.remotecache.RemoteCacheArtifact
-import sbt.internal.server.ServerHandler
+import sbt.internal.server.{ BuildServerReporter, ServerHandler }
 import sbt.internal.util.{ AttributeKey, ProgressState, SourcePosition }
 import sbt.io._
 import sbt.librarymanagement.Configurations.CompilerPlugin
@@ -411,6 +411,7 @@ object Keys {
   val bspScalaTestClassesItem = taskKey[ScalaTestClassesItem]("").withRank(DTask)
   val bspScalaMainClasses = inputKey[Unit]("Corresponds to buildTarget/scalaMainClasses request").withRank(DTask)
   val bspScalaMainClassesItem = taskKey[ScalaMainClassesItem]("").withRank(DTask)
+  val bspReporter = taskKey[BuildServerReporter]("").withRank(DTask)
 
   val useCoursier = settingKey[Boolean]("Use Coursier for dependency resolution.").withRank(BSetting)
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -201,11 +201,11 @@ object BuildServerProtocol {
     bspScalaMainClassesItem := scalaMainClassesTask.value,
     Keys.compile / bspReporter := {
       val targetId = bspTargetIdentifier.value
+      val converter = fileConverter.value
       val underlying = (Keys.compile / compilerReporter).value
       val logger = streams.value.log
-      val srcs = sources.value
       if (bspEnabled.value) {
-        new BuildServerReporterImpl(targetId, logger, underlying, srcs)
+        new BuildServerReporterImpl(targetId, converter, logger, underlying)
       } else {
         new BuildServerForwarder(logger, underlying)
       }


### PR DESCRIPTION
Fixes #5950
Comes after #5948 
Needs https://github.com/sbt/zinc/pull/931 to works perfectly.

Use the Zinc `SourceInfos` in the `CompileAnalysis` to send the final report via BSP.

The `SourceInfos` contains the new problems but also the old problems that are still valid (warnings). 

Unfortunately, the `SourceInfos` is only available when compilation succeeds. It would be great to have https://github.com/sbt/zinc/issues/932 to improve the error reporting on compilation failure.