### PR TITLE
Add compiler-interface to the Scala Instance top loader

### DIFF
--- a/main/src/main/java/sbt/internal/MetaBuildLoader.java
+++ b/main/src/main/java/sbt/internal/MetaBuildLoader.java
@@ -65,11 +65,17 @@ public final class MetaBuildLoader extends URLClassLoader {
    */
   public static MetaBuildLoader makeLoader(final AppProvider appProvider) throws IOException {
     final String jlineJars = "jline-?[0-9.]+-sbt-.*|jline-terminal(-(jna|jansi))?-[0-9.]+";
+    final String testInterfaceJars = "test-interface-[0-9.]+";
+    final String compilerInterfaceJars = "compiler-interface-[0-9.]+(-.*)?";
+    final String jansiJars = "jansi-[0-9.]+";
+    final String jnaJars = "jna-(platform-)?[0-9.]+";
     final String fullPattern =
-        "^(test-interface-[0-9.]+|" + jlineJars + "|jansi-[0-9.]+|jna-(platform-)?[0-9.]+)\\.jar";
+        String.format(
+            "^(%s|%s|%s|%s|%s)\\.jar",
+            jlineJars, testInterfaceJars, compilerInterfaceJars, jansiJars, jnaJars);
     final Pattern pattern = Pattern.compile(fullPattern);
     final File[] cp = appProvider.mainClasspath();
-    final URL[] interfaceURLs = new URL[1];
+    final URL[] interfaceURLs = new URL[2];
     final URL[] jlineURLs = new URL[7];
     final File[] extra =
         appProvider.id().classpathExtra() == null ? new File[0] : appProvider.id().classpathExtra();
@@ -80,7 +86,8 @@ public final class MetaBuildLoader extends URLClassLoader {
       int jlineIndex = 0;
       for (final File file : cp) {
         final String name = file.getName();
-        if (name.contains("test-interface") && pattern.matcher(name).find()) {
+        if ((name.contains("test-interface") || name.contains("compiler-interface"))
+            && pattern.matcher(name).find()) {
           interfaceURLs[interfaceIndex] = file.toURI().toURL();
           interfaceIndex += 1;
         } else if (pattern.matcher(name).find()) {
@@ -133,7 +140,7 @@ public final class MetaBuildLoader extends URLClassLoader {
           }
         };
 
-    final TestInterfaceLoader interfaceLoader = new TestInterfaceLoader(interfaceURLs, topLoader);
+    final SbtInterfaceLoader interfaceLoader = new SbtInterfaceLoader(interfaceURLs, topLoader);
     final JLineLoader jlineLoader = new JLineLoader(jlineURLs, interfaceLoader);
     final File[] siJars = scalaProvider.jars();
     final URL[] lib = new URL[1];

--- a/main/src/main/java/sbt/internal/SbtInterfaceLoader.java
+++ b/main/src/main/java/sbt/internal/SbtInterfaceLoader.java
@@ -10,14 +10,15 @@ package sbt.internal;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-class TestInterfaceLoader extends URLClassLoader {
-  TestInterfaceLoader(final URL[] urls, final ClassLoader parent) {
+// This ClassLoader must contain pure  sbt java interfaces
+class SbtInterfaceLoader extends URLClassLoader {
+  SbtInterfaceLoader(final URL[] urls, final ClassLoader parent) {
     super(urls, parent);
   }
 
   @Override
   public String toString() {
-    return "SbtTestInterfaceClassLoader(" + getURLs()[0] + ")";
+    return "SbtInterfaceClassLoader(" + getURLs()[0] + ")";
   }
 
   static {

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -332,8 +332,10 @@ object Defaults extends BuildCommon {
       exportPipelining := usePipelining.value,
       useScalaReplJLine :== false,
       scalaInstanceTopLoader := {
-        if (!useScalaReplJLine.value) classOf[org.jline.terminal.Terminal].getClassLoader
-        else appConfiguration.value.provider.scalaProvider.launcher.topLoader.getParent
+        // the JLineLoader contains the SbtInterfaceClassLoader
+        if (!useScalaReplJLine.value)
+          classOf[org.jline.terminal.Terminal].getClassLoader // the JLineLoader
+        else classOf[Compilers].getClassLoader // the SbtInterfaceClassLoader
       },
       useSuperShell := { if (insideCI.value) false else ITerminal.console.isSupershellEnabled },
       superShellThreshold :== SysProp.supershellThreshold,


### PR DESCRIPTION
The Scala 3 compiler now has a direct dependency on the `org.scala-sbt:compiler-interface` artifact. When compiling, it is crucial that its loads the  `compiler-interface` classes from the same loader than sbt. Otherwise we have `LinkageException`.

In this PR I moved the `compiler-interface` up in the class loader hierarchy. It is safe because it's a pure java API that has no dependency. Rather than introducing a new loader in the pile of class loaders, I reused the `TestInterfaceClassLoader` and I renamed it `SbtInterfaceClassLoader`.

The hierarchy of class loader now looks like this (the parents are at the bottom):
- `MetaBuildLoader`: all sbt jars
- `FullScalaLoader`: `scala-xml_2.12`, `scala-compiler-2.12.12` and `scala-reflect-2.12.12`
- `LibraryLoader`: `scala-library-2.12.12`
- `JLineLoader`: jline jars
- `SbtInterfaceLoader`: `test-interface` and `compiler-interface`
- topLoader: JDK except Jansi

Depending on `useScalaReplJLine` the `scalaInstanceTopLoader` is `JLineLoader` (which contains `SbtInterfaceLoader`) or `SbtInterfaceLoader` directly.

I tested it successfully against the `3.0.0-M2` compiler and a snapshot of the future `3.0.0-M3` compiler.

