### PR TITLE
Fix for crossSbtVersions triggering lintBuild

### DIFF
--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -32,6 +32,7 @@ object LintUnused {
       concurrentRestrictions,
       commands,
       crossScalaVersions,
+      crossSbtVersions,
       initialize,
       lintUnusedKeysOnLoad,
       onLoad,


### PR DESCRIPTION
Currently crossSbtVersions is incorrectly generating a warning that it is an unused setting (see https://github.com/sbt/sbt/pull/5153). This PR fixes this by adding it to the list of excluded lint keys.

Fixes #6571.