### PR TITLE
Print empty newlines with progress

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -111,7 +111,10 @@ private[sbt] final class ProgressState(
           if (appendNewline) toWrite ++= lineSeparatorBytes
         }
         parts.dropRight(1).foreach(appendLine(_, true))
-        parts.lastOption.foreach(appendLine(_, bytes.endsWith(lineSeparatorBytes)))
+        parts.lastOption match {
+          case Some(l) => appendLine(l, bytes.endsWith(lineSeparatorBytes))
+          case None    => toWrite ++= lineSeparatorBytes
+        }
       } else toWrite ++= bytes
       toWrite ++= clearScreenBytes
       if (endsWithNewLine) {


### PR DESCRIPTION
With the latest sbt code, the `last` command displayed all of the output
without line separators. This occurred because the logic for appending
bytes to System.out split the input bytes on the line separator but if
there was nothing but the line separator in the input bytes then the
result was empty and nothing was printed.