### PR TITLE
Reinstate watchBeforeCommand callback

### DIFF
--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1327,7 +1327,10 @@ private[sbt] object ContinuousCommands {
     }
 
   private[sbt] val preWatchCommand = watchCommand(preWatch) { (channel, state) =>
-    watchState(state, channel).beforeCommand(state)
+    val ws = watchState(state, channel)
+    val newState = ws.beforeCommand(state)
+    ws.callbacks.beforeCommand()
+    newState
   }
   private[sbt] val postWatchCommand = watchCommand(postWatch) { (channel, state) =>
     val cs = watchState(state, channel)

--- a/sbt/src/sbt-test/watch/before-command/build.sbt
+++ b/sbt/src/sbt-test/watch/before-command/build.sbt
@@ -1,0 +1,5 @@
+import java.nio.file.{ Files, Paths }
+
+watchBeforeCommand := { () => Files.write(Paths.get("foo"), "foo".getBytes) }
+
+watchOnIteration := { (_, _, _) => sbt.nio.Watch.CancelWatch }

--- a/sbt/src/sbt-test/watch/before-command/test
+++ b/sbt/src/sbt-test/watch/before-command/test
@@ -1,0 +1,3 @@
+> ~compile
+
+$ exists foo


### PR DESCRIPTION
A user reported that the watchBeforeCommand callback was not being
invoked in sbt 1.4.{0, 1}. This was an oversight that occurred when
refactoring watch for the thin client and there previously had been no
regression test for that callback.