### PR TITLE
Fix #6006: BuildServerReporter on Dotty

### DIFF
--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -2,13 +2,17 @@ ThisBuild / scalaVersion := "2.13.1"
 
 Global / serverLog / logLevel := Level.Debug
 
-lazy val root = (project in file("."))
-  .aggregate(foo, util)
-
-lazy val foo = project.in(file("foo"))
+lazy val runAndTest = project.in(file("run-and-test"))
   .settings(
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   )
   .dependsOn(util)
+
+lazy val reportError = project.in(file("report-error"))
+
+lazy val reportWarning = project.in(file("report-warning"))
+  .settings(
+    scalacOptions += "-deprecation"
+  )
 
 lazy val util = project

--- a/server-test/src/server-test/buildserver/foo/src/test/scala/foo/FooTest.scala
+++ b/server-test/src/server-test/buildserver/foo/src/test/scala/foo/FooTest.scala
@@ -1,9 +1,0 @@
-package foo
-
-import org.scalatest.FreeSpec
-
-class FooTest extends FreeSpec {
-  "test message" in {
-    assert(FooMain.message == "Hello World!")
-  }
-}

--- a/server-test/src/server-test/buildserver/report-error/src/main/scala/reporterror/Error.scala
+++ b/server-test/src/server-test/buildserver/report-error/src/main/scala/reporterror/Error.scala
@@ -1,0 +1,5 @@
+package reportertests
+
+object Error {
+  val version: String = 5
+}

--- a/server-test/src/server-test/buildserver/report-warning/src/main/scala/reportwarning/Warning.scala
+++ b/server-test/src/server-test/buildserver/report-warning/src/main/scala/reportwarning/Warning.scala
@@ -1,0 +1,7 @@
+package reportertests
+
+object Warning {
+  def print() {
+    prtinln("bar")
+  }
+}

--- a/server-test/src/server-test/buildserver/run-and-test/src/main/scala/main/Main.scala
+++ b/server-test/src/server-test/buildserver/run-and-test/src/main/scala/main/Main.scala
@@ -1,6 +1,6 @@
-package foo
+package main
 
-object FooMain extends App {
+object Main extends App {
   lazy val message = "Hello World!"
 
   println(message)

--- a/server-test/src/server-test/buildserver/run-and-test/src/test/scala/tests/FailingTest.scala
+++ b/server-test/src/server-test/buildserver/run-and-test/src/test/scala/tests/FailingTest.scala
@@ -1,4 +1,4 @@
-package foo
+package tests
 
 import org.scalatest.FreeSpec
 

--- a/server-test/src/server-test/buildserver/run-and-test/src/test/scala/tests/PassingTest.scala
+++ b/server-test/src/server-test/buildserver/run-and-test/src/test/scala/tests/PassingTest.scala
@@ -1,0 +1,9 @@
+package tests
+
+import org.scalatest.FreeSpec
+
+class PassingTest extends FreeSpec {
+  "test message" in {
+    assert(main.Main.message == "Hello World!")
+  }
+}


### PR DESCRIPTION
Fixes #6006 

When using `scalac`, the `sourcePath` of the reported positions is virtual file refs.
When using Dotty, the `sourcePath` of the reported positions is absolute path, and so the `BuildServerReporter` was not working.

In the `BuildServerReporter` I now use the `pos.sourceFile` rather than the `pos.sourcePath` to store the diagnostics. The `pos.sourceFile` is much more stable because it is a real file from which I can reliably extract the absolute path.

I have added 2 build server tests. The first one checks that the last report contains an error, the other one checks that the last report contains a warning.