### PR TITLE
onLoad now runs with correct FileTreeRepository and CacheStoreFactory

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -940,13 +940,17 @@ object BuiltinCommands {
 
     val session = Load.initialSession(structure, eval, s0)
     SessionSettings.checkSession(session, s2)
-    val s3 = addCacheStoreFactoryFactory(Project.setProject(session, structure, s2))
+    val s3 = Project.setProject(
+      session,
+      structure,
+      s2,
+      st => setupGlobalFileTreeRepository(addCacheStoreFactoryFactory(st))
+    )
     val s4 = s3.put(Keys.useLog4J.key, Project.extract(s3).get(Keys.useLog4J))
-    val s5 = setupGlobalFileTreeRepository(s4)
     // This is a workaround for the console task in dotty which uses the classloader cache.
     // We need to override the top loader in that case so that it gets the forked jline.
-    s5.extendedClassLoaderCache.setParent(Project.extract(s5).get(Keys.scalaInstanceTopLoader))
-    addSuperShellParams(CheckBuildSources.init(LintUnused.lintUnusedFunc(s5)))
+    s4.extendedClassLoaderCache.setParent(Project.extract(s4).get(Keys.scalaInstanceTopLoader))
+    addSuperShellParams(CheckBuildSources.init(LintUnused.lintUnusedFunc(s4)))
   }
 
   private val setupGlobalFileTreeRepository: State => State = { state =>

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -480,7 +480,7 @@ object Project extends ProjectExtra {
   }
 
   def setProject(session: SessionSettings, structure: BuildStructure, s: State): State =
-    setProject(session, structure, s, st => st)
+    setProject(session, structure, s, identity)
 
   def setProject(
       session: SessionSettings,

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -479,7 +479,15 @@ object Project extends ProjectExtra {
     previousOnUnload(s.runExitHooks())
   }
 
-  def setProject(session: SessionSettings, structure: BuildStructure, s: State): State = {
+  def setProject(session: SessionSettings, structure: BuildStructure, s: State): State =
+    setProject(session, structure, s, st => st)
+
+  def setProject(
+      session: SessionSettings,
+      structure: BuildStructure,
+      s: State,
+      preOnLoad: State => State
+  ): State = {
     val unloaded = runUnloadHooks(s)
     val (onLoad, onUnload) = getHooks(structure.data)
     val newAttrs = unloaded.attributes
@@ -489,7 +497,7 @@ object Project extends ProjectExtra {
     val newState = unloaded.copy(attributes = newAttrs)
     // TODO: Fix this
     onLoad(
-      updateCurrent(newState) /*LogManager.setGlobalLogLevels(updateCurrent(newState), structure.data)*/
+      preOnLoad(updateCurrent(newState)) /*LogManager.setGlobalLogLevels(updateCurrent(newState), structure.data)*/
     )
   }
 


### PR DESCRIPTION
Right now when a project's `onLoad` gets executed, the passed `State` still contains the FileTreeRepository and CacheStoreFactory of a previous "lifecycle" (not sure how I should call that). For example: When running `reload` in the sbt console `onUnload` gets called, ending an "old lifecycle" and immediately afterwards `onLoad` for a "new lifecycle" gets executed.
The problem lies in these 3 lines:

https://github.com/sbt/sbt/blob/4d1af7770181813f1c57838dbe7633f8615ada5a/main/src/main/scala/sbt/Main.scala#L943-L945

[`Project.setProject(...)`](https://github.com/sbt/sbt/blob/v1.4.4/main/src/main/scala/sbt/Project.scala#L480-L492) runs `onUnload` and then `onLoad`, however as you can see in the three lines above only **afterwards** both the "old" CacheStoreFactory and the FileTreeRepository get closed (when `onLoad` was executed already!) and new ones will be created and put in the `State`.

I'm pretty sure this is not correct. I would expect that the `onLoad` already runs with a `State` passed that already contains the new CacheStoreFactory and FileTreeRepository that belongs to its "lifecycle" and not those that were used in the previous, old, now un-loaded "lifecycle" and which will be closed immediately afterwards.

**My proposed fix makes sure that the whole "lifecycle", from `onLoad` til `onUnload`, always uses the same FileTreeRepository and CacheStoreFactory.**

Background:
We have various sbt-plugins that do some setup in `onLoad`, one of these plugins starts a thread and captures the `State` passed to `onLoad` and that thread later uses the captured `State` to execute some commands (via `Commandy.process(.., capturedState)`). However starting with sbt 1.4.0 we now see
```
java.lang.IllegalStateException: Tried to invoke register on closed repostitory sbt.internal.nio.FileTreeRepositoryImpl
```
after running `reload` in the sbt console. The weird thing is after starting `sbt` and the first `onLoad` runs everything works great, only after running `reload` the exception occurs.

We did test this patch by publishing sbt to our local ivy repo and I can confirm it fixes our problem. Also, this bug did not occur in sbt < 1.4.0, because it was only in 1.4 when the FileTreeRepository was closed after running `onLoad` (see
https://github.com/sbt/sbt/commit/a2047a0b2cb5c5180510ed2bca651d1f12733fab#diff-cbd024cb21816130017b587e8bf7fcafc915bf438f8d8d289234b6f1c255828fR895 by @eatkins)

Thanks!