### PR TITLE
improve remote cache extract log message

### DIFF
--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -114,10 +114,10 @@ object RemoteCache {
                   findJar(classifier, v, jars) match {
                     case Some(jar) =>
                       extractJar(art, jar)
-                      log.info(s"remote cache artifact extracted for $classifier")
+                      log.info(s"remote cache artifact extracted for $p $classifier")
 
                     case None =>
-                      log.info(s"remote cache artifact not found for $classifier")
+                      log.info(s"remote cache artifact not found for $p $classifier")
                   }
                 }
                 found = true


### PR DESCRIPTION
### build.sbt

```scala
lazy val common = Def.settings(
  scalaVersion := "2.12.12",
  pushRemoteCacheTo := Some(
    MavenCache("local-cache", (ThisBuild / baseDirectory).value / "remote-cache")
  ),
  remoteCacheId := "fixed-id",
  remoteCacheIdCandidates := Seq(remoteCacheId.value)
)

pushRemoteCache := {}
pullRemoteCache := {}

lazy val p1 = project.settings(common)
lazy val p2 = project.settings(common)
lazy val p3 = project.settings(common)
lazy val p4 = project.settings(common)
lazy val p5 = project.settings(common)
lazy val p6 = project.settings(common)
lazy val p7 = project.settings(common)
lazy val p8 = project.settings(common)
lazy val p9 = project.settings(common)
```

run: `sbt pushRemoteCache clean pullRemoteCache`

### before (sbt 1.4.1) 😢 

```
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-test)
[info] remote cache artifact extracted for Some(cached-compile)
[info] remote cache artifact extracted for Some(cached-test)
```

### after

```
[info] remote cache artifact extracted for p2:p2:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p9:p9:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p8:p8:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p7:p7:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p5:p5:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p1:p1:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p5:p5:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p7:p7:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p2:p2:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p8:p8:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p9:p9:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p1:p1:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p3:p3:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p3:p3:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p4:p4:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p4:p4:0.0.0-fixed-id Some(cached-test)
[info] remote cache artifact extracted for p6:p6:0.0.0-fixed-id Some(cached-compile)
[info] remote cache artifact extracted for p6:p6:0.0.0-fixed-id Some(cached-test)
```