### PR TITLE
Replace EvictionWarning with EvictionError

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2689,6 +2689,8 @@ object Classpaths {
         defaultConfiguration :== Some(Configurations.Compile),
         dependencyOverrides :== Vector.empty,
         libraryDependencies :== Nil,
+        libraryDependencySchemes :== Nil,
+        evictionErrorLevel :== Level.Error,
         excludeDependencies :== Nil,
         ivyLoggingLevel := (// This will suppress "Resolving..." logs on Jenkins and Travis.
         if (insideCI.value)
@@ -3460,13 +3462,7 @@ object Classpaths {
         .withMetadataDirectory(dependencyCacheDirectory.value)
     }
 
-    val evictionOptions = Def.taskDyn {
-      if (executionRoots.value.exists(_.key == evicted.key))
-        Def.task(EvictionWarningOptions.empty)
-      else Def.task((evictionWarningOptions in update).value)
-    }.value
-
-    val extracted = (Project extract state0)
+    val extracted = Project.extract(state0)
     val isPlugin = sbtPlugin.value
     val thisRef = thisProjectRef.value
     val label =
@@ -3486,7 +3482,8 @@ object Classpaths {
       force = shouldForce,
       depsUpdated = transitiveUpdate.value.exists(!_.stats.cached),
       uwConfig = (unresolvedWarningConfiguration in update).value,
-      ewo = evictionOptions,
+      evictionLevel = evictionErrorLevel.value,
+      versionSchemeOverrides = libraryDependencySchemes.value,
       mavenStyle = publishMavenStyle.value,
       compatWarning = compatibilityWarningOptions.value,
       includeCallers = includeCallers,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -455,6 +455,7 @@ object Keys {
   val updateFull = taskKey[UpdateReport]("Resolves and optionally retrieves dependencies, producing a full report with callers.").withRank(CTask)
   val evicted = taskKey[EvictionWarning]("Display detailed eviction warnings.").withRank(CTask)
   val evictionWarningOptions = settingKey[EvictionWarningOptions]("Options on eviction warnings after resolving managed dependencies.").withRank(DSetting)
+  val evictionErrorLevel = settingKey[Level.Value]("The log level for detected eviction errors. Level.Error will throw an error.")
   val transitiveUpdate = taskKey[Seq[UpdateReport]]("UpdateReports for the internal dependencies of this project.").withRank(DTask)
   val updateClassifiers = TaskKey[UpdateReport]("updateClassifiers", "Resolves and optionally retrieves classified artifacts, such as javadocs and sources, for dependency definitions, transitively.", BPlusTask, update)
   val transitiveClassifiers = settingKey[Seq[String]]("List of classifiers used for transitively obtaining extra artifacts for sbt or declared dependencies.").withRank(BSetting)
@@ -533,6 +534,7 @@ object Keys {
   val checksums = settingKey[Seq[String]]("The list of checksums to generate and to verify for dependencies.").withRank(BSetting)
   val forceUpdatePeriod = settingKey[Option[FiniteDuration]]("Duration after which to force a full update to occur").withRank(CSetting)
   val versionScheme = settingKey[Option[String]]("""Version scheme used for the subproject: Supported values are Some("early-semver"), Some("pvp"), and Some("semver-spec")""").withRank(BSetting)
+  val libraryDependencySchemes = settingKey[Seq[ModuleID]]("""Version scheme to use for specific modules set as "org" %% "name" % "<scheme>": Supported values are "early-semver", "pvp", "semver-spec", "always", and "strict".""").withRank(BSetting)
 
   val classifiersModule = taskKey[GetClassifiersModule]("classifiers-module").withRank(CTask)
   val compatibilityWarningOptions = settingKey[CompatibilityWarningOptions]("Configures warnings around Maven incompatibility.").withRank(CSetting)

--- a/sbt/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
+++ b/sbt/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
@@ -1,15 +1,10 @@
-// ThisBuild / useCoursier := false
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / scalaVersion := "2.13.3"
 ThisBuild / versionScheme := Some("semver-spec")
 ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def commonSettings: Seq[Def.Setting[_]] =
   Seq(
-    ivyPaths := IvyPaths(
-      (ThisBuild / baseDirectory).value,
-      Some((LocalRootProject / target).value / "ivy-cache")
-    ),
     fullResolvers := fullResolvers.value.filterNot(_.name == "inter-project"),
     publishTo := Some(MavenCache("local-maven", (LocalRootProject / target).value / "local-maven")),
     resolvers += MavenCache("local-maven", (LocalRootProject / target).value / "local-maven"),
@@ -56,7 +51,17 @@ val use = project
         }
       log.info(s"extraAttributes = $extraAttributes")
       assert(extraAttributes.nonEmpty, s"$extraAttributes is empty")
-      val ew = EvictionWarning(ivyModule.value, (evicted / evictionWarningOptions).value, report)
-      assert(ew.directEvictions.isEmpty, s"${ew.directEvictions} is not empty")
     },
+  )
+
+val use2 = project
+  .settings(commonSettings)
+  .settings(
+    name := "use2",
+    libraryDependencies ++= Seq(
+      "org.http4s" %% "http4s-blaze-server" % "0.21.11",
+      // https://repo1.maven.org/maven2/org/typelevel/cats-effect_2.13/3.0.0-M4/cats-effect_2.13-3.0.0-M4.pom
+      // is published with early-semver
+      "org.typelevel" %% "cats-effect" % "3.0.0-M4",
+    ),
   )

--- a/sbt/src/sbt-test/dependency-management/evicted-semver-spec/test
+++ b/sbt/src/sbt-test/dependency-management/evicted-semver-spec/test
@@ -3,3 +3,4 @@
 > middle/publish
 
 > use/check
+-> use2/update

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentManager.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentManager.scala
@@ -39,7 +39,9 @@ class ZincComponentManager(
     def notFound = invalid(s"Could not find required component '$id'")
     def getOrElse(orElse: => Iterable[File]): Iterable[File] = {
       val existing = provider.component(id)
-      if (existing.isEmpty) orElse else existing
+      // log.info(s"[zinc-lm] existing = ${existing.toList}")
+      if (existing.isEmpty) orElse
+      else existing
     }
 
     def createAndCache = {


### PR DESCRIPTION
Fixes #5976
Ref https://github.com/sbt/librarymanagement/pull/356
Ref https://eed3si9n.com/enforcing-semver-with-sbt-strict-update

This removes the guess-based EvictionWarning, and runs EvictionError instead.
EvictionError uses the `ThisBuild / versionScheme` information supplied by the library authors in addition to `libraryDependencySchemes` that the build users could provide:

```scala
ThisBuild / libraryDependencySchemes += "com.example" %% "name" % "early-semver"
```

as the version scheme "early-semver", "semver-spec", "pvp", "strict", or "always" may be used.
Here's an example of `update` failure:

```scala
[error]  * org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.2.0, 2.0.0, 2.0.0, 2.2.0}
[error]      +- com.example:use2_2.13:0.1.0-SNAPSHOT               (depends on 3.0.0-M4)
[error]      +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)
[error]      +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)
[error]      +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)
[error]      +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)
[error]
[error]
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```

This feature will catch the violation of cats-effect_2.13:3.0.0-M4 version scheme (`early-semver`) without user setting additional overrides. If the user wants to opt-out of this, the user can do so per module:

```scala
ThisBuild / libraryDependencySchemes += "org.typelevel" %% "cats-effect" % "always"
```

or globally as:

```scala
ThisBuild / evictionErrorLevel := Level.Info
```

### credits

The idea of supplying version scheme information via the build, and making eviction into an error was first implemented in https://github.com/scalacenter/sbt-eviction-rules by @alexarchambault and @julienrf at Scala Center.