### PR TITLE
Add support for custom protocol with coursier

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -271,6 +271,7 @@ object Defaults extends BuildCommon {
       csrLogger := LMCoursier.coursierLoggerTask.value,
       csrMavenProfiles :== Set.empty,
       csrReconciliations :== LMCoursier.relaxedForAllModules,
+      csrProtocolHandlerDependencies :== Nil,
     )
 
   /** Core non-plugin settings for sbt builds.  These *must* be on every build or the sbt engine will fail to run at all. */

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -445,6 +445,7 @@ object Keys {
   val csrExtraCredentials = taskKey[Seq[lmcoursier.credentials.Credentials]]("")
   val csrPublications = taskKey[Seq[(lmcoursier.definitions.Configuration, lmcoursier.definitions.Publication)]]("")
   val csrReconciliations = settingKey[Seq[(ModuleMatchers, Reconciliation)]]("Strategy to reconcile version conflicts.")
+  val csrProtocolHandlerDependencies = settingKey[Seq[ModuleID]]("Dependency to fetch to be able to load custom protocols.")
 
   val internalConfigurationMap = settingKey[Configuration => Configuration]("Maps configurations to the actual configuration used to define the classpath.").withRank(CSetting)
   val classpathConfiguration = taskKey[Configuration]("The configuration used to define the classpath.").withRank(CTask)

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -93,7 +93,8 @@ object LMCoursier {
       ivyHome: Option[File],
       strict: Option[CStrict],
       depsOverrides: Seq[ModuleID],
-      log: Logger
+      log: Logger,
+      protocolHandlerDependencies: Seq[ModuleID]
   ): CoursierConfiguration =
     coursierConfiguration(
       rs,
@@ -117,7 +118,8 @@ object LMCoursier {
       strict,
       depsOverrides,
       None,
-      log
+      log,
+      protocolHandlerDependencies
     )
 
   def coursierConfiguration(
@@ -142,7 +144,8 @@ object LMCoursier {
       strict: Option[CStrict],
       depsOverrides: Seq[ModuleID],
       updateConfig: Option[UpdateConfiguration],
-      log: Logger
+      log: Logger,
+      protocolHandlerDependencies: Seq[ModuleID],
   ): CoursierConfiguration = {
     val coursierExcludeDeps = Inputs
       .exclusions(
@@ -195,6 +198,7 @@ object LMCoursier {
       .withStrict(strict)
       .withForceVersions(userForceVersions.toVector)
       .withMissingOk(missingOk)
+      .withProtocolHandlerDependencies(protocolHandlerDependencies)
   }
 
   def coursierConfigurationTask: Def.Initialize[Task[CoursierConfiguration]] = Def.task {
@@ -221,7 +225,8 @@ object LMCoursier {
       CoursierInputsTasks.strictTask.value,
       dependencyOverrides.value,
       Some(updateConfiguration.value),
-      streams.value.log
+      streams.value.log,
+      csrProtocolHandlerDependencies.value,
     )
   }
 
@@ -249,7 +254,8 @@ object LMCoursier {
       CoursierInputsTasks.strictTask.value,
       dependencyOverrides.value,
       Some(updateConfiguration.value),
-      streams.value.log
+      streams.value.log,
+      csrProtocolHandlerDependencies.value
     )
   }
 
@@ -277,7 +283,8 @@ object LMCoursier {
       CoursierInputsTasks.strictTask.value,
       dependencyOverrides.value,
       Some(updateConfiguration.value),
-      streams.value.log
+      streams.value.log,
+      csrProtocolHandlerDependencies.value,
     )
   }
 
@@ -305,7 +312,8 @@ object LMCoursier {
       CoursierInputsTasks.strictTask.value,
       dependencyOverrides.value,
       Some(updateConfiguration.value),
-      streams.value.log
+      streams.value.log,
+      csrProtocolHandlerDependencies.value,
     )
   }
 


### PR DESCRIPTION
In coursier, you can handle custom protocols by defining a protocol handler:
https://get-coursier.io/docs/2.0.10/extra.html#extra-protocols
https://github.com/coursier/coursier/blob/ce251d0288bf029e4eeb8700e8990178559a005d/modules/tests/jvm/src/test/scala/coursier/cache/protocol/TestprotocolHandler.scala

I'm currently implementing support for Google Artifact Resitory:
https://github.com/coursier/coursier/issues/1987#issuecomment-792894989

When dealing with artifact with protocol `artifactregistry` I need to have a plugin available in the classpath. Since lmcoursier is in the sbt launcher classpath, it's not available by adding `libraryDependencies += ...` in `project/plugins.sbt` like you would do for an sbt plugin. Therefore, I propose a way to explicitly declare the artifacts you need to handle the protocol handling.

Users of custom protocol can now specify dependencies to their handler via this sbt setting:


```scala
csrProtocolHandlerDependencies += "org.example" % "google-artifact-repository-coursier" % "0.1.0"
```

Depends on https://github.com/coursier/sbt-coursier/pull/327