### PR TITLE
BSP: implement progress report during compilation

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2353,9 +2353,7 @@ object Defaults extends BuildCommon {
       )
     }
     def onProgress(s: Setup) = {
-      val cp: BspCompileProgress = s.progress.asScala
-        .map(p => new BspCompileProgress(task, Some(p)))
-        .getOrElse(new BspCompileProgress(task, None))
+      val cp = new BspCompileProgress(task, s.progress.asScala)
       s.withProgress(cp)
     }
     val compilers: Compilers = ci.compilers

--- a/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
@@ -1,0 +1,24 @@
+package sbt.internal.server
+
+import xsbti.compile.CompileProgress
+
+private[sbt] final class BspCompileProgress(
+    task: BspCompileTask,
+    underlying: Option[CompileProgress]
+) extends CompileProgress {
+  override def advance(
+      current: Int,
+      total: Int,
+      prevPhase: String,
+      nextPhase: String
+  ): Boolean = {
+    val percentage = current * 100 / total
+    // Report percentages every 5% increments
+    val shouldReportPercentage = percentage % 5 == 0
+    if (shouldReportPercentage) {
+      task.notifyProgress(percentage, total)
+    }
+    underlying.foreach(_.advance(current, total, prevPhase, nextPhase))
+    true
+  }
+}

--- a/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
@@ -1,3 +1,10 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
 package sbt.internal.server
 
 import xsbti.compile.CompileProgress
@@ -18,7 +25,14 @@ private[sbt] final class BspCompileProgress(
     if (shouldReportPercentage) {
       task.notifyProgress(percentage, total)
     }
-    underlying.foreach(_.advance(current, total, prevPhase, nextPhase))
-    true
+    underlying.fold(true)(_.advance(current, total, prevPhase, nextPhase))
+  }
+
+  override def startUnit(phase: String, unitPath: String): Unit = {
+    underlying.foreach(_.startUnit(phase, unitPath))
+  }
+
+  override def afterEarlyOutput(success: Boolean): Unit = {
+    underlying.foreach(_.afterEarlyOutput(success))
   }
 }

--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -26,7 +26,7 @@ object BspCompileTask {
   ): CompileResult = {
     val task = BspCompileTask(targetId, project, config)
     try {
-      task.notifyStart
+      task.notifyStart()
       val result = Retry(compile(task))
       task.notifySuccess(result)
       result

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/TaskProgressParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/TaskProgressParams.scala
@@ -1,0 +1,92 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+/**
+ * @param taskId Unique id of the task with optional reference to parent task id.
+ * @param eventTime Optional timestamp of when the event started in milliseconds since Epoch.
+ * @param message Message describing the task progress.
+ * @param total If known, total amount of work units in this task.
+ * @param progress If known, completed amount of work units in this task.
+ * @param unit Name of a work unit. For example, "files" or "tests". May be empty.
+ * @param dataKind Kind of data to expect in the `data` field.
+ * @param data Optional metadata about the task.
+ */
+final class TaskProgressParams private (
+  val taskId: sbt.internal.bsp.TaskId,
+  val eventTime: Option[Long],
+  val message: Option[String],
+  val total: Option[Long],
+  val progress: Option[Long],
+  val unit: Option[String],
+  val dataKind: Option[String],
+  val data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: TaskProgressParams => (this.taskId == x.taskId) && (this.eventTime == x.eventTime) && (this.message == x.message) && (this.total == x.total) && (this.progress == x.progress) && (this.unit == x.unit) && (this.dataKind == x.dataKind) && (this.data == x.data)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.TaskProgressParams".##) + taskId.##) + eventTime.##) + message.##) + total.##) + progress.##) + unit.##) + dataKind.##) + data.##)
+  }
+  override def toString: String = {
+    "TaskProgressParams(" + taskId + ", " + eventTime + ", " + message + ", " + total + ", " + progress + ", " + unit + ", " + dataKind + ", " + data + ")"
+  }
+  private[this] def copy(taskId: sbt.internal.bsp.TaskId = taskId, eventTime: Option[Long] = eventTime, message: Option[String] = message, total: Option[Long] = total, progress: Option[Long] = progress, unit: Option[String] = unit, dataKind: Option[String] = dataKind, data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue] = data): TaskProgressParams = {
+    new TaskProgressParams(taskId, eventTime, message, total, progress, unit, dataKind, data)
+  }
+  def withTaskId(taskId: sbt.internal.bsp.TaskId): TaskProgressParams = {
+    copy(taskId = taskId)
+  }
+  def withEventTime(eventTime: Option[Long]): TaskProgressParams = {
+    copy(eventTime = eventTime)
+  }
+  def withEventTime(eventTime: Long): TaskProgressParams = {
+    copy(eventTime = Option(eventTime))
+  }
+  def withMessage(message: Option[String]): TaskProgressParams = {
+    copy(message = message)
+  }
+  def withMessage(message: String): TaskProgressParams = {
+    copy(message = Option(message))
+  }
+  def withTotal(total: Option[Long]): TaskProgressParams = {
+    copy(total = total)
+  }
+  def withTotal(total: Long): TaskProgressParams = {
+    copy(total = Option(total))
+  }
+  def withProgress(progress: Option[Long]): TaskProgressParams = {
+    copy(progress = progress)
+  }
+  def withProgress(progress: Long): TaskProgressParams = {
+    copy(progress = Option(progress))
+  }
+  def withUnit(unit: Option[String]): TaskProgressParams = {
+    copy(unit = unit)
+  }
+  def withUnit(unit: String): TaskProgressParams = {
+    copy(unit = Option(unit))
+  }
+  def withDataKind(dataKind: Option[String]): TaskProgressParams = {
+    copy(dataKind = dataKind)
+  }
+  def withDataKind(dataKind: String): TaskProgressParams = {
+    copy(dataKind = Option(dataKind))
+  }
+  def withData(data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): TaskProgressParams = {
+    copy(data = data)
+  }
+  def withData(data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): TaskProgressParams = {
+    copy(data = Option(data))
+  }
+}
+object TaskProgressParams {
+  
+  def apply(taskId: sbt.internal.bsp.TaskId, eventTime: Option[Long], message: Option[String], total: Option[Long], progress: Option[Long], unit: Option[String], dataKind: Option[String], data: Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]): TaskProgressParams = new TaskProgressParams(taskId, eventTime, message, total, progress, unit, dataKind, data)
+  def apply(taskId: sbt.internal.bsp.TaskId, eventTime: Long, message: String, total: Long, progress: Long, unit: String, dataKind: String, data: sjsonnew.shaded.scalajson.ast.unsafe.JValue): TaskProgressParams = new TaskProgressParams(taskId, Option(eventTime), Option(message), Option(total), Option(progress), Option(unit), Option(dataKind), Option(data))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
@@ -33,6 +33,7 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.DependencySourcesItemFormats
   with sbt.internal.bsp.codec.DependencySourcesResultFormats
   with sbt.internal.bsp.codec.TaskStartParamsFormats
+  with sbt.internal.bsp.codec.TaskProgressParamsFormats
   with sbt.internal.bsp.codec.TaskFinishParamsFormats
   with sbt.internal.bsp.codec.CompileParamsFormats
   with sbt.internal.bsp.codec.BspCompileResultFormats

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/TaskProgressParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/TaskProgressParamsFormats.scala
@@ -1,0 +1,41 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait TaskProgressParamsFormats { self: sbt.internal.bsp.codec.TaskIdFormats with sbt.internal.util.codec.JValueFormats with sjsonnew.BasicJsonProtocol =>
+implicit lazy val TaskProgressParamsFormat: JsonFormat[sbt.internal.bsp.TaskProgressParams] = new JsonFormat[sbt.internal.bsp.TaskProgressParams] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.TaskProgressParams = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val taskId = unbuilder.readField[sbt.internal.bsp.TaskId]("taskId")
+      val eventTime = unbuilder.readField[Option[Long]]("eventTime")
+      val message = unbuilder.readField[Option[String]]("message")
+      val total = unbuilder.readField[Option[Long]]("total")
+      val progress = unbuilder.readField[Option[Long]]("progress")
+      val unit = unbuilder.readField[Option[String]]("unit")
+      val dataKind = unbuilder.readField[Option[String]]("dataKind")
+      val data = unbuilder.readField[Option[sjsonnew.shaded.scalajson.ast.unsafe.JValue]]("data")
+      unbuilder.endObject()
+      sbt.internal.bsp.TaskProgressParams(taskId, eventTime, message, total, progress, unit, dataKind, data)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.TaskProgressParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("taskId", obj.taskId)
+    builder.addField("eventTime", obj.eventTime)
+    builder.addField("message", obj.message)
+    builder.addField("total", obj.total)
+    builder.addField("progress", obj.progress)
+    builder.addField("unit", obj.unit)
+    builder.addField("dataKind", obj.dataKind)
+    builder.addField("data", obj.data)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -318,6 +318,32 @@ type TaskStartParams {
     data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
 }
 
+type TaskProgressParams {
+    ## Unique id of the task with optional reference to parent task id.
+    taskId: sbt.internal.bsp.TaskId!
+
+    ## Optional timestamp of when the event started in milliseconds since Epoch.
+    eventTime: Long
+
+    ## Message describing the task progress.
+    message: String
+
+    ## If known, total amount of work units in this task.
+    total: Long
+
+    ## If known, completed amount of work units in this task.
+    progress: Long
+
+    ## Name of a work unit. For example, "files" or "tests". May be empty.
+    unit: String
+
+    ## Kind of data to expect in the `data` field.
+    dataKind: String
+
+    ## Optional metadata about the task.
+    data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
+}
+
 type TaskFinishParams {
     ## Unique id of the task with optional reference to parent task id.
     taskId: sbt.internal.bsp.TaskId!


### PR DESCRIPTION
Fixes #6570

This PR introduces `build/taskProgress` notifications to report the compilation progress (in 5% increments, borrowed from bloop)