### PR TITLE
Fix SimpleInputStream reads into array

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -16,7 +16,7 @@ import org.jline.utils.{ ClosedException, NonBlockingReader }
 import org.jline.terminal.{ Attributes, Size, Terminal => JTerminal }
 import org.jline.terminal.Attributes.{ InputFlag, LocalFlag }
 import org.jline.terminal.Terminal.SignalHandler
-import org.jline.terminal.impl.AbstractTerminal
+import org.jline.terminal.impl.{ AbstractTerminal, DumbTerminal }
 import org.jline.terminal.impl.jansi.JansiSupportImpl
 import org.jline.terminal.impl.jansi.win.JansiWinSysTerminal
 import org.jline.utils.OSUtils
@@ -73,6 +73,11 @@ private[sbt] object JLine3 {
     term
   }
   private[sbt] def apply(term: Terminal): JTerminal = {
+    if (System.getProperty("jline.terminal", "") == "none")
+      new DumbTerminal(term.inputStream, term.outputStream)
+    else wrapTerminal(term)
+  }
+  private[this] def wrapTerminal(term: Terminal): JTerminal = {
     new AbstractTerminal(
       term.name,
       "nocapabilities",

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -486,7 +486,7 @@ object Terminal {
         val _ = readQueue.take
         val b = in.read
         buffer.put(b)
-        if (Thread.interrupted() || (b != -1 && !isRaw.get)) closed.set(true)
+        if (Thread.interrupted() || (b == -1 && isRaw.get)) closed.set(true)
         else impl()
       }
       try impl()
@@ -596,9 +596,12 @@ object Terminal {
   private[sbt] trait SimpleInputStream extends InputStream {
     override def read(b: Array[Byte]): Int = read(b, 0, b.length)
     override def read(b: Array[Byte], off: Int, len: Int): Int = {
-      val byte = read()
-      b(off) = byte.toByte
-      1
+      read() match {
+        case -1 => -1
+        case byte =>
+          b(off) = byte.toByte
+          1
+      }
     }
   }
   private[this] object proxyInputStream extends SimpleInputStream {

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -934,12 +934,9 @@ class NetworkClient(
     val stopped = new AtomicBoolean(false)
     override final def run(): Unit = {
       def read(): Unit = {
-        inputStream.read match {
-          case -1 =>
-          case b =>
-            inLock.synchronized(stdinBytes.offer(b))
-            if (attached.get()) drain()
-        }
+        val b = inputStream.read
+        inLock.synchronized(stdinBytes.offer(b))
+        if (attached.get()) drain()
       }
       try read()
       catch { case _: InterruptedException | NonFatal(_) => stopped.set(true) } finally {


### PR DESCRIPTION
When the read methods of InputStream that take an Array[Byte] as input
are called, they are supposed to return -1 if there are no bytes
available due to an EOF. Previously it was incorrectly writing the -1 as
a byte in the array and returning 1. Now it correctly returns -1.

The condition for closing the WriteableInputStream was also incorrect.
We should only close the input stream if it returns -1 in raw mode.

Fixes #5999