### PR TITLE
Building on #6353 to help identify the issue of #6101 for Windows users.

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -146,13 +146,12 @@ private[sbt] object xMain {
     catch {
       case e: ServerAlreadyBootingException
           if System.console != null && !ITerminal.startedByRemoteClient =>
-        println(
-          s"sbt thinks that server is already booting because of this exception:\n${e.getCause}\nCreate a new server? y/n (default y)"
-        )
-        val exit = ITerminal.get.withRawInput(System.in.read) match {
-          case 110 => Some(Exit(1))
-          case _   => None
-        }
+        println("sbt thinks that server is already booting because of this exception:")
+        e.printStackTrace()
+        println("Create a new server? y/n (default y)")
+        val exit =
+          if (ITerminal.get.withRawInput(System.in.read) == 'n'.toInt) Some(Exit(1))
+          else None
         (None, exit)
       case _: ServerAlreadyBootingException =>
         if (SysProp.forceServerStart) (None, None)


### PR DESCRIPTION
Also make it clear what 110 means.

Before:
![image](https://user-images.githubusercontent.com/2464813/126878721-321d8441-382e-4643-b6a5-0476705a41d1.png)

After:
![image](https://user-images.githubusercontent.com/2464813/126878717-c1f5cb98-1783-496a-a734-a29bfa5008ae.png)

Now can identify which place the original exception comes from.