### PR TITLE
Make sure to also pass absolute sourceFile to sourceMappers

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -474,16 +474,16 @@ object Defaults extends BuildCommon {
       Try(Paths.get(path)).map(_ => true).getOrElse(false)
     }
 
-    val newPath: Option[String] = pos
+    val absSource: Option[File] = pos
       .sourcePath()
       .asScala
       .filter(isValid)
       .map { path =>
-        fc.toPath(VirtualFileRef.of(path)).toAbsolutePath.toString
+        fc.toPath(VirtualFileRef.of(path)).toAbsolutePath.toFile
       }
 
-    newPath
-      .map { path =>
+    absSource
+      .map { file =>
         new Position {
           override def line(): Optional[Integer] = pos.line()
 
@@ -495,9 +495,9 @@ object Defaults extends BuildCommon {
 
           override def pointerSpace(): Optional[String] = pos.pointerSpace()
 
-          override def sourcePath(): Optional[String] = Optional.of(path)
+          override def sourcePath(): Optional[String] = Optional.of(file.getAbsolutePath)
 
-          override def sourceFile(): Optional[File] = pos.sourceFile()
+          override def sourceFile(): Optional[File] = Optional.of(file)
 
           override def startOffset(): Optional[Integer] = pos.startOffset()
 


### PR DESCRIPTION
When passing the `Position` to the `sourcePositionMapper(s)`, we currently only convert  the `sourcePath` _String_ to be absolute. E.g. `${BASE}/some/file.txt` becomes `/home/user/some_project/some/file.txt` (because that was originally needed to fix #5853 where we just cared about the output in the logs, where the `sourcePath` _String_ is used).
However we also need/should make sure that the `sourceFile` _File_ object represents the absolute file to
1) stay in sync with the `sourcePath` _String_ (it would be a bit weird if a `sourcePositionMapper` receives the _`sourcePath`_ String  `/home/user/some_project/some/file.txt` but the _`sourceFile`_ object `${BASE}/some/file.txt`) (Yes that is possible, I just experienced this in Play)
2) for backward compatibility we shouldn't pass a _`sourceFile`_ object `${BASE}/some/file.txt` to a `sourcePositionMappers`, I mean why should a `sourcePositionMappers`, that each app and framework can set up, care about the virtual file internals in sbt? `sourcePositionMappers` should just recive a normal file object, without any `${BASE}` stuff inside (Not sure, but I would guess it's possible some apps that don't handle that ${base} stuff in their sourcepositionmappers are currently broken...)