### PR TITLE
[BSP] Send information when server process fails

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -347,9 +347,14 @@ class NetworkClient(
             .directory(arguments.baseDirectory)
             .redirectInput(Redirect.PIPE)
         processBuilder.environment.put(Terminal.TERMINAL_PROPS, props)
-        val process = processBuilder.start()
-        sbtProcess.set(process)
-        Some(process)
+        Try(processBuilder.start()) match {
+          case Success(process) =>
+            sbtProcess.set(process)
+            Some(process)
+          case Failure(e) =>
+            if (log) console.appendLog(Level.Error, s"Failed to start server : $e")
+            throw new ServerFailedException
+        }
       case _ =>
         if (log) {
           console.appendLog(Level.Info, "sbt server is booting up")


### PR DESCRIPTION
## Steps : 

- With SBT 1.5.3, import a project on Intellij IDEA without a started BSP server (meaning no sbt -bsp was done on a detached terminal).
- The import fails for some reason (For example, the following one : https://github.com/sbt/sbt/pull/6576 ) 

## Problem : 

No information is sent to Intellij, making the problem solution hard to find. 

## Expected : 

Some logs should be sent when the server process fails on starting.

## Solution : 

The current PR allows sending some logs via BSP that can be displayed on Intellij side : 

```
[info] server was not detected. starting an instance

[error] Failed to start server : java.io.IOException: Cannot run program "java" (in directory "......"): error=2, No such file or directory

```

It would probably help fixing the following bug : https://youtrack.jetbrains.com/issue/SCL-18324 