### PR TITLE
Fix EvaluateTask memory leak

### DIFF
--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -72,12 +72,15 @@ final case class State(
  * @param currentExecId provide the execId extracted from the original State.
  * @param combinedParser the parser extracted from the original State.
  */
+@deprecated("unused", "1.4.2")
 private[sbt] final case class SafeState(
     currentExecId: Option[String],
     combinedParser: Parser[() => sbt.State]
 )
 
+@deprecated("unused", "1.4.2")
 private[sbt] object SafeState {
+  @deprecated("use StandardMain.exchange.withState", "1.4.2")
   def apply(s: State) = {
     new SafeState(
       currentExecId = s.currentCommand.map(_.execId).flatten,

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -413,8 +413,12 @@ object EvaluateTask {
       (dummyRoots, roots) :: (Def.dummyStreamsManager, streams) :: (dummyState, state) :: dummies
     )
 
+  @deprecated("use StandardMain.exchange.withState to obtain an instance of State", "1.4.2")
   val lastEvaluatedState: AtomicReference[SafeState] = new AtomicReference()
+  @deprecated("use currentlyRunningTaskEngine", "1.4.2")
   val currentlyRunningEngine: AtomicReference[(SafeState, RunningTaskEngine)] =
+    new AtomicReference()
+  private[sbt] val currentlyRunningTaskEngine: AtomicReference[RunningTaskEngine] =
     new AtomicReference()
 
   /**
@@ -486,7 +490,7 @@ object EvaluateTask {
         shutdownImpl(true)
       }
     }
-    currentlyRunningEngine.set((SafeState(state), runningEngine))
+    currentlyRunningTaskEngine.set(runningEngine)
     // Register with our cancel handler we're about to start.
     val strat = config.cancelStrategy
     val cancelState = strat.onTaskEngineStart(runningEngine)
@@ -494,8 +498,7 @@ object EvaluateTask {
     try run()
     finally {
       strat.onTaskEngineFinish(cancelState)
-      currentlyRunningEngine.set(null)
-      lastEvaluatedState.set(SafeState(state))
+      currentlyRunningTaskEngine.set(null)
     }
   }
 


### PR DESCRIPTION
EvaluateTask was holding references to SafeState that could be quite
large. This was reported as #5992. In that project, I ran the `ci` task
and observed the OOM as reported. I took a heap dump prior to OOM and
got the retained size graph from visualvm (which took hours to compute).
The lastEvaluatedState was holding a reference to SafeState that was
1.7GB. The project max heap size was set to 2GB. Instead of using the
lastEvaluatedState, we can just use StandardMain.exchange.withState.
The cached instances of state were used for task cancellation and
completions. While it is possible that early on in booting
StandardMain.exchange.withState could return a null state, in practice
this won't happen because it is set early on during the sbt boot
commands.

After this change, I successfully ran the `ci` task in the #5992 issue
project with the same memory parameters as their ci config.