### PR TITLE
Fix TastyFiles added twice in Test

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -694,6 +694,10 @@ object Defaults extends BuildCommon {
       else Def.task[Option[File]](None)
     }.value,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),
+    auxiliaryClassFiles ++= {
+      if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
+      else Nil
+    },
     consoleProject / scalaCompilerBridgeBinaryJar := None,
     consoleProject / scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(
       appConfiguration.value.provider.scalaProvider.version
@@ -702,7 +706,7 @@ object Defaults extends BuildCommon {
   // must be a val: duplication detected by object identity
   private[this] lazy val compileBaseGlobal: Seq[Setting[_]] = globalDefaults(
     Seq(
-      auxiliaryClassFiles := Nil,
+      auxiliaryClassFiles :== Nil,
       incOptions := IncOptions.of(),
       classpathOptions :== ClasspathOptionsUtil.boot,
       console / classpathOptions :== ClasspathOptionsUtil.repl,
@@ -905,10 +909,6 @@ object Defaults extends BuildCommon {
       compileAnalysisTargetRoot.value / compileAnalysisFilename.value
     },
     externalHooks := IncOptions.defaultExternal,
-    auxiliaryClassFiles ++= {
-      if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
-      else Nil
-    },
     incOptions := {
       val old = incOptions.value
       old

--- a/sbt/src/sbt-test/compiler-project/scala3-tasty-management/build.sbt
+++ b/sbt/src/sbt-test/compiler-project/scala3-tasty-management/build.sbt
@@ -1,3 +1,8 @@
+import xsbti.compile.TastyFiles
+
 ThisBuild / scalaVersion := "3.0.0-M2"
 
-lazy val root = project.in(file("."))
+TaskKey[Unit]("check") := {
+  assert((Compile / auxiliaryClassFiles).value == Seq(TastyFiles.instance))
+  assert((Test / auxiliaryClassFiles).value == Seq(TastyFiles.instance))
+}

--- a/sbt/src/sbt-test/compiler-project/scala3-tasty-management/test
+++ b/sbt/src/sbt-test/compiler-project/scala3-tasty-management/test
@@ -1,3 +1,4 @@
+> check
 > compile
 
 $ exists target/scala-3.0.0-M2/classes/A.tasty


### PR DESCRIPTION
```
Compile / auxiliaryClassFiles += TastyFiles.instance
Test / auxiliaryClassFiles += TastyFiles.instance
```
results in `TastyFiles` added twice in the `Test` config