### PR TITLE
Fix watch when metals sbt bsp is in use

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -226,9 +226,8 @@ object MainLoop {
             // temporarily set the prompt to running during task evaluation
             c.terminal.setPrompt(Prompt.Running)
             (() => {
-              c.terminal.setPrompt(prevPrompt)
+              if (c.terminal.prompt != Prompt.Watch) c.terminal.setPrompt(prevPrompt)
               ITerminal.set(prevTerminal)
-              c.terminal.setPrompt(prevPrompt)
               c.terminal.flush()
             }) -> progressState.put(Keys.terminalKey, Terminal(c.terminal))
           case _ => (() => ()) -> progressState.put(Keys.terminalKey, Terminal(ITerminal.get))

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1344,8 +1344,7 @@ private[sbt] object ContinuousCommands {
   private[sbt] val postWatchCommand = watchCommand(postWatch) { (channel, state) =>
     val cs = watchState(state, channel)
     StandardMain.exchange.channelForName(channel).foreach { c =>
-      c.terminal.setPrompt(Prompt.Watch)
-      c.unprompt(ConsoleUnpromptEvent(Some(CommandSource(channel))))
+      c.terminal.setPrompt(Prompt.Pending)
     }
     val postState = state.get(watchStates) match {
       case None     => state
@@ -1360,7 +1359,10 @@ private[sbt] object ContinuousCommands {
         cs.callbacks.onExit()
         StandardMain.exchange
           .channelForName(channel)
-          .foreach(_.unprompt(ConsoleUnpromptEvent(Some(CommandSource(channel)))))
+          .foreach { c =>
+            c.terminal.setPrompt(Prompt.Pending)
+            c.unprompt(ConsoleUnpromptEvent(Some(CommandSource(channel))))
+          }
         afterWatchState.get(watchStates) match {
           case None    => afterWatchState
           case Some(w) => afterWatchState.put(watchStates, w - channel)


### PR DESCRIPTION
I discovered that the metals bsp implementation worked very badly with ~. The problem was that metals is able to trigger a bsp compile slightly before the continuous build would trigger. This would cause the ui to get in a bad state. The worst case was that it would actually cause sbt (or the thin client) to exit. A less catastrophic issue was that it was possible for the wrong count to be printed with each iteration.

This PR fixes the watch issue and also cleans up code in `UserThread`. The latter isn't strictly necessary to fix the `~` issues but I was doing some debugging in that portion of the code base and found it hard to read/reason about.