### PR TITLE
Update ipcsocket

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -71,7 +71,8 @@ private[sbt] object Server {
                   )
                 )
               case ConnectionType.Local =>
-                val maxSocketLength = new UnixDomainSocketLibrary.SockaddrUn().sunPath.length - 1
+                val maxSocketLength =
+                  UnixDomainSocketLibraryProvider.maxSocketLength(connection.useJni) - 1
                 val path = socketfile.getAbsolutePath
                 if (path.length > maxSocketLength)
                   sys.error(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"
-  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.1.0"
+  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.3.0"
 
   private val compilerInterface = "org.scala-sbt" % "compiler-interface" % zincVersion
   private val compilerClasspath = "org.scala-sbt" %% "zinc-classpath" % zincVersion


### PR DESCRIPTION
The new version provides an apple silicon arm64 jni implementation of
the ipcsocket api. It also adds a jni implementation for getting the max
socket length which is necessary because jna isn't supported on the
apple arm64 platform yet.