### PR TITLE
Fix new command leaving behind target, take 2

### DIFF
--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -33,30 +33,19 @@ private[sbt] object TemplateCommandUtil {
 
   private def runTemplate(s0: State, inputArg: Seq[String]): State = {
     import BuildPaths._
-    val extracted0 = (Project extract s0)
     val globalBase = getGlobalBase(s0)
-    val stagingDirectory = getStagingDirectory(s0, globalBase).getCanonicalFile
-    val templateStage = stagingDirectory / "new"
-    // This moves the target directory to a staging directory
-    // https://github.com/sbt/sbt/issues/2835
-    val state = extracted0.appendWithSession(
-      Seq(
-        Keys.target := templateStage
-      ),
-      s0
-    )
-    val infos = (state get templateResolverInfos getOrElse Nil).toList
-    val log = state.globalLogging.full
-    val extracted = (Project extract state)
-    val (s2, ivyConf) = extracted.runTask(Keys.ivyConfiguration, state)
+    val infos = (s0 get templateResolverInfos getOrElse Nil).toList
+    val log = s0.globalLogging.full
+    val extracted = (Project extract s0)
+    val (s1, ivyConf) = extracted.runTask(Keys.ivyConfiguration, s0)
     val scalaModuleInfo = extracted.get(Keys.updateSbtClassifiers / Keys.scalaModuleInfo)
     val arguments = inputArg.toList ++
-      (state.remainingCommands match {
+      (s0.remainingCommands match {
         case exec :: Nil if exec.commandLine == "shell" => Nil
         case xs                                         => xs map (_.commandLine)
       })
-    run(infos, arguments, state.configuration, ivyConf, globalBase, scalaModuleInfo, log)
-    TerminateAction :: s2.copy(remainingCommands = Nil)
+    run(infos, arguments, s0.configuration, ivyConf, globalBase, scalaModuleInfo, log)
+    TerminateAction :: s1.copy(remainingCommands = Nil)
   }
 
   private def run(


### PR DESCRIPTION
Fixes #2835

Somehow the fix in #4033 regressed due to various initialization.
Here's a bit more aggressive rebasing of the base directory
that should fix the `project` and `target` directory created during sbt
new.