### PR TITLE
Retain classifiers for transitive dependencies when publishing to Ivy using Coursier

### DIFF
--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -152,6 +152,18 @@ object IvyXml {
 
     val dependencyElems = project.dependencies.toVector.map {
       case (conf, dep) =>
+        val classifier = {
+          val pub = dep.publication
+          if (pub.classifier.value.nonEmpty)
+            Seq(
+              <artifact name={pub.name} type={pub.`type`.value} ext={pub.ext.value} conf="*" e:classifier={
+                pub.classifier.value
+              } />
+            )
+          else
+            Seq.empty
+        }
+
         val excludes = dep.exclusions.toSeq.map {
           case (org, name) =>
             <exclude org={org.value} module={name.value} name="*" type="*" ext="*" conf="" matcher="exact"/>
@@ -161,6 +173,7 @@ object IvyXml {
           <dependency org={dep.module.organization.value} name={dep.module.name.value} rev={
             dep.version
           } conf={s"${conf.value}->${dep.configuration.value}"}>
+          {classifier}
           {excludes}
         </dependency>
 


### PR DESCRIPTION
Fixes #5325 

Notes:
- I reproduced the issue (and tested the fix) on a private repo, but I can provide a public reproducer project if that's useful for someone else
- the format of the `<artifact ... />` XML element is copied from what I got when publishing with `useCoursier := false`, since that worked