### PR TITLE
sjson-new 0.9.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0"
 
   def sjsonNew(n: String) =
-    Def.setting("com.eed3si9n" %% n % "0.9.0") // contrabandSjsonNewVersion.value
+    Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value
   val sjsonNewScalaJson = sjsonNew("sjson-new-scalajson")
   val sjsonNewMurmurhash = sjsonNew("sjson-new-murmurhash")
 


### PR DESCRIPTION
https://github.com/eed3si9n/sjson-new/releases/tag/v0.9.1

Performance fix by caching `implicitly[Manifest[A1]].runtimeClass` call where 13% of total CPU time was spent. (`sbt update` went from 40s to 33s in some builds) https://github.com/eed3si9n/sjson-new/pull/115 by @craffit  