### PR TITLE
Avoid throwing interrupted exception in JoinThread

### DIFF
--- a/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
+++ b/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
@@ -20,11 +20,13 @@ object JoinThread {
           t.interrupt()
           t.join(10)
         } catch { case e: InterruptedException => exception = Some(e) }
-        if (t.isAlive) impl()
+        if (t.isAlive && !deadline.isOverdue) impl()
       }
       impl()
-      if (t.isAlive) System.err.println(s"Unable to join thread $t after $duration")
-      exception.foreach(throw _)
+      if (t.isAlive) {
+        System.err.println(s"Unable to join thread $t after $duration")
+        exception.foreach(throw _)
+      }
     }
   }
 }


### PR DESCRIPTION
I saw a stacktrace when exiting sbtn on windows due to an interrupted
exception being thrown during thread joining. We only want to throw this
exception if we didn't successfully join the thread. I also noticed that
we would try to join the thread forever. There was supposed to be a
timelimit so that we would eventually stop blocking even if we were
unable to join the thread. The limit was set but not respected.