### PR TITLE
[#6631] Enable launcher script use --sbt-boot 

### DIFF
--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -40,7 +40,7 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
 
   IO.withTemporaryDirectory { tempDir =>
     tempDir.mkdirs
-    makeTest("sbt --sbt-boot")(s"--sbt-boot", s""""${tempDir.getAbsolutePath}"""", "--sbt-version", "1.3.13") { out: List[String] =>
+    makeTest("sbt --sbt-boot")("-v", s"--sbt-boot", s""""${tempDir.getAbsolutePath}"""", "--sbt-version", "1.3.13") { out: List[String] =>
       out.foreach{ l => s"line: '$l'" }
       assert(out.contains[String](s"""-Dsbt.boot.directory="${tempDir.getAbsolutePath}""""))
       assert(out.contains[String]("-Dsbt.version=1.3.13"))

--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -1,6 +1,8 @@
 package example.test
 
 import minitest._
+import sbt.io.IO
+import sbt.io.syntax._
 import java.io.File
 
 object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
@@ -36,84 +38,92 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     )
   }
 
-  makeTest("sbt -no-colors")("compile", "-no-colors", "-v") { out: List[String] =>
+  IO.withTemporaryDirectory { tempDir =>
+    tempDir.mkdirs
+    makeTest("sbt --sbt-boot")("--sbt-boot", tempDir.toString, "--sbt-version", "1.3.13") { out: List[String] =>
+      assert(out.contains[String](s"-Dsbt.boot.directory=$tempDir"))
+      assert(out.contains[String]("-Dsbt.version=1.3.13"))
+      assert((tempDir / "sbt-launch" / "1.3.13" / "sbt-launch-1.3.13.jar").isFile)
+    }
+  }
+
+  makeTest("sbt -no-colors")("compile", "-no-colors") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
   }
 
-  makeTest("sbt --no-colors")("compile", "--no-colors", "-v") { out: List[String] =>
+  makeTest("sbt --no-colors")("compile", "--no-colors") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
   }
 
-  makeTest("sbt --color=false")("compile", "--color=false", "-v") { out: List[String] =>
+  makeTest("sbt --color=false")("compile", "--color=false") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.color=false"))
   }
 
-  makeTest("sbt --no-colors in SBT_OPTS", sbtOpts = "--no-colors")("compile", "-v") { out: List[String] =>
+  makeTest("sbt --no-colors in SBT_OPTS", sbtOpts = "--no-colors")("compile") { out: List[String] =>
     if (isWindows) cancel("Test not supported on windows")
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
   }
 
-  makeTest("sbt --debug-inc")("compile", "--debug-inc", "-v") { out: List[String] =>
+  makeTest("sbt --debug-inc")("compile", "--debug-inc") { out: List[String] =>
     assert(out.contains[String]("-Dxsbt.inc.debug=true"))
   }
 
-  makeTest("sbt --supershell=never")("compile", "--supershell=never", "-v") { out: List[String] =>
+  makeTest("sbt --supershell=never")("compile", "--supershell=never") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.supershell=never"))
   }
 
-  makeTest("sbt --timings")("compile", "--timings", "-v") { out: List[String] =>
+  makeTest("sbt --timings")("compile", "--timings") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.task.timings=true"))
   }
 
-  makeTest("sbt -D arguments")("-Dsbt.supershell=false", "compile", "-v") { out: List[String] =>
+  makeTest("sbt -D arguments")("-Dsbt.supershell=false", "compile") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.supershell=false"))
   }
 
-  makeTest("sbt --sbt-version")("--sbt-version", "1.3.13", "-v") { out: List[String] =>
+  makeTest("sbt --sbt-version")("--sbt-version", "1.3.13") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.version=1.3.13"))
   }
 
-  makeTest("sbt -mem 503")("-mem", "503", "-v") { out: List[String] =>
+  makeTest("sbt -mem 503")("-mem", "503") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
   }
 
-  makeTest("sbt with -mem 503, -Xmx in JAVA_OPTS", javaOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
-    assert(out.contains[String]("-Xmx503m"))
-    assert(!out.contains[String]("-Xmx1024m"))
-  }
-
-  makeTest("sbt with -mem 503, -Xmx in SBT_OPTS", sbtOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
+  makeTest("sbt with -mem 503, -Xmx in JAVA_OPTS", javaOpts = "-Xmx1024m")("-mem", "503") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
     assert(!out.contains[String]("-Xmx1024m"))
   }
 
-  makeTest("sbt with -mem 503, -Xss in JAVA_OPTS", javaOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
+  makeTest("sbt with -mem 503, -Xmx in SBT_OPTS", sbtOpts = "-Xmx1024m")("-mem", "503") { out: List[String] =>
+    assert(out.contains[String]("-Xmx503m"))
+    assert(!out.contains[String]("-Xmx1024m"))
+  }
+
+  makeTest("sbt with -mem 503, -Xss in JAVA_OPTS", javaOpts = "-Xss6m")("-mem", "503") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
     assert(!out.contains[String]("-Xss6m"))
   }
 
-  makeTest("sbt with -mem 503, -Xss in SBT_OPTS", sbtOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
+  makeTest("sbt with -mem 503, -Xss in SBT_OPTS", sbtOpts = "-Xss6m")("-mem", "503") { out: List[String] =>
     assert(out.contains[String]("-Xmx503m"))
     assert(!out.contains[String]("-Xss6m"))
   }
 
-  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in JAVA_OPTS", javaOpts = "-Xms2048M -Xmx2048M -Xss6M")("-v") { out: List[String] =>
+  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in JAVA_OPTS", javaOpts = "-Xms2048M -Xmx2048M -Xss6M")("compile") { out: List[String] =>
     assert(out.contains[String]("-Xms2048M"))
     assert(out.contains[String]("-Xmx2048M"))
     assert(out.contains[String]("-Xss6M"))
   }
 
-  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS", sbtOpts = "-Xms2048M -Xmx2048M -Xss6M")( "-v") { out: List[String] =>
+  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS", sbtOpts = "-Xms2048M -Xmx2048M -Xss6M")( "compile") { out: List[String] =>
     assert(out.contains[String]("-Xms2048M"))
     assert(out.contains[String]("-Xmx2048M"))
     assert(out.contains[String]("-Xss6M"))
   }
-
 
   makeTest(
     name = "sbt with -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 in SBT_OPTS",
     sbtOpts = "-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080",
-  )("-v") { out: List[String] =>
+  )("compile") { out: List[String] =>
     assert(out.contains[String]("-Dhttp.proxyHost=proxy"))
     assert(out.contains[String]("-Dhttp.proxyPort=8080"))
   }
@@ -121,18 +131,18 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   makeTest(
     name = "sbt with -XX:ParallelGCThreads=16 -XX:PermSize=128M in SBT_OPTS",
     sbtOpts = "-XX:ParallelGCThreads=16 -XX:PermSize=128M",
-  )("-v") { out: List[String] =>
+  )("compile") { out: List[String] =>
     assert(out.contains[String]("-XX:ParallelGCThreads=16"))
     assert(out.contains[String]("-XX:PermSize=128M"))
   }
 
-  makeTest("sbt with -XX:+UseG1GC -XX:+PrintGC in JAVA_OPTS", javaOpts = "-XX:+UseG1GC -XX:+PrintGC")("-v") { out: List[String] =>
+  makeTest("sbt with -XX:+UseG1GC -XX:+PrintGC in JAVA_OPTS", javaOpts = "-XX:+UseG1GC -XX:+PrintGC")("compile") { out: List[String] =>
     assert(out.contains[String]("-XX:+UseG1GC"))
     assert(out.contains[String]("-XX:+PrintGC"))
     assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
   }
 
-  makeTest("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS", sbtOpts = "-XX:+UseG1GC -XX:+PrintGC")( "-v") { out: List[String] =>
+  makeTest("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS", sbtOpts = "-XX:+UseG1GC -XX:+PrintGC")( "compile") { out: List[String] =>
     assert(out.contains[String]("-XX:+UseG1GC"))
     assert(out.contains[String]("-XX:+PrintGC"))
     assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
@@ -141,7 +151,7 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   test("sbt with -debug in SBT_OPTS appears in sbt commands") {
     if (isWindows) cancel("Test not supported on windows")
 
-    val out: List[String] = sbtProcessWithOpts("compile", "-v")(javaOpts = "", sbtOpts = "-debug").!!.linesIterator.toList
+    val out: List[String] = sbtProcessWithOpts("compile")(javaOpts = "", sbtOpts = "-debug").!!.linesIterator.toList
     // Debug argument must appear in the 'commands' section (after the sbt-launch.jar argument) to work
     val sbtLaunchMatcher = """^.+sbt-launch.jar["]{0,1}$""".r
     val locationOfSbtLaunchJarArg = out.zipWithIndex.collectFirst {
@@ -155,7 +165,7 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
-  makeTest("sbt --jvm-debug <port>")("--jvm-debug", "12345", "-v") { out: List[String] =>
+  makeTest("sbt --jvm-debug <port>")("--jvm-debug", "12345") { out: List[String] =>
     assert(out.contains[String]("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12345"))
   }
 
@@ -165,7 +175,7 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     assert(out.contains[String]("-Dsbt.ivy.home=project/.ivy"))
   }
 
-  makeTest("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("-v") { out: List[String] =>
+  makeTest("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("compile") { out: List[String] =>
     if (isWindows) cancel("Test not supported on windows")
     assert(out.contains[String]("-Dsbt.ivy.home=/ivy/dir"))
   }

--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -40,8 +40,9 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
 
   IO.withTemporaryDirectory { tempDir =>
     tempDir.mkdirs
-    makeTest("sbt --sbt-boot")("--sbt-boot", tempDir.toString, "--sbt-version", "1.3.13") { out: List[String] =>
-      assert(out.contains[String](s"-Dsbt.boot.directory=$tempDir"))
+    makeTest("sbt --sbt-boot")(s"--sbt-boot", s""""${tempDir.getAbsolutePath}"""", "--sbt-version", "1.3.13") { out: List[String] =>
+      out.foreach{ l => s"line: '$l'" }
+      assert(out.contains[String](s"""-Dsbt.boot.directory="${tempDir.getAbsolutePath}""""))
       assert(out.contains[String]("-Dsbt.version=1.3.13"))
       assert((tempDir / "sbt-launch" / "1.3.13" / "sbt-launch-1.3.13.jar").isFile)
     }

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -42,6 +42,7 @@ set sbt_args_ivy=
 set sbt_args_supershell=
 set sbt_args_timings=
 set sbt_args_traces=
+set sbt_args_sbt_boot=
 set sbt_args_sbt_create=
 set sbt_args_sbt_dir=
 set sbt_args_sbt_version=

--- a/sbt
+++ b/sbt
@@ -20,6 +20,7 @@ declare -r default_java_opts="-Dfile.encoding=UTF-8"
 declare sbt_verbose=
 declare sbt_boot=
 declare sbt_debug=
+declare sbt_jar=
 declare build_props_sbt_version=
 declare use_sbtn=
 declare sbtn_command="$SBTN_CMD"
@@ -113,7 +114,7 @@ boot_dir() {
 }
 
 jar_file () {
-  if ! [[ "$sbt_jar" == "" ]]; then
+  if [[ "$sbt_jar" != "" ]]; then
     echo "$sbt_jar"
   elif [[ "$sbt_boot" == "" ]]; then
     echo "$(cygwinpath "${sbt_home}/bin/sbt-launch.jar")"
@@ -644,6 +645,7 @@ map_args () {
        -no-share|--no-share) options=( "${options[@]}" "${noshare_opts[@]}" ) && shift ;;
      -no-global|--no-global) options=( "${options[@]}" "-Dsbt.global.base=$(pwd)/project/.sbtboot" ) && shift ;;
                  -ivy|--ivy) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.ivy.home=$2" ) && shift 2 ;;
+       -sbt-boot|--sbt-boot) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.boot.directory=$2" ) && shift 2 ;;
          -sbt-dir|--sbt-dir) require_arg path "$1" "$2" && options=( "${options[@]}" "-Dsbt.global.base=$2" ) && shift 2 ;;
              -debug|--debug) commands=( "${commands[@]}" "-debug" ) && shift ;;
      -debug-inc|--debug-inc) options=( "${options[@]}" "-Dxsbt.inc.debug=true" ) && shift ;;


### PR DESCRIPTION
This addresses #6631 to use `--sbt-boot` directory to download `sbt-launch.jar` or `sbtn`

Also added some minor `SbtScriptTest` output cleanup.