### PR TITLE
Fix #5994: sourceMappers handles fake positions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -157,4 +157,4 @@ for:
   test_script:
     # The server tests often fail in CI when run together so just run a single test to ensure
     # that the thin client works on windows
-    - sbt "-Dsbt.io.virtual=false" "scripted actions/* classloader-cache/* nio/* watch/*" "serverTestProj/testOnly testpkg.ClientTest"
+    - sbt "-Dsbt.io.virtual=false" "scripted actions/* reporter/source-mapper classloader-cache/* nio/* watch/*" "serverTestProj/testOnly testpkg.ClientTest"

--- a/sbt/src/sbt-test/reporter/source-mapper/build.sbt
+++ b/sbt/src/sbt-test/reporter/source-mapper/build.sbt
@@ -1,0 +1,46 @@
+import java.util.Optional
+import xsbti.Position
+
+val assertAbsolutePathConversion = taskKey[Unit]("checks source mappers convert to absolute path")
+
+val assertHandleFakePos = taskKey[Unit]("checks source mappers handle fake position")
+
+assertAbsolutePathConversion := {
+  val converter = fileConverter.value
+  val source = (Compile/sources).value.head
+  val position = newPosition(converter.toVirtualFile(source.toPath).id, source)
+  val mappedPos = sourcePositionMappers.value
+    .foldLeft(Option(position)) {
+      case (pos, mapper) => pos.flatMap(mapper)
+    }
+  assert {
+    mappedPos.get.sourcePath.asScala.contains(source.getAbsolutePath)
+  }
+}
+
+assertHandleFakePos := {
+  val position = newPosition("<macro>", new File("<macro>"))
+  val mappedPos = sourcePositionMappers.value
+    .foldLeft(Option(position)) {
+      case (pos, mapper) => pos.flatMap(mapper)
+    }
+  assert {
+    mappedPos.get.sourcePath.asScala.get.contains("<macro>")
+  }
+}
+
+def newPosition(path: String, file: File): Position = new Position {
+  override def line(): Optional[Integer] = Optional.empty()
+
+  override def lineContent() = ""
+
+  override def offset(): Optional[Integer] = Optional.empty()
+
+  override def pointer(): Optional[Integer] = Optional.empty()
+
+  override def pointerSpace(): Optional[String] = Optional.empty()
+
+  override def sourcePath(): Optional[String] = Optional.of(path)
+
+  override def sourceFile(): Optional[File] = Optional.of(file)
+}

--- a/sbt/src/sbt-test/reporter/source-mapper/test
+++ b/sbt/src/sbt-test/reporter/source-mapper/test
@@ -1,0 +1,2 @@
+> assertAbsolutePathConversion
+> assertHandleFakePos


### PR DESCRIPTION
Fixes #5994 

Sometimes the compiler reports errors on a file that does not really exist: for instance `pos.sourcePath` can contain `"<macro>"`. In such case the `sourceMappers` should not fail when converting the `pos.sourcePath` to absolute path.

- Fixed `Defaults.toAbsoluteSourceMapper`
- Added scripted tests on the `sourceMappers`
- Run the `reporter:source-mapper` scripted test on windows