### PR TITLE
Support a system property for onChangedBuildSource

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -167,7 +167,17 @@ object Defaults extends BuildCommon {
       fileOutputExcludeFilter :== NothingFilter.toNio,
       inputFileStamper :== sbt.nio.FileStamper.Hash,
       outputFileStamper :== sbt.nio.FileStamper.LastModified,
-      onChangedBuildSource :== sbt.nio.Keys.WarnOnSourceChanges,
+      onChangedBuildSource :== {
+        val sysPropKey = "sbt.build.onchange"
+        sys.props.getOrElse(sysPropKey, "warn") match {
+          case "reload" => sbt.nio.Keys.ReloadOnSourceChanges
+          case "warn"   => sbt.nio.Keys.WarnOnSourceChanges
+          case "ignore" => sbt.nio.Keys.IgnoreSourceChanges
+          case unknown =>
+            System.err.println(s"Unknown $sysPropKey: $unknown.\nUsing warn.")
+            sbt.nio.Keys.WarnOnSourceChanges
+        }
+      },
       clean := { () },
       unmanagedFileStampCache :=
         state.value.get(persistentFileStampCache).getOrElse(new sbt.nio.FileStamp.Cache),

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -167,17 +167,7 @@ object Defaults extends BuildCommon {
       fileOutputExcludeFilter :== NothingFilter.toNio,
       inputFileStamper :== sbt.nio.FileStamper.Hash,
       outputFileStamper :== sbt.nio.FileStamper.LastModified,
-      onChangedBuildSource :== {
-        val sysPropKey = "sbt.build.onchange"
-        sys.props.getOrElse(sysPropKey, "warn") match {
-          case "reload" => sbt.nio.Keys.ReloadOnSourceChanges
-          case "warn"   => sbt.nio.Keys.WarnOnSourceChanges
-          case "ignore" => sbt.nio.Keys.IgnoreSourceChanges
-          case unknown =>
-            System.err.println(s"Unknown $sysPropKey: $unknown.\nUsing warn.")
-            sbt.nio.Keys.WarnOnSourceChanges
-        }
-      },
+      onChangedBuildSource :== SysProp.onChangedBuildSource,
       clean := { () },
       unmanagedFileStampCache :=
         state.value.get(persistentFileStampCache).getOrElse(new sbt.nio.FileStamp.Cache),

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -14,6 +14,7 @@ import scala.util.control.NonFatal
 import scala.concurrent.duration._
 import sbt.internal.util.{ Terminal => ITerminal }
 import sbt.internal.util.complete.SizeParser
+import sbt.nio.Keys._
 
 // See also BuildPaths.scala
 // See also LineReader.scala
@@ -162,4 +163,17 @@ object SysProp {
           case None       => true
         }
     }
+
+  def onChangedBuildSource: WatchBuildSourceOption = {
+    val sysPropKey = "sbt.build.onchange"
+    sys.props.getOrElse(sysPropKey, "warn") match {
+      case "reload" => ReloadOnSourceChanges
+      case "warn"   => WarnOnSourceChanges
+      case "ignore" => IgnoreSourceChanges
+      case unknown =>
+        System.err.println(s"Unknown $sysPropKey: $unknown.\nUsing warn.")
+        sbt.nio.Keys.WarnOnSourceChanges
+    }
+  }
+
 }


### PR DESCRIPTION
It resolves the issue https://github.com/sbt/sbt/issues/5679.

## Overview
A default value of `onChangedBuildSource` can be configured by the system property `sbt.build.onchange`.
As written in the above issue, the valid values of `sbt.build.onchange` are the following.
- `sbt.build.onchange=reload`
- `sbt.build.onchange=warn`
- `sbt.build.onchange=ignore`

The default value `warn` is used if `sbt.build.onchange` is not specified or `sbt.build.onchange` is an invalid value.

## How to test it

There is no test code of this feature, but it can be easily tested manually.
I have tested by my hand using the following command.

```
$ sbt -Dsbt.version=1.4.3-SNAPSHOT -Dsbt.build.onchange=warn "show onChangedBuildSource"
$ sbt -Dsbt.version=1.4.3-SNAPSHOT -Dsbt.build.onchange=reload "show onChangedBuildSource"
$ sbt -Dsbt.version=1.4.3-SNAPSHOT -Dsbt.build.onchange=ignore "show onChangedBuildSource"
$ sbt -Dsbt.version=1.4.3-SNAPSHOT -Dsbt.build.onchange=invalid-one "show onChangedBuildSource"
```