### PR TITLE
Check if target is directory before creating

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -287,8 +287,8 @@ public class BootServerSocket implements AutoCloseable {
     final Path base = configuration.baseDirectory().toPath().toRealPath();
     final Path target = base.resolve("project").resolve("target");
     if (!isWindows) {
+      if (!Files.isDirectory(target)) Files.createDirectories(target);
       socketFile = Paths.get(socketLocation(base));
-      Files.createDirectories(target);
     } else {
       socketFile = null;
     }


### PR DESCRIPTION
When project/target is a symbolic link, sbt 1.4.0 crashes on startup
because Files.createDirectories will throw a FileAlreadyExistsException.
The fix is to first check if the target directory exists before trying
to create it.