### PR TITLE
Fix earlyOutput and remoteCachePom paths

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -623,7 +623,7 @@ object Defaults extends BuildCommon {
       val dir = classDirectory.value
       converter.toVirtualFile(dir.toPath)
     },
-    earlyOutput / artifactPath := earlyArtifactPathSetting(artifact).value,
+    earlyOutput / artifactPath := configArtifactPathSetting(artifact, "early").value,
     earlyOutput := {
       val converter = fileConverter.value
       val jar = (earlyOutput / artifactPath).value
@@ -1591,10 +1591,30 @@ object Defaults extends BuildCommon {
       excludes: ScopedTaskable[FileFilter]
   ): Initialize[Task[Seq[File]]] = collectFiles(dirs: Taskable[Seq[File]], filter, excludes)
 
-  private[sbt] def earlyArtifactPathSetting(art: SettingKey[Artifact]): Initialize[File] =
+  private[sbt] def configArtifactPathSetting(
+      art: SettingKey[Artifact],
+      extraPrefix: String
+  ): Initialize[File] =
     Def.setting {
       val f = artifactName.value
-      crossTarget.value / "early" / f(
+      crossTarget.value /
+        (prefix(configuration.value.name) + extraPrefix) / f(
+        ScalaVersion(
+          (scalaVersion in artifactName).value,
+          (scalaBinaryVersion in artifactName).value
+        ),
+        projectID.value,
+        art.value
+      )
+    }
+
+  private[sbt] def prefixArtifactPathSetting(
+      art: SettingKey[Artifact],
+      extraPrefix: String
+  ): Initialize[File] =
+    Def.setting {
+      val f = artifactName.value
+      crossTarget.value / extraPrefix / f(
         ScalaVersion(
           (scalaVersion in artifactName).value,
           (scalaBinaryVersion in artifactName).value

--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -128,10 +128,17 @@ object RemoteCache {
     },
     remoteCachePom := {
       val s = streams.value
-      val config = makePomConfiguration.value
+      val config = (remoteCachePom / makePomConfiguration).value
       val publisher = Keys.publisher.value
       publisher.makePomFile((pushRemoteCache / ivyModule).value, config, s.log)
       config.file.get
+    },
+    remoteCachePom / artifactPath := {
+      Defaults.prefixArtifactPathSetting(makePom / artifact, "remote-cache").value
+    },
+    remoteCachePom / makePomConfiguration := {
+      val config = makePomConfiguration.value
+      config.withFile((remoteCachePom / artifactPath).value)
     },
     remoteCachePom / remoteCacheArtifact := {
       PomRemoteCacheArtifact((makePom / artifact).value, remoteCachePom)


### PR DESCRIPTION
This fixes the scoping of newly added files in sbt 1.4.0 features.
