### PR TITLE
Fix #6092 - sbt 1.4.0~1.4.3 - all the files in the packaged jar files created at epoch millisecond 0 (1970-01-01 00:00:00)

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1706,7 +1706,7 @@ object Defaults extends BuildCommon {
         config,
         s.cacheStoreFactory,
         s.log,
-        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong * 1000).orElse(Some(0L))
+        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong * 1000)
       )
       config.jar
     }


### PR DESCRIPTION
Fix #6092 - sbt 1.4.0~1.4.3 - all the files in the packaged jar files created at epoch millisecond 0 (1970-01-01 00:00:00)

Before
<img width="816" alt="Screen Shot 2020-11-16 at 6 27 25 pm" src="https://user-images.githubusercontent.com/2307335/99225691-90f42400-283c-11eb-9a1c-924681d5a89e.png">

After
<img width="874" alt="Screen Shot 2020-11-16 at 6 30 14 pm" src="https://user-images.githubusercontent.com/2307335/99225716-99e4f580-283c-11eb-999e-02a8bfc9c7ec.png">
