### PR TITLE
Fixes spurious "@nowarn annotation does not suppress any warnings" in old style sbt plugins with `sbtPlugin := true`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -959,6 +959,13 @@ object Defaults extends BuildCommon {
         Vector("-Ypickle-java", "-Ypickle-write", converter.toPath(earlyOutput.value).toString) ++ old
       else old
     },
+    scalacOptions := {
+      val old = scalacOptions.value
+      if (sbtPlugin.value && VersionNumber(scalaVersion.value)
+            .matchesSemVer(SemanticSelector("=2.12 >=2.12.13")))
+        old ++ Seq("-Wconf:cat=unused-nowarn:s")
+      else old
+    },
     persistJarClasspath :== true,
     classpathEntryDefinesClassVF := {
       (if (persistJarClasspath.value) classpathDefinesClassCache.value

--- a/main/src/main/scala/sbt/plugins/SbtPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SbtPlugin.scala
@@ -8,24 +8,13 @@
 package sbt
 package plugins
 
-import Keys._
-import Def.Setting
-import sbt.SlashSyntax0._
-import sbt.librarymanagement.Configurations.Compile
-import sbt.librarymanagement.{ SemanticSelector, VersionNumber }
+import sbt.Def.Setting
+import sbt.Keys._
 
 object SbtPlugin extends AutoPlugin {
   override def requires = ScriptedPlugin
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    sbtPlugin := true,
-    Compile / scalacOptions ++= {
-      // silence unused @nowarns in 2.12 because of https://github.com/sbt/sbt/issues/6398
-      // the option is only available since 2.12.13
-      if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("=2.12 >=2.12.13")))
-        Some("-Wconf:cat=unused-nowarn:s")
-      else
-        None
-    }
+    sbtPlugin := true
   )
 }

--- a/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
@@ -1,0 +1,6 @@
+lazy val root = project.in(file("."))
+  .settings(
+    scalaVersion := "2.12.13",
+    sbtPlugin := true,
+    scalacOptions ++= Seq("-Xfatal-warnings", "-Xlint")
+  )

--- a/sbt-app/src/sbt-test/project/sbt-plugin/test
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/test
@@ -1,1 +1,3 @@
 > compile
+$ copy-file changes/oldSbtPlugin.sbt build.sbt
+> compile


### PR DESCRIPTION
## What is the problem?
As detailed in #6430, the @nowarn annotation was not suppressing warnings, even after the first attempt to fix this in PR#6431. This first PR fixed the problem for projects using `enablePlugins(SbtPlugin)`, but not for those using `sbtPlugin := true`.

## Why is this a valuable problem to solve?
The annotation was not working as users would expect.

## What is the solution?
I have moved the scalacOptions change from `SbtPlugin.projectSettings` to the scalacOptions in the `JvmPlugin` settings.

## Has this been tested?
Yes, a test has been added. Also, this branch was tested successfully on the twinagle repo (https://github.com/soundcloud/twinagle/pull/224).

Fixes #6430.