### PR TITLE
[1.4.x] Give an explanation in case of ServerAlreadyBootingException

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -345,7 +345,7 @@ public class BootServerSocket implements AutoCloseable {
               : new UnixDomainServerSocket(name, jni);
       return socket;
     } catch (final IOException e) {
-      throw new ServerAlreadyBootingException();
+      throw new ServerAlreadyBootingException(e);
     }
   }
 

--- a/main-command/src/main/java/sbt/internal/ServerAlreadyBootingException.java
+++ b/main-command/src/main/java/sbt/internal/ServerAlreadyBootingException.java
@@ -7,4 +7,11 @@
 
 package sbt.internal;
 
-public class ServerAlreadyBootingException extends Exception {}
+import java.io.IOException;
+
+public class ServerAlreadyBootingException extends Exception {
+
+  public ServerAlreadyBootingException(IOException e) {
+    super(e);
+  }
+}

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -119,9 +119,11 @@ private[sbt] object xMain {
   ): (Option[BootServerSocket], Option[Exit]) =
     try (Some(new BootServerSocket(configuration)) -> None)
     catch {
-      case _: ServerAlreadyBootingException
+      case e: ServerAlreadyBootingException
           if System.console != null && !ITerminal.startedByRemoteClient =>
-        println("sbt server is already booting. Create a new server? y/n (default y)")
+        println(
+          s"sbt thinks that server is already booting because of this exception:\n${e.getCause}\nCreate a new server? y/n (default y)"
+        )
         val exit = ITerminal.get.withRawInput(System.in.read) match {
           case 110 => Some(Exit(1))
           case _   => None


### PR DESCRIPTION
This is a backport of #6353 by @sideeffffect 
Ref https://github.com/sbt/sbt/issues/6101

Give and explanation in case of ServerAlreadyBootingException