### PR TITLE
Fixes opt-out for scripted batch execution

### DIFF
--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -78,7 +78,7 @@ object ScriptedPlugin extends AutoPlugin {
     scriptedClasspath := getJars(ScriptedConf).value,
     scriptedTests := scriptedTestsTask.value,
     scriptedParallelInstances := 1,
-    scriptedBatchExecution := false,
+    scriptedBatchExecution := true,
     scriptedRun := scriptedRunTask.value,
     scriptedDependencies := {
       def use[A](@deprecated("unused", "") x: A*): Unit = () // avoid unused warnings


### PR DESCRIPTION
sbt 1.4.0 made batch execution the default behavior. The following setting can be used to opt out of the behavior:

```scala
scriptedBatchExecution := false
```

To increase parallelism use:

```scala
scriptedParallelInstances := 2
```

### original description

This PR makes the scripted plugin work the way it used to in older sbt versions when `scriptedBatchExecution := false`. It also makes `scriptedBatchExecution := true` the default because I think the performance improvement is worth it for most builds even though it can cause issues like in #6042. I can remove the second commit if there is disagreement on changing the default.
