### PR TITLE
make -client the same as --client

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -210,6 +210,7 @@ $AliasCommand name=
   def Client: String = "client"
   def ClientDetailed: String =
     "Provides an interactive prompt from which commands can be run on a server."
+  def JavaClient: String = "--java-client"
   def DashClient: String = "-client"
   def DashDashClient: String = "--client"
   def DashDashDetachStdio: String = "--detach-stdio"

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -15,7 +15,7 @@ import java.util.Properties
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.atomic.AtomicBoolean
 
-import sbt.BasicCommandStrings.{ Shell, Shutdown, TemplateCommand }
+import sbt.BasicCommandStrings.{ JavaClient, Shell, Shutdown, TemplateCommand }
 import sbt.Project.LoadAction
 import sbt.compiler.EvalImports
 import sbt.internal.Aggregation.AnyKeys
@@ -23,22 +23,22 @@ import sbt.internal.CommandStrings.BootCommand
 import sbt.internal._
 import sbt.internal.client.BspClient
 import sbt.internal.inc.ScalaInstance
+import sbt.internal.io.Retry
 import sbt.internal.nio.{ CheckBuildSources, FileTreeRepository }
 import sbt.internal.server.{ BuildServerProtocol, NetworkChannel }
 import sbt.internal.util.Types.{ const, idFun }
-import sbt.internal.util.{ Terminal => ITerminal, _ }
 import sbt.internal.util.complete.{ Parser, SizeParser }
+import sbt.internal.util.{ Terminal => ITerminal, _ }
 import sbt.io._
 import sbt.io.syntax._
 import sbt.util.{ Level, Logger, Show }
+import xsbti.AppProvider
 import xsbti.compile.CompilerCache
 
 import scala.annotation.{ nowarn, tailrec }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
-import sbt.internal.io.Retry
-import xsbti.AppProvider
 
 /** This class is the entry point for sbt. */
 final class xMain extends xsbti.AppMain {
@@ -58,7 +58,7 @@ private[sbt] object xMain {
   }
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     try {
-      import BasicCommandStrings.{ DashClient, DashDashClient, DashDashServer, runEarly }
+      import BasicCommandStrings.{ DashDashClient, DashDashServer, runEarly }
       import BasicCommands.early
       import BuiltinCommands.defaults
       import sbt.internal.CommandStrings.{ BootCommand, DefaultsCommand, InitCommand }
@@ -69,7 +69,7 @@ private[sbt] object xMain {
       val userCommands = configuration.arguments
         .map(_.trim)
         .filterNot(_ == DashDashServer)
-      val isClient: String => Boolean = cmd => (cmd == DashClient) || (cmd == DashDashClient)
+      val isClient: String => Boolean = cmd => (cmd == JavaClient) || (cmd == DashDashClient)
       val isBsp: String => Boolean = cmd => (cmd == "-bsp") || (cmd == "--bsp")
       val isServer = !userCommands.exists(c => isBsp(c) || isClient(c))
       val bootServerSocket = if (isServer) getSocketOrExit(configuration) match {

--- a/sbt
+++ b/sbt
@@ -582,7 +582,7 @@ process_args () {
           --numeric-version) print_sbt_version=1 && shift ;;
            --script-version) print_sbt_script_version=1 && shift ;;
           -d|-debug|--debug) sbt_debug=1 && addSbt "-debug" && shift ;;
-                   --client) use_sbtn=1 && shift ;;
+           -client|--client) use_sbtn=1 && shift ;;
                    --server) use_sbtn=0 && shift ;;
 
                  -mem|--mem) require_arg integer "$1" "$2" && addMemory "$2" && shift 2 ;;


### PR DESCRIPTION
The problem was that -client was different from --client, which makes for a confusing user experience. So, this change makes
them the same and re-names -client to --java-client. The value of this is that hopefully -client and --client being the same feels more logical to users.

fixes #6078 