### PR TITLE
Make it possible to not write the bsp connection file

### DIFF
--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -97,6 +97,13 @@ object BasicKeys {
       10000
     )
 
+  val bspEnabled =
+    AttributeKey[Boolean](
+      "bspEnabled",
+      "Enable/Disable BSP for this build, project or configuration",
+      10000
+    )
+
   // Unlike other BasicKeys, this is not used directly as a setting key,
   // and severLog / logLevel is used instead.
   private[sbt] val serverLogLevel =

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -98,10 +98,13 @@ private[sbt] object Server {
               }
               log.info(s"sbt server started at ${connection.shortName}")
               writePortfile()
-              BuildServerConnection.writeConnectionFile(
-                appConfiguration.provider.id.version,
-                appConfiguration.baseDirectory
-              )
+              if (connection.bspEnabled) {
+                log.debug("Writing bsp connection file")
+                BuildServerConnection.writeConnectionFile(
+                  appConfiguration.provider.id.version,
+                  appConfiguration.baseDirectory
+                )
+              }
               running.set(true)
               p.success(())
               while (running.get()) {
@@ -241,6 +244,7 @@ private[sbt] case class ServerConnection(
     appConfiguration: AppConfiguration,
     windowsServerSecurityLevel: Int,
     useJni: Boolean,
+    bspEnabled: Boolean,
 ) {
   def shortName: String = {
     connectionType match {

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -394,7 +394,7 @@ object Keys {
   val exportPipelining = settingKey[Boolean]("Product early output so downstream subprojects can do pipelining.").withRank(BSetting)
 
   val bspConfig = taskKey[Unit]("Create or update the BSP connection files").withRank(DSetting)
-  val bspEnabled = settingKey[Boolean]("Enable/Disable BSP for this build, project or configuration")
+  val bspEnabled = SettingKey[Boolean](BasicKeys.bspEnabled)
   val bspTargetIdentifier = settingKey[BuildTargetIdentifier]("Build target identifier of a project and configuration.").withRank(DSetting)
   val bspWorkspace = settingKey[Map[BuildTargetIdentifier, Scope]]("Mapping of BSP build targets to sbt scopes").withRank(DSetting)
   val bspInternalDependencyConfigurations = settingKey[Seq[(ProjectRef, Set[ConfigKey])]]("The project configurations that this configuration depends on, possibly transitivly").withRank(DSetting)

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -14,6 +14,7 @@ import Project._
 import BasicKeys.serverLogLevel
 import Keys.{
   stateBuildStructure,
+  bspEnabled,
   colorShellPrompt,
   commands,
   configuration,
@@ -519,6 +520,7 @@ object Project extends ProjectExtra {
     val startSvr: Option[Boolean] = get(autoStartServer)
     val host: Option[String] = get(serverHost)
     val port: Option[Int] = get(serverPort)
+    val enabledBsp: Option[Boolean] = get(bspEnabled)
     val timeout: Option[Option[FiniteDuration]] = get(serverIdleTimeout)
     val authentication: Option[Set[ServerAuthentication]] = get(serverAuthentication)
     val connectionType: Option[ConnectionType] = get(serverConnectionType)
@@ -536,6 +538,7 @@ object Project extends ProjectExtra {
         .put(historyPath.key, history)
         .put(windowsServerSecurityLevel.key, winSecurityLevel)
         .put(serverUseJni.key, useJni)
+        .setCond(bspEnabled.key, enabledBsp)
         .setCond(autoStartServer.key, startSvr)
         .setCond(serverPort.key, port)
         .setCond(serverHost.key, host)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -190,6 +190,7 @@ private[sbt] final class CommandExchange {
     lazy val handlers = s.get(fullServerHandlers).getOrElse(Nil)
     lazy val win32Level = s.get(windowsServerSecurityLevel).getOrElse(2)
     lazy val useJni = s.get(serverUseJni).getOrElse(false)
+    lazy val enableBsp = s.get(bspEnabled).getOrElse(true)
     lazy val portfile = s.baseDir / "project" / "target" / "active.json"
 
     def onIncomingSocket(socket: Socket, instance: ServerInstance): Unit = {
@@ -225,6 +226,7 @@ private[sbt] final class CommandExchange {
         s.configuration,
         win32Level,
         useJni,
+        enableBsp,
       )
       val serverInstance = Server.start(connection, onIncomingSocket, s.log)
       // don't throw exception when it times out

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -78,10 +78,14 @@ object BuildServerProtocol {
   )
 
   lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
-    bspConfig := BuildServerConnection.writeConnectionFile(
-      sbtVersion.value,
-      (ThisBuild / baseDirectory).value
-    ),
+    bspConfig := {
+      if (bspEnabled.value) {
+        BuildServerConnection.writeConnectionFile(
+          sbtVersion.value,
+          (ThisBuild / baseDirectory).value
+        )
+      } else ()
+    },
     bspEnabled := true,
     bspWorkspace := bspWorkspaceSetting.value,
     bspWorkspaceBuildTargets := Def.taskDyn {

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -84,7 +84,11 @@ object BuildServerProtocol {
           sbtVersion.value,
           (ThisBuild / baseDirectory).value
         )
-      } else ()
+      } else {
+        val logger = streams.value.log
+        logger.warn("BSP is disabled for this build")
+        logger.info("add 'Global / bspEnabled := true' to enable BSP")
+      }
     },
     bspEnabled := true,
     bspWorkspace := bspWorkspaceSetting.value,


### PR DESCRIPTION
Made the bspConfig task dependendant on the bspConfig value.
Changed the bspConfig setting to use a attributeKey so we can use it in the server as well.

I think this should fix #6066 