### PR TITLE
Work around "a pure expression does nothing" warning, take 3

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -201,7 +201,8 @@ object Instance {
     val tx = util.transformWrappers(tree, (n, tpe, t, replace) => sub(n, tpe, t, replace))
     // resetting attributes must be: a) local b) done here and not wider or else there are obscure errors
     val tr = makeApp(inner(tx))
-    c.Expr[i.M[N[T]]](tr)
+    val noWarn = q"""($tr: @scala.annotation.nowarn("cat=other-pure-statement"))"""
+    c.Expr[i.M[N[T]]](noWarn)
   }
 
   import Types._


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6161
Ref https://github.com/scala/bug/issues/12112

This uses the configurable warning backported to Scala 2.12.