### PR TITLE
[1.5.0-M1] Improve error report for scala3doc missing

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2070,7 +2070,7 @@ object Defaults extends BuildCommon {
               if (isScala3 && !allDeps.exists(isScala3Doc)) {
                 Array(
                   "Unresolved scala3doc artifact",
-                  "Add 'resolvers += Resolver.JCenterRepository'"
+                  "add 'ThisBuild / resolvers += Resolver.JCenterRepository'"
                 ).foreach(m => s.log.error(m))
               }
               val docSrcs = if (isScala3) tFiles else srcs


### PR DESCRIPTION
Fixes #6264 

The error message appears only when running doc task if `scala3doc` is missing.

Failure
```shell
sbt:root> doc
[info] compiling 13 Scala sources to /foo/target/scala-3.0.0-M3/classes ...
[error] Unresolved scala3doc artifact
[error] Add 'resolvers += Resolver.JCenterRepository'
[info] Main Scala API documentation to /foo/target/scala-3.0.0-M3/api...
[error] stack trace is suppressed; run last foo / Compile / doc for the full output
[error] (foo / Compile / doc) java.lang.ClassNotFoundException: dotty.tools.dottydoc.Main
[error] Total time: 1 s, completed Jan 18, 2021, 8:20:48 PM
```

Success:
```shell
sbt:root> doc
[info] Main Scala API documentation to /foo/target/scala-3.0.0-M3/api...
[warn] Setting -bootclasspath is currently not supported.
[warn] one warning found
[info] Main Scala API documentation successful.
[success] Total time: 2 s, completed Jan 18, 2021, 8:20:56 PM
```

Now I realize that `[warn] Setting -bootclasspath is currently not supported.`. I don't think its a blocker but I'll create an issue and try to fix it.