### PR TITLE
Fix carriage return in supershell progress state

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -107,7 +107,7 @@ private[sbt] final class ProgressState(
         val parts = new String(bytes, "UTF-8").split(System.lineSeparator)
         def appendLine(l: String, appendNewline: Boolean): Unit = {
           toWrite ++= l.getBytes("UTF-8")
-          toWrite ++= clearScreenBytes
+          if (!l.getBytes("UTF-8").endsWith("\r")) toWrite ++= clearScreenBytes
           if (appendNewline) toWrite ++= lineSeparatorBytes
         }
         parts.dropRight(1).foreach(appendLine(_, true))

--- a/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import java.io.{ File, PrintStream }
+
+import org.scalatest.{ BeforeAndAfterAll, FlatSpec }
+import sbt.internal.util.Terminal.SimpleTerminal
+
+import scala.io.Source
+
+class ProgressStateSpec extends FlatSpec with BeforeAndAfterAll {
+
+  private lazy val fileIn = new File("/tmp/tmp.txt")
+  private lazy val fileOut = Source.fromFile("/tmp/tmp.txt")
+
+  override def afterAll(): Unit = {
+    fileIn.delete()
+    fileOut.close()
+    super.afterAll()
+  }
+
+  "test" should "not clear after carriage return (\\r) " in {
+    val ps = new ProgressState(1, 8)
+    val in = "Hello\r\nWorld".getBytes()
+
+    ps.write(SimpleTerminal, in, new PrintStream(fileIn), hasProgress = true)
+
+    val clearScreenBytes = ConsoleAppender.ClearScreenAfterCursor.getBytes("UTF-8")
+    val check = fileOut.getLines().toList.map { line =>
+      line.getBytes("UTF-8").endsWith(clearScreenBytes)
+    }
+
+    assert(check === List(false, true))
+  }
+}


### PR DESCRIPTION
Preserved the carriage return if followed by a line feed.