### PR TITLE
Fix watch shell option

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -222,11 +222,9 @@ object MainLoop {
         val (restoreTerminal, termState) = channelName.flatMap(exchange.channelForName) match {
           case Some(c) =>
             val prevTerminal = ITerminal.set(c.terminal)
-            val prevPrompt = c.terminal.prompt
             // temporarily set the prompt to running during task evaluation
             c.terminal.setPrompt(Prompt.Running)
             (() => {
-              if (c.terminal.prompt != Prompt.Watch) c.terminal.setPrompt(prevPrompt)
               ITerminal.set(prevTerminal)
               c.terminal.flush()
             }) -> progressState.put(Keys.terminalKey, Terminal(c.terminal))


### PR DESCRIPTION
When a user returns to the shell with 's' in recent versions of sbt, the
prompt is not initially displayed. This ends up being because MainLoop
was incorrectly setting the terminal prompt to Prompt.Watch when it
exited watch. I realized in debugging the issue that it didn't make
sense to restort the terminal prompt to the initial value before task
evaluation. By removing that logic, the 's' option option started
working correctly again.