### PR TITLE
Remove ansi control characters from piped output

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -91,9 +91,9 @@ private[sbt] final class ProgressState(
       printStream: PrintStream,
       hasProgress: Boolean
   ): Unit = {
-    val canClearPrompt = currentLineBytes.get.isEmpty
-    addBytes(terminal, bytes)
     if (hasProgress) {
+      val canClearPrompt = currentLineBytes.get.isEmpty
+      addBytes(terminal, bytes)
       val toWrite = new ArrayBuffer[Byte]
       terminal.prompt match {
         case a: Prompt.AskUser if a.render.nonEmpty && canClearPrompt =>

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -331,7 +331,7 @@ object Terminal {
   private[sbt] def withStreams[T](isServer: Boolean)(f: => T): T =
     // In ci environments, don't touch the io streams unless run with -Dsbt.io.virtual=true
     if (System.getProperty("sbt.io.virtual", "") == "true" || (logFormatEnabled.getOrElse(true) && !isCI)) {
-      hasProgress.set(isServer)
+      hasProgress.set(isServer && formatEnabledInEnv)
       consoleTerminalHolder.set(newConsoleTerminal())
       activeTerminal.set(consoleTerminalHolder.get)
       try withOut(withIn(f))


### PR DESCRIPTION
When piping an sbt task to a file, the expectation is that sbt will not
write ansi control characters and colors unless the users specifies that
with, e.g. -D.sbt.color=true. With sbt 1.4.0, all output bytes are
routed through the progress output processor which tries to ensure that
progress lines are not interleaved with log lines. The issue was that
the hasProgress flag was being set to true for the server process even
when the formatEnabledInEnv flag was set to false. This caused each log
line to have a leading clear screen before cursor ansi control code
written which would appear in the output file.