### PR TITLE
[1.4.x] Various backports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ npm-debug.log
 .idea
 .bloop
 .metals
+.bsp/
 /project/metals.sbt

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -157,7 +157,7 @@ final class ContextUtil[C <: blackbox.Context](val ctx: C) {
     case _ => ()
   }
 
-  @deprecated("1.3.0", "Use that variant that specifies the M instance types to exclude")
+  @deprecated("Use that variant that specifies the M instance types to exclude", since = "1.3.0")
   /**
    * A function that checks the provided tree for illegal references to M instances defined in the
    *  expression passed to the macro and for illegal dereferencing of M instances.

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
@@ -64,6 +64,8 @@ object Util {
   lazy val isNonCygwinWindows: Boolean = isWindows && !isCygwin
   lazy val isCygwinWindows: Boolean = isWindows && isCygwin
 
+  lazy val isEmacs: Boolean = Option(System.getenv("INSIDE_EMACS")).isDefined
+
   def nil[A]: List[A] = List.empty[A]
   def nilSeq[A]: Seq[A] = Seq.empty[A]
   def none[A]: Option[A] = (None: Option[A])

--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -63,11 +63,14 @@ object LineReader {
          * `testOnly testOnly\ com.foo.FooSpec` instead of `testOnly com.foo.FooSpec`.
          */
         if (c.append.nonEmpty) {
-          if (!pl.line().endsWith(" ")) {
-            candidates.add(new Candidate(pl.line().split(" ").last + c.append))
-          } else {
-            candidates.add(new Candidate(c.append))
+          val cand = pl.line() match {
+            case line if line.endsWith(" ") => c.append
+            case line                       => line.split(" ").last + c.append
           }
+          // https://github.com/jline/jline3/blob/9a4971868e4bdd29a36e454de01f54d3cd6071e0/reader/src/main/java/org/jline/reader/Candidate.java#L123-L131
+          // "If the candidate is complete and is selected, a space separator will be added."
+          val complete = false
+          candidates.add(new Candidate(cand, cand, null, null, null, null, complete))
         }
       }
     }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -317,7 +317,10 @@ object Terminal {
     props
       .map(_.color)
       .orElse(isColorEnabledProp)
-      .getOrElse(logFormatEnabled.getOrElse(true) && ((hasConsole && !isDumbTerminal) || isCI))
+      .getOrElse(
+        logFormatEnabled
+          .getOrElse(true) && ((hasConsole && !isDumbTerminal) || isCI || Util.isEmacs)
+      )
   }
   private[this] lazy val isColorEnabledProp: Option[Boolean] =
     sys.props.get("sbt.color").orElse(sys.props.get("sbt.colour")).flatMap(parseLogOption)
@@ -867,7 +870,8 @@ object Terminal {
         .map(_.supershell)
         .getOrElse(System.getProperty("sbt.supershell") match {
           case null =>
-            !(sys.env.contains("BUILD_NUMBER") || sys.env.contains("CI")) && isColorEnabled
+            !(sys.env.contains("BUILD_NUMBER") || sys.env
+              .contains("CI")) && isColorEnabled && !Util.isEmacs
           case "true" => true
           case _      => false
         })

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -330,8 +330,14 @@ class NetworkClient(
 
         val cmd = List(arguments.sbtScript) ++ arguments.sbtArguments ++
           List(BasicCommandStrings.DashDashDetachStdio, BasicCommandStrings.DashDashServer)
+
+        // https://github.com/sbt/sbt/issues/6271
+        val nohup =
+          if (Util.isEmacs && !Util.isWindows) List("nohup")
+          else Nil
+
         val processBuilder =
-          new ProcessBuilder(cmd: _*)
+          new ProcessBuilder((nohup ++ cmd): _*)
             .directory(arguments.baseDirectory)
             .redirectInput(Redirect.PIPE)
         processBuilder.environment.put(Terminal.TERMINAL_PROPS, props)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4175,6 +4175,10 @@ trait BuildExtra extends BuildCommon with DefExtra {
     baseDirectory.value / name
   }
 
+  @deprecated(
+    "externalIvyFile is not supported by Couriser, and will be removed in the future",
+    since = "1.5.0"
+  )
   def externalIvyFile(
       file: Initialize[File] = inBase("ivy.xml"),
       iScala: Initialize[Option[ScalaModuleInfo]] = scalaModuleInfo
@@ -4186,6 +4190,10 @@ trait BuildExtra extends BuildCommon with DefExtra {
       managedScalaInstance.value
     )
 
+  @deprecated(
+    "externalPom is not supported by Coursier, and will be removed in the future",
+    since = "1.5.0"
+  )
   def externalPom(
       file: Initialize[File] = inBase("pom.xml"),
       iScala: Initialize[Option[ScalaModuleInfo]] = scalaModuleInfo,

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -8,6 +8,7 @@
 package sbt
 
 import java.io.PrintWriter
+import java.util.concurrent.RejectedExecutionException
 import java.util.Properties
 
 import sbt.BasicCommandStrings.{ StashOnFailure, networkExecPrefix }
@@ -240,6 +241,13 @@ object MainLoop {
           FastTrackCommands
             .evaluate(termState, exec.commandLine)
             .getOrElse(Command.process(exec.commandLine, termState))
+        } catch {
+          case _: RejectedExecutionException =>
+            // No stack trace since this is just to notify the user which command they cancelled
+            object Cancelled extends Throwable(exec.commandLine, null, true, false) {
+              override def toString: String = s"Cancelled: ${exec.commandLine}"
+            }
+            throw Cancelled
         } finally {
           // Flush the terminal output after command evaluation to ensure that all output
           // is displayed in the thin client before we report the command status. Also
@@ -328,5 +336,4 @@ object MainLoop {
     if (prevState.onFailure.isDefined && state.onFailure.isEmpty &&
         state.currentCommand.fold(true)(_ != StashOnFailure)) ExitCode(ErrorCodes.UnknownError)
     else ExitCode.Success
-
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.5"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.6"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -305,7 +305,9 @@ object ConcurrentRestrictions {
 
       def take(): R = {
         if (closed.get)
-          throw new IllegalStateException("Tried to get values for a closed completion service")
+          throw new RejectedExecutionException(
+            "Tried to get values for a closed completion service"
+          )
         jservice.take().get()
       }
     }


### PR DESCRIPTION
This backports
- Updates to Coursier 2.0.9, fixing authentication with Sonatype Nexus #6278/https://github.com/coursier/coursier/pull/1948 by @cchepelov   
- Fixes Ctrl-C printing out stack trace #6213 by @eatkins 
- Fixes tab completion adding extra whitespace #6257 by @eed3si9n 
- GNU Emacs support for `sbtn` and `sbt --client` #6276 by @fommil 
- Deprecates `externalPom(...)` and `externalIvyFile(...)` #6284 by @eed3si9n 
