### PR TITLE
Instantiate only test runners needed by current TestDefinitions

### DIFF
--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -308,11 +308,10 @@ object Tests {
       frameworks: Map[TestFramework, Framework],
       testLoader: ClassLoader,
       runners: Map[TestFramework, Runner],
-      discovered: Vector[TestDefinition],
+      o: ProcessedOptions,
       config: Execution,
       log: ManagedLogger
   ): Task[Output] = {
-    val o = processOptions(config, discovered, log)
     testTask(
       testLoader,
       frameworks,
@@ -324,6 +323,18 @@ object Tests {
       o.testListeners,
       config
     )
+  }
+
+  def apply(
+      frameworks: Map[TestFramework, Framework],
+      testLoader: ClassLoader,
+      runners: Map[TestFramework, Runner],
+      discovered: Vector[TestDefinition],
+      config: Execution,
+      log: ManagedLogger
+  ): Task[Output] = {
+    val o = processOptions(config, discovered, log)
+    apply(frameworks, testLoader, runners, o, config, log)
   }
 
   def testTask(

--- a/sbt/src/sbt-test/tests/filter-runners/build.sbt
+++ b/sbt/src/sbt-test/tests/filter-runners/build.sbt
@@ -1,0 +1,9 @@
+val scalatest = "org.scalatest" %% "scalatest" % "3.2.2"
+val munit = "org.scalameta" %% "munit" % "0.7.22"
+
+ThisBuild / scalaVersion := "2.12.12"
+
+libraryDependencies += scalatest % Test
+libraryDependencies += munit % Test
+
+testFrameworks += new TestFramework("munit.Framework")

--- a/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/MunitSpec.scala
+++ b/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/MunitSpec.scala
@@ -1,0 +1,9 @@
+package example
+
+import munit.FunSuite
+
+class Spec extends FunSuite {
+  test("munit should work") {
+    assertEquals(1, 1)
+  }
+}

--- a/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/ScalaTestSpec.scala
+++ b/sbt/src/sbt-test/tests/filter-runners/src/test/scala/example/ScalaTestSpec.scala
@@ -1,0 +1,10 @@
+package example
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScalaTestSpec extends AnyFlatSpec with Matchers {
+  "ScalaTest" should "work" in {
+    1 shouldBe 1
+  }
+}

--- a/sbt/src/sbt-test/tests/filter-runners/test
+++ b/sbt/src/sbt-test/tests/filter-runners/test
@@ -1,0 +1,2 @@
+> testOnly example.MunitSpec example.ScalaTestSpec
+> testOnly example.MunitSpec -- "--tests=munit"


### PR DESCRIPTION
Fixes #6412
Same as #6416, but for `develop` branch instead of `1.4.x`.

For example do not instantiate test runner for ScalaTest if only MUnit test spec is being run.

As it turned out, test runners don't need to be created to determine if test suites are ScalaTest or MUnit etc. Every `TestDefinition` has fingerprint which carries this information. So sbt can decide which test runner to instantiate based on fingerprint of `TestDefinition`s user wants to run.

So rather that creating all test runners up front, this PR adds logic which decides what test runners to create based on `TestDefinition`s which user wants to run.

To get hold of all `TestDefinition`s  user wants to run `Tests.ProcessedOptions` needs to be created. So creation of `Tests.ProcessedOptions` has been moved one layer up, so it can be used to filter test runners. 

Rather than creating `Tests.ProcessedOptions`  in `ForkTests` or `Tests` it is now being passed in as a parameter. This is to avoid doing the same work twice.
