### PR TITLE
preserve semanticdb files in pullRemoteCache task

### DIFF
--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -291,7 +291,12 @@ object RemoteCache {
     IO.delete(output)
     IO.unzip(jar, output, preserveLastModified = preserveLastModified)
     processOutput(output)
-    IO.delete(output / "META-INF")
+
+    // preserve semanticdb dir
+    // https://github.com/scalameta/scalameta/blob/a7927ee8e012cfff/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala#L9
+    Option((output / "META-INF").listFiles).foreach(
+      _.iterator.filterNot(_.getName == "semanticdb").foreach(IO.delete)
+    )
   }
 
   private def extractAnalysis(output: File, analysisFile: File): Unit = {
@@ -300,7 +305,6 @@ object RemoteCache {
     if (expandedAnalysis.exists) {
       IO.move(expandedAnalysis, analysisFile)
     }
-    IO.delete(metaDir)
   }
 
   private def extractTestResult(output: File, testResult: File): Unit = {

--- a/sbt/src/sbt-test/actions/remote-cache-semanticdb/build.sbt
+++ b/sbt/src/sbt-test/actions/remote-cache-semanticdb/build.sbt
@@ -1,0 +1,17 @@
+name := "my-project"
+
+scalaVersion := "2.12.12"
+
+semanticdbIncludeInJar := true
+
+semanticdbEnabled := true
+
+pushRemoteCacheTo := Some(
+  MavenCache("local-cache", (ThisBuild / baseDirectory).value / "remote-cache-semanticdb")
+)
+
+remoteCacheId := "fixed-id"
+
+remoteCacheIdCandidates := Seq(remoteCacheId.value)
+
+pushRemoteCacheConfiguration := pushRemoteCacheConfiguration.value.withOverwrite(true)

--- a/sbt/src/sbt-test/actions/remote-cache-semanticdb/src/main/scala/MyClass.scala
+++ b/sbt/src/sbt-test/actions/remote-cache-semanticdb/src/main/scala/MyClass.scala
@@ -1,0 +1,1 @@
+object MyClass

--- a/sbt/src/sbt-test/actions/remote-cache-semanticdb/src/test/scala/MyTest.scala
+++ b/sbt/src/sbt-test/actions/remote-cache-semanticdb/src/test/scala/MyTest.scala
@@ -1,0 +1,1 @@
+object MyTest

--- a/sbt/src/sbt-test/actions/remote-cache-semanticdb/test
+++ b/sbt/src/sbt-test/actions/remote-cache-semanticdb/test
@@ -1,0 +1,53 @@
+> pushRemoteCache
+
+# Generated sources, compiled classes
+$ exists target/scala-2.12/classes/MyClass.class
+$ exists target/scala-2.12/classes/MyClass$.class
+$ exists target/scala-2.12/classes/META-INF/semanticdb/src/main/scala/MyClass.scala.semanticdb
+$ exists target/scala-2.12/zinc/inc_compile_2.12.zip
+$ exists target/scala-2.12/test-classes/MyTest.class
+$ exists target/scala-2.12/test-classes/MyTest$.class
+$ exists target/scala-2.12/test-classes/META-INF/semanticdb/src/test/scala/MyTest.scala.semanticdb
+$ exists target/scala-2.12/test-zinc/inc_compile_2.12.zip
+
+# Pom file
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id.pom
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id.pom.md5
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id.pom.sha1
+
+# Compile
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-compile.jar
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-compile.jar.md5
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-compile.jar.sha1
+
+# Test
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-test.jar
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-test.jar.md5
+$ exists remote-cache-semanticdb/my-project/my-project_2.12/0.0.0-fixed-id/my-project_2.12-0.0.0-fixed-id-cached-test.jar.sha1
+
+> clean
+
+$ absent target/scala-2.12/classes/MyClass.class
+$ absent target/scala-2.12/classes/MyClass$.class
+$ absent target/scala-2.12/classes/META-INF
+$ absent target/scala-2.12/zinc/inc_compile_2.12.zip
+$ absent target/scala-2.12/test-classes/MyTest.class
+$ absent target/scala-2.12/test-classes/MyTest$.class
+$ absent target/scala-2.12/test-classes/META-INF
+$ absent target/scala-2.12/test-zinc/inc_compile_2.12.zip
+
+> pullRemoteCache
+
+# Files extracted from the cache artifacts
+$ exists target/scala-2.12/classes/MyClass.class
+$ exists target/scala-2.12/classes/MyClass$.class
+$ exists target/scala-2.12/classes/META-INF/semanticdb/src/main/scala/MyClass.scala.semanticdb
+$ exists target/scala-2.12/zinc/inc_compile_2.12.zip
+$ exists target/scala-2.12/test-classes/MyTest.class
+$ exists target/scala-2.12/test-classes/MyTest$.class
+$ exists target/scala-2.12/test-classes/META-INF/semanticdb/src/test/scala/MyTest.scala.semanticdb
+$ exists target/scala-2.12/test-zinc/inc_compile_2.12.zip
+
+# Artifacts can be pushed twice (enabled overriding)
+> pushRemoteCache
+


### PR DESCRIPTION
https://github.com/sbt/sbt/pull/5630 deletes all all `META-INF` dir, but I think we should keep `semanticdb` dir.

https://github.com/scalameta/scalameta/blob/a7927ee8e012cfff/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala#L9