### PR TITLE
JLine 3.19.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
   val sjsonNewMurmurhash = sjsonNew("sjson-new-murmurhash")
 
   val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-42b717d4418374417765c7651dca69b1b75d8b84"
-  val jline3Version = "3.17.1"
+  val jline3Version = "3.19.0"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
   val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6348

Intentionally or unintentionally the JLine 3 leaks over from sbt to
Scala REPL currently.
I think this enables things like sbtn to transmit tab completion and
other console interaction over a socket to sbt server.
Scala 2.13.5 REPL now causes some issue of displaying warning
each time the user hits tab for tab completion.
This works around the issue by upgrading to the latest JLine 3.