### PR TITLE
Environment variables support in BSP debug session

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -503,7 +503,10 @@ object BuildServerProtocol {
               ErrorCodes.ParseError,
               e.getMessage
             )
-          case Success(value) => value
+          case Success(value) =>
+            value.withEnvironmentVariables(
+              envVars.value.map { case (k, v) => s"$k=$v" }.toVector ++ value.environmentVariables
+            )
         }
 
       case Some(dataKind) =>
@@ -522,7 +525,7 @@ object BuildServerProtocol {
           ),
           runParams.arguments,
           defaultJvmOptions.toVector,
-          Vector.empty
+          envVars.value.map { case (k, v) => s"$k=$v" }.toVector
         )
     }
 
@@ -588,7 +591,7 @@ object BuildServerProtocol {
       workingDirectory = Some(baseDirectory.value),
       runJVMOptions = mainClass.jvmOptions,
       connectInput = connectInput.value,
-      envVars = envVars.value ++ mainClass.environmentVariables
+      envVars = mainClass.environmentVariables
         .flatMap(_.split("=", 2).toList match {
           case key :: value :: Nil => Some(key -> value)
           case _                   => None
@@ -655,7 +658,12 @@ object BuildServerProtocol {
   private def scalaMainClassesTask: Initialize[Task[ScalaMainClassesItem]] = Def.task {
     val jvmOptions = Keys.javaOptions.value.toVector
     val mainClasses = Keys.discoveredMainClasses.value.map(
-      ScalaMainClass(_, Vector(), jvmOptions, Vector.empty)
+      ScalaMainClass(
+        _,
+        Vector(),
+        jvmOptions,
+        envVars.value.map { case (k, v) => s"$k=$v" }.toVector
+      )
     )
     ScalaMainClassesItem(
       bspTargetIdentifier.value,

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClass.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/ScalaMainClass.scala
@@ -8,26 +8,28 @@ package sbt.internal.bsp
  * @param class The main class to run.
  * @param arguments The user arguments to the main entrypoint.
  * @param jvmOptions The jvm options for the application.
+ * @param environmentVariables Additional environment variables for the application.
  */
 final class ScalaMainClass private (
   val `class`: String,
   val arguments: Vector[String],
-  val jvmOptions: Vector[String]) extends Serializable {
+  val jvmOptions: Vector[String],
+  val environmentVariables: Vector[String]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: ScalaMainClass => (this.`class` == x.`class`) && (this.arguments == x.arguments) && (this.jvmOptions == x.jvmOptions)
+    case x: ScalaMainClass => (this.`class` == x.`class`) && (this.arguments == x.arguments) && (this.jvmOptions == x.jvmOptions) && (this.environmentVariables == x.environmentVariables)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClass".##) + `class`.##) + arguments.##) + jvmOptions.##)
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.ScalaMainClass".##) + `class`.##) + arguments.##) + jvmOptions.##) + environmentVariables.##)
   }
   override def toString: String = {
-    "ScalaMainClass(" + `class` + ", " + arguments + ", " + jvmOptions + ")"
+    "ScalaMainClass(" + `class` + ", " + arguments + ", " + jvmOptions + ", " + environmentVariables + ")"
   }
-  private[this] def copy(`class`: String = `class`, arguments: Vector[String] = arguments, jvmOptions: Vector[String] = jvmOptions): ScalaMainClass = {
-    new ScalaMainClass(`class`, arguments, jvmOptions)
+  private[this] def copy(`class`: String = `class`, arguments: Vector[String] = arguments, jvmOptions: Vector[String] = jvmOptions, environmentVariables: Vector[String] = environmentVariables): ScalaMainClass = {
+    new ScalaMainClass(`class`, arguments, jvmOptions, environmentVariables)
   }
   def withClass(`class`: String): ScalaMainClass = {
     copy(`class` = `class`)
@@ -38,8 +40,11 @@ final class ScalaMainClass private (
   def withJvmOptions(jvmOptions: Vector[String]): ScalaMainClass = {
     copy(jvmOptions = jvmOptions)
   }
+  def withEnvironmentVariables(environmentVariables: Vector[String]): ScalaMainClass = {
+    copy(environmentVariables = environmentVariables)
+  }
 }
 object ScalaMainClass {
   
-  def apply(`class`: String, arguments: Vector[String], jvmOptions: Vector[String]): ScalaMainClass = new ScalaMainClass(`class`, arguments, jvmOptions)
+  def apply(`class`: String, arguments: Vector[String], jvmOptions: Vector[String], environmentVariables: Vector[String]): ScalaMainClass = new ScalaMainClass(`class`, arguments, jvmOptions, environmentVariables)
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/ScalaMainClassFormats.scala
@@ -14,8 +14,9 @@ implicit lazy val ScalaMainClassFormat: JsonFormat[sbt.internal.bsp.ScalaMainCla
       val `class` = unbuilder.readField[String]("class")
       val arguments = unbuilder.readField[Vector[String]]("arguments")
       val jvmOptions = unbuilder.readField[Vector[String]]("jvmOptions")
+      val environmentVariables = unbuilder.readField[Vector[String]]("environmentVariables")
       unbuilder.endObject()
-      sbt.internal.bsp.ScalaMainClass(`class`, arguments, jvmOptions)
+      sbt.internal.bsp.ScalaMainClass(`class`, arguments, jvmOptions, environmentVariables)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -25,6 +26,7 @@ implicit lazy val ScalaMainClassFormat: JsonFormat[sbt.internal.bsp.ScalaMainCla
     builder.addField("class", obj.`class`)
     builder.addField("arguments", obj.arguments)
     builder.addField("jvmOptions", obj.jvmOptions)
+    builder.addField("environmentVariables", obj.environmentVariables)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -631,4 +631,7 @@ type ScalaMainClass {
 
   ## The jvm options for the application.
   jvmOptions: [String]
+
+  ## Additional environment variables for the application.
+  environmentVariables: [String]
 }


### PR DESCRIPTION
Fixes #6396 
Very basic parser for `"key=value"` strings, but it is how metals generate them https://github.com/scalameta/metals/blob/3ada84f575f4a7ca82f4eefad32d2e21d03b349a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala#L188