### PR TITLE
Fixes metabuild library dependency resolution

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2496,7 +2496,6 @@ object Classpaths {
       managedClasspath := {
         val isMeta = isMetaBuild.value
         val force = reresolveSbtArtifacts.value
-        val csr = useCoursier.value
         val app = appConfiguration.value
         val sbtCp0 = app.provider.mainClasspath.toList
         val sbtCp = sbtCp0 map { Attributed.blank(_) }
@@ -2505,7 +2504,7 @@ object Classpaths {
           classpathTypes.value,
           update.value
         )
-        if (isMeta && !force && !csr) mjars ++ sbtCp
+        if (isMeta && !force) mjars ++ sbtCp
         else mjars
       },
       exportedProducts := ClasspathImpl.trackedExportedProducts(TrackLevel.TrackAlways).value,
@@ -3077,7 +3076,6 @@ object Classpaths {
       val isMeta = isMetaBuild.value
       val force = reresolveSbtArtifacts.value
       val excludes = excludeDependencies.value
-      val csr = useCoursier.value
       val o = sbtdeps.organization
       val sbtModulesExcludes = Vector[ExclusionRule](
         o % "sbt",
@@ -3088,7 +3086,7 @@ object Classpaths {
         o %% "util-position",
         o %% "io"
       )
-      if (isMeta && !force && !csr) excludes.toVector ++ sbtModulesExcludes
+      if (isMeta && !force) excludes.toVector ++ sbtModulesExcludes
       else excludes
     },
     dependencyOverrides ++= {


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/pull/4443
Fixes https://github.com/sbt/sbt/issues/5750

In #4443 I implemented an optimization where the metabuild would no longer re-resolve numerous sbt artifacts for metabuilds each time, and instead use whatever the JARs provided by the launcher. At the time, this technique didn't work for Coursier so I've placed in some workarounds for it. Now that Coursier's resolution has improved, it seems like the workaround is actually causing more harm. This removes the bandaid, and local testing shows that it seems to be working.

For instance, we no longer need to put in `ThisBuild / useCoursier := false` in sbt/sbt's `project/plugins.sbt`.