### PR TITLE
Use lint***Filter instead of ***LintKeys for more reliable tests

### DIFF
--- a/sbt/src/sbt-test/project/lint/build.sbt
+++ b/sbt/src/sbt-test/project/lint/build.sbt
@@ -2,14 +2,18 @@ ThisBuild / doc / scalacOptions += "-Xsomething"
 
 ThisBuild / shellPrompt := { state => "sbt> " }
 
+// watch related settings
+ThisBuild / sbt.nio.Keys.watchTriggers := Seq()
+ThisBuild / sbt.nio.Keys.watchPersistFileStamps := true
+
 lazy val lintBuildTest = taskKey[Unit]("")
 
 lazy val root = (project in file("."))
   .settings(
     lintBuildTest := {
       val state = Keys.state.value
-      val includeKeys = (includeLintKeys in Global).value map { _.scopedKey.key.label }
-      val excludeKeys = (excludeLintKeys in Global).value map { _.scopedKey.key.label }
+      val includeKeys = (lintIncludeFilter in Global).value
+      val excludeKeys = (lintExcludeFilter in Global).value
       val result = sbt.internal.LintUnused.lintUnused(state, includeKeys, excludeKeys)
       result foreach {
         case (_, "ThisBuild / doc / scalacOptions", _) => ()


### PR DESCRIPTION
Use `lint***Filter` instead of `***LintKeys` for more reliable tests.
I have found this improvement when I attempted to solve the issue https://github.com/sbt/sbt/issues/5849.

## Problem

`lintUnusedTask` passes the result of `lintExcludeFilter` as the argument  to `lintUnused`.
https://github.com/sbt/sbt/blob/28833db333f2aa6961df849a9ea46fb3094c048a/main/src/main/scala/sbt/internal/LintUnused.scala#L60-L69

`lintExcludeFilter` excludes watch related settings which has the prefix `watch`.
https://github.com/sbt/sbt/blob/28833db333f2aa6961df849a9ea46fb3094c048a/main/src/main/scala/sbt/internal/LintUnused.scala#L24-L27

But, in the test, `excludeLintKeys` are passed to `lintUnused`.
`excludeLintKeys` are used in `lintExcludeFilter`, and it doesn't exclude watch related settings.
Thus, excluding watch related settings from lint keys are not well tested.
https://github.com/sbt/sbt/blob/28833db333f2aa6961df849a9ea46fb3094c048a/sbt/src/sbt-test/project/lint/build.sbt#L11-L13

I think I can say same thing also about `lintIncludeFilter` and `includeLintKeys`.

## Solution

- Use `lintExcludeFilter` instead of `excludeLintKeys` in the test
- Use `lintIncludeFilter` instead of `includeLintKeys` in the test