### PR TITLE
load .inputrc file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -307,6 +307,7 @@ val completeProj = (project in file("internal") / "util-complete")
     name := "Completion",
     libraryDependencies += jline,
     libraryDependencies += jline3Reader,
+    libraryDependencies += jline3Builtins,
     mimaSettings,
     // Parser is used publicly, so we can't break bincompat.
     mimaBinaryIssueFilters := Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,6 +89,7 @@ object Dependencies {
   val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
+  val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
   val jansi = "org.fusesource.jansi" % "jansi" % "1.18"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.0"


### PR DESCRIPTION
I think jline2 automatically load `.inputrc` file. But jline3 changed behavior.

https://github.com/jline/jline3/commit/9ccfe0b121d2ea72a8524c84a9bda5abaa68d45a