### PR TITLE
Move scalaInstanceTopLoader to compileBase settings

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -662,10 +662,20 @@ object Defaults extends BuildCommon {
   def compileBase = inTask(console)(compilersSetting :: Nil) ++ compileBaseGlobal ++ Seq(
     useScalaReplJLine :== false,
     scalaInstanceTopLoader := {
-      // the JLineLoader contains the SbtInterfaceClassLoader
-      if (!useScalaReplJLine.value)
-        classOf[org.jline.terminal.Terminal].getClassLoader // the JLineLoader
-      else classOf[Compilers].getClassLoader // the SbtInterfaceClassLoader
+      val topLoader = if (!useScalaReplJLine.value) {
+        // the JLineLoader contains the SbtInterfaceClassLoader
+        classOf[org.jline.terminal.Terminal].getClassLoader
+      } else classOf[Compilers].getClassLoader // the SbtInterfaceClassLoader
+
+      // Scala 2.10 shades jline in the console so we need to make sure that it loads a compatible
+      // jansi version. Because of the shading, console does not work with the thin client for 2.10.x.
+      if (scalaVersion.value.startsWith("2.10.")) new ClassLoader(topLoader) {
+        override protected def loadClass(name: String, resolve: Boolean): Class[_] = {
+          if (name.startsWith("org.fusesource")) throw new ClassNotFoundException(name)
+          super.loadClass(name, resolve)
+        }
+      }
+      else topLoader
     },
     scalaInstance := scalaInstanceTask.value,
     crossVersion := (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled),
@@ -1163,16 +1173,6 @@ object Defaults extends BuildCommon {
       state: State,
       topLoader: ClassLoader,
   ): ScalaInstance = {
-    // Scala 2.10 shades jline in the console so we need to make sure that it loads a compatible
-    // jansi version. Because of the shading, console does not work with the thin client for 2.10.x.
-    val jansiExclusionLoader = if (version.startsWith("2.10.")) new ClassLoader(topLoader) {
-      override protected def loadClass(name: String, resolve: Boolean): Class[_] = {
-        if (name.startsWith("org.fusesource")) throw new ClassNotFoundException(name)
-        super.loadClass(name, resolve)
-      }
-    }
-    else topLoader
-
     val classLoaderCache = state.extendedClassLoaderCache
     val compilerJars = allCompilerJars.filterNot(libraryJars.contains).distinct.toArray
     val docJars = allDocJars
@@ -1181,7 +1181,7 @@ object Defaults extends BuildCommon {
       .toArray
     val allJars = libraryJars ++ compilerJars ++ docJars
 
-    val libraryLoader = classLoaderCache(libraryJars.toList, jansiExclusionLoader)
+    val libraryLoader = classLoaderCache(libraryJars.toList, topLoader)
     val compilerLoader = classLoaderCache(compilerJars.toList, libraryLoader)
     val fullLoader =
       if (docJars.isEmpty) compilerLoader

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -332,13 +332,6 @@ object Defaults extends BuildCommon {
       turbo :== SysProp.turbo,
       usePipelining :== SysProp.pipelining,
       exportPipelining := usePipelining.value,
-      useScalaReplJLine :== false,
-      scalaInstanceTopLoader := {
-        // the JLineLoader contains the SbtInterfaceClassLoader
-        if (!useScalaReplJLine.value)
-          classOf[org.jline.terminal.Terminal].getClassLoader // the JLineLoader
-        else classOf[Compilers].getClassLoader // the SbtInterfaceClassLoader
-      },
       useSuperShell := { if (insideCI.value) false else ITerminal.console.isSupershellEnabled },
       superShellThreshold :== SysProp.supershellThreshold,
       superShellMaxTasks :== SysProp.supershellMaxTasks,
@@ -667,6 +660,13 @@ object Defaults extends BuildCommon {
 
   // This is included into JvmPlugin.projectSettings
   def compileBase = inTask(console)(compilersSetting :: Nil) ++ compileBaseGlobal ++ Seq(
+    useScalaReplJLine :== false,
+    scalaInstanceTopLoader := {
+      // the JLineLoader contains the SbtInterfaceClassLoader
+      if (!useScalaReplJLine.value)
+        classOf[org.jline.terminal.Terminal].getClassLoader // the JLineLoader
+      else classOf[Compilers].getClassLoader // the SbtInterfaceClassLoader
+    },
     scalaInstance := scalaInstanceTask.value,
     crossVersion := (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled),
     pluginCrossBuild / sbtBinaryVersion := binarySbtVersion(

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -974,9 +974,6 @@ object BuiltinCommands {
       st => setupGlobalFileTreeRepository(addCacheStoreFactoryFactory(st))
     )
     val s4 = s3.put(Keys.useLog4J.key, Project.extract(s3).get(Keys.useLog4J))
-    // This is a workaround for the console task in dotty which uses the classloader cache.
-    // We need to override the top loader in that case so that it gets the forked jline.
-    s4.extendedClassLoaderCache.setParent(Project.extract(s4).get(Keys.scalaInstanceTopLoader))
     addSuperShellParams(CheckBuildSources.init(LintUnused.lintUnusedFunc(s4)))
   }
 


### PR DESCRIPTION
- Move `scalaInstanceTopLoader` and `useScalaReplJLine` to `compileBase`:
They are/should only be used in the `JvmPlugin` to create the `scalaInstance`.

- Move `jansiExclusionLoader` (for Scala 2.10 only) to the `scalaInstanceTopLoader` implementation

- Remove the `ClassLoaderCache` hack for dotty:
It is not needed anymore, since dotty uses sbt 1.5

- Make `Defaults.makeScalaInstance` public:
`ScalaInstance` and the `scalaInstance` task are public. But, to create a custom `scalaInstance` we need the `extendedClassLoaderCache` which is package private. That's why I think `makeScalaInstance` should be public.

This will allow us to properly bootstrap the Scala compiler in the dotty repository. See https://github.com/lampepfl/dotty/pull/12259.