### PR TITLE
Fix SBT Warn on slow HostName

### DIFF
--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -51,7 +51,7 @@ class JUnitXmlTestsListener(val outputDir: String, legacyTestReport: Boolean, lo
       logger.warn(
         s"Getting the hostname $name was slow (${elapsed / 1.0e6} ms). " +
           "This is likely because the computer's hostname is not set. You can set the " +
-          "hostname with the command: scutil --set HostName $(scutil --get LocalHostName)."
+          """hostname with the command: scutil --set HostName "$(scutil --get LocalHostName).local"."""
       )
     }
     name


### PR DESCRIPTION
Turns out the snippet provided in the warning was incorrect and did not resolve the issue properly. Adding `.local` to the end of the HostName will resolve the slowness.

See the 2nd answer here: 

https://apple.stackexchange.com/questions/175320/why-is-my-hostname-resolution-taking-so-long