### PR TITLE
Fixes tab completion of global keys

### DIFF
--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -304,7 +304,12 @@ object Act {
         case Some(ProjectRef(uri, _)) => index.keys(Some(BuildRef(uri)), conf, task)
         case _                        => Set()
       }
-    val keys: Set[String] = index.keys(proj, conf, task) ++ buildKeys
+    val globalKeys: Set[String] =
+      proj match {
+        case Some(_) => index.keys(None, conf, task)
+        case _       => Set()
+      }
+    val keys: Set[String] = index.keys(proj, conf, task) ++ buildKeys ++ globalKeys
     keyParser(keys)
   }
 

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -118,14 +118,16 @@ object ClientTest extends AbstractServerTest {
       "compileIncSetup",
       "compileIncremental",
       "compileJava",
+      "compileOrder",
       "compileOutputs",
       "compileProgress",
       "compileScalaBackend",
       "compileSplit",
+      "compilerCache",
       "compilers",
     )
 
-    assert(complete("compi") == expected)
+    assert(complete("compi").toVector == expected)
   }
   test("testOnly completions") { _ =>
     val testOnlyExpected = Vector(


### PR DESCRIPTION
Fixes #1373
Fixes #6715

Following my own PR #2855 around `ThisBuild`, this attempts to fix the
tab completion of globally scoped keys from the shell.

<img width="1966" alt="mima" src="https://user-images.githubusercontent.com/184683/142084392-9433606a-d64f-4a3d-80d9-1e997ae38272.png">


