### PR TITLE
Fixes Ctrl-C printing out stack trace

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -8,6 +8,7 @@
 package sbt
 
 import java.io.PrintWriter
+import java.util.concurrent.RejectedExecutionException
 import java.util.Properties
 
 import sbt.BasicCommandStrings.{ StashOnFailure, networkExecPrefix }
@@ -240,6 +241,13 @@ object MainLoop {
           FastTrackCommands
             .evaluate(termState, exec.commandLine)
             .getOrElse(Command.process(exec.commandLine, termState))
+        } catch {
+          case _: RejectedExecutionException =>
+            // No stack trace since this is just to notify the user which command they cancelled
+            object Cancelled extends Throwable(exec.commandLine, null, true, false) {
+              override def toString: String = s"Cancelled: ${exec.commandLine}"
+            }
+            throw Cancelled
         } finally {
           // Flush the terminal output after command evaluation to ensure that all output
           // is displayed in the thin client before we report the command status. Also
@@ -328,5 +336,4 @@ object MainLoop {
     if (prevState.onFailure.isDefined && state.onFailure.isEmpty &&
         state.currentCommand.fold(true)(_ != StashOnFailure)) ExitCode(ErrorCodes.UnknownError)
     else ExitCode.Success
-
 }

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -305,7 +305,9 @@ object ConcurrentRestrictions {
 
       def take(): R = {
         if (closed.get)
-          throw new IllegalStateException("Tried to get values for a closed completion service")
+          throw new RejectedExecutionException(
+            "Tried to get values for a closed completion service"
+          )
         jservice.take().get()
       }
     }


### PR DESCRIPTION
sbt 1.4.x was printing a very verbose and annoying
RejectedExectionException when the user cancelled tasks with ctrl+c.

Fixes #6192