### PR TITLE
Fix compiler class loader jars

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1182,12 +1182,7 @@ object Defaults extends BuildCommon {
     val allJars = libraryJars ++ compilerJars ++ docJars
 
     val libraryLoader = classLoaderCache(libraryJars.toList, jansiExclusionLoader)
-    val compilerLoader = classLoaderCache(
-      // It should be `compilerJars` but it would break on `3.0.0-M2` because of
-      // https://github.com/lampepfl/dotty/blob/d932af954ef187d7bdb87500d49ed0ff530bd1e7/sbt-bridge/src/xsbt/CompilerClassLoader.java#L108-L117
-      allCompilerJars.toList,
-      libraryLoader
-    )
+    val compilerLoader = classLoaderCache(compilerJars.toList, libraryLoader)
     val fullLoader =
       if (docJars.isEmpty) compilerLoader
       else classLoaderCache(docJars.distinct.toList, compilerLoader)

--- a/sbt-app/src/sbt-test/compiler-project/scala3-tasty-management/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/scala3-tasty-management/build.sbt
@@ -1,6 +1,6 @@
 import xsbti.compile.TastyFiles
 
-ThisBuild / scalaVersion := "3.0.0-M2"
+ThisBuild / scalaVersion := "3.0.0-M3"
 
 TaskKey[Unit]("check") := {
   assert((Compile / auxiliaryClassFiles).value == Seq(TastyFiles.instance))

--- a/sbt-app/src/sbt-test/compiler-project/scala3-tasty-management/test
+++ b/sbt-app/src/sbt-test/compiler-project/scala3-tasty-management/test
@@ -1,12 +1,12 @@
 > check
 > compile
 
-$ exists target/scala-3.0.0-M2/classes/A.tasty
-$ exists target/scala-3.0.0-M2/classes/B.tasty
+$ exists target/scala-3.0.0-M3/classes/A.tasty
+$ exists target/scala-3.0.0-M3/classes/B.tasty
 
 $ delete src/main/scala/B.scala
 
 > compile
 
-$ exists target/scala-3.0.0-M2/classes/A.tasty
--$ exists target/scala-3.0.0-M2/classes/B.tasty
+$ exists target/scala-3.0.0-M3/classes/A.tasty
+-$ exists target/scala-3.0.0-M3/classes/B.tasty

--- a/sbt-app/src/sbt-test/dependency-management/scala3-compiler-bridge-binary/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/scala3-compiler-bridge-binary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "3.0.0-M2"
+ThisBuild / scalaVersion := "3.0.0-M3"
 
 lazy val check = taskKey[Unit]("")
 

--- a/sbt-app/src/sbt-test/project/scala3-sandwich-sjs/build.sbt
+++ b/sbt-app/src/sbt-test/project/scala3-sandwich-sjs/build.sbt
@@ -1,15 +1,15 @@
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / scalacOptions += "-Ytasty-reader"
 
 lazy val scala3code = project
   .enablePlugins(ScalaJSPlugin)
-  .settings(scalaVersion := "3.0.0-M1")
+  .settings(scalaVersion := "3.0.0")
 
 lazy val app = project
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(scala3code)
   .settings(
-    scalaVersion := "2.13.4",
+    scalaVersion := "2.13.6",
     scalacOptions += "-Ytasty-reader",
     scalaJSUseMainModuleInitializer := true
   )

--- a/sbt-app/src/sbt-test/project/scala3-sandwich-sjs/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/project/scala3-sandwich-sjs/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")

--- a/sbt-app/src/sbt-test/project/scala3-sandwich/build.sbt
+++ b/sbt-app/src/sbt-test/project/scala3-sandwich/build.sbt
@@ -1,6 +1,6 @@
-ThisBuild / scalaVersion := "3.0.0-M1"
+ThisBuild / scalaVersion := "3.0.0"
 
-lazy val scala213 = "2.13.4"
+lazy val scala213 = "2.13.6"
 
 lazy val root = (project in file("."))
   .aggregate(fooApp, fooCore, barApp, barCore)


### PR DESCRIPTION
Use the exact list of compiler jars in the cache key of the compiler class loader. This makes the cache more reliable for someone who creates its own Scala instance, as in https://github.com/lampepfl/dotty/pull/12771.