### PR TITLE
Remove debug command from actions/remote-cache

### DIFF
--- a/sbt/src/sbt-test/actions/remote-cache/test
+++ b/sbt/src/sbt-test/actions/remote-cache/test
@@ -50,7 +50,6 @@ $ exists target/scala-2.12/test-classes/MyTest.class
 $ exists target/scala-2.12/test-classes/MyTest$.class
 $ exists target/scala-2.12/test-zinc/inc_compile_2.12.zip
 
-> debug
 > checkIterations 1
 
 # Artifacts can be pushed twice (enabled overriding)


### PR DESCRIPTION
The presence of the > debug command causes all output after this test to
get very verbose.