### PR TITLE
Work around "a pure expression does nothing" warning

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -312,6 +312,16 @@ final class ContextUtil[C <: blackbox.Context](val ctx: C) {
               case Converted.Failure(p, m)       => ctx.abort(p, m)
               case _: Converted.NotApplicable[_] => super.transform(tree)
             }
+          // try to workaround https://github.com/scala/bug/issues/12112 by removing raw Ident(_) in blocks
+          case Block(stats0, expr0) =>
+            val stats = stats0 flatMap { stat0 =>
+              val stat = super.transform(stat0)
+              stat match {
+                case Typed(ident @ Ident(_), _) if ident.symbol.isSynthetic => None
+                case _                                                      => Some(stat)
+              }
+            }
+            Block(stats, super.transform(expr0))
           case _ => super.transform(tree)
         }
     }

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -321,7 +321,8 @@ final class ContextUtil[C <: blackbox.Context](val ctx: C) {
                 case _                                                      => Some(stat)
               }
             }
-            Block(stats, super.transform(expr0))
+            val expr = super.transform(expr0)
+            Block(stats, expr).setType(expr.tpe)
           case _ => super.transform(tree)
         }
     }

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -187,7 +187,9 @@ object Instance {
       qual.foreach(checkQual)
       val vd = util.freshValDef(tpe, qual.pos, functionSym)
       inputs ::= new Input(tpe, qual, vd)
-      util.refVal(selection, vd)
+      // try to workaround https://github.com/scala/bug/issues/12112 by calling Predef.identity(...)
+      val rv = util.refVal(selection, vd)
+      q"scala.Predef.identity[$tpe]($rv: $tpe)"
     }
     def sub(name: String, tpe: Type, qual: Tree, replace: Tree): Converted[c.type] = {
       val tag = c.WeakTypeTag[T](tpe)

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -187,9 +187,7 @@ object Instance {
       qual.foreach(checkQual)
       val vd = util.freshValDef(tpe, qual.pos, functionSym)
       inputs ::= new Input(tpe, qual, vd)
-      // try to workaround https://github.com/scala/bug/issues/12112 by calling Predef.identity(...)
-      val rv = util.refVal(selection, vd)
-      q"scala.Predef.identity[$tpe]($rv: $tpe)"
+      util.refVal(selection, vd)
     }
     def sub(name: String, tpe: Type, qual: Tree, replace: Tree): Converted[c.type] = {
       val tag = c.WeakTypeTag[T](tpe)

--- a/sbt/src/sbt-test/project/setting-macro/project/PureExpressionPlugin.scala
+++ b/sbt/src/sbt-test/project/setting-macro/project/PureExpressionPlugin.scala
@@ -1,0 +1,15 @@
+package pkgtest
+
+import sbt._, Keys._
+
+// https://github.com/scala/bug/issues/12112
+object PureExpressionPlugin extends AutoPlugin {
+  lazy val testPureExpression = taskKey[Unit]("")
+  override def projectSettings: Seq[Setting[_]] = {
+    testPureExpression := {
+      updateFull.value
+      (Compile / compile).value
+      (Test / test).value
+    }
+  }
+}

--- a/sbt/src/sbt-test/project/setting-macro/project/plugins.sbt
+++ b/sbt/src/sbt-test/project/setting-macro/project/plugins.sbt
@@ -1,0 +1,1 @@
+Compile / scalacOptions += "-Xfatal-warnings"


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/12112

## steps

`Compile / scalacOptions += "-Xfatal-warnings"` in `project/plugins.sbt`.

```scala
package pkgtest

import sbt._, Keys._

// https://github.com/scala/bug/issues/12112
object PureExpressionPlugin extends AutoPlugin {
  lazy val testPureExpression = taskKey[Unit]("")
  override def projectSettings: Seq[Setting[_]] = {
    testPureExpression := {
      updateFull.value
      (Compile / compile).value
      (Test / test).value
    }
  }
}
```

## problem 

```scala
[error] /private/var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_d9dc839f/project/PureExpressionPlugin.scala:10:18: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
[error]       updateFull.value
[error]                  ^
[error] /private/var/folders/hg/2602nfrs2958vnshglyl3srw0000gn/T/sbt_d9dc839f/project/PureExpressionPlugin.scala:11:27: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
[error]       (Compile / compile).value
[error]                           ^
[error] two errors found
[error] Compilation failed
```

## notes

Current app transformation macro creates a tree that looks like:

```scala
FullInstance.app[[T0[x]](T0[Int], T0[Int]), Unit](scala.Tuple2(task2, task1), (($p$macro$3: (Int, Int)) => {
  <synthetic> val $q$macro$2: Int = $p$macro$3._1;
  <synthetic> val $q$macro$1: Int = $p$macro$3._2;
  {
    ($q$macro$1: Int);
    ($q$macro$2: Int);
    ()
  }
}))(AList.tuple2[Int, Int])
```

Starting Scala 2.12.12 the compiler's "pure expression does nothing" has become more enthusiastic/accurate in its reach, and it started warning about the naked reference to `$q$macro$1` that appears to do nothing, even though in reality it would trigger the tasks and do something in the context of sbt. It's just _that_ particular line ends up macroed away into a pure expression.

A somewhat bizarre workaround is to make a fake call to a method just to satisfy this warning. I've chosen `scala.Predef.identity` here so it can be composed together with the existing expression nesting when they exist.