### PR TITLE
Fix for realpathish in top-level directories

### DIFF
--- a/sbt
+++ b/sbt
@@ -46,11 +46,18 @@ realpathish () {
     COUNT=$(($COUNT + 1))
   done
 
+  TARGET_DIR="$(pwd -P)"
+  if [ "$TARGET_DIR" == "/" ]; then
+    TARGET_FILE="/$TARGET_FILE"
+  else
+    TARGET_FILE="$TARGET_DIR/$TARGET_FILE"
+  fi
+
   # make sure we grab the actual windows path, instead of cygwin's path.
   if [[ "x$FIX_CYGPATH" != "x" ]]; then
-    echo "$(cygwinpath "$(pwd -P)/$TARGET_FILE")"
+    echo "$(cygwinpath "$TARGET_FILE")"
   else
-    echo "$(pwd -P)/$TARGET_FILE"
+    echo "$TARGET_FILE"
   fi
 )
 }


### PR DESCRIPTION
The `realpathish` function returns a slightly wrong path for top-level directories. `realpathish /root` gives `//root`. A copy of this issue in `sbt-native-packager` caused a real issue for us. (https://github.com/lynxkite/lynxkite/issues/200) That's fixed now (https://github.com/sbt/sbt-native-packager/pull/1451) but I thought maybe you would want the fix too.

Thanks for sbt! I've recently upgraded from 0.13.17 to 1.4.7 and it's awesome!