### PR TITLE
Remove scalatest_2.11-3.0.5.jar from travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - sbt -Dsbt.io.virtual=false $SBT_VERSION_PROP -Dsbt.ci=true -J-XX:ReservedCodeCacheSize=128m -J-Xmx800M -J-Xms800M -J-server "$SBT_CMD"
 
 before_cache:
+  - find $HOME/.cache/coursier/v1 -name "scalatest_2.11-3.0.5.jar" -delete
   - find $HOME/.cache/coursier/v1 -name "ivydata-*.properties" -delete
   - find $HOME/.ivy2              -name "ivydata-*.properties" -delete
   - find $HOME/.sbt               -name "*.lock"               -delete


### PR DESCRIPTION
The scripted tests/test-cross test is failing on travis and it seems to
be due to bad cache entry for the scalatest_2.11-3.0.5.jar. The travis
ci ui supposed to allow you to delete cache entries, but that feature
seems to be broken in sbt/sbt. This commit could probably be reverted
once it's merged assuming it works.