### PR TITLE
dotty-library is called scala3-library now

### DIFF
--- a/main-command/src/main/scala/sbt/internal/classpath/ClassLoaderCache.scala
+++ b/main-command/src/main/scala/sbt/internal/classpath/ClassLoaderCache.scala
@@ -179,7 +179,8 @@ private[sbt] class ClassLoaderCache(
   }
   override def apply(files: List[File]): ClassLoader = {
     files match {
-      case d :: s :: Nil if d.getName.startsWith("dotty-library") =>
+      case d :: s :: Nil
+          if d.getName.startsWith("dotty-library") || d.getName.startsWith("scala3-library") =>
         apply(files, classOf[org.jline.terminal.Terminal].getClassLoader)
       case _ =>
         val key = new Key(files)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6058

I though this would help with
https://github.com/lampepfl/dotty/issues/10558 but `sbt repl` still
hides the input after typing a line and pressing enter even after this
change.