### PR TITLE
Make the thin client `cancel` command work reliably

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -162,7 +162,7 @@ private[sbt] final class CommandExchange {
       e.source.map(_.channelName) == Some(c.name) && e.commandLine != Shutdown
     }
     currentExec.filter(_.source.map(_.channelName) == Some(c.name)).foreach { e =>
-      Util.ignoreResult(NetworkChannel.cancel(e.execId, e.execId.getOrElse("0")))
+      Util.ignoreResult(NetworkChannel.cancel(e.execId, e.execId.getOrElse("0"), force = false))
     }
     try commandQueue.put(Exec(s"${ContinuousCommands.stopWatch} ${c.name}", None))
     catch { case _: InterruptedException => }
@@ -447,7 +447,7 @@ private[sbt] final class CommandExchange {
       terminal.write(13, 13, 13, 4)
       terminal.printStream.println("\nconsole session killed by remote sbt client")
     } else {
-      Util.ignoreResult(NetworkChannel.cancel(e.execId, e.execId.getOrElse("0")))
+      Util.ignoreResult(NetworkChannel.cancel(e.execId, e.execId.getOrElse("0"), force = true))
     }
   }
 

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -923,7 +923,8 @@ object NetworkChannel {
   case object InBody extends ChannelState
   private[sbt] def cancel(
       execID: Option[String],
-      id: String
+      id: String,
+      force: Boolean
   ): Either[String, String] = {
 
     Option(EvaluateTask.currentlyRunningTaskEngine.get) match {
@@ -945,7 +946,7 @@ object NetworkChannel {
 
         // direct comparison on strings and
         // remove hotspring unicode added character for numbers
-        if (checkId) {
+        if (checkId || force) {
           runningEngine.cancelAndShutdown()
           Right(runningExecId)
         } else {


### PR DESCRIPTION
When the sbt server is running a task, it presents all connected clients
with a message that instructs them that they cancel the running task.
Unfortunately, this often didn't work and the task would keep running
after cancel was entered. The reason for this was because the exec id
passed in to NetworkChannel did not necessarily match the exec id of the
running task. Because cancel in this case is not really exec specific,
this commit adds a flag to NetworkChannel.cancel that forces it to
cancel the running task regardless of what execID is passed in.