### PR TITLE
Fixes IntegrationTest configuration not tagged as test in BSP

### DIFF
--- a/protocol/src/main/scala/sbt/internal/bsp/BuildTargetTag.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildTargetTag.scala
@@ -18,6 +18,7 @@ object BuildTargetTag {
 
   def fromConfig(config: String): Vector[String] = config match {
     case "test"    => Vector(test)
+    case "it"      => Vector(integrationTest)
     case "compile" => Vector(library)
     case _         => Vector.empty
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6548 

This tiny PR adds the "integration-test" tag to the `IntegrationTest` configuration when using [BSP](https://build-server-protocol.github.io/docs/specification.html#build-target)