### PR TITLE
Improve BSP processing logs

### DIFF
--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -205,8 +205,10 @@ object MainLoop {
   def processCommand(exec: Exec, state: State): State = {
     val channelName = exec.source map (_.channelName)
     val exchange = StandardMain.exchange
-    exchange notifyStatus
+    exchange.setState(state)
+    exchange.notifyStatus(
       ExecStatusEvent("Processing", channelName, exec.execId, Vector())
+    )
     try {
       def process(): State = {
         val progressState = state.get(sbt.Keys.currentTaskProgress) match {

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -256,7 +256,7 @@ object BuildServerProtocol {
             val _ = callback.appendExec(Keys.bspWorkspaceBuildTargets.key.toString, Some(r.id))
 
           case r: JsonRpcRequestMessage if r.method == "workspace/reload" =>
-            val _ = callback.appendExec(s"$bspReload ${r.id}", None)
+            val _ = callback.appendExec(s"$bspReload ${r.id}", Some(r.id))
 
           case r: JsonRpcRequestMessage if r.method == "build/shutdown" =>
             callback.jsonRpcRespond(JNull, Some(r.id))


### PR DESCRIPTION
Fixes #6334 
Fixes https://youtrack.jetbrains.com/issue/SCL-18723

- A processing log is sent when the command being processed has been issued by a server request
- The processing log is not sent if the request has already been responded.
- The processing log has the lowest severity level
- The processing log relates to its request

In Metals:
![image](https://user-images.githubusercontent.com/13123162/110451358-69171d80-80c4-11eb-8855-1a79afb893a1.png)

In Intellij:
![image](https://user-images.githubusercontent.com/13123162/110451582-9ebc0680-80c4-11eb-81e5-92d472812746.png)

