### PR TITLE
Remove unnecessary log line in thin client

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -492,7 +492,6 @@ class NetworkClient(
         val message = timing(startTime, now)
         val ec = exitCode
         if (batchMode.get || !attached.get) {
-          console.appendLog(Level.Info, s"$name completed")
           if (ec == 0) console.success(message)
           else console.appendLog(Level.Error, message)
         }


### PR DESCRIPTION
When a batch command is run with the thin client, it logs an info
message that the command completed. This is unnecessary given that
completion is implied by the success or failure method that follows. It
made the output look a little different in the thin client vs the
console.