### PR TITLE
Set color by default only if log format enabled

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -314,7 +314,10 @@ object Terminal {
   private[this] def useColorDefault: Boolean = {
     // This approximates that both stdin and stdio are connected,
     // so by default color will be turned off for pipes and redirects.
-    props.map(_.color).orElse(isColorEnabledProp).getOrElse((hasConsole && !isDumbTerminal) || isCI)
+    props
+      .map(_.color)
+      .orElse(isColorEnabledProp)
+      .getOrElse((hasConsole && !isDumbTerminal && logFormatEnabled.getOrElse(true)) || isCI)
   }
   private[this] lazy val isColorEnabledProp: Option[Boolean] =
     sys.props.get("sbt.color").orElse(sys.props.get("sbt.colour")).flatMap(parseLogOption)


### PR DESCRIPTION
I noticed that if you run `sbt -Dsbt.log.noformat=true` there are colors
printed when using the latest sbt code. When running with that property
set, the expectation is there are no colors.