### PR TITLE
Fix supershell line interlacing with logs

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -100,7 +100,10 @@ private[sbt] final class ProgressState(
           toWrite ++= (DeleteLine + ClearScreenAfterCursor + CursorLeft1000).getBytes("UTF-8")
         case _ =>
       }
-      toWrite ++= bytes
+      bytes.foreach { b =>
+        if (b == 10) toWrite ++= ClearScreenAfterCursor.getBytes("UTF-8")
+        toWrite += b
+      }
       toWrite ++= ClearScreenAfterCursor.getBytes("UTF-8")
       if (bytes.endsWith(lineSeparatorBytes)) {
         if (progressLines.get.nonEmpty) {


### PR DESCRIPTION
In 3b09ff6af7c4e108152e8dfdb10f6a1f05c4ab34, we stopped adding a clear
screen after curser after each log line. This inadvertently caused
supershell lines to get interlaced with log lines. This can be fixed by
writing a ClearScreenAfterCursor after every newline character that we
write to stdout.

As a bonus, I had also long noticed that supershell log lines would get
interlaced with the serverTestProj/test output and this change fixes
that as well.