### PR TITLE
lm-coursier-shaded 2.0.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,16 +27,16 @@ for:
   - mkdir ~/sbt
   - tar -xf ~/sbt-bin.tgz --directory ~/sbt
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.0/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@1.8.0-222
-  - jabba use adopt@1.8.0-222
+  - jabba install adopt@1.8.0-275
+  - jabba use adopt@1.8.0-275
   - curl -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java8-linux-amd64-20.1.0.tar.gz > graalvm.tar.gz
   - tar -xf graalvm.tar.gz
   - export PATH="~/sbt/sbt/bin:$PATH"
-  - export PATH="$PATH:~/.jabba/jdk/adopt@1.8.0-222/bin"
-  - export JAVA_HOME="~/.jabba/jdk/adopt@1.8.0-222"
+  - export PATH="$PATH:~/.jabba/jdk/adopt@1.8.0-275/bin"
+  - export JAVA_HOME="~/.jabba/jdk/adopt@1.8.0-275"
 
   test_script:
-    - export PATH="$PATH:~/.jabba/jdk/adopt@1.8.0-222/bin"
+    - export PATH="$PATH:~/.jabba/jdk/adopt@1.8.0-275/bin"
     - export PATH="$PATH:graalvm-ce-java8-20.1.0/bin"
     - gu install native-image
     - sbt "-Dsbt.io.virtual=false" "-Dsbt.native-image=$(pwd)/graalvm-ce-java8-20.1.0/bin/native-image" "sbtClientProj/buildNativeThinClient"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompileJVM2_12", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCoreJVM2_12", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.6"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.7"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6300

This upgrades Coursier from 2.0.9 to 2.0.12

- https://github.com/coursier/coursier/releases/tag/v2.0.11 contains some optimization by @jtjeferreira related to `reload` memory leak
- https://github.com/coursier/coursier/releases/tag/v2.0.12 contains HTTP 403 handling that I added for `updateClassifiers` (used by IntelliJ import)