### PR TITLE
[BSP] Fix failing import 

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -342,7 +342,12 @@ class NetworkClient(
                 s"either upgrade $sbtScript to its latest version or make sure it is accessible from $$PATH, and run 'sbt bspConfig'"
               )
             }
-            List("java") ++ arguments.sbtArguments ++
+            val java = Option(Properties.javaHome)
+              .map { javaHome =>
+                s"$javaHome/bin/java"
+              }
+              .getOrElse("java")
+            List(java) ++ arguments.sbtArguments ++
               List("-jar", lj, DashDashDetachStdio, DashDashServer)
           case _ =>
             List(arguments.sbtScript) ++ arguments.sbtArguments ++


### PR DESCRIPTION
## Steps : 

- With SBT 1.5.3, import a project on Intellij IDEA **without** a started BSP server (meaning no `sbt -bsp` was done on a detached terminal). 
-  java is not defined in `/usr/bin/java` (for example when using [sdkman](https://sdkman.io/))

## Problem : 

The import fails, with a `java` not found message.

## Expected : 

The project should be successfully imported. 

### Solution : 

This PR adds the `java_home` path to the process builder instead of using directly the `java` command. 