### PR TITLE
Fix ExitCode calc on StashOnFailure

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -251,7 +251,7 @@ object MainLoop {
         } finally {
           // Flush the terminal output after command evaluation to ensure that all output
           // is displayed in the thin client before we report the command status. Also
-          // set the promt to whatever it was before we started evaluating the task.
+          // set the prompt to whatever it was before we started evaluating the task.
           restoreTerminal()
         }
         if (exec.execId.fold(true)(!_.startsWith(networkExecPrefix)) &&
@@ -334,6 +334,7 @@ object MainLoop {
   // so we also use that to indicate that the execution failed
   private[this] def exitCodeFromStateOnFailure(state: State, prevState: State): ExitCode =
     if (prevState.onFailure.isDefined && state.onFailure.isEmpty &&
-        state.currentCommand.fold(true)(_ != StashOnFailure)) ExitCode(ErrorCodes.UnknownError)
-    else ExitCode.Success
+        state.currentCommand.fold(true)(_.commandLine != StashOnFailure)) {
+      ExitCode(ErrorCodes.UnknownError)
+    } else ExitCode.Success
 }


### PR DESCRIPTION
Previous sbt.Exec != String match would never fail