### PR TITLE
Flush terminal output stream after readline

### DIFF
--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -565,6 +565,7 @@ final class NetworkChannel(
       logShutdown: Boolean,
       remainingCommands: Option[(String, String)]
   ): Unit = {
+    doFlush()
     terminal.close()
     StandardMain.exchange.removeChannel(this)
     super.shutdown(logShutdown)


### PR DESCRIPTION
With the thin client, when running the command `exit`, it is often the
case that the log message `[info] disconnected` is printed on the same
line as the prompt. This is because there is a small flush delay on the
network client's output stream channel that causes the disconnected info
message to be logged before the the newline that jline 3 echoes to the
client has been printed. To fix this we can manually flush the terminal
output stream before exiting.