### PR TITLE
Fix tab completion perf regression

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -63,14 +63,11 @@ object LineReader {
          * `testOnly testOnly\ com.foo.FooSpec` instead of `testOnly com.foo.FooSpec`.
          */
         if (c.append.nonEmpty) {
-          val comp =
-            if (!pl.line().endsWith(" ")) pl.line().split(" ").last + c.append else c.append
-          // tell jline to append a " " if the completion would be valid with a " " appended
-          // which can be the case for input tasks and some commands. We need to exclude
-          // the empty string and ";" which always seem to be present.
-          val complete = (Parser.completions(parser, comp + " ", 10).get.map(_.display) --
-            Set(";", "")).nonEmpty
-          candidates.add(new Candidate(comp, comp, null, null, null, null, complete))
+          if (!pl.line().endsWith(" ")) {
+            candidates.add(new Candidate(pl.line().split(" ").last + c.append))
+          } else {
+            candidates.add(new Candidate(c.append))
+          }
         }
       }
     }


### PR DESCRIPTION
This reverts commit edf43a473b18f5c185475aa39d227eeb94e3ea8e.
This fixes performance regression of tab completion observed in https://github.com/sbt/sbt/issues/6204

As originally mentioned by @eatkins, JLine 3 will automatically append a white space character (`" "`) to the completion
candidate. In practice it doesn't really seem to bother the shell if we put in `"++2.11.12"` or `"++2.11.12 "` with the whitespace so I think it's ok to do so for now.

Perhaps in the future the parser could return a signal indicating `++2.11.12` and then End-of-Line or Whitespace-and-more?