### PR TITLE
Fixes scala-compiler not included into the metabuild

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1362,7 +1362,9 @@ def scriptedTask(launch: Boolean): Def.Initialize[InputTask[Unit]] = Def.inputTa
     scriptedLaunchOpts.value ++ (if (launch) Some(launchJar) else None),
     scalaVersion.value,
     version.value,
-    (scriptedSbtReduxProj / Test / fullClasspathAsJars).value.map(_.data),
+    (scriptedSbtReduxProj / Test / fullClasspathAsJars).value
+      .map(_.data)
+      .filterNot(_.getName.contains("scala-compiler")),
     streams.value.log
   )
 }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2506,14 +2506,15 @@ object Classpaths {
         val isMeta = isMetaBuild.value
         val force = reresolveSbtArtifacts.value
         val app = appConfiguration.value
-        val sbtCp0 = app.provider.mainClasspath.toList
-        val sbtCp = sbtCp0 map { Attributed.blank(_) }
+        def isJansiOrJLine(f: File) = f.getName.contains("jline") || f.getName.contains("jansi")
+        val scalaInstanceJars = app.provider.scalaProvider.jars.filterNot(isJansiOrJLine)
+        val sbtCp = (scalaInstanceJars ++ app.provider.mainClasspath).map(Attributed.blank)
         val mjars = managedJars(
           classpathConfiguration.value,
           classpathTypes.value,
           update.value
         )
-        if (isMeta && !force) mjars ++ sbtCp
+        if (isMeta && !force) (mjars ++ sbtCp).distinct
         else mjars
       },
       exportedProducts := ClasspathImpl.trackedExportedProducts(TrackLevel.TrackAlways).value,

--- a/sbt/src/sbt-test/project/plugin-scala-compiler-dependency/project/Plugin.scala
+++ b/sbt/src/sbt-test/project/plugin-scala-compiler-dependency/project/Plugin.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc
+
+object Plugin

--- a/sbt/src/sbt-test/project/plugin-scala-compiler-dependency/test
+++ b/sbt/src/sbt-test/project/plugin-scala-compiler-dependency/test
@@ -1,0 +1,2 @@
+> show sbtVersion
+# we just want to test that the project loads


### PR DESCRIPTION
When using the launcher's classpath for the metabuild, the
scala-compiler jar can be missing. This is because the managedJars
method only returns the scala-library jar and not the rest of the scala
instance. To fix this, we can always prepend the scala instance jars to
the classpath.

In order to simulate the issue in scripted, I had to manually remove the
scala-compiler.jar from the scripted classpath or else the scripted test
that I added doesn't actually do anything because the scala-compiler.jar
would end up on the app.provider.mainClasspath.

Fixes #4452