### PR TITLE
Fix ctrl+c handling after exiting watch

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -121,6 +121,10 @@ object LineReader {
           // ignore
         }
         historyPath.foreach(f => reader.setVariable(JLineReader.HISTORY_FILE, f))
+        val signalRegistration = terminal match {
+          case _: Terminal.ConsoleTerminal => Some(Signals.register(() => terminal.write(-1)))
+          case _                           => None
+        }
         try terminal.withRawInput {
           Option(mask.map(reader.readLine(prompt, _)).getOrElse(reader.readLine(prompt)))
         } catch {
@@ -132,6 +136,7 @@ object LineReader {
               _: UncheckedIOException =>
             throw new InterruptedException
         } finally {
+          signalRegistration.foreach(_.remove())
           terminal.prompt.reset()
           term.close()
         }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -172,7 +172,7 @@ private[sbt] object JLine3 {
           if (buffer.isEmpty && !peek) fillBuffer()
           (if (peek) buffer.peek else buffer.take) match {
             case null => -2
-            case i    => if (i == -3) throw new ClosedException else i
+            case i    => if (i == -3) throw new InterruptedException else i
           }
         }
         override def peek(timeout: Long): Int = buffer.peek() match {

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -116,7 +116,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
           case None    => StandardMain.exchange.run(s) -> ConsoleChannel.defaultName
         }
         val ws = ContinuousCommands.setupWatchState(channel, initialCount, commands, s1)
-        s"${ContinuousCommands.runWatch} $channel" :: ws
+        s"${ContinuousCommands.runWatch} $channel" :: s"${ContinuousCommands.waitWatch} $channel" :: ws
     }
 
   @deprecated("The input task version of watch is no longer available", "1.4.0")
@@ -1279,7 +1279,7 @@ private[sbt] object ContinuousCommands {
       case None => state
       case Some(cs) =>
         val pre = StashOnFailure :: s"$preWatch $channel" :: Nil
-        val post = FailureWall :: PopOnFailure :: s"$postWatch $channel" :: s"$waitWatch $channel" :: Nil
+        val post = FailureWall :: PopOnFailure :: s"$postWatch $channel" :: Nil
         pre ::: cs.commands.toList ::: post ::: state
     }
   }


### PR DESCRIPTION
I noticed that there were scenarios in which after exiting a continuous build that `ctrl+c` would not exit sbt in the jline 3 shell. The underlying cause was that `~` adds a custom signal handler and when it was removed, it seemed to have been replaced with a no-op signal handler. This PR fixes that behavior by explicitly adding a signal handler in LineReader that will cause the jline shell to exit on `ctrl+c`. While debugging this, I also found some minor issues in the Continuous.waitWatch command that are also addressed by this PR.