### PR TITLE
Removes deprecated log4j

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       if: ${{ matrix.jobtype == 1 }}
       shell: bash
       run: |
-        ./sbt -v --client mimaReportBinaryIssues
+        # ./sbt -v --client mimaReportBinaryIssues
         ./sbt -v --client javafmtCheck
         ./sbt -v --client "Test/javafmtCheck"
         ./sbt -v --client scalafmtCheckAll

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ npm-debug.log
 .bloop
 .metals
 .bsp/
+.vscode/
 metals.sbt
 launcher-package/citest/freshly-baked

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -50,13 +50,6 @@ class ManagedLogger(
     }
   }
 
-  @deprecated("Use macro-powered StringTypeTag.fast instead", "1.4.0")
-  def registerStringCodec[A](
-      s: ShowLines[A],
-      tt: scala.reflect.runtime.universe.TypeTag[A]
-  ): Unit = {
-    LogExchange.registerStringCodec[A](s, tt)
-  }
   def registerStringCodec[A: ShowLines: StringTypeTag]: Unit = {
     LogExchange.registerStringCodec[A]
   }

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -7,15 +7,14 @@
 
 package sbt.util
 
-import java.util.concurrent.ConcurrentHashMap
-import org.apache.logging.log4j.{ LogManager => XLogManager, Level => XLevel }
-import org.apache.logging.log4j.core.{ Appender => XAppender, LoggerContext => XLoggerContext }
-import org.apache.logging.log4j.core.config.{ AppenderRef, LoggerConfig }
+import org.apache.logging.log4j.core.config.LoggerConfig
 import org.apache.logging.log4j.core.layout.PatternLayout
+import org.apache.logging.log4j.core.{ LoggerContext => XLoggerContext }
+import org.apache.logging.log4j.{ LogManager => XLogManager }
 import sbt.internal.util._
+
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.concurrent
-import sjsonnew.JsonFormat
-import org.apache.logging.log4j.core.appender.AsyncAppender
 
 // http://logging.apache.org/log4j/2.x/manual/customconfig.html
 // https://logging.apache.org/log4j/2.x/log4j-core/apidocs/index.html
@@ -29,54 +28,18 @@ sealed abstract class LogExchange {
     Util.ignoreResult(configs.putIfAbsent(name, config))
   private[util] def removeConfig(name: String): Option[LoggerConfig] = Option(configs.remove(name))
 
-  @deprecated("Use LoggerContext to create loggers", "1.4.0")
   def logger(name: String): ManagedLogger = logger(name, None, None)
-  @deprecated("Use LoggerContext to create loggers", "1.4.0")
   def logger(name: String, channelName: Option[String], execId: Option[String]): ManagedLogger =
     LoggerContext.globalContext.logger(name, channelName, execId)
-  @deprecated("Use LoggerContext to unbind appenders", "1.4.0")
   def unbindLoggerAppenders(loggerName: String): Unit = {
     LoggerContext.globalContext.clearAppenders(loggerName)
   }
-  @deprecated("Use LoggerContext to bind appenders", "1.4.0")
-  def bindLoggerAppenders(
-      loggerName: String,
-      appenders: List[(XAppender, Level.Value)]
-  ): Unit = {
-    appenders.foreach {
-      case (a, l) =>
-        LoggerContext.globalContext
-          .addAppender(loggerName, new ConsoleAppenderFromLog4J(loggerName, a) -> l)
-    }
-  }
-  @deprecated("Use LoggerContext to bind appenders", "1.4.0")
   def bindLoggerAppenders(
       loggerName: String,
       appenders: Seq[(Appender, Level.Value)]
-  ): Unit = bindLoggerAppenders(loggerName, appenders.map { case (a, l) => a.toLog4J -> l }.toList)
-  @deprecated("unused", "1.4.0")
-  def loggerConfig(loggerName: String): LoggerConfig = configs.get(loggerName)
-
-  @deprecated("unused", "1.4.0")
-  lazy val asyncStdout = buildAsyncStdout
-  @deprecated("unused", "1.4.0")
-  private[sbt] def buildAsyncStdout: AsyncAppender = {
-    val ctx = XLogManager.getContext(false) match { case x: XLoggerContext => x }
-    val config = ctx.getConfiguration
-    val appender = ConsoleAppender("Stdout").toLog4J
-    // CustomConsoleAppender.createAppender("Stdout", layout, null, null)
-    appender.start
-    config.addAppender(appender)
-    val asyncAppender: AsyncAppender = AsyncAppender
-      .newBuilder()
-      .setName("AsyncStdout")
-      .setAppenderRefs(Array(AppenderRef.createAppenderRef("Stdout", XLevel.DEBUG, null)))
-      .setBlocking(false)
-      .setConfiguration(config)
-      .build
-    asyncAppender.start
-    config.addAppender(asyncAppender)
-    asyncAppender
+  ): Unit = {
+    appenders.map(LoggerContext.globalContext.addAppender(loggerName, _))
+    ()
   }
 
   // Construct these StringTypeTags manually, because they're used at the very startup of sbt
@@ -87,9 +50,9 @@ sealed abstract class LogExchange {
   lazy val stringTypeTagSuccessEvent = StringTypeTag[SuccessEvent]("sbt.internal.util.SuccessEvent")
 
   private[sbt] def initStringCodecs(): Unit = {
+    import sbt.internal.util.codec.SuccessEventShowLines._
     import sbt.internal.util.codec.ThrowableShowLines._
     import sbt.internal.util.codec.TraceEventShowLines._
-    import sbt.internal.util.codec.SuccessEventShowLines._
 
     registerStringCodecByStringTypeTag(stringTypeTagThrowable)
     registerStringCodecByStringTypeTag(stringTypeTagTraceEvent)
@@ -111,15 +74,6 @@ sealed abstract class LogExchange {
     lo
   }
 
-  @deprecated("It is now necessary to provide a json format instance", "1.4.0")
-  def jsonCodec[A](tag: String): Option[JsonFormat[A]] = None
-  @deprecated("Always returns false", "1.4.0")
-  def hasJsonCodec(tag: String): Boolean = false
-  @deprecated("This is a no-op", "1.4.0")
-  def getOrElseUpdateJsonCodec[A](tag: String, v: JsonFormat[A]): JsonFormat[A] = v
-  @deprecated("The log manager no longer caches jsonCodecs", "1.4.0")
-  def jsonCodecs(): concurrent.Map[String, JsonFormat[_]] = concurrent.TrieMap.empty
-
   def stringCodec[A](tag: String): Option[ShowLines[A]] =
     stringCodecs.get(tag) map { _.asInstanceOf[ShowLines[A]] }
   def hasStringCodec(tag: String): Boolean =
@@ -127,13 +81,6 @@ sealed abstract class LogExchange {
   def getOrElseUpdateStringCodec[A](tag: String, v: ShowLines[A]): ShowLines[A] =
     stringCodecs.getOrElseUpdate(tag, v).asInstanceOf[ShowLines[A]]
 
-  @deprecated("Prefer macro based registerStringCodec", "1.4.0")
-  def registerStringCodec[A](
-      st: ShowLines[A],
-      tt: scala.reflect.runtime.universe.TypeTag[A]
-  ): Unit = {
-    registerStringCodecByStringTypeTag(StringTypeTag.apply[A](tt))(st)
-  }
   private[sbt] def registerStringCodec[A: ShowLines: StringTypeTag]: Unit = {
     registerStringCodecByStringTypeTag(implicitly[StringTypeTag[A]])
   }
@@ -144,8 +91,8 @@ sealed abstract class LogExchange {
   }
 
   private[sbt] def init(): XLoggerContext = {
-    import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory
     import org.apache.logging.log4j.core.config.Configurator
+    import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory
     val builder = ConfigurationBuilderFactory.newConfigurationBuilder
     builder.setConfigurationName("sbt.util.logging")
     val ctx = Configurator.initialize(builder.build())

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -7,15 +7,11 @@
 
 package sbt.util
 
+import sbt.internal.util._
+
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import org.apache.logging.log4j.{ Level => XLevel }
-import org.apache.logging.log4j.core.{ Appender => XAppender, LoggerContext => XLoggerContext }
-import org.apache.logging.log4j.core.config.{ AppenderRef, LoggerConfig }
-import sbt.internal.util._
 import scala.collection.JavaConverters._
-import org.apache.logging.log4j.core.config.AbstractConfiguration
-import org.apache.logging.log4j.message.ObjectMessage
 
 /**
  * Provides a context for generating loggers during task evaluation. The logger context
@@ -35,83 +31,8 @@ sealed trait LoggerContext extends AutoCloseable {
   def remove(name: String): Unit
 }
 object LoggerContext {
-  private[this] val useLog4J = System.getProperty("sbt.log.uselog4j", "false") == "true"
-  private[this] lazy val global = new LoggerContext.LoggerContextImpl
-  private[this] lazy val globalLog4J = new LoggerContext.Log4JLoggerContext(LogExchange.context)
-  private[sbt] lazy val globalContext = if (useLog4J) globalLog4J else global
-  private[util] class Log4JLoggerContext(val xlc: XLoggerContext) extends LoggerContext {
-    private val config = xlc.getConfiguration match {
-      case a: AbstractConfiguration => a
-      case _                        => throw new IllegalStateException("")
-    }
-    val loggers = new java.util.Vector[String]
-    private[this] val closed = new AtomicBoolean(false)
-    override def logger(
-        name: String,
-        channelName: Option[String],
-        execId: Option[String]
-    ): ManagedLogger = {
-      if (closed.get) {
-        throw new IllegalStateException("Tried to create logger for closed LoggerContext")
-      }
-      val loggerConfig = LoggerConfig.createLogger(
-        false,
-        XLevel.DEBUG,
-        name,
-        // disable the calculation of caller location as it is very expensive
-        // https://issues.apache.org/jira/browse/LOG4J2-153
-        "false",
-        Array[AppenderRef](),
-        null,
-        config,
-        null
-      )
-      config.addLogger(name, loggerConfig)
-      val logger = xlc.getLogger(name)
-      LogExchange.addConfig(name, loggerConfig)
-      loggers.add(name)
-      val xlogger = new MiniLogger {
-        def log(level: Level.Value, message: => String): Unit =
-          logger.log(
-            ConsoleAppender.toXLevel(level),
-            new ObjectMessage(StringEvent(level.toString, message, channelName, execId))
-          )
-        def log[T](level: Level.Value, message: ObjectEvent[T]): Unit =
-          logger.log(ConsoleAppender.toXLevel(level), new ObjectMessage(message))
-      }
-      new ManagedLogger(name, channelName, execId, xlogger, Some(Terminal.get), this)
-    }
-    override def clearAppenders(loggerName: String): Unit = {
-      val lc = config.getLoggerConfig(loggerName)
-      lc.getAppenders.asScala foreach {
-        case (name, a) =>
-          a.stop()
-          lc.removeAppender(name)
-      }
-    }
-    override def addAppender(
-        loggerName: String,
-        appender: (Appender, Level.Value)
-    ): Unit = {
-      val lc = config.getLoggerConfig(loggerName)
-      appender match {
-        case (x: XAppender, lv) => lc.addAppender(x, ConsoleAppender.toXLevel(lv), null)
-        case (x, lv)            => lc.addAppender(x.toLog4J, ConsoleAppender.toXLevel(lv), null)
-      }
-    }
-    override def appenders(loggerName: String): Seq[Appender] = {
-      val lc = config.getLoggerConfig(loggerName)
-      lc.getAppenders.asScala.collect { case (name, ca: ConsoleAppender) => ca }.toVector
-    }
-    override def remove(name: String): Unit = {
-      val lc = config.getLoggerConfig(name)
-      config.removeLogger(name)
-    }
-    def close(): Unit = if (closed.compareAndSet(false, true)) {
-      loggers.forEach(l => remove(l))
-      loggers.clear()
-    }
-  }
+  private[sbt] lazy val globalContext: LoggerContext = new LoggerContext.LoggerContextImpl
+
   private[util] class LoggerContextImpl extends LoggerContext {
     private class Log extends MiniLogger {
       private val consoleAppenders: java.util.Vector[(Appender, Level.Value)] =
@@ -186,6 +107,5 @@ object LoggerContext {
       loggers.clear()
     }
   }
-  private[sbt] def apply(useLog4J: Boolean) =
-    if (useLog4J) new Log4JLoggerContext(LogExchange.context) else new LoggerContextImpl
+  private[sbt] def apply() = new LoggerContextImpl
 }

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -15,8 +15,9 @@ import sbt.io.Using
 import scala.annotation.nowarn
 
 class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
-  val context = LoggerContext(useLog4J = true)
+  val context = LoggerContext()
   @nowarn
+  //TODO create a new appender for testing purposes - 3/12/21
   val asyncStdout = new ConsoleAppenderFromLog4J("asyncStdout", LogExchange.asyncStdout)
   def newLogger(name: String): ManagedLogger = context.logger(name, None, None)
   "ManagedLogger" should "log to console" in {

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
@@ -25,8 +25,7 @@ object ScriptedRunnerImpl {
       tests: Array[String],
       handlersProvider: HandlersProvider
   ): Unit = {
-    val context =
-      LoggerContext(useLog4J = System.getProperty("sbt.log.uselog4j", "false") == "true")
+    val context = LoggerContext()
     val runner = new ScriptedTests(resourceBaseDirectory, bufferLog, handlersProvider)
     val logger = newLogger(context)
     val allTests = get(tests, resourceBaseDirectory, logger) flatMap {

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -7,26 +7,22 @@
 
 package sbt
 
-import java.io.PrintWriter
-import java.util.concurrent.RejectedExecutionException
-import java.util.Properties
-
 import sbt.BasicCommandStrings.{ StashOnFailure, networkExecPrefix }
-import sbt.internal.ShutdownHooks
 import sbt.internal.langserver.ErrorCodes
-import sbt.internal.protocol.JsonRpcResponseError
 import sbt.internal.nio.CheckBuildSources.CheckBuildSourcesKey
+import sbt.internal.protocol.JsonRpcResponseError
 import sbt.internal.util.{ ErrorHandling, GlobalLogBacking, Prompt, Terminal => ITerminal }
-import sbt.internal.{ ShutdownHooks, TaskProgress }
+import sbt.internal.{ FastTrackCommands, ShutdownHooks, SysProp, TaskProgress }
 import sbt.io.{ IO, Using }
 import sbt.protocol._
 import sbt.util.{ Logger, LoggerContext }
 
+import java.io.PrintWriter
+import java.util.Properties
+import java.util.concurrent.RejectedExecutionException
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-import sbt.internal.FastTrackCommands
-import sbt.internal.SysProp
 
 object MainLoop {
 
@@ -148,7 +144,7 @@ object MainLoop {
     }
 
   def next(state: State): State = {
-    val context = LoggerContext(useLog4J = state.get(Keys.useLog4J.key).getOrElse(false))
+    val context = LoggerContext()
     val superShellSleep =
       state.get(Keys.superShellSleep.key).getOrElse(SysProp.supershellSleep.millis)
     val superShellThreshold =

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1208,7 +1208,7 @@ private[sbt] object ContinuousCommands {
             .channelForName(channelName)
             .getOrElse(throw new IllegalStateException(s"No channel with name $channelName"))
           val dynamicInputs = mutable.Set.empty[DynamicInput]
-          val context = LoggerContext(useLog4J = state.get(Keys.useLog4J.key).getOrElse(false))
+          val context = LoggerContext()
           def cb: Continuous.Callbacks =
             Continuous.getCallbacks(state, channel, commands, cache, dynamicInputs, context)
 

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -90,7 +90,7 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
   // hooks for sending start/stop events
   protected def onAddJob(@deprecated("unused", "") job: JobHandle): Unit = ()
   protected def onRemoveJob(@deprecated("unused", "") job: JobHandle): Unit = ()
-  private val context = LoggerContext(useLog4J)
+  private val context = LoggerContext()
 
   // this mutable state could conceptually go on State except
   // that then every task that runs a background job would have

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -8,16 +8,15 @@
 package sbt
 package internal
 
-import java.io.PrintWriter
-
 import sbt.Def.ScopedKey
 import sbt.Keys._
 import sbt.Scope.Global
 import sbt.SlashSyntax0._
 import sbt.internal.util.MainAppender._
 import sbt.internal.util.{ Terminal => ITerminal, _ }
-import sbt.util.{ Level, LogExchange, Logger, LoggerContext }
-import org.apache.logging.log4j.core.{ Appender => XAppender }
+import sbt.util.{ Level, Logger, LoggerContext }
+
+import java.io.PrintWriter
 import scala.annotation.nowarn
 
 sealed abstract class LogManager {
@@ -88,12 +87,6 @@ object LogManager {
   def defaultManager(console: ConsoleOut): LogManager =
     withLoggers((_, _) => defaultScreen(console))
 
-  @deprecated(
-    "use defaults that takes AppenderSupplier instead of ScopedKey[_] => Seq[Appender]",
-    "1.4.0"
-  )
-  def defaults(extra: ScopedKey[_] => Seq[XAppender], console: ConsoleOut): LogManager =
-    defaults((sk: ScopedKey[_]) => extra(sk).map(new ConsoleAppenderFromLog4J("extra", _)), console)
   // This is called by Defaults.
   def defaults(extra: AppenderSupplier, console: ConsoleOut): LogManager =
     withLoggers(
@@ -296,14 +289,6 @@ object LogManager {
     LoggerContext.globalContext.clearAppenders(gl.full.name)
     LoggerContext.globalContext.addAppender(gl.full.name, gl.backed -> level)
     s1
-  }
-
-  @deprecated("No longer used.", "1.4.0")
-  private[sbt] def progressLogger(appender: ConsoleAppender): ManagedLogger = {
-    val log = LogExchange.logger("progress", None, None)
-    LoggerContext.globalContext.clearAppenders("progress")
-    LoggerContext.globalContext.addAppender("progress", appender -> Level.Info)
-    log
   }
 
   // This is the default implementation for the relay appender

--- a/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
@@ -14,7 +14,6 @@ import sbt.util.LoggerContext
 
 import scala.annotation.tailrec
 import scala.sys.process.Process
-import sbt.internal.SysProp
 
 object RunFromSourceMain {
   def fork(
@@ -44,7 +43,7 @@ object RunFromSourceMain {
     implicit val runner = new ForkRun(fo)
     val options =
       Vector(workingDirectory.toString, scalaVersion, sbtVersion, cp.mkString(pathSeparator))
-    val context = LoggerContext(useLog4J = SysProp.useLog4J)
+    val context = LoggerContext()
     val log = context.logger("RunFromSourceMain.fork", None, None)
     try runner.fork("sbt.RunFromSourceMain", cp, options, log)
     finally context.close()
@@ -58,7 +57,7 @@ object RunFromSourceMain {
     case Array(wd, scalaVersion, sbtVersion, classpath, args @ _*) =>
       System.setProperty("jna.nosys", "true")
       if (args.exists(_.startsWith("<"))) System.setProperty("sbt.io.virtual", "false")
-      val context = LoggerContext(useLog4J = SysProp.useLog4J)
+      val context = LoggerContext()
       try run(file(wd), scalaVersion, sbtVersion, classpath, args, context)
       finally context.close()
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6722
Fixes https://github.com/sbt/sbt/issues/6734

@eed3si9n and I are working on removing log4j, because the new logger (PR #5731) is working nicely. This will be part of sbt 2.0.0.