### PR TITLE
bump lm-coursier-shaded to 2.0.6 (includes coursier 2.0.9)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.5"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.6"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
Fixes: #5200 

Coursier 2.0.9 fixes an issue with connecting to repositories that conform to the newer RFC 7617, rather than the older RFC 2617, when challenging the user for credentials.

This caused an inability to resolve artifacts from a private Nexus repository.