### PR TITLE
Strip ansi and color codes from terminal output

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -495,8 +495,10 @@ trait Appender extends AutoCloseable {
     // the output may have unwanted colors but it would still be legible. This should
     // only be relevant if the log message string itself contains ansi escape sequences
     // other than color codes which is very unlikely.
-    val toWrite = if (!ansiCodesSupported) {
-      if (useFormat) EscHelpers.stripMoves(msg) else EscHelpers.removeEscapeSequences(msg)
+    val toWrite = if (!ansiCodesSupported || !useFormat && msg.getBytes.contains(27.toByte)) {
+      val (bytes, len) =
+        EscHelpers.strip(msg.getBytes, stripAnsi = !ansiCodesSupported, stripColor = !useFormat)
+      new String(bytes, 0, len)
     } else msg
     out.println(toWrite)
   }

--- a/internal/util-logging/src/test/scala/sbt/internal/util/CleanStringSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/CleanStringSpec.scala
@@ -45,23 +45,25 @@ class CleanStringSpec extends FlatSpec {
   }
   it should "remove moves in string with only moves" in {
     val original =
-      new String(Array[Byte](27, 91, 50, 75, 27, 91, 51, 65, 27, 91, 49, 48, 48, 48, 68))
-    assert(EscHelpers.stripMoves(original) == "")
+      Array[Byte](27, 91, 50, 75, 27, 91, 51, 65, 27, 91, 49, 48, 48, 48, 68)
+    val (bytes, len) = EscHelpers.strip(original, stripAnsi = true, stripColor = true)
+    assert(len == 0)
   }
   it should "remove moves in string with moves and letters" in {
-    val original = new String(
+    val original =
       Array[Byte](27, 91, 50, 75, 27, 91, 51, 65) ++ "foo".getBytes ++ Array[Byte](27, 91, 49, 48,
         48, 48, 68)
-    )
-    assert(EscHelpers.stripMoves(original) == "foo")
+    val (bytes, len) = EscHelpers.strip(original, stripAnsi = true, stripColor = true)
+    assert(new String(bytes, 0, len) == "foo")
   }
   it should "preserve colors" in {
-    val original = new String(
+    val original =
       Array[Byte](27, 91, 49, 48, 48, 48, 68, 27, 91, 48, 74, 102, 111, 111, 27, 91, 51, 54, 109,
         62, 32, 27, 91, 48, 109)
-    ) // this is taken from an sbt prompt that looks like "foo> " with the > rendered blue
+    // this is taken from an sbt prompt that looks like "foo> " with the > rendered blue
     val colorArrow = new String(Array[Byte](27, 91, 51, 54, 109, 62))
-    assert(EscHelpers.stripMoves(original) == "foo" + colorArrow + " " + scala.Console.RESET)
+    val (bytes, len) = EscHelpers.strip(original, stripAnsi = true, stripColor = false)
+    assert(new String(bytes, 0, len) == "foo" + colorArrow + " " + scala.Console.RESET)
   }
   it should "remove unusual escape characters" in {
     val original = new String(
@@ -69,5 +71,29 @@ class CleanStringSpec extends FlatSpec {
         48, 52, 108)
     )
     assert(EscHelpers.stripColorsAndMoves(original).isEmpty)
+  }
+  it should "remove bracketed paste csi" in {
+    // taken from a test project prompt
+    val original =
+      Array[Byte](27, 91, 63, 50, 48, 48, 52, 104, 115, 98, 116, 58, 114, 101, 112, 114, 111, 62,
+        32)
+    val (bytes, len) = EscHelpers.strip(original, stripAnsi = true, stripColor = false)
+    assert(new String(bytes, 0, len) == "sbt:repro> ")
+  }
+  it should "strip colors" in {
+    // taken from utest output
+    val original =
+      Array[Byte](91, 105, 110, 102, 111, 93, 32, 27, 91, 51, 50, 109, 43, 27, 91, 51, 57, 109, 32,
+        99, 111, 109, 46, 97, 99, 109, 101, 46, 67, 111, 121, 111, 116, 101, 84, 101, 115, 116, 46,
+        109, 97, 107, 101, 84, 114, 97, 112, 32, 27, 91, 50, 109, 57, 109, 115, 27, 91, 48, 109, 32,
+        32, 27, 91, 48, 74, 10)
+    val (bytes, len) = EscHelpers.strip(original, stripAnsi = false, stripColor = true)
+    val expected = "[info] + com.acme.CoyoteTest.makeTrap 9ms  " +
+      new String(Array[Byte](27, 91, 48, 74, 10))
+    assert(new String(bytes, 0, len) == expected)
+
+    val (bytes2, len2) = EscHelpers.strip(original, stripAnsi = true, stripColor = true)
+    val expected2 = "[info] + com.acme.CoyoteTest.makeTrap 9ms  \n"
+    assert(new String(bytes2, 0, len2) == expected2)
   }
 }


### PR DESCRIPTION
It is possible for downstream dependencies to print or log messages
containing ansi escape sequences and/or color codes. In older versions
of sbt, these would be printed even if the user had disabled ansi codes
or color via the sbt.log.noformat or sbt.color parameters. This commit
adds a general api to EscHelpers that strips general ansi codes and
color codes independently via flags. We can then use that api to ensure
that all bytes written to System.out are stripped of ansi escape and
color codes if the terminal properties demand this.

The motivation was that JLine 3 will prepend the prompt string with
\E[?2004h, which turns on bracketed paste mode
(https://en.wikipedia.org/wiki/ANSI_escape_code). If the sbt shell is
started with a terminal that doesn't support general ansi escape codes,
such as the jEdit shell, ?2004h gets printed to the shell. To fix this,
we can strip ansi codes from all output if the terminal doesn't support
general ansic codes. This has the additional side effect of any ansi
codes that appear in log messages or printlns that are added by non-sbt
code will be stripped. It's unlikely that this is all that common.

In addition to the JLine use case, I've noticed that utest prints
colored output during test runs. Prior to this change, the colored
output was present even when sbt was run with `-Dsbt.color=false` and
after this change, the colors are correctly stripped.