### PR TITLE
Fixes shutdown hook error in timing report

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -290,6 +290,7 @@ private[sbt] final class CommandExchange {
     // interrupt and kill the thread
     server.foreach(_.shutdown())
     server = None
+    EvaluateTask.onShutdown
   }
 
   // This is an interface to directly respond events.

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -8,6 +8,7 @@
 package sbt
 package internal
 
+import sbt.EvaluateTask.addShutdownHandler
 import sbt.internal.util.{ ConsoleOut, RMap }
 import sbt.util.{ Level, Logger }
 
@@ -38,7 +39,7 @@ private[sbt] final class TaskTimings(reportOnShutdown: Boolean, logger: Logger)
 
   if (reportOnShutdown) {
     start = System.nanoTime
-    ShutdownHooks.add(() => report())
+    addShutdownHandler(() => report())
   }
 
   override def initial(): Unit = {


### PR DESCRIPTION
This fixes the closed channel exception generated when running `sbt -timings help`. This bug was introduced in sbt 1.4 where a wrapper was created (`Terminal.scala`) around the terminal. This meant that the shutdown hook which had been used previously was no longer working.

This has been fixed by avoiding the use of the JVM shutdown hook and instead manually running the thunk at a place in the code where the programme is still able to respond.

fixes #6253