### PR TITLE
Fix size of server running message

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -156,7 +156,7 @@ private[sbt] final class ProgressState(
 private[sbt] object ProgressState {
   private val SERVER_IS_RUNNING = "sbt server is running "
   // the + 2 is for the quotation marks
-  private val SERVER_IS_RUNNING_LENGTH = SERVER_IS_RUNNING.length + 2
+  private val SERVER_IS_RUNNING_LENGTH = SERVER_IS_RUNNING.length + 3
 
   /**
    * Receives a new task report and replaces the old one. In the event that the new
@@ -174,7 +174,6 @@ private[sbt] object ProgressState {
     val isRunning = terminal.prompt == Prompt.Running
     val isBatch = terminal.prompt == Prompt.Batch
     val isWatch = terminal.prompt == Prompt.Watch
-    val noPrompt = terminal.prompt == Prompt.NoPrompt
     if (terminal.isSupershellEnabled) {
       setShowProgress(true) // used by Zinc to not show "done compiling"
       if (!pe.skipIfActive.getOrElse(false) || (!isRunning && !isBatch)) {
@@ -193,8 +192,7 @@ private[sbt] object ProgressState {
             pe.command.toSeq.flatMap { cmd =>
               val width = terminal.getWidth
               val sanitized = if ((cmd.length + SERVER_IS_RUNNING_LENGTH) > width) {
-                if (SERVER_IS_RUNNING_LENGTH + cmd.length < width) cmd
-                else cmd.take(cmd.length - 3 - SERVER_IS_RUNNING_LENGTH) + "..."
+                cmd.take(width - 3 - SERVER_IS_RUNNING_LENGTH) + "..."
               } else cmd
               val tail = if (isWatch) Nil else "enter 'cancel' to stop evaluation" :: Nil
               s"$SERVER_IS_RUNNING '$sanitized'" :: tail


### PR DESCRIPTION
Fixes #6333 

The message is truncated to fit a single line.

![sbt-bsp-fixed](https://user-images.githubusercontent.com/13123162/109032938-73014f80-76c6-11eb-97b8-a939d04da815.gif)
