### PR TITLE
Reset ZipEntry timestamps to 2010-01-01 to prevent negative value

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1778,7 +1778,10 @@ object Defaults extends BuildCommon {
         config,
         s.cacheStoreFactory,
         s.log,
-        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong * 1000).orElse(Some(0L))
+        sys.env
+          .get("SOURCE_DATE_EPOCH")
+          .map(_.toLong * 1000)
+          .orElse(Some(1262304000000L)) // 2010-01-01
       )
       config.jar
     }


### PR DESCRIPTION
Due to https://github.com/sbt/sbt/pull/5344, sbt sets `0L` as timestamp by default.

However, it might set a negative value to `ZipEntry.mtime` depends on the timezone and this causes an issue when we unzip files created by sbt using `ZipInputStream` because while 1980-01-01 is set to `ZipEntry.xdostime` when 0 is given to `IO.jar()`, a negative value could be set to `ZipEntry.mtime` due to the following timezone adjustment:
https://github.com/sbt/io/blob/2af89897a55827e92543cda620c96db44e84e908/io/src/main/scala/sbt/io/IO.scala#L656

Since `ZipEntry.getTime()` returns `mtime` not `xdostime` as long as it's available, if we unzip files by `IO.unzip()` (with `preserveLastModified` option), timestamps of extracted files would be a date in the far future. I think this is not good as the default behavior of packaging.

~~The origin of `xdostime` is `1980-01-01` even if `0` is given. Therefore, it would be better to give 315500400000L (= 1980-01-01) to reset `ZipEntry`'s timestamp to prevent setting a negative value.~~

Updated: As commented by @eed3si9n, Bazel seems to use 2010-01-01 (1262304000000L) for this purpose. I updated this pull request to use this value.

