### PR TITLE
Add system property to override semanticdb version

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -93,8 +93,10 @@ object SysProp {
   def ci: Boolean = getOrFalse("sbt.ci")
   def allowRootDir: Boolean = getOrFalse("sbt.rootdir")
   def legacyTestReport: Boolean = getOrFalse("sbt.testing.legacyreport")
-  def semanticdb: Boolean = getOrFalse("sbt.semanticdb")
   def forceServerStart: Boolean = getOrFalse("sbt.server.forcestart")
+
+  def semanticdb: Boolean = getOrFalse("sbt.semanticdb")
+  def semanticdbVersion: Option[String] = sys.props.get("sbt.semanticdb.version")
 
   def watchMode: String =
     sys.props.get("sbt.watch.mode").getOrElse("auto")

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -26,7 +26,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.4.10"
+    semanticdbVersion := SysProp.semanticdbVersion.getOrElse("4.4.10")
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
While it is possible to change the version using an sbt setting, having a sysprop helps when enabling semanticdb for some projects using a Scala a version that is not supported by the default version defined in sbt.

For example, users will be able to do something like:

    sbt -Dsbt.semanticdb=true -Dsbt.semanticdb.version=4.4.10

#6144 is an example where this fixed would be used without requiring any changes to the project.
