### PR TITLE
[1.4.x] Reset ZipEntry timestamps to 2010-01-01 in order to prevent negative value

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1707,7 +1707,10 @@ object Defaults extends BuildCommon {
         config,
         s.cacheStoreFactory,
         s.log,
-        sys.env.get("SOURCE_DATE_EPOCH").map(_.toLong * 1000).orElse(Some(0L))
+        sys.env
+          .get("SOURCE_DATE_EPOCH")
+          .map(_.toLong * 1000)
+          .orElse(Some(1262304000000L)) // 2010-01-01
       )
       config.jar
     }


### PR DESCRIPTION
Backport https://github.com/sbt/sbt/pull/6254 for 1.4.x