### PR TITLE
Add --sbt-launch-jar in bsp connection details

### DIFF
--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -18,11 +18,16 @@ object BuildServerConnection {
   final val bspVersion = "2.0.0-M5"
   final val languages = Vector("scala")
 
+  private final val SbtLaunchJar = "sbt-launch(-.*)?\\.jar".r
+
   private[sbt] def writeConnectionFile(sbtVersion: String, baseDir: File): Unit = {
     import bsp.codec.JsonProtocol._
     val bspConnectionFile = new File(baseDir, ".bsp/sbt.json")
     val javaHome = System.getProperty("java.home")
     val classPath = System.getProperty("java.class.path")
+    val sbtLaunchJar = classPath
+      .split(File.pathSeparator)
+      .find(jar => SbtLaunchJar.findFirstIn(jar).nonEmpty)
     val argv =
       Vector(
         s"$javaHome/bin/java",
@@ -32,7 +37,7 @@ object BuildServerConnection {
         classPath,
         "xsbt.boot.Boot",
         "-bsp"
-      )
+      ) ++ sbtLaunchJar.map(jar => s"--sbt-launch-jar=$jar")
     val details = BspConnectionDetails(name, sbtVersion, bspVersion, languages, argv)
     val json = Converter.toJson(details).get
     IO.write(bspConnectionFile, CompactPrinter(json), append = false)


### PR DESCRIPTION
Fixes #6176 

When `sbt` is started by the `sbt-launch` jar then the BSP connection details is created with `--sbt-launch-jar=<path to the sbt-launch jar>`.

For instance, running
```shell
> sbt bspConfig
```
creates the following  `.bsp/sbt.json`  file

```json
{
  "name":"sbt",
  "version":"1.5.0-SNAPSHOT",
  "bspVersion":"2.0.0-M5",
  "languages":["scala"],
  "argv":[
    "/home/piquerez/.cache/coursier/jvm/adopt@1.11.0-7/bin/java",
    "-Xms100m",
    "-Xmx100m",
    "-classpath",
    "/home/piquerez/.sdkman/candidates/sbt/1.4.4/bin/sbt-launch.jar",
    "xsbt.boot.Boot",
    "-bsp",
    "--sbt-launch-jar=/home/piquerez/.sdkman/candidates/sbt/1.4.4/bin/sbt-launch.jar"
  ]
}
```