### PR TITLE
Fix Scala 2.13-3.0 sandwich on Scala >= 3.0.0

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3786,7 +3786,7 @@ object Classpaths {
 
   private[sbt] def isScala2Scala3Sandwich(sbv1: String, sbv2: String): Boolean = {
     def compare(a: String, b: String): Boolean =
-      a == "2.13" && (b.startsWith("0.") || b.startsWith("3.0"))
+      a == "2.13" && (b.startsWith("0.") || b.startsWith("3"))
     compare(sbv1, sbv2) || compare(sbv2, sbv1)
   }
 


### PR DESCRIPTION
The binary version of Scala >= 3.0.0 will be 3, but the logic was
hardcoded for 3.0.