### PR TITLE
Don't throw ClosedException on ctrl+d

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -117,9 +117,7 @@ private[sbt] object JLine3 {
           }
           res match {
             case 3 /* ctrl+c */ => throw new ClosedException
-            case 4 /* ctrl+d */ if term.prompt.render().endsWith(term.prompt.mkPrompt()) =>
-              throw new ClosedException
-            case r => r
+            case r              => r
           }
         }
       }


### PR DESCRIPTION
Issue #5974 reported that ctrl+d was not working as expected in the
scala 2.13.{2,3} console. This was because we were throwing an exception
whenever ctrl+d was read instead of allowing the jline line reader to
handle it. I can't remember exactly why I added the throw here but I
validated that both the sbt shell and the scala console had the expected
behavior from the comments in #5974 after this change.