### PR TITLE
Launcher 1.3.0-M3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   private val libraryManagementCore = "org.scala-sbt" %% "librarymanagement-core" % lmVersion
   private val libraryManagementIvy = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion
 
-  val launcherVersion = "1.3.0-M2"
+  val launcherVersion = "1.3.0-M3"
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"


### PR DESCRIPTION
This bring in the fixes for 1.5.0-RC1 regressions:
- https://github.com/sbt/launcher/pull/89
- https://github.com/sbt/launcher/pull/92
- https://github.com/sbt/launcher/pull/93