### PR TITLE
[BSP] Respond error after random failure when compiling

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -509,8 +509,9 @@ object BuildServerProtocol {
       case Value(_) => StatusCode.Success
       case Inc(cause) =>
         cause.getCause match {
-          case _: CompileFailed => StatusCode.Error
-          case err              => throw cause
+          case _: CompileFailed        => StatusCode.Error
+          case _: InterruptedException => StatusCode.Cancelled
+          case err                     => throw cause
         }
     }
   }

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -10,7 +10,6 @@ package internal
 package server
 
 import java.net.URI
-
 import sbt.BuildSyntax._
 import sbt.Def._
 import sbt.Keys._
@@ -28,6 +27,7 @@ import sbt.std.TaskExtra
 import sbt.util.Logger
 import sjsonnew.shaded.scalajson.ast.unsafe.{ JNull, JValue }
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser => JsonParser }
+import xsbti.CompileFailed
 
 // import scala.annotation.nowarn
 import scala.util.control.NonFatal
@@ -507,9 +507,11 @@ object BuildServerProtocol {
   private def bspCompileTask: Def.Initialize[Task[Int]] = Def.task {
     Keys.compile.result.value match {
       case Value(_) => StatusCode.Success
-      case Inc(_)   =>
-        // Cancellation is not yet implemented
-        StatusCode.Error
+      case Inc(cause) =>
+        cause.getCause match {
+          case _: CompileFailed => StatusCode.Error
+          case err              => throw cause
+        }
     }
   }
 

--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -15,4 +15,13 @@ lazy val reportWarning = project.in(file("report-warning"))
     scalacOptions += "-deprecation"
   )
 
+// check that the buildTarget/compile request fails with the custom message defined below
+lazy val respondError = project.in(file("respond-error"))
+  .settings(
+    Compile / compile := {
+      val _ = (Compile / compile).value
+      throw new MessageOnlyException("custom message")
+    }
+  )
+
 lazy val util = project

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -16,19 +16,19 @@ object BuildServerTest extends AbstractServerTest {
   test("build/initialize") { _ =>
     initializeRequest()
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"10"""") &&
+      (s contains """"id":"8"""") &&
       (s contains """"resourcesProvider":true""")
     })
   }
 
   test("workspace/buildTargets") { _ =>
     svr.sendJsonRpc(
-      """{ "jsonrpc": "2.0", "id": "11", "method": "workspace/buildTargets", "params": {} }"""
+      """{ "jsonrpc": "2.0", "id": "16", "method": "workspace/buildTargets", "params": {} }"""
     )
     assert(processing("workspace/buildTargets"))
     assert {
       svr.waitForString(10.seconds) { s =>
-        (s contains """"id":"11"""") &&
+        (s contains """"id":"16"""") &&
         (s contains """"displayName":"util"""")
       }
     }
@@ -37,13 +37,13 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/sources") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#util/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "12", "method": "buildTarget/sources", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "24", "method": "buildTarget/sources", "params": {
         |  "targets": [{ "uri": "$x" }]
         |} }""".stripMargin
     )
     assert(processing("buildTarget/sources"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"12"""") &&
+      (s contains """"id":"24"""") &&
       (s contains "util/src/main/scala")
     })
   }
@@ -51,13 +51,13 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/compile") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#util/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "13", "method": "buildTarget/compile", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "32", "method": "buildTarget/compile", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
     assert(processing("buildTarget/compile"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"13"""") &&
+      (s contains """"id":"32"""") &&
       (s contains """"statusCode":1""")
     })
   }
@@ -65,24 +65,24 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/scalacOptions") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#util/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "14", "method": "buildTarget/scalacOptions", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "40", "method": "buildTarget/scalacOptions", "params": {
         |  "targets": [{ "uri": "$x" }]
         |} }""".stripMargin
     )
     assert(processing("buildTarget/scalacOptions"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"14"""") &&
+      (s contains """"id":"40"""") &&
       (s contains "scala-library-2.13.1.jar")
     })
   }
 
   test("workspace/reload") { _ =>
     svr.sendJsonRpc(
-      """{ "jsonrpc": "2.0", "id": "15", "method": "workspace/reload"}"""
+      """{ "jsonrpc": "2.0", "id": "48", "method": "workspace/reload"}"""
     )
     assert(processing("workspace/reload"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"15"""") &&
+      (s contains """"id":"48"""") &&
       (s contains """"result":null""")
     })
   }
@@ -90,13 +90,13 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/scalaMainClasses") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#runAndTest/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "16", "method": "buildTarget/scalaMainClasses", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "56", "method": "buildTarget/scalaMainClasses", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
     assert(processing("buildTarget/scalaMainClasses"))
     assert(svr.waitForString(30.seconds) { s =>
-      (s contains """"id":"16"""") &&
+      (s contains """"id":"56"""") &&
       (s contains """"class":"main.Main"""")
     })
   }
@@ -104,7 +104,7 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/run") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#runAndTest/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "17", "method": "buildTarget/run", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "64", "method": "buildTarget/run", "params": {
          |  "target": { "uri": "$x" },
          |  "dataKind": "scala-main-class",
          |  "data": { "class": "main.Main" }
@@ -116,7 +116,7 @@ object BuildServerTest extends AbstractServerTest {
       (s contains """"message":"Hello World!"""")
     })
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"17"""") &&
+      (s contains """"id":"64"""") &&
       (s contains """"statusCode":1""")
     })
   }
@@ -124,13 +124,13 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/scalaTestClasses") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#runAndTest/Test"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "18", "method": "buildTarget/scalaTestClasses", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "72", "method": "buildTarget/scalaTestClasses", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
     assert(processing("buildTarget/scalaTestClasses"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"18"""") &&
+      (s contains """"id":"72"""") &&
       (s contains """"tests.FailingTest"""") &&
       (s contains """"tests.PassingTest"""")
     })
@@ -139,13 +139,13 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/test: run all tests") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#runAndTest/Test"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "19", "method": "buildTarget/test", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "80", "method": "buildTarget/test", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
     assert(processing("buildTarget/test"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"19"""") &&
+      (s contains """"id":"80"""") &&
       (s contains """"statusCode":2""")
     })
   }
@@ -153,7 +153,7 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/test: run one test class") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#runAndTest/Test"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "20", "method": "buildTarget/test", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "84", "method": "buildTarget/test", "params": {
          |  "targets": [{ "uri": "$x" }],
          |  "dataKind": "scala-test",
          |  "data": {
@@ -168,7 +168,7 @@ object BuildServerTest extends AbstractServerTest {
     )
     assert(processing("buildTarget/test"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"20"""") &&
+      (s contains """"id":"84"""") &&
       (s contains """"statusCode":1""")
     })
   }
@@ -176,7 +176,7 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/compile: report error") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#reportError/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "21", "method": "buildTarget/compile", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "88", "method": "buildTarget/compile", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
@@ -190,7 +190,7 @@ object BuildServerTest extends AbstractServerTest {
   test("buildTarget/compile: report warning") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#reportWarning/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "22", "method": "buildTarget/compile", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "90", "method": "buildTarget/compile", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
@@ -201,22 +201,37 @@ object BuildServerTest extends AbstractServerTest {
     })
   }
 
+  test("buildTarget/compile: respond error") { _ =>
+    val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#respondError/Compile"
+    svr.sendJsonRpc(
+      s"""{ "jsonrpc": "2.0", "id": "92", "method": "buildTarget/compile", "params": {
+         |  "targets": [{ "uri": "$x" }]
+         |} }""".stripMargin
+    )
+    assert(svr.waitForString(10.seconds) { s =>
+      s.contains(""""id":"92"""") &&
+      s.contains(""""error"""") &&
+      s.contains(""""code":-32603""") &&
+      s.contains("custom message")
+    })
+  }
+
   test("buildTarget/resources") { _ =>
     val x = s"${svr.baseDirectory.getAbsoluteFile.toURI}#util/Compile"
     svr.sendJsonRpc(
-      s"""{ "jsonrpc": "2.0", "id": "23", "method": "buildTarget/resources", "params": {
+      s"""{ "jsonrpc": "2.0", "id": "96", "method": "buildTarget/resources", "params": {
          |  "targets": [{ "uri": "$x" }]
          |} }""".stripMargin
     )
     assert(processing("buildTarget/resources"))
     assert(svr.waitForString(10.seconds) { s =>
-      (s contains """"id":"23"""") && (s contains "util/src/main/resources/")
+      (s contains """"id":"96"""") && (s contains "util/src/main/resources/")
     })
   }
 
   private def initializeRequest(): Unit = {
     svr.sendJsonRpc(
-      """{ "jsonrpc": "2.0", "id": "10", "method": "build/initialize",
+      """{ "jsonrpc": "2.0", "id": "8", "method": "build/initialize",
         |  "params": {
         |    "displayName": "test client",
         |    "version": "1.0.0",


### PR DESCRIPTION
Fixes #6562 reported by @samuelClarencTeads

- When a BSP task fails we send an error response that contains the error message.
- When the `bspCompileItem` catches an exception: if it is a `CompileFailed` we respond with a `StatusCode.Error` result, if it is an `InterruptedException` we respond with a `StatusCode.Cancelled` result, otherwise we send an error response.
- The old error response with a `-33000` code and no message is made silent if another response has already been sent.
- Add a server test to check the error message on a custom compilation failure