### PR TITLE
Silence unused-nowarn in meta-build

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1172,6 +1172,7 @@ private[sbt] object Load {
           opts
         )
       },
+      scalacOptions += "-Wconf:cat=unused-nowarn:s",
       onLoadMessage := ("loading project definition from " + baseDirectory.value)
     )
   )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6398

It would be better to have https://github.com/scala/scala/pull/9491 in 2.12 but we don't have it yet.