### PR TITLE
Don't print socket exception on exit

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -11,7 +11,7 @@ package client
 
 import java.io.{ File, IOException, InputStream, PrintStream }
 import java.lang.ProcessBuilder.Redirect
-import java.net.Socket
+import java.net.{ Socket, SocketException }
 import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
@@ -888,6 +888,7 @@ class NetworkClient(
         status.set("Processing")
       }
     } catch {
+      case e: SocketException if command.toString.contains("exit") => running.set(false)
       case e: IOException =>
         errorStream.println(s"Caught exception writing command to server: $e")
         running.set(false)


### PR DESCRIPTION
When exiting the thin client when using tcp rather than a domain socket,
an error message is printed about a socket exception.