### PR TITLE
Disable multiple main class warning w/ qualified key

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -982,12 +982,17 @@ object Defaults extends BuildCommon {
     selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
     run / mainClass := (run / selectMainClass).value,
     mainClass := {
-      val logWarning = state.value.currentCommand
-        .flatMap(_.commandLine.split(" ").headOption.map(_.trim))
-        .fold(true) {
-          case "run" | "runMain" => false
-          case _                 => true
-        }
+      val logWarning = state.value.currentCommand.forall(!_.commandLine.split(" ").exists {
+        case "run" | "runMain" => true
+        case r =>
+          r.split("/") match {
+            case Array(parts @ _*) =>
+              parts.lastOption match {
+                case Some("run" | "runMain") => true
+                case _                       => false
+              }
+          }
+      })
       pickMainClassOrWarn(discoveredMainClasses.value, streams.value.log, logWarning)
     },
     runMain := foregroundRunMainTask.evaluated,


### PR DESCRIPTION
If the user runs foo/runMain in a project with multiple main classes,
sbt will still warn the user about their being multiple main classes
even though this is a pointless warning since the user either is running
runMain which requires a main class. The run task is also excluded since
by default it prompts the user with a main class selector. The previous
logic for doing this filtering was bad because it only looked at the
first command in a sequence and couldn't handle the foo/runMain case
since it was looking for an exact match with `run` or `runMain`. This
commit relaxes those restrictions to look at all of the strings in the
command as well as splitting the string to check if the last part of the
key ends in run or runMain. This logic could theoretically be incorrect
if the user wrote an input task that was expecting run or runMain as
user input but even in that case the only consequence would be that they
wouldn't see the multiple main class warning which generally isn't all
the helpful unless you are packaging a jar that expects there to be only
one main class. It seems unlikely that that the user would be running a
custom input task that is both packaging a jar and expecting run or
runMain as input strings.