### PR TITLE
Publish all plugin dependencies

### DIFF
--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -14,6 +14,7 @@ import sbt.Def._
 import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.Project._
+import sbt.ScopeFilter.Make._
 import sbt.SlashSyntax0._
 import sbt.internal.inc.ModuleUtilities
 import sbt.internal.inc.classpath.ClasspathUtil
@@ -94,7 +95,7 @@ object ScriptedPlugin extends AutoPlugin {
     scriptedDependencies := {
       def use[A](@deprecated("unused", "") x: A*): Unit = () // avoid unused warnings
       val analysis = (Test / Keys.compile).value
-      val pub = (publishLocal).value
+      val pub = publishLocal.all(ScopeFilter(projects = inDependencies(ThisProject))).value
       use(analysis, pub)
     },
     scripted := scriptedTask.evaluated,

--- a/sbt/src/sbt-test/project/scripted-dependencies/build.sbt
+++ b/sbt/src/sbt-test/project/scripted-dependencies/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file("."))
+  .enablePlugins(SbtPlugin)
+  .dependsOn(lib)
+
+lazy val lib = project in file("lib")

--- a/sbt/src/sbt-test/project/scripted-dependencies/project/plugins.sbt
+++ b/sbt/src/sbt-test/project/scripted-dependencies/project/plugins.sbt
@@ -1,0 +1,3 @@
+libraryDependencies += {
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+}

--- a/sbt/src/sbt-test/project/scripted-dependencies/test
+++ b/sbt/src/sbt-test/project/scripted-dependencies/test
@@ -1,0 +1,2 @@
+$ copy-file test-files/test src/sbt-test/group/name/test
+> scripted

--- a/sbt/src/sbt-test/project/scripted-dependencies/test-files/test
+++ b/sbt/src/sbt-test/project/scripted-dependencies/test-files/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
If the plugin depends on another project then scripted tests fail as the scriptedDependencies only publishes the plugin. This publishes the plugin and its dependencies.

I couldn't get the test to work. Maybe that is why the others are disabled?