### PR TITLE
Add --sbt-cache argument and update localCacheDirectory key description

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerTest.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
   // 1.3.0, 1.3.0-M4
-  private val versionRegEx = "\\d(\\.\\d+){2}(-\\w+)?"
+  private[test] val versionRegEx = "\\d(\\.\\d+){2}(-\\w+)?"
 
   lazy val isWindows: Boolean = sys.props("os.name").toLowerCase(java.util.Locale.ENGLISH).contains("windows")
   lazy val sbtScript =
@@ -44,13 +44,6 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
 
   test("sbt --numeric-version should print sbt script version") {
     val out = sbtProcess("--numeric-version").!!.trim
-    val expectedVersion = "^"+versionRegEx+"$"
-    assert(out.matches(expectedVersion))
-    ()
-  }
-
-  test("sbt --script-version should print sbtVersion") {
-    val out = sbtProcess("--script-version").!!.trim
     val expectedVersion = "^"+versionRegEx+"$"
     assert(out.matches(expectedVersion))
     ()

--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -109,7 +109,6 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     assert(out.contains[String]("-Xss6M"))
   }
 
-
   makeTest(
     name = "sbt with -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 in SBT_OPTS",
     sbtOpts = "-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080",
@@ -168,5 +167,16 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   makeTest("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("-v") { out: List[String] =>
     if (isWindows) cancel("Test not supported on windows")
     assert(out.contains[String]("-Dsbt.ivy.home=/ivy/dir"))
+  }
+
+  test("sbt --script-version should print sbtVersion") {
+    val out = sbtProcess("--script-version").!!.trim
+    val expectedVersion = "^"+SbtRunnerTest.versionRegEx+"$"
+    assert(out.matches(expectedVersion))
+    ()
+  }
+
+  makeTest("--sbt-cache")("--sbt-cache", "./cachePath") { out: List[String] =>
+    assert(out.contains[String](s"-Dsbt.global.localcache=./cachePath"))
   }
 }

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -42,6 +42,8 @@ set sbt_args_ivy=
 set sbt_args_supershell=
 set sbt_args_timings=
 set sbt_args_traces=
+set sbt_args_sbt_boot=
+set sbt_args_sbt_cache=
 set sbt_args_sbt_create=
 set sbt_args_sbt_dir=
 set sbt_args_sbt_version=
@@ -251,6 +253,21 @@ if defined _sbt_boot_arg (
  set _sbt_boot_arg=
  if not "%~1" == "" (
    set sbt_args_sbt_boot=%1
+   shift
+   goto args_loop
+ ) else (
+   echo "%~0" is missing a value
+   goto error
+ )
+)
+
+if "%~0" == "-sbt-cache" set _sbt_cache_arg=true
+if "%~0" == "--sbt-cache" set _sbt_cache_arg=true
+
+if defined _sbt_cache_arg (
+ set _sbt_cache_arg=
+ if not "%~1" == "" (
+   set sbt_args_sbt_cache=%1
    shift
    goto args_loop
  ) else (
@@ -585,6 +602,10 @@ if defined sbt_args_sbt_dir (
 
 if defined sbt_args_sbt_boot (
   set _SBT_OPTS=-Dsbt.boot.directory=!sbt_args_sbt_boot! !_SBT_OPTS!
+)
+
+if defined sbt_args_sbt_cache (
+  set _SBT_OPTS=-Dsbt.global.localcache=!sbt_args_sbt_cache! !_SBT_OPTS!
 )
 
 if defined sbt_args_ivy (
@@ -932,6 +953,7 @@ echo   --timings           display task timings report on shutdown
 echo   --sbt-create        start sbt even if current directory contains no sbt project
 echo   --sbt-dir   ^<path^>  path to global settings/plugins directory ^(default: ~/.sbt^)
 echo   --sbt-boot  ^<path^>  path to shared boot directory ^(default: ~/.sbt/boot in 0.11 series^)
+echo   --sbt-cache ^<path^>  path to global cache directory ^(default: operating system specific^)
 echo   --ivy       ^<path^>  path to local Ivy repository ^(default: ~/.ivy2^)
 echo   --mem    ^<integer^>  set memory options ^(default: %sbt_default_mem%^)
 echo   --no-share          use all local caches; no sharing

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -392,7 +392,7 @@ object Keys {
   val pushRemoteCacheTo = settingKey[Option[Resolver]]("The resolver to publish remote cache to.")
   val remoteCacheResolvers = settingKey[Seq[Resolver]]("Resolvers for remote cache.")
   val remoteCachePom = taskKey[File]("Generates a pom for publishing when publishing Maven-style.")
-  val localCacheDirectory = settingKey[File]("Directory to pull the remote cache to.")
+  val localCacheDirectory = settingKey[File]("Operating system specific cache directory.")
   val usePipelining = settingKey[Boolean]("Use subproject pipelining for compilation.").withRank(BSetting)
   val exportPipelining = settingKey[Boolean]("Product early output so downstream subprojects can do pipelining.").withRank(BSetting)
 

--- a/sbt
+++ b/sbt
@@ -538,6 +538,7 @@ Usage: `basename "$0"` [options]
   --sbt-create        start sbt even if current directory contains no sbt project
   --sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt)
   --sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
+  --sbt-cache <path>  path to global cache directory (default: operating system specific)
   --ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
   --mem    <integer>  set memory options (default: $sbt_default_mem)
   --no-share          use all local caches; no sharing
@@ -648,6 +649,10 @@ process_args () {
              -batch|--batch) exec </dev/null && shift ;;
 
          -sbt-jar|--sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
+     -sbt-cache|--sbt-cache) require_arg path "$1" "$2" &&
+                             sbt_cache="$2" &&
+                             addJava "-Dsbt.global.localcache=$2" &&
+                             shift 2 ;;
  -sbt-version|--sbt-version) require_arg version "$1" "$2" && sbt_version="$2" && shift 2 ;;
      -java-home|--java-home) require_arg path "$1" "$2" &&
                              java_cmd="$2/bin/java" &&


### PR DESCRIPTION
# Description

This PR addresses https://github.com/sbt/sbt/issues/6625 and also "resolves" some conflation of the usage/terminology of the `localCacheDirectory: settingKey[File]`.

The original description was: `Directory to pull the remote cache to.`
The proposed change is: `Operating system specific cache directory.`

This is a similar concept to "disk-cache" in bazel, and while the initial usage of `localCacheDirectory` in `sbt` was for the remote cache support, the implementation in `SysProp` (https://github.com/sbt/sbt/blob/fe5497938a8b2898dcbab49b60e0f2ef53b06c29/main/src/main/scala/sbt/internal/SysProp.scala#L188) is more consistent with the "disk-cache" term.

The `Remote Cache` functionality is just one of many possible consumers of `localCacheDirectory` (e.g. `sbt-assembly` could use this), so I believe the updated description is more consistent, flexible, and less confusing. 

### TODO
~~- [x] Add `cache_dir ()` helper~~
- [x] Add tests