### PR TITLE
Work around "a pure expression does nothing" warning, take 2

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -312,16 +312,6 @@ final class ContextUtil[C <: blackbox.Context](val ctx: C) {
               case Converted.Failure(p, m)       => ctx.abort(p, m)
               case _: Converted.NotApplicable[_] => super.transform(tree)
             }
-          // try to workaround https://github.com/scala/bug/issues/12112 by removing raw Ident(_) in blocks
-          case Block(stats0, expr0) =>
-            val stats = stats0 flatMap { stat0 =>
-              val stat = super.transform(stat0)
-              stat match {
-                case Typed(ident @ Ident(_), _) if ident.symbol.isSynthetic => None
-                case _                                                      => Some(stat)
-              }
-            }
-            Block(stats, super.transform(expr0))
           case _ => super.transform(tree)
         }
     }

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -321,8 +321,7 @@ final class ContextUtil[C <: blackbox.Context](val ctx: C) {
                 case _                                                      => Some(stat)
               }
             }
-            val expr = super.transform(expr0)
-            Block(stats, expr).setType(expr.tpe)
+            Block(stats, super.transform(expr0))
           case _ => super.transform(tree)
         }
     }

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -187,7 +187,9 @@ object Instance {
       qual.foreach(checkQual)
       val vd = util.freshValDef(tpe, qual.pos, functionSym)
       inputs ::= new Input(tpe, qual, vd)
-      util.refVal(selection, vd)
+      // try to workaround https://github.com/scala/bug/issues/12112 by calling Predef.identity(...)
+      val rv = util.refVal(selection, vd)
+      q"scala.Predef.identity[$tpe]($rv: $tpe)"
     }
     def sub(name: String, tpe: Type, qual: Tree, replace: Tree): Converted[c.type] = {
       val tag = c.WeakTypeTag[T](tpe)

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -187,9 +187,7 @@ object Instance {
       qual.foreach(checkQual)
       val vd = util.freshValDef(tpe, qual.pos, functionSym)
       inputs ::= new Input(tpe, qual, vd)
-      // try to workaround https://github.com/scala/bug/issues/12112 by calling Predef.identity(...)
-      val rv = util.refVal(selection, vd)
-      q"scala.Predef.identity[$tpe]($rv: $tpe)"
+      util.refVal(selection, vd)
     }
     def sub(name: String, tpe: Type, qual: Tree, replace: Tree): Converted[c.type] = {
       val tag = c.WeakTypeTag[T](tpe)

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -204,10 +204,11 @@ object BuildServerProtocol {
       val converter = fileConverter.value
       val underlying = (Keys.compile / compilerReporter).value
       val logger = streams.value.log
+      val meta = isMetaBuild.value
       if (bspEnabled.value) {
-        new BuildServerReporterImpl(targetId, converter, logger, underlying)
+        new BuildServerReporterImpl(targetId, converter, meta, logger, underlying)
       } else {
-        new BuildServerForwarder(logger, underlying)
+        new BuildServerForwarder(meta, logger, underlying)
       }
     }
   )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6126

In #5981 I tried to work around the spruious post-macro "a pure expression does nothing" warning (scala/bug#12112) by trying to remove some pure-looking expressions out of the tree.

This quickly backfired when it was reported that sbt 1.4.3 was not evaluating some code. This backs out the macro-level manipulation, and instead try to silence the warning at the reporter level. This feels safer, and it seems to work just as well.