### PR TITLE
[1.4.x] lm 1.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.4.0")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.4.0")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.4.1")
   val zincVersion = nightlyVersion.getOrElse("1.4.3")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion


### PR DESCRIPTION
Ref https://github.com/sbt/ivy/pull/40
Fixes #5483

### from Set explicit HTTP Accept header to avoid text/html

By default, `java.net.HttpURLConnection` HTTP `Accept` header is set to `text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2`

This leads to Microsoft servers responding with a 203 status code and an HTML pages when uploading or downloading artifacts to Azure Artifacts.

Given that Maven also have a similar issue (`text/html` as the preferred response content-type), Microsoft has implemented a workaround that ignores the `Accept` header values when `User-Agent` is `Apache Maven/*`. However, this workaround is not implemented on their side for SBT.

This pull request sets HTTP `Accept` header to `application/octet-stream, application/json, application/xml, */*` to fix this behavior, as evidenced here:

https://dev.azure.com/aironek/sbt-test/_build/results?buildId=43&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=b60649db-91ed-45ce-b0dd-c9633ee87772

Given that the last component is `*/*`, this shoud be backward-compatible with other serivces (Nexus, Artifactory, etc) that reply with different content-types.