### PR TITLE
Bump metabuild Scala version to 2.12.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       JAVA_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
-      SCALA_212: 2.12.14
+      SCALA_212: 2.12.15
       SCALA_213: 2.13.6
       UTIL_TESTS: "utilCache/test utilControl/test utilInterface/test utilLogging/test utilPosition/test utilRelation/test utilScripted/test utilTracking/test"
       SBT_LOCAL: false

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -131,6 +131,10 @@ Listening for transport dt_socket at address: 5005
 Please note that this alternative launcher does _not_ have feature parity with sbt/launcher. (Meta)
 contributions welcome! :-D
 
+### Updating Scala version
+
+See https://github.com/sbt/sbt/pull/6522 for the list of files to change for Scala version upgrade.
+
 ### Diagnosing build failures
 
 Globally included plugins can interfere building `sbt`; if you are getting errors building sbt, try disabling all globally included plugins and try again.

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ ThisBuild / scmInfo := Some(
 ThisBuild / resolvers += Resolver.mavenLocal
 
 Global / semanticdbEnabled := !(Global / insideCI).value
+// Change main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala too, if you change this.
 Global / semanticdbVersion := "4.4.28"
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
 Global / excludeLint := (Global / excludeLint).?.value.getOrElse(Set.empty)

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ ThisBuild / scmInfo := Some(
 ThisBuild / resolvers += Resolver.mavenLocal
 
 Global / semanticdbEnabled := !(Global / insideCI).value
-Global / semanticdbVersion := "4.4.20"
+Global / semanticdbVersion := "4.4.28"
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
 Global / excludeLint := (Global / excludeLint).?.value.getOrElse(Set.empty)
 Global / excludeLint += componentID

--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -26,7 +26,7 @@ lazy val sbtVersionToRelease = sys.props.getOrElse("sbt.build.version", sys.env.
       }))
 
 lazy val scala210 = "2.10.7"
-lazy val scala212 = "2.12.14"
+lazy val scala212 = "2.12.15"
 lazy val scala210Jline = "org.scala-lang" % "jline" % scala210
 lazy val jansi = {
   if (sbtVersionToRelease startsWith "1.") "org.fusesource.jansi" % "jansi" % "1.12"

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -973,7 +973,7 @@ object Defaults extends BuildCommon {
       val old = scalacOptions.value
       if (sbtPlugin.value && VersionNumber(scalaVersion.value)
             .matchesSemVer(SemanticSelector("=2.12 >=2.12.13")))
-        old ++ Seq("-Wconf:cat=unused-nowarn:s")
+        old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
       else old
     },
     persistJarClasspath :== true,

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -99,7 +99,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.14"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.15"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -26,7 +26,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.4.20"
+    semanticdbVersion := "4.4.28"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.14"
+  val scala212 = "2.12.15"
   val scala213 = "2.13.6"
   val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala212
@@ -116,5 +116,5 @@ object Dependencies {
 
   val hedgehog = "qa.hedgehog" %% "hedgehog-sbt" % "0.6.1"
   val disruptor = "com.lmax" % "disruptor" % "3.4.2"
-  val kindProjector = ("org.typelevel" % "kind-projector" % "0.13.0").cross(CrossVersion.full)
+  val kindProjector = ("org.typelevel" % "kind-projector" % "0.13.2").cross(CrossVersion.full)
 }

--- a/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
@@ -1,5 +1,6 @@
 lazy val check = taskKey[Unit]("")
 lazy val compile2 = taskKey[Unit]("")
+lazy val scala212 = "2.12.15"
 
 lazy val root = (project in file("."))
   .aggregate(foo, bar, client)
@@ -10,19 +11,19 @@ lazy val root = (project in file("."))
 
 lazy val foo = project
   .settings(
-    crossScalaVersions := Seq("2.12.14", "2.13.1"),
+    crossScalaVersions := Seq(scala212, "2.13.1"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0",
 
     check := {
       // This tests that +check will respect bar's crossScalaVersions and not switch
       val x = (LocalProject("bar") / scalaVersion).value
-      assert(x == "2.12.14", s"$x == 2.12.12")
+      assert(x == scala212, s"$x == $scala212")
       (Compile / compile).value
     },
     (Test / testOnly) := {
       // This tests that +testOnly will respect bar's crossScalaVersions and not switch
       val x = (LocalProject("bar") / scalaVersion).value
-      assert(x == "2.12.14", s"$x == 2.12.12")
+      assert(x == scala212, s"$x == $scala212")
       val _ = (Test / testOnly).evaluated
     },
     compile2 := {
@@ -35,7 +36,7 @@ lazy val foo = project
 
 lazy val bar = project
   .settings(
-    crossScalaVersions := Seq("2.12.14"),
+    crossScalaVersions := Seq(scala212),
     check := (Compile / compile).value,
     compile2 := (Compile / compile).value,
   )
@@ -46,14 +47,14 @@ lazy val baz = project
     check := {
       // This tests that +baz/check will respect bar's crossScalaVersions and not switch
       val x = (LocalProject("bar") / scalaVersion).value
-      assert(x == "2.12.14", s"$x == 2.12.14")
+      assert(x == scala212, s"$x == $scala212")
       (Compile / compile).value
     },
   )
 
 lazy val client = project
   .settings(
-    crossScalaVersions := Seq("2.12.14", "2.13.1"),
+    crossScalaVersions := Seq(scala212, "2.13.1"),
     check := (Compile / compile).value,
     compile2 := (Compile / compile).value,
   )

--- a/sbt-app/src/sbt-test/actions/cross-advanced/test
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/test
@@ -17,7 +17,7 @@
 ## test + with command or alias
 > clean
 ## for command cross building you do need crossScalaVerions on root
-> set root/crossScalaVersions := Seq("2.12.14", "2.13.1")
+> set root/crossScalaVersions := Seq("2.12.15", "2.13.1")
 > + build
 $ exists foo/target/scala-2.12
 $ exists foo/target/scala-2.13

--- a/sbt-app/src/sbt-test/project/sbt-plugin/build.sbt
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = project.in(file("."))
   .enablePlugins(SbtPlugin)
   .settings(
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.15",
     scalacOptions ++= Seq("-Xfatal-warnings", "-Xlint")
   )

--- a/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
@@ -1,6 +1,6 @@
 lazy val root = project.in(file("."))
   .settings(
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.15",
     sbtPlugin := true,
     scalacOptions ++= Seq("-Xfatal-warnings", "-Xlint")
   )

--- a/sbt-app/src/sbt-test/project/semanticdb-version/build.sbt
+++ b/sbt-app/src/sbt-test/project/semanticdb-version/build.sbt
@@ -1,3 +1,4 @@
+// Don't have to upgrade this while updating 2.12
 ThisBuild / scalaVersion := "2.12.14"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := "4.4.20"

--- a/sbt-app/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt-app/src/sbt-test/project/semanticdb/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / scalaVersion := "2.12.15"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbIncludeInJar := true
 

--- a/sbt-app/src/sbt-test/tests/scala-instance-classloader/build.sbt
+++ b/sbt-app/src/sbt-test/tests/scala-instance-classloader/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.ScalaInstance
 lazy val OtherScala = config("other-scala").hide
 lazy val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.5.17"
-ThisBuild / scalaVersion := "2.12.14"
+ThisBuild / scalaVersion := "2.12.15"
 
 lazy val root = (project in file("."))
   .configs(OtherScala)

--- a/server-test/src/server-test/response/build.sbt
+++ b/server-test/src/server-test/response/build.sbt
@@ -1,6 +1,6 @@
 import sbt.internal.server.{ ServerHandler, ServerIntent }
 
-ThisBuild / scalaVersion := "2.12.14"
+ThisBuild / scalaVersion := "2.12.15"
 
 Global / serverLog / logLevel := Level.Debug
 // custom handler

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -102,22 +102,23 @@ object BuildServerTest extends AbstractServerTest {
          |} }""".stripMargin
     )
 
-    assert(svr.waitForString(10.seconds) { s =>
+    // This doesn't always come back in 10s on CI.
+    assert(svr.waitForString(60.seconds) { s =>
       s.contains("build/taskStart") &&
       s.contains(""""message":"Compiling runAndTest"""")
     })
 
-    assert(svr.waitForString(10.seconds) { s =>
+    assert(svr.waitForString(60.seconds) { s =>
       s.contains("build/taskProgress") &&
       s.contains(""""message":"Compiling runAndTest (15%)"""")
     })
 
-    assert(svr.waitForString(10.seconds) { s =>
+    assert(svr.waitForString(60.seconds) { s =>
       s.contains("build/taskProgress") &&
       s.contains(""""message":"Compiling runAndTest (100%)"""")
     })
 
-    assert(svr.waitForString(10.seconds) { s =>
+    assert(svr.waitForString(60.seconds) { s =>
       s.contains("build/taskFinish") &&
       s.contains(""""message":"Compiled runAndTest"""")
     })


### PR DESCRIPTION
This is a continuation of https://github.com/sbt/sbt/pull/6663 contributed by @Nirvikalpa108 

This updates the Scala version used by the metabuild to Scala 2.12.15 (https://github.com/scala/scala/releases/tag/v2.12.15), and adds `-Xsource:3` flag during the compilation of metabuild.
