### PR TITLE
Support ansi by default if color is supported

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -460,8 +460,7 @@ trait Appender extends AutoCloseable {
       // according to https://github.com/sbt/sbt/issues/5608, sometimes we get a null message
       if (message == null) ()
       else {
-        val len =
-          labelColor.length + label.length + messageColor.length + reset.length * 3 + ClearScreenAfterCursor.length
+        val len = labelColor.length + label.length + messageColor.length + reset.length * 3
         val builder: StringBuilder = new StringBuilder(len)
         message.linesIterator.foreach { line =>
           builder.ensureCapacity(len + line.length + 4)
@@ -477,7 +476,6 @@ trait Appender extends AutoCloseable {
           fmted(labelColor, label)
           builder.append("] ")
           fmted(messageColor, line)
-          if (ansiCodesSupported) builder.append(ClearScreenAfterCursor)
           write(builder.toString)
         }
       }
@@ -495,7 +493,7 @@ trait Appender extends AutoCloseable {
     // the output may have unwanted colors but it would still be legible. This should
     // only be relevant if the log message string itself contains ansi escape sequences
     // other than color codes which is very unlikely.
-    val toWrite = if (!ansiCodesSupported || !useFormat && msg.getBytes.contains(27.toByte)) {
+    val toWrite = if ((!ansiCodesSupported || !useFormat) && msg.getBytes.contains(27.toByte)) {
       val (bytes, len) =
         EscHelpers.strip(msg.getBytes, stripAnsi = !ansiCodesSupported, stripColor = !useFormat)
       new String(bytes, 0, len)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -308,7 +308,7 @@ object Terminal {
   }
   private[this] lazy val superShellEnabled = sys.props.get("sbt.supershell").map(_ == "true")
   private[sbt] lazy val isAnsiSupported: Boolean =
-    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault && !isCI)
+    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault)
   private[this] val isDumbTerminal = "dumb" == System.getenv("TERM")
   private[this] val hasConsole = Option(java.lang.System.console).isDefined
   private[this] def useColorDefault: Boolean = {

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -308,7 +308,8 @@ object Terminal {
   }
   private[sbt] lazy val isAnsiSupported: Boolean =
     logFormatEnabled.getOrElse(useColorDefault)
-  private[this] val isDumbTerminal = "dumb" == System.getenv("TERM")
+  private[this] val isDumb = "dumb" == System.getenv("TERM")
+  private[this] def isDumbTerminal = isDumb || System.getProperty("jline.terminal", "") == "none"
   private[this] val hasConsole = Option(java.lang.System.console).isDefined
   private[this] def useColorDefault: Boolean = {
     // This approximates that both stdin and stdio are connected,
@@ -337,7 +338,7 @@ object Terminal {
     // In ci environments, don't touch the io streams unless run with -Dsbt.io.virtual=true
     if (System.getProperty("sbt.io.virtual", "") == "true" || !isCI) {
       hasProgress.set(isServer && isAnsiSupported)
-      consoleTerminalHolder.set(newConsoleTerminal())
+      if (hasConsole && !isDumbTerminal) consoleTerminalHolder.set(newConsoleTerminal())
       activeTerminal.set(consoleTerminalHolder.get)
       try withOut(withIn(f))
       finally {
@@ -745,7 +746,7 @@ object Terminal {
   private[sbt] def reset(): Unit = {
     jline.TerminalFactory.reset()
     console.close()
-    consoleTerminalHolder.set(newConsoleTerminal())
+    if (hasConsole && !isDumbTerminal) consoleTerminalHolder.set(newConsoleTerminal())
   }
 
   // translate explicit class names to type in order to support
@@ -761,7 +762,7 @@ object Terminal {
           case "jline.WindowsTerminal"                          => "windows"
           case "jline.AnsiWindowsTerminal"                      => "windows"
           case "jline.UnsupportedTerminal"                      => "none"
-          case null if isDumbTerminal                           => "none"
+          case null if isDumb                                   => "none"
           case x                                                => x
         }
     if (newValue != null) {

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -306,9 +306,8 @@ object Terminal {
       case _       => sys.props.get("sbt.log.format").flatMap(parseLogOption)
     }
   }
-  private[this] lazy val superShellEnabled = sys.props.get("sbt.supershell").map(_ == "true")
   private[sbt] lazy val isAnsiSupported: Boolean =
-    logFormatEnabled.orElse(superShellEnabled).getOrElse(useColorDefault)
+    logFormatEnabled.getOrElse(useColorDefault)
   private[this] val isDumbTerminal = "dumb" == System.getenv("TERM")
   private[this] val hasConsole = Option(java.lang.System.console).isDefined
   private[this] def useColorDefault: Boolean = {
@@ -754,7 +753,7 @@ object Terminal {
   private[this] def fixTerminalProperty(): Unit = {
     val terminalProperty = "jline.terminal"
     val newValue =
-      if (!isAnsiSupported) "none"
+      if (!isAnsiSupported && System.getProperty("sbt.io.virtual", "") == "false") "none"
       else
         System.getProperty(terminalProperty) match {
           case "jline.UnixTerminal"                             => "unix"

--- a/server-test/src/test/scala/testpkg/TestServer.scala
+++ b/server-test/src/test/scala/testpkg/TestServer.scala
@@ -163,7 +163,7 @@ case class TestServer(
   val forkOptions =
     ForkOptions()
       .withOutputStrategy(OutputStrategy.StdoutOutput)
-      .withRunJVMOptions(Vector("-Dsbt.ci=true", "-Dsbt.io.virtual=false"))
+      .withRunJVMOptions(Vector("-Djline.terminal=none", "-Dsbt.io.virtual=false"))
   val process =
     RunFromSourceMain.fork(forkOptions, baseDirectory, scalaVersion, sbtVersion, classpath)
 


### PR DESCRIPTION
Scalatest will check the ansiCodesSupported value of a console appender
to decide whether or not to colorize its output. We were setting
isAnsiSupported to false by default in ci to prevent the ConsoleAppender
from adding ansi codes to the output. The only place though where we
were doing that was in adding a ClearScreenAfterCursor to the end of
each log line. This was done for supershell but there is actually other
logic in supershell processing that adds these anyway.