### PR TITLE
Close jline 3 terminal when console exits

### DIFF
--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -65,15 +65,17 @@ final class Console(compiler: AnalyzingCompiler) {
         )
       } catch { case _: InterruptedException | _: ClosedChannelException => }
     val previous = sys.props.get("scala.color").getOrElse("auto")
+    val jline3term = sbt.internal.util.JLine3(terminal)
     try {
       sys.props("scala.color") = if (terminal.isColorEnabled) "true" else "false"
       terminal.withRawOutput {
         jline.TerminalFactory.set(terminal.toJLine)
-        DeprecatedJLine.setTerminalOverride(sbt.internal.util.JLine3(terminal))
+        DeprecatedJLine.setTerminalOverride(jline3term)
         terminal.withRawInput(Run.executeTrapExit(console0, log))
       }
     } finally {
       sys.props("scala.color") = previous
+      jline3term.close()
     }
   }
 }


### PR DESCRIPTION
The jline 3 Terminal is an autocloseable and should be closed when we're
down with it. I'm not exactly sure what resources we were potentially
leaking, but the jline3term variable is an instance of the jline
AbstractTerminal class which I know can create a thread in some
circumstances. This came up while working on #6185.