### PR TITLE
[1.4.x] Instantiate only test runners needed by current testDefinitions

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -23,15 +23,13 @@ import sbt.internal.util.{ RunningProcesses, Terminal }
 private[sbt] object ForkTests {
   def apply(
       runners: Map[TestFramework, Runner],
-      tests: Vector[TestDefinition],
+      opts: ProcessedOptions,
       config: Execution,
       classpath: Seq[File],
       fork: ForkOptions,
       log: Logger,
       tags: (Tag, Int)*
   ): Task[TestOutput] = {
-    val opts = processOptions(config, tests, log)
-
     import std.TaskExtra._
     val dummyLoader = this.getClass.getClassLoader // can't provide the loader for test classes, which is in another jvm
     def all(work: Seq[ClassLoader => Unit]) = work.fork(f => f(dummyLoader))
@@ -48,14 +46,14 @@ private[sbt] object ForkTests {
 
   def apply(
       runners: Map[TestFramework, Runner],
-      tests: Vector[TestDefinition],
+      opts: ProcessedOptions,
       config: Execution,
       classpath: Seq[File],
       fork: ForkOptions,
       log: Logger,
       tag: Tag
   ): Task[TestOutput] = {
-    apply(runners, tests, config, classpath, fork, log, tag -> 1)
+    apply(runners, opts, config, classpath, fork, log, tag -> 1)
   }
 
   private[this] def mainTestTask(

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -46,14 +46,27 @@ private[sbt] object ForkTests {
 
   def apply(
       runners: Map[TestFramework, Runner],
-      opts: ProcessedOptions,
+      tests: Vector[TestDefinition],
+      config: Execution,
+      classpath: Seq[File],
+      fork: ForkOptions,
+      log: Logger,
+      tags: (Tag, Int)*
+  ): Task[TestOutput] = {
+    val opts: Tests.ProcessedOptions = processOptions(config.options, tests, log)
+    apply(runners, opts, config, classpath, fork, log, tags: _*)
+  }
+
+  def apply(
+      runners: Map[TestFramework, Runner],
+      tests: Vector[TestDefinition],
       config: Execution,
       classpath: Seq[File],
       fork: ForkOptions,
       log: Logger,
       tag: Tag
   ): Task[TestOutput] = {
-    apply(runners, opts, config, classpath, fork, log, tag -> 1)
+    apply(runners, tests, config, classpath, fork, log, tag -> 1)
   }
 
   private[this] def mainTestTask(

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -53,7 +53,7 @@ private[sbt] object ForkTests {
       log: Logger,
       tags: (Tag, Int)*
   ): Task[TestOutput] = {
-    val opts: Tests.ProcessedOptions = processOptions(config.options, tests, log)
+    val opts: Tests.ProcessedOptions = processOptions(config, tests, log)
     apply(runners, opts, config, classpath, fork, log, tags: _*)
   }
 

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -325,6 +325,18 @@ object Tests {
     )
   }
 
+  def apply(
+      frameworks: Map[TestFramework, Framework],
+      testLoader: ClassLoader,
+      runners: Map[TestFramework, Runner],
+      discovered: Vector[TestDefinition],
+      config: Execution,
+      log: ManagedLogger
+  ): Task[Output] = {
+    val o = processOptions(config.options, discovered, log)
+    apply(frameworks, testLoader, runners, o, config, log)
+  }
+
   def testTask(
       loader: ClassLoader,
       frameworks: Map[TestFramework, Framework],

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -249,7 +249,7 @@ object Tests {
       val testListeners: Vector[TestReportListener]
   )
   private[sbt] def processOptions(
-      options: Seq[TestOption],
+      config: Execution,
       discovered: Vector[TestDefinition],
       log: Logger
   ): ProcessedOptions = {
@@ -261,7 +261,7 @@ object Tests {
     val testListeners = new ListBuffer[TestReportListener]
     val undefinedFrameworks = new ListBuffer[String]
 
-    for (option <- options) {
+    for (option <- config.options) {
       option match {
         case Filter(include) => testFilters += include; ()
         case Filters(includes) =>
@@ -333,7 +333,7 @@ object Tests {
       config: Execution,
       log: ManagedLogger
   ): Task[Output] = {
-    val o = processOptions(config.options, discovered, log)
+    val o = processOptions(config, discovered, log)
     apply(frameworks, testLoader, runners, o, config, log)
   }
 

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -249,7 +249,7 @@ object Tests {
       val testListeners: Vector[TestReportListener]
   )
   private[sbt] def processOptions(
-      config: Execution,
+      options: Seq[TestOption],
       discovered: Vector[TestDefinition],
       log: Logger
   ): ProcessedOptions = {
@@ -261,7 +261,7 @@ object Tests {
     val testListeners = new ListBuffer[TestReportListener]
     val undefinedFrameworks = new ListBuffer[String]
 
-    for (option <- config.options) {
+    for (option <- options) {
       option match {
         case Filter(include) => testFilters += include; ()
         case Filters(includes) =>
@@ -308,11 +308,10 @@ object Tests {
       frameworks: Map[TestFramework, Framework],
       testLoader: ClassLoader,
       runners: Map[TestFramework, Runner],
-      discovered: Vector[TestDefinition],
+      o: ProcessedOptions,
       config: Execution,
       log: ManagedLogger
   ): Task[Output] = {
-    val o = processOptions(config, discovered, log)
     testTask(
       testLoader,
       frameworks,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1423,7 +1423,7 @@ object Defaults extends BuildCommon {
     val processedOptions: Map[Tests.Group, Tests.ProcessedOptions] =
       groups
         .map(
-          group => group -> Tests.processOptions(config.options, group.tests.toVector, s.log)
+          group => group -> Tests.processOptions(config, group.tests.toVector, s.log)
         )
         .toMap
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1419,7 +1419,27 @@ object Defaults extends BuildCommon {
       strategy: ClassLoaderLayeringStrategy,
       projectId: String
   ): Initialize[Task[Tests.Output]] = {
-    val runners = createTestRunners(frameworks, loader, config)
+
+    val processedOptions: Map[Tests.Group, Tests.ProcessedOptions] =
+      groups
+        .map(
+          group => group -> Tests.processOptions(config.options, group.tests.toVector, s.log)
+        )
+        .toMap
+
+    val testDefinitions: Iterable[TestDefinition] = processedOptions.values.flatMap(_.tests)
+
+    val filteredFrameworks: Map[TestFramework, Framework] = frameworks.filter {
+      case (_, framework) =>
+        TestFramework.getFingerprints(framework).exists { t =>
+          testDefinitions.exists { test =>
+            TestFramework.matches(t, test.fingerprint)
+          }
+        }
+    }
+
+    val runners = createTestRunners(filteredFrameworks, loader, config)
+
     val groupTasks = groups map { group =>
       group.runPolicy match {
         case Tests.SubProcess(opts) =>
@@ -1428,7 +1448,7 @@ object Defaults extends BuildCommon {
           s.log.debug(s"Forking tests - parallelism = ${forkedConfig.parallel}")
           ForkTests(
             runners,
-            group.tests.toVector,
+            processedOptions(group),
             forkedConfig,
             cp.files,
             opts,
@@ -1443,7 +1463,7 @@ object Defaults extends BuildCommon {
             frameworks,
             loader,
             runners,
-            group.tests.toVector,
+            processedOptions(group),
             config.copy(tags = config.tags ++ group.tags),
             s.log
           )

--- a/sbt/src/sbt-test/tests/filter-runners/build.sbt
+++ b/sbt/src/sbt-test/tests/filter-runners/build.sbt
@@ -1,0 +1,9 @@
+val scalatest = "org.scalatest" %% "scalatest" % "3.2.2"
+val munit = "org.scalameta" %% "munit" % "0.7.22"
+
+ThisBuild / scalaVersion := "2.12.12"
+
+libraryDependencies += scalatest % Test
+libraryDependencies += munit % Test
+
+testFrameworks += new TestFramework("munit.Framework")

--- a/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/MunitSpec.scala
+++ b/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/MunitSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import munit.FunSuite
+
+class Spec extends FunSuite {
+  test("munit should work") {
+    assertEquals(1, 1)
+  }
+}

--- a/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/ScalaTestSpec.scala
+++ b/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/ScalaTestSpec.scala
@@ -1,0 +1,10 @@
+package example
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScalaTestSpec extends AnyFlatSpec with Matchers {
+  "ScalaTest" should "work" in {
+    1 shouldBe 1
+  }
+}

--- a/sbt/src/sbt-test/tests/filter-runners/test
+++ b/sbt/src/sbt-test/tests/filter-runners/test
@@ -1,0 +1,2 @@
+> testOnly example.MunitSpec example.ScalaTestSpec
+> testOnly example.MunitSpec -- "--tests=munit"


### PR DESCRIPTION
For example do not instantiate test runner for ScalaTest if only MUnit test spec is being run.

As it turned out, test runners don't need to be created to determine if test suites are ScalaTest or MUnit etc. Every `TestDefinition` has fingerprint which carries this information. So sbt can decide which test runner to instantiate based on fingerprint of `TestDefinition`s user wants to run.

So rather that creating all test runners up front, this PR adds logic which decides what test runners to create based on `TestDefinition`s which user wants to run.

To get hold of all `TestDefinition`s  user wants to run `Tests.ProcessedOptions` needs to be created. So creation of `Tests.ProcessedOptions` has been moved one layer up, so it can be used to filter test runners. 

Rather than creating `Tests.ProcessedOptions`  in `ForkTests` or `Tests` it is now being passed in as a parameter. This is to avoid doing the same work twice.

Closes #6412