### PR TITLE
Bump scalatest version in tests/test-cross

### DIFF
--- a/sbt/src/sbt-test/tests/test-cross/build.sbt
+++ b/sbt/src/sbt-test/tests/test-cross/build.sbt
@@ -1,4 +1,4 @@
-val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalatest = "org.scalatest" %% "scalatest" % "3.0.6"
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
The travis build has been failing with issues with the scalatest 3.0.5
jar so let's try with 3.0.6.