### PR TITLE
Set SimpleTerminal properties based on system props

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -960,8 +960,8 @@ object Terminal {
     override def getStringCapability(capability: String): String = null
     override def getWidth: Int = 0
     override def inputStream: InputStream = nullInputStream
-    override def isAnsiSupported: Boolean = false
-    override def isColorEnabled: Boolean = false
+    override def isAnsiSupported: Boolean = formatEnabledInEnv
+    override def isColorEnabled: Boolean = isColorEnabledProp.getOrElse(formatEnabledInEnv)
     override def isEchoEnabled: Boolean = false
     override def isSuccessEnabled: Boolean = true
     override def isSupershellEnabled: Boolean = false


### PR DESCRIPTION
When running sbt 1.4.0 with -Dsbt.ci=true and -Dsbt.color=true, there is
no color output. This was because in this scenario, a SimpleTerminal was
used and isAnsiSupported and isColorEnabled were hardcoded to false
rather than reading the values from the system properties.