### PR TITLE
packageTimestamp setting

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -265,6 +265,7 @@ object Keys {
   val packageCache = taskKey[File]("Produces the main artifact for caching.")
 
   val packageOptions = taskKey[Seq[PackageOption]]("Options for packaging.").withRank(BTask)
+  val packageTimestamp = settingKey[Option[Long]]("Overwrites timestamps in JAR file to make the build reproducible; None keeps the existing timestamps (useful for web resources)").withRank(CSetting)
   val packageConfiguration = taskKey[Package.Configuration]("Collects all inputs needed for packaging.").withRank(DTask)
   val artifactPath = settingKey[File]("The location of a generated artifact.").withRank(BPlusSetting)
   val artifact = settingKey[Artifact]("Describes an artifact.").withRank(BMinusSetting)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6235

In sbt 1.4.0 (#5344) we started wiping out the timestamps in JAR
to make the builds more repeatable.
This had an unintended consequence of breaking Play's last-modified response header (playframework/playframework#10572).

This adds a global setting called `packageTimestamp`, which is
initialized as follows:

```scala
packageTimestamp :== Package.defaultTimestamp,
```

Here the `Package.defaultTimestamp` would pick either the value from the
`SOURCE_DATE_EPOCH` environment variable or 2010-01-01.

To opt out of this default, the user can use:

```scala
ThisBuild / packageTimestamp := Package.keepTimestamps

// or

ThisBuild / packageTimestamp := Package.gitCommitDateTimestamp
```

### Before (sbt 1.4.6)

```
$ ll example
total 32
-rw-r--r--  1 eed3si9n  wheel   901 Jan  1  1970 Greeting.class
-rw-r--r--  1 eed3si9n  wheel  3079 Jan  1  1970 Hello$.class
-rw-r--r--  1 eed3si9n  wheel   738 Jan  1  1970 Hello$delayedInit$body.class
-rw-r--r--  1 eed3si9n  wheel   875 Jan  1  1970 Hello.class
```

### After (using Package.gitCommitDateTimestamp)

```
$ unzip -v target/scala-2.13/root_2.13-0.1.0-SNAPSHOT.jar
Archive:  target/scala-2.13/root_2.13-0.1.0-SNAPSHOT.jar
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
     288  Defl:N      136  53% 01-25-2021 03:09 888682a9  META-INF/MANIFEST.MF
       0  Stored        0   0% 01-25-2021 03:09 00000000  example/
     901  Defl:N      601  33% 01-25-2021 03:09 3543f377  example/Greeting.class
    3079  Defl:N     1279  59% 01-25-2021 03:09 848b4386  example/Hello$.class
     738  Defl:N      464  37% 01-25-2021 03:09 571f4288  example/Hello$delayedInit$body.class
     875  Defl:N      594  32% 01-25-2021 03:09 ad295259  example/Hello.class
--------          -------  ---                            -------
    5881             3074  48%                            6 files
```