### PR TITLE
Optionally provide sbt jline terminal for some tasks

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -335,6 +335,8 @@ object Defaults extends BuildCommon {
         if (!useScalaReplJLine.value) classOf[org.jline.terminal.Terminal].getClassLoader
         else appConfiguration.value.provider.scalaProvider.launcher.topLoader.getParent
       },
+      inProcessTopClassLoader := classOf[sbt.testing.Framework].getClassLoader,
+      needsJLine3 := Nil,
       useSuperShell := { if (insideCI.value) false else ITerminal.console.isSupershellEnabled },
       superShellThreshold :== SysProp.supershellThreshold,
       superShellMaxTasks :== SysProp.supershellMaxTasks,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -595,6 +595,8 @@ object Keys {
 
   val useScalaReplJLine = settingKey[Boolean]("Toggles whether or not to use sbt's forked jline in the scala repl. Enabling this flag may break the thin client in the scala console.").withRank(KeyRanks.Invisible)
   val scalaInstanceTopLoader = settingKey[ClassLoader]("The top classloader for the scala instance").withRank(KeyRanks.Invisible)
+  val inProcessTopClassLoader = settingKey[ClassLoader]("The top classloader for in process tasks that need to run code in a separate classloader").withRank(KeyRanks.Invisible)
+  val needsJLine3 = settingKey[Seq[String]]("The names of tasks that require that we set a jline3 terminal")
 
   val stateStreams = AttributeKey[Streams]("stateStreams", "Streams manager, which provides streams for different contexts.  Setting this on State will override the default Streams implementation.")
   val resolvedScoped = Def.resolvedScoped

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -29,7 +29,6 @@ private[sbt] object ClassLoaders {
   private implicit class SeqFileOps(val files: Seq[File]) extends AnyVal {
     def urls: Array[URL] = files.toArray.map(_.toURI.toURL)
   }
-  private[this] val interfaceLoader = classOf[sbt.testing.Framework].getClassLoader
   /*
    * Get the class loader for a test task. The configuration could be IntegrationTest or Test.
    */
@@ -48,6 +47,7 @@ private[sbt] object ClassLoaders {
     val allowZombies = allowZombieClassLoaders.value
     buildLayers(
       strategy = classLoaderLayeringStrategy.value,
+      topLoader = inProcessTopClassLoader.value,
       si = si,
       fullCP = fullCP,
       allDependenciesSet = dependencyJars(dependencyClasspath).value.filterNot(exclude).toSet,
@@ -98,6 +98,7 @@ private[sbt] object ClassLoaders {
             val transformedDependencies = allDeps.map(f => mappings.getOrElse(f.getName, f))
             buildLayers(
               strategy = classLoaderLayeringStrategy.value: @sbtUnchecked,
+              topLoader = inProcessTopClassLoader.value,
               si = instance,
               fullCP = classpath.map(f => f -> IO.getModifiedTimeOrZero(f)),
               allDependenciesSet = transformedDependencies.toSet,
@@ -133,6 +134,7 @@ private[sbt] object ClassLoaders {
    */
   private def buildLayers(
       strategy: ClassLoaderLayeringStrategy,
+      topLoader: ClassLoader,
       si: ScalaInstance,
       fullCP: Seq[(File, Long)],
       allDependenciesSet: Set[File],
@@ -146,7 +148,7 @@ private[sbt] object ClassLoaders {
   ): ClassLoader = {
     val cpFiles = fullCP.map(_._1)
     strategy match {
-      case Flat => new FlatLoader(cpFiles.urls, interfaceLoader, tmp, close, allowZombies, logger)
+      case Flat => new FlatLoader(cpFiles.urls, topLoader, tmp, close, allowZombies, logger)
       case _ =>
         val layerDependencies = strategy match {
           case _: AllLibraryJars => true
@@ -155,8 +157,8 @@ private[sbt] object ClassLoaders {
         val scalaLibraryLayer = {
           cache.apply(
             si.libraryJars.map(j => j -> IO.getModifiedTimeOrZero(j)).toList,
-            interfaceLoader,
-            () => new ScalaLibraryClassLoader(si.libraryJars.map(_.toURI.toURL), interfaceLoader)
+            topLoader,
+            () => new ScalaLibraryClassLoader(si.libraryJars.map(_.toURI.toURL), topLoader)
           )
         }
         val cpFiles = fullCP.map(_._1)


### PR DESCRIPTION
The dotty repl task doesn't work with sbt 1.4.x when started with
in-process runMain. There were two problems:
1. the top classloader for run was not the jline 3 classloader so sbt
   was unable to override TerminalBuilder.build
2. even when setting the top loader to the jline 3 classloader, we
   weren't actually setting the global value so that it could be
   connsumed by TerminalBuilder.build

I didn't want to create a JLine3 terminal for every evaluation of
MainLoop.process so I added a setting, needsJLine3, which provides a
list of tasks for which we need to setup a jline 3 terminal before
evaluation.

In addition to these changes, the dotty build.sbt needs to add some
settings:

inProcessTopClassLoader := scalaInstanceTopLoader.value,
Global / needsJLine3 += "repl",
and in the repl task, it needs to add
terminal.value.setMode(canonical = false, echo = false)