### PR TITLE
Fix watch for dumb terminals

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -327,6 +327,9 @@ object Terminal {
     if (isColorEnabled && doRed) Console.RED + str + Console.RESET
     else str
 
+  private[this] def hasVirtualIO = System.getProperty("sbt.io.virtual", "") == "true" || !isCI
+  private[sbt] def canPollSystemIn: Boolean = hasConsole && !isDumbTerminal && hasVirtualIO
+
   /**
    *
    * @param isServer toggles whether or not this is a server of client process
@@ -337,7 +340,7 @@ object Terminal {
   private[sbt] def withStreams[T](isServer: Boolean)(f: => T): T = {
     // In ci environments, don't touch the io streams unless run with -Dsbt.io.virtual=true
     if (hasConsole && !isDumbTerminal) consoleTerminalHolder.set(newConsoleTerminal())
-    if (System.getProperty("sbt.io.virtual", "") == "true" || !isCI) {
+    if (hasVirtualIO) {
       hasProgress.set(isServer && isAnsiSupported)
       activeTerminal.set(consoleTerminalHolder.get)
       try withOut(withIn(f))


### PR DESCRIPTION
On terminals with virtual io disabled, we'd spin up a thread for each
watch iteration that performed a blocking read from the terminal input
stream. This thread could not be joined which would cause the triggered
execution to be delayed by 1 second while sbt blocked trying to join
that thread. It also meant that input probably didn't work correctly
since the user would end up with many threads polling from system in.
The fix to this problem is to poll the terminal input stream if it is
unsafe to do a blocking read, which is the case for dumb terminals or if
virtual io is disabled.