### PR TITLE
Fix sourcePositionMappers added by Play not getting called

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1033,6 +1033,8 @@ lazy val mainProj = (project in file("main"))
       // internal impl
       exclude[IncompatibleSignatureProblem]("sbt.internal.Act.configIdent"),
       exclude[IncompatibleSignatureProblem]("sbt.internal.Act.taskAxis"),
+      // private[sbt] method, used to call the correct sourcePositionMapper
+      exclude[DirectMissingMethodProblem]("sbt.Defaults.foldMappers"),
     )
   )
   .configure(

--- a/sbt/src/sbt-test/reporter/source-mapper/build.sbt
+++ b/sbt/src/sbt-test/reporter/source-mapper/build.sbt
@@ -1,46 +1,41 @@
-import java.util.Optional
-import xsbti.Position
+import sbt.internal.util.ConsoleAppender
+
+extraAppenders := { s => Seq(ConsoleAppender(FakePrintWriter)) }
+
+val assertEmptySourcePositionMappers = taskKey[Unit]("checks that sourcePositionMappers is empty")
 
 val assertAbsolutePathConversion = taskKey[Unit]("checks source mappers convert to absolute path")
 
-val assertHandleFakePos = taskKey[Unit]("checks source mappers handle fake position")
+val assertVirtualFile = taskKey[Unit]("checks source mappers handle virtual files")
+
+val resetMessages = taskKey[Unit]("empties the messages list")
+
+assertEmptySourcePositionMappers := {
+  assert {
+    sourcePositionMappers.value.isEmpty
+  }
+}
 
 assertAbsolutePathConversion := {
-  val converter = fileConverter.value
   val source = (Compile/sources).value.head
-  val position = newPosition(converter.toVirtualFile(source.toPath).id, source)
-  val mappedPos = sourcePositionMappers.value
-    .foldLeft(Option(position)) {
-      case (pos, mapper) => pos.flatMap(mapper)
-    }
   assert {
-    mappedPos.get.sourcePath.asScala.contains(source.getAbsolutePath)
+    FakePrintWriter.messages.exists(_.contains(s"${source.getAbsolutePath}:3:15: comparing values of types Int and String using `==` will always yield false"))
+  }
+  assert {
+    FakePrintWriter.messages.forall(!_.contains("${BASE}"))
   }
 }
 
-assertHandleFakePos := {
-  val position = newPosition("<macro>", new File("<macro>"))
-  val mappedPos = sourcePositionMappers.value
-    .foldLeft(Option(position)) {
-      case (pos, mapper) => pos.flatMap(mapper)
-    }
+assertVirtualFile := {
+  val source = (Compile/sources).value.head
   assert {
-    mappedPos.get.sourcePath.asScala.get.contains("<macro>")
+    FakePrintWriter.messages.exists(_.contains("${BASE}/src/main/scala/Foo.scala:3:15: comparing values of types Int and String using `==` will always yield false"))
+  }
+  assert {
+    FakePrintWriter.messages.forall(!_.contains(source.getAbsolutePath))
   }
 }
 
-def newPosition(path: String, file: File): Position = new Position {
-  override def line(): Optional[Integer] = Optional.empty()
-
-  override def lineContent() = ""
-
-  override def offset(): Optional[Integer] = Optional.empty()
-
-  override def pointer(): Optional[Integer] = Optional.empty()
-
-  override def pointerSpace(): Optional[String] = Optional.empty()
-
-  override def sourcePath(): Optional[String] = Optional.of(path)
-
-  override def sourceFile(): Optional[File] = Optional.of(file)
+resetMessages := {
+  FakePrintWriter.resetMessages
 }

--- a/sbt/src/sbt-test/reporter/source-mapper/project/FakePrintWriter.scala
+++ b/sbt/src/sbt-test/reporter/source-mapper/project/FakePrintWriter.scala
@@ -1,0 +1,6 @@
+object FakePrintWriter extends java.io.PrintWriter("fake-print-writer") {
+  @volatile var messages = List.empty[String]
+  def resetMessages = messages = List.empty[String]
+  override def println(x: String): Unit = messages = x :: messages
+  override def print(x: String): Unit = messages = x :: messages
+}

--- a/sbt/src/sbt-test/reporter/source-mapper/src/main/scala/Foo.scala
+++ b/sbt/src/sbt-test/reporter/source-mapper/src/main/scala/Foo.scala
@@ -1,0 +1,4 @@
+object Foo {
+  // Will cause a warning
+  val bar = 1 == ""
+}

--- a/sbt/src/sbt-test/reporter/source-mapper/test
+++ b/sbt/src/sbt-test/reporter/source-mapper/test
@@ -1,2 +1,12 @@
+> assertEmptySourcePositionMappers
+
+> printWarnings
 > assertAbsolutePathConversion
-> assertHandleFakePos
+
+> resetMessages
+
+> set reportAbsolutePath := false
+> printWarnings
+> assertVirtualFile
+
+> resetMessages


### PR DESCRIPTION
Setting a default for `sourcePositionMappers` (done in #5857) is a very, _very_ bad idea.
Such a default sourcePositionMapper acts as a "catch all" when "resolving" the sourcePositionMappers setting, therefore sourcePositionMappers that were added by Applications or Framworks (like Play) will _never_ have the chance to get called.
Concrete example: A typical Play application adds following two sourcePositionMappers:
- The twirl one: https://github.com/playframework/twirl/blob/1.5.0/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala#L72
  - Used to map a generated twirl template in the target folder (like `*.template.scala`) to its origin twirl template (`*.scala.html` files)
- The routes compiler one: https://github.com/playframework/playframework/blob/2.8.7/dev-mode/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala#L138
   - Used to map a generated routes file in the target folder (like `Routes.scala`) to its origin routes file (usually `conf/routes`)

We end up with following list of sourcePositionMappers, in this order:
`(the default one)` -> `(the twirl one)` -> `(the routes one)`

Usually if a sourcePositionMapper can not map a file it will return `None` and thanks to the `foldMappers` method that build that chain the next mapper will be tried. However the default sourcePositionMapper will never ever continue to the other mappers, because it will always return a position (see the `toAbsoluteSourceMapper` it will always return `Some`) (Also because `reportAbsolutePath` is true by default...)

The solution to this problem is to _never_ add a default sourcePositionMapper, but instead it should fall back to the default one in case no `sourcePositionMappers` was set at all by an application *and* to pass the modified position with the absolute source to the existing mappers:
`(the twirl one with absolute source passed)` -> `(the routes one with absolute source passed)` -> `(the default one)`