### PR TITLE
Fixes IntelliJ import on Windows + Fixes shell when supershell is disabled

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -460,8 +460,7 @@ trait Appender extends AutoCloseable {
       // according to https://github.com/sbt/sbt/issues/5608, sometimes we get a null message
       if (message == null) ()
       else {
-        val len =
-          labelColor.length + label.length + messageColor.length + reset.length * 3 + ClearScreenAfterCursor.length
+        val len = labelColor.length + label.length + messageColor.length + reset.length * 3
         val builder: StringBuilder = new StringBuilder(len)
         message.linesIterator.foreach { line =>
           builder.ensureCapacity(len + line.length + 4)
@@ -477,7 +476,6 @@ trait Appender extends AutoCloseable {
           fmted(labelColor, label)
           builder.append("] ")
           fmted(messageColor, line)
-          if (ansiCodesSupported) builder.append(ClearScreenAfterCursor)
           write(builder.toString)
         }
       }
@@ -495,7 +493,7 @@ trait Appender extends AutoCloseable {
     // the output may have unwanted colors but it would still be legible. This should
     // only be relevant if the log message string itself contains ansi escape sequences
     // other than color codes which is very unlikely.
-    val toWrite = if (!ansiCodesSupported || !useFormat && msg.getBytes.contains(27.toByte)) {
+    val toWrite = if ((!ansiCodesSupported || !useFormat) && msg.getBytes.contains(27.toByte)) {
       val (bytes, len) =
         EscHelpers.strip(msg.getBytes, stripAnsi = !ansiCodesSupported, stripColor = !useFormat)
       new String(bytes, 0, len)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -306,9 +306,7 @@ object Terminal {
       case _       => sys.props.get("sbt.log.format").flatMap(parseLogOption)
     }
   }
-  private[this] lazy val superShellEnabled = sys.props.get("sbt.supershell").map(_ == "true")
-  private[sbt] lazy val isAnsiSupported: Boolean =
-    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault)
+  private[sbt] lazy val isAnsiSupported: Boolean = logFormatEnabled.getOrElse(useColorDefault)
   private[this] val isDumbTerminal = "dumb" == System.getenv("TERM")
   private[this] val hasConsole = Option(java.lang.System.console).isDefined
   private[this] def useColorDefault: Boolean = {
@@ -754,7 +752,7 @@ object Terminal {
   private[this] def fixTerminalProperty(): Unit = {
     val terminalProperty = "jline.terminal"
     val newValue =
-      if (!isAnsiSupported) "none"
+      if (!isAnsiSupported && System.getProperty("sbt.io.virtual", "") == "false") "none"
       else
         System.getProperty(terminalProperty) match {
           case "jline.UnixTerminal"                             => "unix"

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -308,7 +308,7 @@ object Terminal {
   }
   private[this] lazy val superShellEnabled = sys.props.get("sbt.supershell").map(_ == "true")
   private[sbt] lazy val isAnsiSupported: Boolean =
-    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault && !isCI)
+    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault)
   private[this] val isDumbTerminal = "dumb" == System.getenv("TERM")
   private[this] val hasConsole = Option(java.lang.System.console).isDefined
   private[this] def useColorDefault: Boolean = {

--- a/server-test/src/test/scala/testpkg/TestServer.scala
+++ b/server-test/src/test/scala/testpkg/TestServer.scala
@@ -163,7 +163,7 @@ case class TestServer(
   val forkOptions =
     ForkOptions()
       .withOutputStrategy(OutputStrategy.StdoutOutput)
-      .withRunJVMOptions(Vector("-Dsbt.ci=true", "-Dsbt.io.virtual=false"))
+      .withRunJVMOptions(Vector("-Djline.terminal=none", "-Dsbt.io.virtual=false"))
   val process =
     RunFromSourceMain.fork(forkOptions, baseDirectory, scalaVersion, sbtVersion, classpath)
 


### PR DESCRIPTION
Intellij import was broken in sbt 1.4.2 because we increased the
scenarios in which virtual io is used. The problem wasn't actually
virtual io but that we create a console terminal with jline3 and that
could cause issues reading input from System.in. This can be fixed by
only creating an instance of ConsoleTerminal if a console is actually
available for the sbt process. When hasConsole is false, the
consoleTerminalHolder will point to the SimpleTerminal whose inputStream
method just reads directly from System.in. After making this change, I
verified that intellij import worked again on windows.