### PR TITLE
Fix semanticdb on Scala > 3.0.0-M3

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -43,7 +43,9 @@ object SemanticdbPlugin extends AutoPlugin {
     },
     semanticdbOptions += {
       val sv = scalaVersion.value
-      if (ScalaInstance.isDotty(sv)) "-Ysemanticdb"
+      if (sv.startsWith("0.") || sv.startsWith("3.0.0-M1") || sv.startsWith("3.0.0-M2"))
+        "-Ysemanticdb"
+      else if (sv.startsWith("3.")) "-Xsemanticdb"
       else "-Yrangepos"
     }
   ) ++


### PR DESCRIPTION
In Scala 3.0.0-M3 and forward, the `-Ysemanticdb` option is dropped and replaced by the `-Xsemanticdb`.

This is a consequence of https://github.com/lampepfl/dotty/pull/10655.