### PR TITLE
Updates to Coursier 2.0.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.0"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.2"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.2"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.3"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
https://github.com/coursier/sbt-coursier/releases/tag/v2.0.2 which includes https://github.com/coursier/coursier/releases/tag/v2.0.5
https://github.com/coursier/coursier/releases/tag/v2.0.6

- Computed checksums of downloaded files are now written in the cache, and read from there later on. This short-circuits checksum computation for anything already in cache, which can significantly speed up resolutions with large dependency graphs.