### PR TITLE
`in` is no longer in

### DIFF
--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -10,6 +10,7 @@ package sbt
 import sbt.Def.{ Initialize, ScopedKey }
 import sbt.Previous._
 import sbt.Scope.Global
+import sbt.SlashSyntax0._
 import sbt.internal.util._
 import sbt.std.TaskExtra._
 import sbt.util.StampedFormat
@@ -146,7 +147,7 @@ object Previous {
 
   /** Public as a macro implementation detail.  Do not call directly. */
   def runtime[T](skey: TaskKey[T])(implicit format: JsonFormat[T]): Initialize[Task[Option[T]]] = {
-    val inputs = (cache in Global) zip Def.validated(skey, selfRefOk = true) zip (references in Global)
+    val inputs = (Global / cache) zip Def.validated(skey, selfRefOk = true) zip (Global / references)
     inputs {
       case ((prevTask, resolved), refs) =>
         val key = Key(resolved, resolved)
@@ -159,9 +160,9 @@ object Previous {
   def runtimeInEnclosingTask[T](skey: TaskKey[T])(
       implicit format: JsonFormat[T]
   ): Initialize[Task[Option[T]]] = {
-    val inputs = (cache in Global)
+    val inputs = (Global / cache)
       .zip(Def.validated(skey, selfRefOk = true))
-      .zip(references in Global)
+      .zip(Global / references)
       .zip(Def.resolvedScoped)
     inputs {
       case (((prevTask, resolved), refs), inTask: ScopedKey[Task[_]] @unchecked) =>

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -20,16 +20,29 @@ final case class Scope(
     task: ScopeAxis[AttributeKey[_]],
     extra: ScopeAxis[AttributeMap]
 ) {
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(project: Reference, config: ConfigKey): Scope =
     copy(project = Select(project), config = Select(config))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(config: ConfigKey, task: AttributeKey[_]): Scope =
     copy(config = Select(config), task = Select(task))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(project: Reference, task: AttributeKey[_]): Scope =
     copy(project = Select(project), task = Select(task))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(project: Reference, config: ConfigKey, task: AttributeKey[_]): Scope =
     copy(project = Select(project), config = Select(config), task = Select(task))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(project: Reference): Scope = copy(project = Select(project))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(config: ConfigKey): Scope = copy(config = Select(config))
+
+  @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(task: AttributeKey[_]): Scope = copy(task = Select(task))
 
   override def toString: String = this match {
@@ -42,6 +55,9 @@ object Scope {
   val ThisScope: Scope = Scope(This, This, This, This)
   val Global: Scope = Scope(Zero, Zero, Zero, Zero)
   val GlobalScope: Scope = Global
+
+  private[sbt] final val inIsDeprecated =
+    "`in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash"
 
   def resolveScope(thisScope: Scope, current: URI, rootProject: URI => String): Scope => Scope =
     resolveProject(current, rootProject) compose replaceThis(thisScope) compose subThisProject

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -92,7 +92,7 @@ object SlashSyntax {
   }
 
   /** RichScope wraps a general scope to provide the `/` operator for scoping. */
-  final class RichScope(protected val scope: Scope) extends HasSlashKey
+  final class RichScope(protected val scope: Scope) extends HasSlashKeyOrAttrKey
 
 }
 

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -9,6 +9,7 @@ package sbt
 
 import sbt.librarymanagement.Configuration
 import sbt.internal.util.AttributeKey
+import scala.annotation.nowarn
 
 /**
  * SlashSyntax implements the slash syntax to scope keys for build.sbt DSL.
@@ -60,19 +61,25 @@ object SlashSyntax {
 
   sealed trait HasSlashKey {
     protected def scope: Scope
+    @nowarn
     final def /[K](key: Scoped.ScopingSetting[K]): K = key in scope
   }
 
   sealed trait HasSlashKeyOrAttrKey extends HasSlashKey {
+    @nowarn
     final def /(key: AttributeKey[_]): RichScope = new RichScope(scope in key)
   }
 
   /** RichReference wraps a reference to provide the `/` operator for scoping. */
   final class RichReference(protected val scope: Scope) extends HasSlashKeyOrAttrKey {
+    @nowarn
     def /(c: ConfigKey): RichConfiguration = new RichConfiguration(scope in c)
+
+    @nowarn
     def /(c: Configuration): RichConfiguration = new RichConfiguration(scope in c)
 
     // This is for handling `Zero / Zero / name`.
+    @nowarn
     def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
       new RichConfiguration(scope.copy(config = configAxis))
   }

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -68,6 +68,7 @@ sealed abstract class SettingKey[T]
 
   final def scopedKey: ScopedKey[T] = ScopedKey(scope, key)
 
+  // @deprecated(Scope.inIsDeprecated, "1.5.0")
   final def in(scope: Scope): SettingKey[T] =
     Scoped.scopedSetting(Scope.replaceThis(this.scope)(scope), this.key)
 
@@ -140,6 +141,7 @@ sealed abstract class TaskKey[T]
 
   def scopedKey: ScopedKey[Task[T]] = ScopedKey(scope, key)
 
+  // @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(scope: Scope): TaskKey[T] =
     Scoped.scopedTask(Scope.replaceThis(this.scope)(scope), this.key)
 
@@ -206,6 +208,7 @@ sealed trait InputKey[T]
 
   def scopedKey: ScopedKey[InputTask[T]] = ScopedKey(scope, key)
 
+  // @deprecated(Scope.inIsDeprecated, "1.5.0")
   def in(scope: Scope): InputKey[T] =
     Scoped.scopedInput(Scope.replaceThis(this.scope)(scope), this.key)
 
@@ -244,18 +247,32 @@ object Scoped {
    *
    */
   sealed trait ScopingSetting[ResultType] {
+    // @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(s: Scope): ResultType
 
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(p: Reference): ResultType = in(Select(p), This, This)
+
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(t: Scoped): ResultType = in(This, This, Select(t.key))
+
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(c: ConfigKey): ResultType = in(This, Select(c), This)
+
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(c: ConfigKey, t: Scoped): ResultType = in(This, Select(c), Select(t.key))
+
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(p: Reference, c: ConfigKey): ResultType = in(Select(p), Select(c), This)
+
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(p: Reference, t: Scoped): ResultType = in(Select(p), This, Select(t.key))
 
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(p: Reference, c: ConfigKey, t: Scoped): ResultType =
       in(Select(p), Select(c), Select(t.key))
 
+    @deprecated(Scope.inIsDeprecated, "1.5.0")
     def in(
         p: ScopeAxis[Reference],
         c: ScopeAxis[ConfigKey],

--- a/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
+++ b/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
@@ -26,6 +26,7 @@ import sbt.ConfigKey
 import sbt.librarymanagement.syntax._
 import sbt.{ InputKey, SettingKey, TaskKey }
 import sbt.internal.util.{ AttributeKey, AttributeMap }
+import scala.annotation.nowarn
 
 object BuildSettingsInstances {
   val genFile: Gen[File] = Gen.oneOf(new File("."), new File("/tmp")) // for now..
@@ -99,6 +100,7 @@ object BuildSettingsInstances {
   def genSettingKey[A: Manifest]: Gen[SettingKey[A]] = genLabel map (x => SettingKey[A](x.value))
   def genTaskKey[A: Manifest]: Gen[TaskKey[A]] = genLabel map (x => TaskKey[A](x.value))
 
+  @nowarn
   def withScope[K <: Scoped.ScopingSetting[K]](keyGen: Gen[K]): Arbitrary[K] = Arbitrary {
     Gen.frequency(
       5 -> keyGen,

--- a/main-settings/src/test/scala/sbt/ScopeDisplaySpec.scala
+++ b/main-settings/src/test/scala/sbt/ScopeDisplaySpec.scala
@@ -10,10 +10,13 @@ package sbt
 import org.scalatest.FlatSpec
 import sbt.internal.util.{ AttributeKey, AttributeMap }
 import sbt.io.syntax.file
+import scala.annotation.nowarn
 
 class ScopeDisplaySpec extends FlatSpec {
   val project = ProjectRef(file("foo/bar"), "bar")
   val mangledName = "bar_slash_blah_blah_blah"
+
+  @nowarn
   val scopedKey = Def.ScopedKey(Scope.Global in project, AttributeKey[Task[String]](mangledName))
   val am = AttributeMap.empty.put(Scope.customShowString, "blah")
   val sanitizedKey = scopedKey.copy(scope = scopedKey.scope.copy(extra = Select(am)))

--- a/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
@@ -16,7 +16,9 @@ import sbt.ConfigKey
 import sbt.internal.util.AttributeKey
 
 import BuildSettingsInstances._
+import scala.annotation.nowarn
 
+@nowarn
 object SlashSyntaxSpec extends Properties("SlashSyntax") with SlashSyntax {
   property("Global / key == key in Global") = {
     forAll((k: Key) => expectValue(k in Global)(Global / k))

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -11,6 +11,7 @@ import java.io.File
 
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.Keys._
+import sbt.SlashSyntax0._
 import sbt.internal.Act
 import sbt.internal.CommandStrings._
 import sbt.internal.inc.ScalaInstance
@@ -102,9 +103,9 @@ object Cross {
 
   private def crossVersions(extracted: Extracted, proj: ResolvedReference): Seq[String] = {
     import extracted._
-    (crossScalaVersions in proj get structure.data) getOrElse {
+    ((proj / crossScalaVersions) get structure.data) getOrElse {
       // reading scalaVersion is a one-time deal
-      (scalaVersion in proj get structure.data).toSeq
+      ((proj / scalaVersion) get structure.data).toSeq
     }
   }
 
@@ -358,16 +359,16 @@ object Cross {
         instance match {
           case Some((home, inst)) =>
             Seq(
-              scalaVersion in scope := version,
-              crossScalaVersions in scope := scalaVersions,
-              scalaHome in scope := Some(home),
-              scalaInstance in scope := inst
+              scope / scalaVersion := version,
+              scope / crossScalaVersions := scalaVersions,
+              scope / scalaHome := Some(home),
+              scope / scalaInstance := inst
             )
           case None =>
             Seq(
-              scalaVersion in scope := version,
-              crossScalaVersions in scope := scalaVersions,
-              scalaHome in scope := None
+              scope / scalaVersion := version,
+              scope / crossScalaVersions := scalaVersions,
+              scope / scalaHome := None
             )
         }
     }

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -14,6 +14,7 @@ import sbt.Def.{ ScopedKey, Setting, dummyState }
 import sbt.Keys.{ TaskProgress => _, name => _, _ }
 import sbt.Project.richInitializeTask
 import sbt.Scope.Global
+import sbt.SlashSyntax0._
 import sbt.internal.Aggregation.KeyValue
 import sbt.internal.TaskName._
 import sbt.internal._
@@ -269,11 +270,11 @@ object EvaluateTask {
   }
   // TODO - Should this pull from Global or from the project itself?
   private[sbt] def forcegc(extracted: Extracted, structure: BuildStructure): Boolean =
-    getSetting(Keys.forcegc in Global, GCUtil.defaultForceGarbageCollection, extracted, structure)
+    getSetting((Global / Keys.forcegc), GCUtil.defaultForceGarbageCollection, extracted, structure)
   // TODO - Should this pull from Global or from the project itself?
   private[sbt] def minForcegcInterval(extracted: Extracted, structure: BuildStructure): Duration =
     getSetting(
-      Keys.minForcegcInterval in Global,
+      (Global / Keys.minForcegcInterval),
       GCUtil.defaultMinForcegcInterval,
       extracted,
       structure
@@ -285,12 +286,12 @@ object EvaluateTask {
       extracted: Extracted,
       structure: BuildStructure
   ): T =
-    (key in extracted.currentRef).get(structure.data).getOrElse(default)
+    (extracted.currentRef / key).get(structure.data).getOrElse(default)
 
   def injectSettings: Seq[Setting[_]] = Seq(
-    (state in Global) ::= dummyState,
-    (streamsManager in Global) ::= Def.dummyStreamsManager,
-    (executionRoots in Global) ::= dummyRoots,
+    Global / state ::= dummyState,
+    Global / streamsManager ::= Def.dummyStreamsManager,
+    Global / executionRoots ::= dummyRoots,
   )
 
   @deprecated("Use variant which doesn't take a logger", "1.1.1")
@@ -508,7 +509,7 @@ object EvaluateTask {
       state: State,
       streams: Streams
   ): Unit =
-    for (referenced <- Previous.references in Global get Project.structure(state).data)
+    for (referenced <- (Global / Previous.references) get Project.structure(state).data)
       Previous.complete(referenced, results, streams)
 
   def applyResults[T](
@@ -589,7 +590,7 @@ object EvaluateTask {
   // if the return type Seq[Setting[_]] is not explicitly given, scalac hangs
   val injectStreams: ScopedKey[_] => Seq[Setting[_]] = scoped =>
     if (scoped.key == streams.key) {
-      Seq(streams in scoped.scope := {
+      Seq(scoped.scope / streams := {
         (streamsManager map { mgr =>
           val stream = mgr(scoped)
           stream.open()

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -15,6 +15,7 @@ import sbt.internal.util.AttributeKey
 import sbt.util.Show
 import std.Transform.DummyTaskMap
 import sbt.EvaluateTask.extractedTaskConfig
+import scala.annotation.nowarn
 
 final case class Extracted(
     structure: BuildStructure,
@@ -43,6 +44,7 @@ final case class Extracted(
   def getOpt[T](key: TaskKey[T]): Option[Task[T]] =
     structure.data.get(inCurrent(key.scope), key.key)
 
+  @nowarn
   private[this] def inCurrent[T](scope: Scope): Scope =
     if (scope.project == This) scope in currentRef else scope
 
@@ -110,6 +112,7 @@ final case class Extracted(
     )(showKey)
   }
 
+  @nowarn
   private[this] def resolve[K <: Scoped.ScopingSetting[K] with Scoped](key: K): K =
     key in Scope.resolveScope(GlobalScope, currentRef.build, rootProject)(key.scope)
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -12,16 +12,19 @@ import DefaultParsers._
 import sbt.Keys._
 import Scope.GlobalScope
 import Def.ScopedKey
+import sbt.SlashSyntax0._
 import sbt.internal.Load
 import sbt.internal.CommandStrings._
 import Cross.{ spacedFirst, requireSession }
 import sbt.librarymanagement.VersionNumber
 import Project.inScope
+import scala.annotation.nowarn
 
 /**
  * Module responsible for plugin cross building.
  */
 private[sbt] object PluginCross {
+  @nowarn
   lazy val pluginSwitch: Command = {
     def switchParser(state: State): Parser[(String, String)] = {
       lazy val switchArgs = token(NotSpace.examples()) ~ (token(
@@ -68,14 +71,14 @@ private[sbt] object PluginCross {
     def crossVersions(state: State): List[String] = {
       val x = Project.extract(state)
       import x._
-      ((crossSbtVersions in currentRef) get structure.data getOrElse Nil).toList
+      ((currentRef / crossSbtVersions) get structure.data getOrElse Nil).toList
     }
     Command.arb(requireSession(crossParser), pluginCrossHelp) {
       case (state, command) =>
         val x = Project.extract(state)
         import x._
         val versions = crossVersions(state)
-        val current = (sbtVersion in pluginCrossBuild)
+        val current = (pluginCrossBuild / sbtVersion)
           .get(structure.data)
           .map(PluginSwitchCommand + " " + _)
           .toList
@@ -86,7 +89,7 @@ private[sbt] object PluginCross {
 
   def scalaVersionSetting: Def.Initialize[String] = Def.setting {
     val scalaV = scalaVersion.value
-    val sv = (sbtBinaryVersion in pluginCrossBuild).value
+    val sv = (pluginCrossBuild / sbtBinaryVersion).value
     val isPlugin = sbtPlugin.value
     if (isPlugin) scalaVersionFromSbtBinaryVersion(sv)
     else scalaV

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -14,6 +14,7 @@ import sbt.Def._
 import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.Project._
+import sbt.SlashSyntax0._
 import sbt.internal.inc.ModuleUtilities
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.librarymanagement.cross.CrossVersionUtil
@@ -60,7 +61,7 @@ object ScriptedPlugin extends AutoPlugin {
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     ivyConfigurations ++= Seq(ScriptedConf, ScriptedLaunchConf),
-    scriptedSbt := (sbtVersion in pluginCrossBuild).value,
+    scriptedSbt := (pluginCrossBuild / sbtVersion).value,
     sbtLauncher := getJars(ScriptedLaunchConf).map(_.get.head).value,
     sbtTestDirectory := sourceDirectory.value / "sbt-test",
     libraryDependencies ++= (CrossVersion.partialVersion(scriptedSbt.value) match {
@@ -92,12 +93,12 @@ object ScriptedPlugin extends AutoPlugin {
     scriptedRun := scriptedRunTask.value,
     scriptedDependencies := {
       def use[A](@deprecated("unused", "") x: A*): Unit = () // avoid unused warnings
-      val analysis = (Keys.compile in Test).value
+      val analysis = (Test / Keys.compile).value
       val pub = (publishLocal).value
       use(analysis, pub)
     },
     scripted := scriptedTask.evaluated,
-    watchTriggers in scripted += Glob(sbtTestDirectory.value, RecursiveGlob)
+    scripted / watchTriggers += Glob(sbtTestDirectory.value, RecursiveGlob)
   )
 
   private[sbt] def scriptedTestsTask: Initialize[Task[AnyRef]] =

--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -12,6 +12,7 @@ import java.nio.file.Path
 import java.io.File
 
 import sbt.BasicCommandStrings.TerminateAction
+import sbt.SlashSyntax0._
 import sbt.io._, syntax._
 import sbt.util._
 import sbt.internal.util.complete.{ DefaultParsers, Parser }, DefaultParsers._
@@ -48,7 +49,7 @@ private[sbt] object TemplateCommandUtil {
     val log = state.globalLogging.full
     val extracted = (Project extract state)
     val (s2, ivyConf) = extracted.runTask(Keys.ivyConfiguration, state)
-    val scalaModuleInfo = extracted.get(Keys.scalaModuleInfo in Keys.updateSbtClassifiers)
+    val scalaModuleInfo = extracted.get(Keys.updateSbtClassifiers / Keys.scalaModuleInfo)
     val arguments = inputArg.toList ++
       (state.remainingCommands match {
         case exec :: Nil if exec.commandLine == "shell" => Nil

--- a/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
@@ -17,6 +17,7 @@ import lmcoursier.definitions.{
 }
 import sbt.librarymanagement._
 import sbt.Keys._
+import sbt.SlashSyntax0._
 
 object CoursierArtifactsTasks {
   def coursierPublicationsTask(
@@ -48,18 +49,12 @@ object CoursierArtifactsTasks {
         for ((config, targetConfig) <- configsMap) yield {
 
           val publish = getOpt(
-            publishArtifact
-              .in(projectRef)
-              .in(packageBin)
-              .in(config)
+            projectRef / config / packageBin / publishArtifact
           ).getOrElse(false)
 
           if (publish)
             getOpt(
-              artifact
-                .in(projectRef)
-                .in(packageBin)
-                .in(config)
+              projectRef / config / packageBin / artifact
             ).map(targetConfig -> _)
           else
             None
@@ -69,18 +64,12 @@ object CoursierArtifactsTasks {
         for ((config, targetConfig) <- configsMap) yield {
 
           val publish = getOpt(
-            publishArtifact
-              .in(projectRef)
-              .in(packageSrc)
-              .in(config)
+            projectRef / config / packageSrc / publishArtifact
           ).getOrElse(false)
 
           if (publish)
             getOpt(
-              artifact
-                .in(projectRef)
-                .in(packageSrc)
-                .in(config)
+              projectRef / config / packageSrc / artifact
             ).map(sourcesConfigOpt.getOrElse(targetConfig) -> _)
           else
             None
@@ -91,18 +80,12 @@ object CoursierArtifactsTasks {
 
           val publish =
             getOpt(
-              publishArtifact
-                .in(projectRef)
-                .in(packageDoc)
-                .in(config)
+              projectRef / config / packageDoc / publishArtifact
             ).getOrElse(false)
 
           if (publish)
             getOpt(
-              artifact
-                .in(projectRef)
-                .in(packageDoc)
-                .in(config)
+              projectRef / config / packageDoc / artifact
             ).map(docsConfigOpt.getOrElse(targetConfig) -> _)
           else
             None
@@ -134,8 +117,7 @@ object CoursierArtifactsTasks {
       // No obvious way of getting the corresponding  publishArtifact  value for the ones
       // only here, it seems.
       val extraSbtArtifacts = getOpt(
-        sbt.Keys.artifacts
-          .in(projectRef)
+        projectRef / sbt.Keys.artifacts
       ).getOrElse(Nil)
         .filterNot(stdArtifactsSet)
 

--- a/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
@@ -11,6 +11,7 @@ package coursierint
 import sbt.librarymanagement._
 import sbt.Keys._
 import sbt.ScopeFilter.Make._
+import sbt.SlashSyntax0._
 
 object CoursierRepositoriesTasks {
   private object CResolvers {
@@ -108,7 +109,7 @@ object CoursierRepositoriesTasks {
         .bootRepositories(appConfiguration.value)
         .toSeq
         .flatten ++ // required because of the hack above it seems
-        externalResolvers.in(updateSbtClassifiers).value
+        (updateSbtClassifiers / externalResolvers).value
 
     val pluginIvySnapshotsFound = resolvers.exists {
       case repo: URLRepository =>

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -315,8 +315,8 @@ object LMCoursier {
       }
     }
     import scala.collection.JavaConverters._
-    (Keys.credentials in ThisBuild).value foreach registerCredentials
-    (Keys.credentials in LocalRootProject).value foreach registerCredentials
+    (ThisBuild / Keys.credentials).value foreach registerCredentials
+    (LocalRootProject / Keys.credentials).value foreach registerCredentials
     Keys.credentials.value foreach registerCredentials
     credentialRegistry.values.asScala.toVector
   }

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -12,11 +12,13 @@ import java.text.DateFormat
 
 import sbt.Def.ScopedKey
 import sbt.Keys.{ showSuccess, showTiming, timingFormat }
+import sbt.SlashSyntax0._
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }
 import sbt.internal.util._
 import sbt.std.Transform.DummyTaskMap
 import sbt.util.{ Logger, Show }
+import scala.annotation.nowarn
 
 sealed trait Aggregation
 object Aggregation {
@@ -127,7 +129,8 @@ object Aggregation {
   ): Unit = {
     import extracted._
     def get(key: SettingKey[Boolean]): Boolean =
-      key in currentRef get structure.data getOrElse true
+      (currentRef / key).get(structure.data) getOrElse true
+
     if (get(showSuccess)) {
       if (get(showTiming)) {
         val msg = timingString(start, stop, structure.data, currentRef)
@@ -143,7 +146,7 @@ object Aggregation {
       data: Settings[Scope],
       currentRef: ProjectRef,
   ): String = {
-    val format = timingFormat in currentRef get data getOrElse defaultFormat
+    val format = (currentRef / timingFormat).get(data) getOrElse defaultFormat
     timing(format, startTime, endTime)
   }
 
@@ -287,6 +290,7 @@ object Aggregation {
       ScopedKey(resolved, key.key)
     }
 
+  @nowarn
   def aggregationEnabled(key: ScopedKey[_], data: Settings[Scope]): Boolean =
     Keys.aggregate in Scope.fillTaskAxis(key.scope, key.key) get data getOrElse true
   private[sbt] val suppressShow =

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -20,6 +20,7 @@ import sbt.io.syntax._
 import sbt.internal.util.{ AttributeEntry, AttributeKey, AttributeMap, Attributed, Settings }
 import sbt.internal.util.Attributed.data
 import sbt.util.Logger
+import scala.annotation.nowarn
 
 final class BuildStructure(
     val units: Map[URI, LoadedBuildUnit],
@@ -396,6 +397,8 @@ object BuildStreams {
 
   def refTarget(ref: ResolvedReference, fallbackBase: File, data: Settings[Scope]): File =
     refTarget(GlobalScope.copy(project = Select(ref)), fallbackBase, data)
+
+  @nowarn
   def refTarget(scope: Scope, fallbackBase: File, data: Settings[Scope]): File =
     (Keys.target in scope get data getOrElse outputDirectory(fallbackBase)) / StreamsDirectory
 }

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -14,6 +14,7 @@ import java.nio.file.Path
 
 import sbt.ClassLoaderLayeringStrategy._
 import sbt.Keys._
+import sbt.SlashSyntax0._
 import sbt.internal.classpath.ClassLoaderCache
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.inc.classpath.ClasspathUtil
@@ -36,7 +37,7 @@ private[sbt] object ClassLoaders {
   private[sbt] def testTask: Def.Initialize[Task[ClassLoader]] = Def.task {
     val si = scalaInstance.value
     val cp = fullClasspath.value.map(_.data)
-    val dependencyStamps = modifiedTimes((outputFileStamps in dependencyClasspathFiles).value).toMap
+    val dependencyStamps = modifiedTimes((dependencyClasspathFiles / outputFileStamps).value).toMap
     def getLm(f: File): Long = dependencyStamps.getOrElse(f, IO.getModifiedTimeOrZero(f))
     val rawCP = cp.map(f => f -> getLm(f))
     val fullCP =
@@ -75,13 +76,13 @@ private[sbt] object ClassLoaders {
         if (options.nonEmpty) {
           val mask = ScopeMask(project = false)
           val showJavaOptions = Scope.displayMasked(
-            (javaOptions in resolvedScope).scopedKey.scope,
-            (javaOptions in resolvedScope).key.label,
+            (resolvedScope / javaOptions).scopedKey.scope,
+            (resolvedScope / javaOptions).key.label,
             mask
           )
           val showFork = Scope.displayMasked(
-            (fork in resolvedScope).scopedKey.scope,
-            (fork in resolvedScope).key.label,
+            (resolvedScope / fork).scopedKey.scope,
+            (resolvedScope / fork).key.label,
             mask
           )
           s.log.warn(s"$showJavaOptions will be ignored, $showFork is set to false")

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -52,7 +52,7 @@ private[sbt] object ClasspathImpl {
   def trackedExportedProducts(track: TrackLevel): Initialize[Task[Classpath]] =
     Def.task {
       val _ = (packageBin / dynamicDependency).value
-      val art = (artifact in packageBin).value
+      val art = (packageBin / artifact).value
       val module = projectID.value
       val config = configuration.value
       for { (f, analysis) <- trackedExportedProductsImplTask(track).value } yield APIMappings
@@ -65,7 +65,7 @@ private[sbt] object ClasspathImpl {
   def trackedExportedJarProducts(track: TrackLevel): Initialize[Task[Classpath]] =
     Def.task {
       val _ = (packageBin / dynamicDependency).value
-      val art = (artifact in packageBin).value
+      val art = (packageBin / artifact).value
       val module = projectID.value
       val config = configuration.value
       for { (f, analysis) <- trackedJarProductsImplTask(track).value } yield APIMappings
@@ -114,7 +114,7 @@ private[sbt] object ClasspathImpl {
       track: TrackLevel
   ): Initialize[Task[Seq[(File, CompileAnalysis)]]] =
     Def.taskDyn {
-      val jar = (artifactPath in packageBin).value
+      val jar = (packageBin / artifactPath).value
       TrackLevel.intersection(track, exportToInternal.value) match {
         case TrackLevel.TrackAlways =>
           Def.task {

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -14,12 +14,14 @@ import java.nio.file.{ DirectoryNotEmptyException, Files, Path }
 import sbt.Def._
 import sbt.Keys._
 import sbt.Project.richInitializeTask
+import sbt.SlashSyntax0._
 import sbt.io.syntax._
 import sbt.nio.Keys._
 import sbt.nio.file._
 import sbt.nio.file.syntax._
 import sbt.util.Level
 import sjsonnew.JsonFormat
+import scala.annotation.nowarn
 
 private[sbt] object Clean {
 
@@ -51,16 +53,16 @@ private[sbt] object Clean {
   }
 
   private[this] def cleanFilter(scope: Scope): Def.Initialize[Task[Path => Boolean]] = Def.task {
-    val excludes = (cleanKeepFiles in scope).value.map {
+    val excludes = (scope / cleanKeepFiles).value.map {
       // This mimics the legacy behavior of cleanFilesTask
       case f if f.isDirectory => Glob(f, AnyPath)
       case f                  => f.toGlob
-    } ++ (cleanKeepGlobs in scope).value
+    } ++ (scope / cleanKeepGlobs).value
     p: Path => excludes.exists(_.matches(p))
   }
   private[this] def cleanDelete(scope: Scope): Def.Initialize[Task[Path => Unit]] = Def.task {
     // Don't use a regular logger because the logger actually writes to the target directory.
-    val debug = (logLevel in scope).?.value.orElse(state.value.get(logLevel.key)) match {
+    val debug = (scope / logLevel).?.value.orElse(state.value.get(logLevel.key)) match {
       case Some(Level.Debug) =>
         (string: String) => println(s"[debug] $string")
       case _ =>
@@ -83,15 +85,15 @@ private[sbt] object Clean {
     Def.taskDyn {
       val state = Keys.state.value
       val extracted = Project.extract(state)
-      val view = (fileTreeView in scope).value
+      val view = (scope / fileTreeView).value
       val manager = streamsManager.value
       Def.task {
         val excludeFilter = cleanFilter(scope).value
         val delete = cleanDelete(scope).value
-        val targetDir = (target in scope).?.value.map(_.toPath)
+        val targetDir = (scope / target).?.value.map(_.toPath)
 
         targetDir.filter(_ => full).foreach(deleteContents(_, excludeFilter, view, delete))
-        (cleanFiles in scope).?.value.getOrElse(Nil).foreach { f =>
+        (scope / cleanFiles).?.value.getOrElse(Nil).foreach { f =>
           deleteContents(f.toPath, excludeFilter, view, delete)
         }
 
@@ -105,7 +107,7 @@ private[sbt] object Clean {
           }
         val streamsGlobs =
           (streamsKey.toSeq ++ stampsKey).map(k => manager(k).cacheDirectory.toGlob / **)
-        ((fileOutputs in scope).value.filter(g => targetDir.fold(true)(g.base.startsWith)) ++ streamsGlobs)
+        ((scope / fileOutputs).value.filter(g => targetDir.fold(true)(g.base.startsWith)) ++ streamsGlobs)
           .foreach { g =>
             val filter: Path => Boolean = { path =>
               !g.matches(path) || excludeFilter(path)
@@ -127,18 +129,20 @@ private[sbt] object Clean {
   private[this] implicit class ToSeqPathOps[T](val t: T) extends AnyVal {
     def toSeqPath(implicit toSeqPath: ToSeqPath[T]): Seq[Path] = toSeqPath(t)
   }
+
+  @nowarn
   private[sbt] def cleanFileOutputTask[T: JsonFormat: ToSeqPath](
       taskKey: TaskKey[T]
   ): Def.Initialize[Task[Unit]] =
     Def.taskDyn {
       val scope = taskKey.scope in taskKey.key
       Def.task {
-        val targetDir = (target in scope).value.toPath
+        val targetDir = (scope / target).value.toPath
         val filter = cleanFilter(scope).value
         // We do not want to inadvertently delete files that are not in the target directory.
         val excludeFilter: Path => Boolean = path => !path.startsWith(targetDir) || filter(path)
         val delete = cleanDelete(scope).value
-        val st = streams.in(scope).value
+        val st = (scope / streams).value
         taskKey.previous.foreach(_.toSeqPath.foreach(p => if (!excludeFilter(p)) delete(p)))
         delete(st.cacheDirectory.toPath / Previous.DependencyDirectory)
       }

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -8,6 +8,7 @@
 package sbt
 package internal
 
+import sbt.SlashSyntax0._
 import sbt.internal.classpath.AlternativeZincUtil
 import sbt.internal.inc.{ ScalaInstance, ZincLmUtil }
 import sbt.internal.util.Terminal
@@ -25,7 +26,7 @@ object ConsoleProject {
     val (state1, dependencyResolution) =
       extracted.runTask(Keys.dependencyResolution, state)
     val (_, scalaCompilerBridgeBinaryJar) =
-      extracted.runTask(Keys.scalaCompilerBridgeBinaryJar.in(Keys.consoleProject), state1)
+      extracted.runTask(Keys.consoleProject / Keys.scalaCompilerBridgeBinaryJar, state1)
     val scalaInstance = {
       val scalaProvider = state.configuration.provider.scalaProvider
       ScalaInstance(scalaProvider.version, scalaProvider)
@@ -50,8 +51,7 @@ object ConsoleProject {
           componentProvider = app.provider.components,
           secondaryCacheDir = Option(zincDir),
           dependencyResolution = dependencyResolution,
-          compilerBridgeSource =
-            extracted.get(Keys.scalaCompilerBridgeSource.in(Keys.consoleProject)),
+          compilerBridgeSource = extracted.get(Keys.consoleProject / Keys.scalaCompilerBridgeSource),
           scalaJarsTarget = zincDir,
           classLoaderCache = state1.get(BasicKeys.classLoaderCache),
           log = log

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 import sbt.BasicCommandStrings._
 import sbt.Def._
 import sbt.Keys._
+import sbt.SlashSyntax0._
 import sbt.internal.Continuous.{ ContinuousState, FileStampRepository }
 import sbt.internal.LabeledFunctions._
 import sbt.internal.io.WatchState
@@ -379,18 +380,18 @@ private[sbt] object Continuous extends DeprecatedContinuous {
         (settings.inputOptionsMessage, parser, alt)
       case _ =>
         val options =
-          extracted.getOpt(watchInputOptions in ThisBuild).getOrElse(Watch.defaultInputOptions)
+          extracted.getOpt((ThisBuild / watchInputOptions)).getOrElse(Watch.defaultInputOptions)
         val message = extracted
-          .getOpt(watchInputOptionsMessage in ThisBuild)
+          .getOpt((ThisBuild / watchInputOptionsMessage))
           .getOrElse(Watch.defaultInputOptionsMessage(options))
         val parser = extracted
-          .getOpt(watchInputParser in ThisBuild)
+          .getOpt((ThisBuild / watchInputParser))
           .getOrElse(Watch.defaultInputParser(options))
         val alt = extracted
-          .getOpt(watchInputStream in ThisBuild)
+          .getOpt((ThisBuild / watchInputStream))
           .map { _ =>
-            (watchInputStream in ThisBuild) -> extracted
-              .getOpt(watchInputHandler in ThisBuild)
+            (ThisBuild / watchInputStream) -> extracted
+              .getOpt((ThisBuild / watchInputHandler))
               .getOrElse(defaultInputHandler(parser))
           }
         (message, parser, alt)
@@ -425,7 +426,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
       // Print the default watch message if there are multiple tasks
       if (configs.size > 1) {
         val onStartWatch =
-          extracted.getOpt(watchStartMessage in project).getOrElse(Watch.defaultStartWatch)
+          extracted.getOpt((project / watchStartMessage)).getOrElse(Watch.defaultStartWatch)
         onStartWatch(count, project, commands).foreach(logger.info(_))
       }
       res
@@ -442,7 +443,7 @@ private[sbt] object Continuous extends DeprecatedContinuous {
   )(implicit extracted: Extracted): (Int => Option[(Watch.Event, Watch.Action)], () => Unit) = {
     val trackMetaBuild = configs.forall(_.watchSettings.trackMetaBuild)
     val buildGlobs =
-      if (trackMetaBuild) extracted.getOpt(fileInputs in checkBuildSources).getOrElse(Nil)
+      if (trackMetaBuild) extracted.getOpt((checkBuildSources / fileInputs)).getOrElse(Nil)
       else Nil
 
     val retentionPeriod = configs.map(_.watchSettings.antiEntropyRetentionPeriod).max
@@ -1041,9 +1042,9 @@ private[sbt] object Continuous extends DeprecatedContinuous {
       lazy val taskScope = Project.fillTaskAxis(scopedKey).scope
       scopedKey.scope match {
         case scope if scope.task.toOption.isDefined =>
-          extracted.getOpt(settingKey in scope) orElse extracted.getOpt(settingKey in taskScope)
+          extracted.getOpt((scope / settingKey)) orElse extracted.getOpt((taskScope / settingKey))
         case scope =>
-          extracted.getOpt(settingKey in taskScope) orElse extracted.getOpt(settingKey in scope)
+          extracted.getOpt((taskScope / settingKey)) orElse extracted.getOpt((scope / settingKey))
       }
     }
 
@@ -1063,12 +1064,12 @@ private[sbt] object Continuous extends DeprecatedContinuous {
       lazy val taskScope = Project.fillTaskAxis(scopedKey).scope
       scopedKey.scope match {
         case scope if scope.task.toOption.isDefined =>
-          if (extracted.getOpt(taskKey in scope).isDefined) Some(taskKey in scope)
-          else if (extracted.getOpt(taskKey in taskScope).isDefined) Some(taskKey in taskScope)
+          if (extracted.getOpt((scope / taskKey)).isDefined) Some((scope / taskKey))
+          else if (extracted.getOpt((taskScope / taskKey)).isDefined) Some((taskScope / taskKey))
           else None
         case scope =>
-          if (extracted.getOpt(taskKey in taskScope).isDefined) Some(taskKey in taskScope)
-          else if (extracted.getOpt(taskKey in scope).isDefined) Some(taskKey in scope)
+          if (extracted.getOpt((taskScope / taskKey)).isDefined) Some((taskScope / taskKey))
+          else if (extracted.getOpt((scope / taskKey)).isDefined) Some((scope / taskKey))
           else None
       }
     }

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -16,6 +16,7 @@ import sbt.io.Path
 import sbt.io.syntax._
 import sbt.Cross._
 import sbt.Def.{ ScopedKey, Setting }
+import sbt.SlashSyntax0._
 import sbt.internal.util.complete.DefaultParsers._
 import sbt.internal.util.AttributeKey
 import sbt.internal.util.complete.{ DefaultParsers, Parser }
@@ -169,7 +170,7 @@ private[sbt] object CrossJava {
       proj: ResolvedReference
   ): Map[String, File] = {
     import extracted._
-    (Keys.fullJavaHomes in proj get structure.data).get
+    ((proj / Keys.fullJavaHomes) get structure.data).get
   }
 
   private def getJavaHomesTyped(
@@ -185,14 +186,14 @@ private[sbt] object CrossJava {
   ): Seq[String] = {
     import extracted._
     import Keys._
-    (crossJavaVersions in proj get structure.data).getOrElse(Nil)
+    ((proj / crossJavaVersions) get structure.data).getOrElse(Nil)
   }
 
   private def getCrossJavaHomes(extracted: Extracted, proj: ResolvedReference): Seq[File] = {
     import extracted._
     import Keys._
-    val fjh = (fullJavaHomes in proj get structure.data).get
-    (crossJavaVersions in proj get structure.data) map { jvs =>
+    val fjh = ((proj / fullJavaHomes) get structure.data).get
+    ((proj / crossJavaVersions) get structure.data) map { jvs =>
       jvs map { jv =>
         lookupJavaHome(jv, fjh)
       }
@@ -235,7 +236,7 @@ private[sbt] object CrossJava {
           }
           val scope = Scope(Select(proj), Zero, Zero, Zero)
           Seq(
-            javaHome in scope := Some(home)
+            (scope / javaHome) := Some(home)
           )
       }
 

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 
 import sbt.Def.{ Classpath, ScopedKey, Setting }
 import sbt.Scope.GlobalScope
+import sbt.SlashSyntax0._
 import sbt.internal.inc.classpath.ClasspathFilter
 import sbt.internal.util.{ Attributed, ManagedLogger }
 import sbt.io.syntax._
@@ -514,9 +515,9 @@ private[sbt] object DefaultBackgroundJobService {
     backgroundJobServices.clear()
   }
   private[sbt] lazy val backgroundJobServiceSetting: Setting[_] =
-    (Keys.bgJobService in GlobalScope) := {
-      val path = (sbt.Keys.bgJobServiceDirectory in GlobalScope).value
-      val useLog4J = (Keys.useLog4J in GlobalScope).value
+    (GlobalScope / Keys.bgJobService) := {
+      val path = (GlobalScope / sbt.Keys.bgJobServiceDirectory).value
+      val useLog4J = (GlobalScope / Keys.useLog4J).value
       val newService = new DefaultBackgroundJobService(path, useLog4J)
       backgroundJobServices.putIfAbsent(path, newService) match {
         case null => newService
@@ -526,7 +527,7 @@ private[sbt] object DefaultBackgroundJobService {
       }
     }
   private[sbt] lazy val backgroundJobServiceSettings: Seq[Def.Setting[_]] = Def.settings(
-    Keys.bgJobServiceDirectory in GlobalScope := {
+    (GlobalScope / Keys.bgJobServiceDirectory) := {
       sbt.Keys.appConfiguration.value.baseDirectory / "target" / "bg-jobs"
     },
     backgroundJobServiceSetting

--- a/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -22,6 +22,7 @@ import compiler.{ Eval, EvalImports }
 import sbt.internal.util.complete.DefaultParsers.validID
 import Def.{ ScopedKey, Setting }
 import Scope.GlobalScope
+import sbt.SlashSyntax0._
 import sbt.internal.parser.SbtParser
 
 import sbt.io.IO
@@ -389,7 +390,7 @@ object Index {
         case _ => ()
       }
     )
-    val onComplete = Keys.onComplete in GlobalScope get ss getOrElse (() => ())
+    val onComplete = (GlobalScope / Keys.onComplete) get ss getOrElse (() => ())
     new Triggers[Task](runBefore, triggeredBy, map => { onComplete(); map })
   }
 

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -25,6 +25,7 @@ import Configurations.Compile
 import Def.Setting
 import Keys._
 import Scope.Global
+import sbt.SlashSyntax0._
 
 import sbt.io.IO
 
@@ -46,9 +47,9 @@ object IvyConsole {
       val depSettings: Seq[Setting[_]] = Seq(
         libraryDependencies ++= managed.reverse,
         resolvers ++= repos.reverse.toVector,
-        unmanagedJars in Compile ++= Attributed blankSeq unmanaged.reverse,
-        logLevel in Global := Level.Warn,
-        showSuccess in Global := false
+        Compile / unmanagedJars ++= Attributed blankSeq unmanaged.reverse,
+        Global / logLevel := Level.Warn,
+        Global / showSuccess := false
       )
       val append = Load.transformSettings(
         Load.projectScope(currentRef),

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -11,6 +11,7 @@ package internal
 import java.io.File
 import java.util.concurrent.Callable
 
+import sbt.SlashSyntax0._
 import sbt.internal.librarymanagement._
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._
@@ -265,7 +266,7 @@ private[sbt] object LibraryManagement {
         val updateConf = {
           import UpdateLogging.{ Full, DownloadOnly, Default }
           val conf = updateConfiguration.value
-          val maybeUpdateLevel = (logLevel in update).?.value
+          val maybeUpdateLevel = (update / logLevel).?.value
           val conf1 = maybeUpdateLevel.orElse(state0.get(logLevel.key)) match {
             case Some(Level.Debug) if conf.logging == Default => conf.withLogging(logging = Full)
             case Some(_) if conf.logging == Default           => conf.withLogging(logging = DownloadOnly)
@@ -283,10 +284,10 @@ private[sbt] object LibraryManagement {
           Reference.display(thisProjectRef.value),
           updateConf,
           identity,
-          skip = (skip in update).value,
+          skip = (update / skip).value,
           force = shouldForce,
           depsUpdated = transitiveUpdate.value.exists(!_.stats.cached),
-          uwConfig = (unresolvedWarningConfiguration in update).value,
+          uwConfig = (update / unresolvedWarningConfiguration).value,
           evictionLevel = Level.Debug,
           versionSchemeOverrides = Nil,
           assumedEvictionErrorLevel = Level.Debug,
@@ -310,7 +311,7 @@ private[sbt] object LibraryManagement {
         val app = appConfiguration.value
         val srcTypes = sourceArtifactTypes.value
         val docTypes = docArtifactTypes.value
-        val uwConfig = (unresolvedWarningConfiguration in update).value
+        val uwConfig = (update / unresolvedWarningConfiguration).value
         val out = is.withIvy(s.log)(_.getSettings.getDefaultIvyUserDir)
         withExcludes(out, mod.classifiers, lock(app)) { excludes =>
           lm.updateClassifiers(

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -13,6 +13,7 @@ import Def.{ Setting, ScopedKey }
 import sbt.internal.util.{ FilePosition, NoPosition, SourcePosition }
 import java.io.File
 import Scope.Global
+import sbt.SlashSyntax0._
 import sbt.Def._
 
 object LintUnused {
@@ -63,8 +64,8 @@ object LintUnused {
     val _ = Def.spaceDelimited().parsed // not used yet
     val state = Keys.state.value
     val log = streams.value.log
-    val includeKeys = (lintIncludeFilter in Global).value
-    val excludeKeys = (lintExcludeFilter in Global).value
+    val includeKeys = (Global / lintIncludeFilter).value
+    val excludeKeys = (Global / lintExcludeFilter).value
     val result = lintUnused(state, includeKeys, excludeKeys)
     if (result.isEmpty) log.success("ok")
     else lintResultLines(result) foreach { log.warn(_) }
@@ -74,9 +75,9 @@ object LintUnused {
   def lintUnusedFunc(s: State): State = {
     val log = s.log
     val extracted = Project.extract(s)
-    val includeKeys = extracted.get(lintIncludeFilter in Global)
-    val excludeKeys = extracted.get(lintExcludeFilter in Global)
-    if (extracted.get(lintUnusedKeysOnLoad in Global)) {
+    val includeKeys = extracted.get((Global / lintIncludeFilter))
+    val excludeKeys = extracted.get((Global / lintExcludeFilter))
+    if (extracted.get((Global / lintUnusedKeysOnLoad))) {
       val result = lintUnused(s, includeKeys, excludeKeys)
       lintResultLines(result) foreach { log.warn(_) }
     }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -12,11 +12,13 @@ import java.io.PrintWriter
 
 import sbt.Def.ScopedKey
 import sbt.Keys._
-import sbt.Scope.GlobalScope
+import sbt.Scope.Global
+import sbt.SlashSyntax0._
 import sbt.internal.util.MainAppender._
 import sbt.internal.util.{ Terminal => ITerminal, _ }
 import sbt.util.{ Level, LogExchange, Logger, LoggerContext }
 import org.apache.logging.log4j.core.{ Appender => XAppender }
+import scala.annotation.nowarn
 
 sealed abstract class LogManager {
   def apply(
@@ -59,6 +61,7 @@ object LogManager {
 
   // This is called by mkStreams
   //
+  @nowarn
   def construct(
       data: Settings[Scope],
       state: State
@@ -70,6 +73,7 @@ object LogManager {
       manager(data, state, task, to, context)
     }
 
+  @nowarn
   def constructBackgroundLog(
       data: Settings[Scope],
       state: State
@@ -309,7 +313,7 @@ object LogManager {
 
   private[sbt] def settingsLogger(state: State): Def.Setting[_] =
     // strict to avoid retaining a reference to `state`
-    sLog in GlobalScope :== globalWrapper(state)
+    Global / sLog :== globalWrapper(state)
 
   // construct a Logger that delegates to the global logger, but only holds a weak reference
   //  this is an approximation to the ideal that would invalidate the delegate after loading completes

--- a/main/src/main/scala/sbt/internal/PluginsDebug.scala
+++ b/main/src/main/scala/sbt/internal/PluginsDebug.scala
@@ -12,6 +12,7 @@ import sbt.internal.util.{ AttributeKey, Dag, Relation, Util }
 import sbt.util.Logger
 
 import Def.Setting
+import sbt.SlashSyntax0._
 import Plugins._
 import PluginsDebug._
 import java.net.URI
@@ -169,7 +170,7 @@ private[sbt] object PluginsDebug {
     val extracted = Project.extract(s)
     import extracted._
     def definesPlugin(p: ResolvedProject): Boolean = p.autoPlugins.contains(plugin)
-    def projectForRef(ref: ProjectRef): ResolvedProject = get(Keys.thisProject in ref)
+    def projectForRef(ref: ProjectRef): ResolvedProject = get(ref / Keys.thisProject)
     val perBuild: Map[URI, Set[AutoPlugin]] =
       structure.units.mapValues(unit => availableAutoPlugins(unit).toSet).toMap
     val pluginsThisBuild = perBuild.getOrElse(currentRef.build, Set.empty).toList

--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -33,6 +33,7 @@ import sbt.internal.remotecache._
 import sbt.internal.inc.{ HashUtil, JarUtils }
 import sbt.util.InterfaceUtil.toOption
 import sbt.util.Logger
+import scala.annotation.nowarn
 
 object RemoteCache {
   final val cachedCompileClassifier = "cached-compile"
@@ -151,6 +152,7 @@ object RemoteCache {
   ) ++ inConfig(Compile)(configCacheSettings(compileArtifact(Compile, cachedCompileClassifier)))
     ++ inConfig(Test)(configCacheSettings(testArtifact(Test, cachedTestClassifier))))
 
+  @nowarn
   def configCacheSettings[A <: RemoteCacheArtifact](
       cacheArtifactTask: Def.Initialize[Task[A]]
   ): Seq[Def.Setting[_]] =

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -17,6 +17,7 @@ import Keys._
 import EvaluateConfigurations.{ evaluateConfiguration => evaluate }
 import Configurations.Compile
 import Scope.Global
+import sbt.SlashSyntax0._
 
 import sbt.io.{ Hash, IO }
 
@@ -50,13 +51,13 @@ object Script {
       val embeddedSettings = blocks(script).flatMap { block =>
         evaluate(eval(), script, block.lines, currentUnit.imports, block.offset + 1)(currentLoader)
       }
-      val scriptAsSource = sources in Compile := script :: Nil
+      val scriptAsSource = (Compile / sources) := script :: Nil
       val asScript = scalacOptions ++= Seq("-Xscript", script.getName.stripSuffix(".scala"))
       val scriptSettings = Seq(
         asScript,
         scriptAsSource,
-        logLevel in Global := Level.Warn,
-        showSuccess in Global := false
+        (Global / logLevel) := Level.Warn,
+        (Global / showSuccess) := false
       )
       val append = Load.transformSettings(
         Load.projectScope(currentRef),

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -18,6 +18,7 @@ import Scope.Global
 import Types.idFun
 import complete._
 import DefaultParsers._
+import scala.annotation.nowarn
 
 /**
  * The resulting `session` and verbose and quiet summaries of the result of a set operation.
@@ -53,6 +54,8 @@ private[sbt] object SettingCompletions {
     val projectScope = Load.projectScope(currentRef)
     def resolve(s: Setting[_]): Seq[Setting[_]] =
       Load.transformSettings(projectScope, currentRef.build, rootProject, s :: Nil)
+
+    @nowarn
     def rescope[T](setting: Setting[T]): Seq[Setting[_]] = {
       val akey = setting.key.key
       val global = ScopedKey(Global, akey)

--- a/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
+++ b/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
@@ -19,7 +19,7 @@ import sbt.nio.FileStamper
 import sbt.nio.Keys._
 import sbt.nio.file.Glob
 
-import scala.annotation.tailrec
+import scala.annotation.{ nowarn, tailrec }
 
 private[sbt] object WatchTransitiveDependencies {
   private implicit class SourceOps(val source: Source) {
@@ -53,6 +53,8 @@ private[sbt] object WatchTransitiveDependencies {
     def structure: BuildStructure = extracted.structure
     def data: Map[Scope, AttributeMap] = extracted.structure.data.data
   }
+
+  @nowarn
   private def argumentsImpl(
       scopedKey: ScopedKey[_],
       extracted: Extracted,
@@ -127,6 +129,7 @@ private[sbt] object WatchTransitiveDependencies {
     (inputGlobs ++ triggerGlobs ++ legacy(keys :+ scopedKey, args)).distinct.sorted
   }
 
+  @nowarn
   private def legacy(keys: Seq[ScopedKey[_]], args: Arguments): Seq[DynamicInput] = {
     import args._
     val projectScopes =
@@ -160,6 +163,8 @@ private[sbt] object WatchTransitiveDependencies {
       case Right(globs) => globs.map(toDynamicInput)
     }
   }
+
+  @nowarn
   @tailrec
   private def collectKeys(
       arguments: Arguments,

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -36,7 +36,7 @@ import sbt.internal.util.complete.{ Parser, Parsers }
 import sbt.protocol._
 import sbt.util.Logger
 
-import scala.annotation.tailrec
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.util.Try
@@ -418,6 +418,7 @@ final class NetworkChannel(
     }
   }
 
+  @nowarn
   protected def onCompletionRequest(execId: Option[String], cp: CompletionParams) = {
     if (initialized) {
       try {

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -63,6 +63,7 @@ private[sbt] object Settings {
    * @param fileOutputScopes the set of scopes for which the fileOutputs setting is defined
    * @return the injected settings
    */
+  @nowarn
   private[this] def maybeAddOutputsAndFileStamps(
       setting: Def.Setting[_],
       fileOutputScopes: Set[Scope]
@@ -104,6 +105,8 @@ private[sbt] object Settings {
       case _ => Nil
     }
   }
+
+  @nowarn
   private[sbt] val inject: Def.ScopedKey[_] => Seq[Def.Setting[_]] = scopedKey =>
     scopedKey.key match {
       case transitiveDynamicInputs.key =>
@@ -138,6 +141,7 @@ private[sbt] object Settings {
    * @return a task definition that retrieves the file input files and their attributes scoped
    *         to a particular task.
    */
+  @nowarn
   private[sbt] def inputPathSettings(setting: Def.Setting[_]): Seq[Def.Setting[_]] = {
     val scopedKey = setting.key
     val scope = scopedKey.scope
@@ -168,6 +172,7 @@ private[sbt] object Settings {
    * @param scope the key whose file inputs we are seeking
    * @return a task definition that retrieves all of the input paths scoped to the input key.
    */
+  @nowarn
   private[this] def allFilesImpl(scope: Scope): Def.Setting[_] = {
     addTaskDefinition(Keys.allInputFiles in scope := {
       val filter =
@@ -187,6 +192,7 @@ private[sbt] object Settings {
    * @param scope the scope corresponding to the task whose fileInputs we are seeking
    * @return a task definition that retrieves the changed input files scoped to the key.
    */
+  @nowarn
   private[this] def changedInputFilesImpl(scope: Scope): List[Def.Setting[_]] =
     changedFilesImpl(scope, changedInputFiles, inputFileStamps) ::
       (watchForceTriggerOnAnyChange in scope := {
@@ -195,6 +201,8 @@ private[sbt] object Settings {
           case None    => false
         }
       }) :: Nil
+
+  @nowarn
   private[this] def changedFilesImpl(
       scope: Scope,
       changeKey: TaskKey[Seq[(Path, FileStamp)] => FileChanges],
@@ -242,6 +250,7 @@ private[sbt] object Settings {
    * @param scope the scope to add the custom clean
    * @return a task specific clean implementation
    */
+  @nowarn
   private[sbt] def cleanImpl(scope: Scope): Def.Setting[_] = addTaskDefinition {
     sbt.Keys.clean in scope := Clean.task(scope, full = false).value
   }
@@ -252,6 +261,7 @@ private[sbt] object Settings {
    * @param taskKey the task for which we add a custom clean implementation
    * @return a task specificic clean implementation
    */
+  @nowarn
   private[sbt] def cleanImpl[T: JsonFormat: ToSeqPath](taskKey: TaskKey[T]): Def.Setting[_] = {
     val taskScope = taskKey.scope in taskKey.key
     addTaskDefinition(sbt.Keys.clean in taskScope := Def.taskDyn {
@@ -299,6 +309,7 @@ private[sbt] object Settings {
     })
   }
 
+  @nowarn
   private[this] def outputsAndStamps[T: JsonFormat: ToSeqPath](
       taskKey: TaskKey[T]
   ): List[Def.Setting[_]] = {
@@ -306,6 +317,8 @@ private[sbt] object Settings {
     val changes = changedFilesImpl(scope, changedOutputFiles, outputFileStamps) :: Nil
     allOutputPathsImpl(scope) :: outputFileStampsImpl(scope) :: cleanImpl(taskKey) :: changes
   }
+
+  @nowarn
   private[this] def allOutputPathsImpl(scope: Scope): Def.Setting[_] =
     addTaskDefinition(allOutputFiles in scope := {
       val filter =
@@ -331,6 +344,8 @@ private[sbt] object Settings {
         fileOutputGlobs.exists(_.matches(p)) || !attributeFilter(p)
       }
     })
+
+  @nowarn
   private[this] def outputFileStampsImpl(scope: Scope): Def.Setting[_] =
     addTaskDefinition(outputFileStamps in scope := {
       val stamper: Path => Option[FileStamp] = (outputFileStamper in scope).value match {

--- a/main/src/main/scala/sbt/nio/Watch.scala
+++ b/main/src/main/scala/sbt/nio/Watch.scala
@@ -14,6 +14,7 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import sbt.BasicCommandStrings.{ ContinuousExecutePrefix, TerminateAction }
+import sbt.SlashSyntax0._
 import sbt._
 import sbt.internal.LabeledFunctions._
 import sbt.internal.nio.FileEvent
@@ -620,7 +621,7 @@ object Watch {
     watchStartMessage :== Watch.defaultStartWatch,
     watchTriggeredMessage :== Watch.defaultOnTriggerMessage,
     watchForceTriggerOnAnyChange :== false,
-    watchPersistFileStamps := (sbt.Keys.turbo in ThisBuild).value,
+    watchPersistFileStamps := (ThisBuild / sbt.Keys.turbo).value,
     watchTriggers :== Nil,
     watchAntiEntropyPollPeriod := Watch.defaultAntiEntropyPollPeriod,
   )

--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -46,7 +46,7 @@ object DependencyTreeSettings {
         // concatenating & inlining ivySbt & ivyModule default task implementations, as `SbtAccess.inTask` does
         // NOT correctly force the scope when applied to `TaskKey.toTask` instances (as opposed to raw
         // implementations like `Classpaths.mkIvyConfiguration` or `Classpaths.updateTask`)
-        val is = new IvySbt((ivyConfiguration in dependencyTreeIgnoreMissingUpdate).value)
+        val is = new IvySbt((dependencyTreeIgnoreMissingUpdate / ivyConfiguration).value)
         new is.Module(moduleSettings.value)
       },
       // don't fail on missing dependencies
@@ -161,7 +161,7 @@ object DependencyTreeSettings {
       key / asString := renderer(dependencyTreeModuleGraph0.value),
       key / toFile := {
         val (targetFile, force) = targetFileAndForceParser.parsed
-        writeToFile(key.key.label, (asString in key).value, targetFile, force, streams.value)
+        writeToFile(key.key.label, (key / asString).value, targetFile, force, streams.value)
       },
     )
 


### PR DESCRIPTION
Ref #6309

This deprecates the sbt 0.13 style `key in (Compile, intask)` syntax.

### Note

I've implemented semi-automatic update mechanism using Scalafix - https://eed3si9n.com/syntactic-scalafix-rule-for-unified-slash-syntax