### PR TITLE
Add bsp DebugSession messages

### DIFF
--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugSessionAddress.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugSessionAddress.scala
@@ -1,0 +1,33 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/** @param uri The target's Uri */
+final class DebugSessionAddress private (
+  val uri: java.net.URI) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: DebugSessionAddress => (this.uri == x.uri)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.bsp.DebugSessionAddress".##) + uri.##)
+  }
+  override def toString: String = {
+    "DebugSessionAddress(" + uri + ")"
+  }
+  private[this] def copy(uri: java.net.URI = uri): DebugSessionAddress = {
+    new DebugSessionAddress(uri)
+  }
+  def withUri(uri: java.net.URI): DebugSessionAddress = {
+    copy(uri = uri)
+  }
+}
+object DebugSessionAddress {
+  
+  def apply(uri: java.net.URI): DebugSessionAddress = new DebugSessionAddress(uri)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugSessionParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugSessionParams.scala
@@ -1,0 +1,52 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * @param targets A sequence of build targets affected by the debugging action.
+ * @param dataKind The kind of data to expect in the `data` field.
+ * @param data A language-agnostic JSON object interpreted by the server.
+ */
+final class DebugSessionParams private (
+  val targets: Vector[sbt.internal.bsp.BuildTargetIdentifier],
+  val dataKind: Option[String],
+  val data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: DebugSessionParams => (this.targets == x.targets) && (this.dataKind == x.dataKind) && (this.data == x.data)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.DebugSessionParams".##) + targets.##) + dataKind.##) + data.##)
+  }
+  override def toString: String = {
+    "DebugSessionParams(" + targets + ", " + dataKind + ", " + data + ")"
+  }
+  private[this] def copy(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier] = targets, dataKind: Option[String] = dataKind, data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue] = data): DebugSessionParams = {
+    new DebugSessionParams(targets, dataKind, data)
+  }
+  def withTargets(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier]): DebugSessionParams = {
+    copy(targets = targets)
+  }
+  def withDataKind(dataKind: Option[String]): DebugSessionParams = {
+    copy(dataKind = dataKind)
+  }
+  def withDataKind(dataKind: String): DebugSessionParams = {
+    copy(dataKind = Option(dataKind))
+  }
+  def withData(data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): DebugSessionParams = {
+    copy(data = data)
+  }
+  def withData(data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): DebugSessionParams = {
+    copy(data = Option(data))
+  }
+}
+object DebugSessionParams {
+  
+  def apply(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier], dataKind: Option[String], data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): DebugSessionParams = new DebugSessionParams(targets, dataKind, data)
+  def apply(targets: Vector[sbt.internal.bsp.BuildTargetIdentifier], dataKind: String, data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): DebugSessionParams = new DebugSessionParams(targets, Option(dataKind), Option(data))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugSessionAddressFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugSessionAddressFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait DebugSessionAddressFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val DebugSessionAddressFormat: JsonFormat[sbt.internal.bsp.DebugSessionAddress] = new JsonFormat[sbt.internal.bsp.DebugSessionAddress] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.DebugSessionAddress = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val uri = unbuilder.readField[java.net.URI]("uri")
+      unbuilder.endObject()
+      sbt.internal.bsp.DebugSessionAddress(uri)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.DebugSessionAddress, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("uri", obj.uri)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugSessionParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugSessionParamsFormats.scala
@@ -1,0 +1,31 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait DebugSessionParamsFormats { self: sbt.internal.bsp.codec.BuildTargetIdentifierFormats with sbt.internal.util.codec.JValueFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val DebugSessionParamsFormat: JsonFormat[sbt.internal.bsp.DebugSessionParams] = new JsonFormat[sbt.internal.bsp.DebugSessionParams] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.DebugSessionParams = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val targets = unbuilder.readField[Vector[sbt.internal.bsp.BuildTargetIdentifier]]("targets")
+      val dataKind = unbuilder.readField[Option[String]]("dataKind")
+      val data = unbuilder.readField[Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]]("data")
+      unbuilder.endObject()
+      sbt.internal.bsp.DebugSessionParams(targets, dataKind, data)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.DebugSessionParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("targets", obj.targets)
+    builder.addField("dataKind", obj.dataKind)
+    builder.addField("data", obj.data)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
@@ -9,6 +9,8 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.BuildTargetCapabilitiesFormats
   with sbt.internal.util.codec.JValueFormats
   with sbt.internal.bsp.codec.BuildTargetFormats
+  with sbt.internal.bsp.codec.DebugSessionAddressFormats
+  with sbt.internal.bsp.codec.DebugSessionParamsFormats
   with sbt.internal.bsp.codec.TaskIdFormats
   with sbt.internal.bsp.codec.TextDocumentIdentifierFormats
   with sbt.internal.bsp.codec.PositionFormats

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -63,6 +63,22 @@ type BuildTargetCapabilities {
   canRun: Boolean!
 }
 
+type DebugSessionAddress {
+  ## The target's Uri
+  uri: java.net.URI!
+}
+
+type DebugSessionParams {
+  ## A sequence of build targets affected by the debugging action.
+  targets: [sbt.internal.bsp.BuildTargetIdentifier]
+
+  ## The kind of data to expect in the `data` field.
+  dataKind: String
+
+  ## A language-agnostic JSON object interpreted by the server.
+  data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
+}
+
 type TaskId {
   ## A unique identifier
   id: String!


### PR DESCRIPTION
This only adds the contraband messages for DAP.

Example usage in sbt plugin:

```
  override def projectSettings = Seq(
    Keys.serverHandlers += ServerHandler { callback: ServerCallback =>
      import callback._
      //import sjsonnew.BasicJsonProtocol._
      import sbt.internal.protocol.JsonRpcRequestMessage
      ServerIntent.request {
        case r: JsonRpcRequestMessage if r.method == "debugSession/start" => {
...
              val debugAddress = DebugSessionAddress(uri)
              jsonRpcRespond(debugAddress, Some(r.id))
```

Which provides the native sbt `JsonFormat` for sending and parsing the two DAP `DebugSessionAddress` and `DebugSessionParams`