### PR TITLE
lazily initialize ProxyTerminal to SimpleTerminal

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -346,7 +346,7 @@ object Terminal {
       consoleTerminalHolder.set(newConsoleTerminal())
     if (hasVirtualIO) {
       hasProgress.set(isServer && isAnsiSupported)
-      activeTerminal.set(consoleTerminalHolder.get)
+      Terminal.set(consoleTerminalHolder.get)
       try withOut(withIn(f))
       finally {
         jline.TerminalFactory.reset()
@@ -382,7 +382,16 @@ object Terminal {
   }
 
   private[this] object ProxyTerminal extends Terminal {
-    private def t: Terminal = activeTerminal.get
+    private def t: Terminal = {
+      val current = activeTerminal.get
+      // if the activeTerminal is yet to be initialized on use,
+      // initialize to the conventional simple terminal for compatibility and testing
+      if (current ne null) current
+      else {
+        Terminal.set(Terminal.SimpleTerminal)
+        activeTerminal.get
+      }
+    }
     override private[sbt] def progressState: ProgressState = t.progressState
     override private[sbt] def enterRawMode(): Unit = t.enterRawMode()
     override private[sbt] def exitRawMode(): Unit = t.exitRawMode()

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -21,8 +21,8 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
   "ManagedLogger" should "log to console" in {
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
-    log.info("test")
-    log.debug("test")
+    log.info("test_info")
+    log.debug("test_debug")
   }
 
   it should "support event logging" in {


### PR DESCRIPTION
Problem
-------
Console.systemOut is hooked up to Terminal.get, which internally calls
ProxyTerminal, which lets us deffer the wiring of terminal to
activeTerminal. This mechanism allows us to swap out the terminal
capable of standard out forwarding for sbtn.
However, as it stands this breaks the contract of being able to use
Console.systemOut with wrapped inside of `Terminal.withStreams() {...}`.

Solution
--------
Check if `activeTerminal.get` returns `null`, and if so initialize it to
the conventional `Terminal.SimpleTerminal`, which behaves as expected.