### PR TITLE
[1.4.x] lm-coursier 2.0.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.4"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.5"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/6228

Ref https://github.com/dirs-dev/directories-jvm/issues/43
Updates directories-jvm to 23
https://github.com/coursier/sbt-coursier/releases/tag/v2.0.5
https://github.com/coursier/coursier/releases/tag/v2.0.8