### PR TITLE
[1.4.x] Bump semanticdb version to 4.4.0

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -26,7 +26,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.3.20"
+    semanticdbVersion := "4.4.0"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
Fixes #6144

Bump semanticdb to `4.4.0` since it is the only one compatible with `2.13.4` (https://mvnrepository.com/artifact/org.scalameta/semanticdb-scalac). It is also compatible with all previous versions:
- `2.13.4`
- `2.13.3`
- `2.13.2`
- `2.13.1`
- `2.13.0`
- `2.12.12`
- `2.12.11`
- `2.12.10`
- `2.12.9`
- `2.12.8`
- `2.11.12`