### PR TITLE
Bump max heap size in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             jobtype: 5
     runs-on: ${{ matrix.os }}
     env:
-      JAVA_OPTS: -Xms800M -Xmx800M -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
+      JAVA_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
       SCALA_212: 2.12.12
       SCALA_213: 2.13.1
       UTIL_TESTS: utilCache/test;utilControl/test;utilInterface/test;utilLogging/test;utilPosition/test;utilRelation/test;utilScripted/test;utilTracking/test


### PR DESCRIPTION
I have noticed that sbt runs better on my computer with 2G of heap.
Assuming we have that much memory on github actions, it seems like a
good idea to increase it there as well.