### PR TITLE
Warn on missing versionScheme

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3045,6 +3045,14 @@ object Classpaths {
       )
     },
     publishConfiguration := {
+      val s = streams.value
+      val vs = versionScheme.value
+      if (vs.isEmpty)
+        s.log.warn(
+          s"""versionScheme setting is empty; set `ThisBuild / versionScheme := Some("early-semver")` or `Some("pvp")`
+             |so tooling can use it for evction errors etc - https://www.scala-sbt.org/1.x/docs/Publishing.html""".stripMargin
+        )
+      else ()
       publishConfig(
         publishMavenStyle.value,
         deliverPattern(crossTarget.value),


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6303

This will print warning on publishing when versionScheme is not set.

```
[warn] versionScheme setting is empty; set `ThisBuild / versionScheme := Some("early-semver")` or `Some("pvp")`
[warn] so tooling can use it for evction errors etc - https://www.scala-sbt.org/1.x/docs/Publishing.html
```