### PR TITLE
Use `-Dsbt.script` to start sbt server

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -330,6 +330,18 @@ class NetworkClient(
 
         val cmd = arguments.sbtLaunchJar match {
           case Some(lj) =>
+            if (log) {
+              val sbtScript = if (Properties.isWin) "sbt.bat" else "sbt"
+              console.appendLog(Level.Warn, s"server is started using sbt-launch jar directly")
+              console.appendLog(
+                Level.Warn,
+                "this is not the recommended way: .sbtopts and .jvmopts files are not loaded and SBT_OPTS is ignored"
+              )
+              console.appendLog(
+                Level.Warn,
+                s"either upgrade $sbtScript to its latest version or make sure it is accessible from $$PATH, and run 'sbt bspConfig'"
+              )
+            }
             List("java") ++ arguments.sbtArguments ++
               List("-jar", lj, DashDashDetachStdio, DashDashServer)
           case _ =>

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -7,11 +7,12 @@
 
 package sbt.internal.bsp
 
-import java.io.File
-
-import sbt.internal.bsp
+import sbt.internal.bsp.codec.JsonProtocol.BspConnectionDetailsFormat
 import sbt.io.IO
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter }
+
+import java.io.File
+import java.nio.file.{ Files, Paths }
 
 object BuildServerConnection {
   final val name = "sbt"
@@ -21,26 +22,45 @@ object BuildServerConnection {
   private final val SbtLaunchJar = "sbt-launch(-.*)?\\.jar".r
 
   private[sbt] def writeConnectionFile(sbtVersion: String, baseDir: File): Unit = {
-    import bsp.codec.JsonProtocol._
     val bspConnectionFile = new File(baseDir, ".bsp/sbt.json")
-    val javaHome = System.getProperty("java.home")
-    val classPath = System.getProperty("java.class.path")
-    val sbtLaunchJar = classPath
-      .split(File.pathSeparator)
-      .find(jar => SbtLaunchJar.findFirstIn(jar).nonEmpty)
-      .map(_.replaceAllLiterally(" ", "%20"))
-    val argv =
-      Vector(
-        s"$javaHome/bin/java",
-        "-Xms100m",
-        "-Xmx100m",
-        "-classpath",
-        classPath,
-        "xsbt.boot.Boot",
-        "-bsp"
-      ) ++ sbtLaunchJar.map(jar => s"--sbt-launch-jar=$jar")
+    val argv = Option(System.getProperty("sbt.script"))
+      .map(_.replaceAllLiterally("%20", " "))
+      .orElse(sbtScriptInPath) match {
+      case Some(sbtScript) =>
+        Vector(sbtScript, "-bsp", s"-Dsbt.script=${sbtScript.replaceAllLiterally(" ", "%20")}")
+      case None =>
+        // IntelliJ can start sbt even if the sbt script is not accessible from $PATH.
+        // To do so it uses its own bundled sbt-launch.jar.
+        // In that case, we must pass the path of the sbt-launch.jar to the BSP connection
+        // so that the server can be started.
+        // A known problem in that situation is that the .sbtopts and .jvmopts are not loaded.
+        val javaHome = System.getProperty("java.home")
+        val classPath = System.getProperty("java.class.path")
+        val sbtLaunchJar = classPath
+          .split(File.pathSeparator)
+          .find(jar => SbtLaunchJar.findFirstIn(jar).nonEmpty)
+          .map(_.replaceAllLiterally(" ", "%20"))
+
+        Vector(
+          s"$javaHome/bin/java",
+          "-Xms100m",
+          "-Xmx100m",
+          "-classpath",
+          classPath,
+          "xsbt.boot.Boot",
+          "-bsp"
+        ) ++ sbtLaunchJar.map(jar => s"--sbt-launch-jar=$jar")
+    }
     val details = BspConnectionDetails(name, sbtVersion, bspVersion, languages, argv)
     val json = Converter.toJson(details).get
     IO.write(bspConnectionFile, CompactPrinter(json), append = false)
+  }
+
+  private def sbtScriptInPath: Option[String] = {
+    // For those who use an old sbt script, the -Dsbt.script is not set
+    // As a fallback we try to find the sbt script in $PATH
+    val envPath = Option(System.getenv("PATH")).getOrElse("")
+    val allPaths = envPath.split(File.pathSeparator).map(Paths.get(_))
+    allPaths.map(_.resolve("sbt")).find(Files.exists(_)).map(_.toString)
   }
 }

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -13,6 +13,7 @@ import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter }
 
 import java.io.File
 import java.nio.file.{ Files, Paths }
+import scala.util.Properties
 
 object BuildServerConnection {
   final val name = "sbt"
@@ -23,34 +24,34 @@ object BuildServerConnection {
 
   private[sbt] def writeConnectionFile(sbtVersion: String, baseDir: File): Unit = {
     val bspConnectionFile = new File(baseDir, ".bsp/sbt.json")
-    val argv = Option(System.getProperty("sbt.script"))
-      .map(_.replaceAllLiterally("%20", " "))
-      .orElse(sbtScriptInPath) match {
-      case Some(sbtScript) =>
-        Vector(sbtScript, "-bsp", s"-Dsbt.script=${sbtScript.replaceAllLiterally(" ", "%20")}")
-      case None =>
-        // IntelliJ can start sbt even if the sbt script is not accessible from $PATH.
-        // To do so it uses its own bundled sbt-launch.jar.
-        // In that case, we must pass the path of the sbt-launch.jar to the BSP connection
-        // so that the server can be started.
-        // A known problem in that situation is that the .sbtopts and .jvmopts are not loaded.
-        val javaHome = System.getProperty("java.home")
-        val classPath = System.getProperty("java.class.path")
-        val sbtLaunchJar = classPath
-          .split(File.pathSeparator)
-          .find(jar => SbtLaunchJar.findFirstIn(jar).nonEmpty)
-          .map(_.replaceAllLiterally(" ", "%20"))
+    val javaHome = System.getProperty("java.home")
+    val classPath = System.getProperty("java.class.path")
 
-        Vector(
-          s"$javaHome/bin/java",
-          "-Xms100m",
-          "-Xmx100m",
-          "-classpath",
-          classPath,
-          "xsbt.boot.Boot",
-          "-bsp"
-        ) ++ sbtLaunchJar.map(jar => s"--sbt-launch-jar=$jar")
-    }
+    val sbtScript = Option(System.getProperty("sbt.script"))
+      .orElse(sbtScriptInPath)
+      .map(script => s"-Dsbt.script=$script")
+
+    // IntelliJ can start sbt even if the sbt script is not accessible from $PATH.
+    // To do so it uses its own bundled sbt-launch.jar.
+    // In that case, we must pass the path of the sbt-launch.jar to the BSP connection
+    // so that the server can be started.
+    // A known problem in that situation is that the .sbtopts and .jvmopts are not loaded.
+    val sbtLaunchJar = classPath
+      .split(File.pathSeparator)
+      .find(jar => SbtLaunchJar.findFirstIn(jar).nonEmpty)
+      .map(_.replaceAllLiterally(" ", "%20"))
+      .map(jar => s"--sbt-launch-jar=$jar")
+
+    val argv =
+      Vector(
+        s"$javaHome/bin/java",
+        "-Xms100m",
+        "-Xmx100m",
+        "-classpath",
+        classPath,
+        "xsbt.boot.Boot",
+        "-bsp"
+      ) ++ sbtScript.orElse(sbtLaunchJar)
     val details = BspConnectionDetails(name, sbtVersion, bspVersion, languages, argv)
     val json = Converter.toJson(details).get
     IO.write(bspConnectionFile, CompactPrinter(json), append = false)
@@ -61,6 +62,9 @@ object BuildServerConnection {
     // As a fallback we try to find the sbt script in $PATH
     val envPath = Option(System.getenv("PATH")).getOrElse("")
     val allPaths = envPath.split(File.pathSeparator).map(Paths.get(_))
-    allPaths.map(_.resolve("sbt")).find(Files.exists(_)).map(_.toString)
+    allPaths
+      .map(_.resolve("sbt"))
+      .find(file => Files.exists(file))
+      .map(_.toString.replaceAllLiterally(" ", "%20"))
   }
 }

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -60,11 +60,12 @@ object BuildServerConnection {
   private def sbtScriptInPath: Option[String] = {
     // For those who use an old sbt script, the -Dsbt.script is not set
     // As a fallback we try to find the sbt script in $PATH
+    val fileName = if (Properties.isWin) "sbt.bat" else "sbt"
     val envPath = Option(System.getenv("PATH")).getOrElse("")
     val allPaths = envPath.split(File.pathSeparator).map(Paths.get(_))
     allPaths
-      .map(_.resolve("sbt"))
-      .find(file => Files.exists(file))
+      .map(_.resolve(fileName))
+      .find(file => Files.exists(file) && Files.isExecutable(file))
       .map(_.toString.replaceAllLiterally(" ", "%20"))
   }
 }

--- a/sbt
+++ b/sbt
@@ -299,6 +299,16 @@ addDefaultMemory() {
   fi
 }
 
+addSbtScriptProperty () {
+  if [[ "${java_args[@]}" == -Dsbt.script=* ]]; then
+    :
+  else
+    sbt_script=$0
+    sbt_script=${sbt_script/ /%20}
+    addJava "-Dsbt.script=$sbt_script"
+  fi
+}
+
 require_arg () {
   local type="$1"
   local opt="$2"
@@ -769,6 +779,7 @@ else
   java_version="$(jdk_version)"
   vlog "[process_args] java_version = '$java_version'"
   addDefaultMemory
+  addSbtScriptProperty
   set -- "${residual_args[@]}"
   argumentCount=$#
   run

--- a/sbt
+++ b/sbt
@@ -300,7 +300,7 @@ addDefaultMemory() {
 }
 
 addSbtScriptProperty () {
-  if [[ "${java_args[@]}" == -Dsbt.script=* ]]; then
+  if [[ "${java_args[@]}" == *-Dsbt.script=* ]]; then
     :
   else
     sbt_script=$0


### PR DESCRIPTION
In order to start the sbt server we must use the sbt script because it is the only way to load the .sbtopts and the .jvmopts files properly.

To do so the sbt script can pass a `-Dsbt.script` option to the Java process:
- If the Java process is an sbt client: the value of `-Dsbt.script` is used to start the server
- If the Java process is an sbt server: the value of `-Dsbt.script`  is written into the `.bsp/sbt.json` file

Example of `bsp/sbt.json` file:

```json
{
  "name":"sbt",
  "version":"1.5.5-SNAPSHOT",
  "bspVersion":"2.0.0-M5",
  "languages":["scala"],
  "argv":[
    "/home/.sdkman/candidates/sbt/current/bin/sbt",
    "-bsp",
    "-Dsbt.script=/home/.sdkman/candidates/sbt/current/bin/sbt"
  ]
}
```

This PR fixes #6575 and #6476, and part of #6468.
This PR makes #6580 not necessary (except if IntelliJ starts sbt using the sbt-launch.jar directly).
