### PR TITLE
Make BSP requests robust to some target failures

### DIFF
--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -25,3 +25,18 @@ lazy val respondError = project.in(file("respond-error"))
   )
 
 lazy val util = project
+
+def somethingBad = throw new MessageOnlyException("I am a bad build target")
+// other build targets should not be affected by this bad build target
+lazy val badBuildTarget = project.in(file("bad-build-target"))
+  .settings(
+    Compile / bspBuildTarget := somethingBad,
+    Compile / bspBuildTargetSourcesItem := somethingBad,
+    Compile / bspBuildTargetResourcesItem := somethingBad,
+    Compile / bspBuildTargetDependencySourcesItem := somethingBad,
+    Compile / bspBuildTargetScalacOptionsItem := somethingBad,
+    Compile / bspBuildTargetCompileItem := somethingBad,
+    Compile / bspScalaMainClasses := somethingBad,
+    Test / bspBuildTarget := somethingBad,
+    Test / bspScalaTestClasses := somethingBad,
+  )


### PR DESCRIPTION
The request of the form `buildTarget/*` often take a sequence of build targets as parameter. So far if there is an error on a single build target the entire request fails.
This is not the best because the client wants the result of the other build targets anyway:
For example:
- `workspace/buildTargets`: if one build target has an invalid Scala version we still want to import the other ones
- `buildTarget/scalacOptions`: if a dependency cannot be resolved we still want to import the build targets that do not depend on it
- `buildTarget/scalaMainClasses`: if buildTarget does not compile we still want the main classes of the other targets
...

The change is to respond to BSP requests with the successful build targets and  to ignore the failed ones.
This is implemented the same in Bloop since before BSP in sbt.

In  https://github.com/build-server-protocol/build-server-protocol/issues/204, I make a proposal to add the failed build targets in the response. That would be even better but is probably not really necessary at this time.

(Fix #6598 by side effect @ckipp01)