### PR TITLE
--no-server mode

### DIFF
--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -4,7 +4,8 @@ import minitest._
 import java.io.File
 
 object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
-  lazy val isWindows: Boolean = sys.props("os.name").toLowerCase(java.util.Locale.ENGLISH).contains("windows")
+  lazy val isWindows: Boolean =
+    sys.props("os.name").toLowerCase(java.util.Locale.ENGLISH).contains("windows")
   lazy val sbtScript =
     if (isWindows) new File("target/universal/stage/bin/sbt.bat")
     else new File("target/universal/stage/bin/sbt")
@@ -12,12 +13,13 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   private val javaBinDir = new File("integration-test", "bin").getAbsolutePath
 
   private def makeTest(
-    name: String,
-    javaOpts: String = "",
-    sbtOpts: String = "",
+      name: String,
+      javaOpts: String = "",
+      sbtOpts: String = "",
   )(args: String*)(f: List[String] => Any) = {
     test(name) {
-      val out = sbtProcessWithOpts(args: _*)(javaOpts = javaOpts, sbtOpts = sbtOpts).!!.linesIterator.toList
+      val out =
+        sbtProcessWithOpts(args: _*)(javaOpts = javaOpts, sbtOpts = sbtOpts).!!.linesIterator.toList
       f(out)
       ()
     }
@@ -26,12 +28,14 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   def sbtProcess(args: String*) = sbtProcessWithOpts(args: _*)("", "")
   def sbtProcessWithOpts(args: String*)(javaOpts: String, sbtOpts: String) = {
     val path = sys.env("PATH")
-    sbt.internal.Process(Seq(sbtScript.getAbsolutePath) ++ args, new File("citest"),
+    sbt.internal.Process(
+      Seq(sbtScript.getAbsolutePath) ++ args,
+      new File("citest"),
       "JAVA_OPTS" -> javaOpts,
       "SBT_OPTS" -> sbtOpts,
       if (isWindows)
         "JAVACMD" -> new File(javaBinDir, "java.cmd").getAbsolutePath()
-      else 
+      else
         "PATH" -> (javaBinDir + File.pathSeparator + path)
     )
   }
@@ -48,9 +52,14 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     assert(out.contains[String]("-Dsbt.color=false"))
   }
 
-  makeTest("sbt --no-colors in SBT_OPTS", sbtOpts = "--no-colors")("compile", "-v") { out: List[String] =>
-    if (isWindows) cancel("Test not supported on windows")
-    assert(out.contains[String]("-Dsbt.log.noformat=true"))
+  makeTest("sbt --no-colors in SBT_OPTS", sbtOpts = "--no-colors")("compile", "-v") {
+    out: List[String] =>
+      if (isWindows) cancel("Test not supported on windows")
+      assert(out.contains[String]("-Dsbt.log.noformat=true"))
+  }
+
+  makeTest("sbt --no-server")("compile", "--no-server", "-v") { out: List[String] =>
+    assert(out.contains[String]("-Dsbt.server.autostart=false"))
   }
 
   makeTest("sbt --debug-inc")("compile", "--debug-inc", "-v") { out: List[String] =>
@@ -77,33 +86,43 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     assert(out.contains[String]("-Xmx503m"))
   }
 
-  makeTest("sbt with -mem 503, -Xmx in JAVA_OPTS", javaOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
-    assert(out.contains[String]("-Xmx503m"))
-    assert(!out.contains[String]("-Xmx1024m"))
+  makeTest("sbt with -mem 503, -Xmx in JAVA_OPTS", javaOpts = "-Xmx1024m")("-mem", "503", "-v") {
+    out: List[String] =>
+      assert(out.contains[String]("-Xmx503m"))
+      assert(!out.contains[String]("-Xmx1024m"))
   }
 
-  makeTest("sbt with -mem 503, -Xmx in SBT_OPTS", sbtOpts = "-Xmx1024m")("-mem", "503", "-v") { out: List[String] =>
-    assert(out.contains[String]("-Xmx503m"))
-    assert(!out.contains[String]("-Xmx1024m"))
+  makeTest("sbt with -mem 503, -Xmx in SBT_OPTS", sbtOpts = "-Xmx1024m")("-mem", "503", "-v") {
+    out: List[String] =>
+      assert(out.contains[String]("-Xmx503m"))
+      assert(!out.contains[String]("-Xmx1024m"))
   }
 
-  makeTest("sbt with -mem 503, -Xss in JAVA_OPTS", javaOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
-    assert(out.contains[String]("-Xmx503m"))
-    assert(!out.contains[String]("-Xss6m"))
+  makeTest("sbt with -mem 503, -Xss in JAVA_OPTS", javaOpts = "-Xss6m")("-mem", "503", "-v") {
+    out: List[String] =>
+      assert(out.contains[String]("-Xmx503m"))
+      assert(!out.contains[String]("-Xss6m"))
   }
 
-  makeTest("sbt with -mem 503, -Xss in SBT_OPTS", sbtOpts = "-Xss6m")("-mem", "503", "-v") { out: List[String] =>
-    assert(out.contains[String]("-Xmx503m"))
-    assert(!out.contains[String]("-Xss6m"))
+  makeTest("sbt with -mem 503, -Xss in SBT_OPTS", sbtOpts = "-Xss6m")("-mem", "503", "-v") {
+    out: List[String] =>
+      assert(out.contains[String]("-Xmx503m"))
+      assert(!out.contains[String]("-Xss6m"))
   }
 
-  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in JAVA_OPTS", javaOpts = "-Xms2048M -Xmx2048M -Xss6M")("-v") { out: List[String] =>
+  makeTest(
+    "sbt with -Xms2048M -Xmx2048M -Xss6M in JAVA_OPTS",
+    javaOpts = "-Xms2048M -Xmx2048M -Xss6M"
+  )("-v") { out: List[String] =>
     assert(out.contains[String]("-Xms2048M"))
     assert(out.contains[String]("-Xmx2048M"))
     assert(out.contains[String]("-Xss6M"))
   }
 
-  makeTest("sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS", sbtOpts = "-Xms2048M -Xmx2048M -Xss6M")( "-v") { out: List[String] =>
+  makeTest(
+    "sbt with -Xms2048M -Xmx2048M -Xss6M in SBT_OPTS",
+    sbtOpts = "-Xms2048M -Xmx2048M -Xss6M"
+  )("-v") { out: List[String] =>
     assert(out.contains[String]("-Xms2048M"))
     assert(out.contains[String]("-Xmx2048M"))
     assert(out.contains[String]("-Xss6M"))
@@ -125,13 +144,18 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     assert(out.contains[String]("-XX:PermSize=128M"))
   }
 
-  makeTest("sbt with -XX:+UseG1GC -XX:+PrintGC in JAVA_OPTS", javaOpts = "-XX:+UseG1GC -XX:+PrintGC")("-v") { out: List[String] =>
+  makeTest(
+    "sbt with -XX:+UseG1GC -XX:+PrintGC in JAVA_OPTS",
+    javaOpts = "-XX:+UseG1GC -XX:+PrintGC"
+  )("-v") { out: List[String] =>
     assert(out.contains[String]("-XX:+UseG1GC"))
     assert(out.contains[String]("-XX:+PrintGC"))
     assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
   }
 
-  makeTest("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS", sbtOpts = "-XX:+UseG1GC -XX:+PrintGC")( "-v") { out: List[String] =>
+  makeTest("sbt with -XX:-UseG1GC -XX:-PrintGC in SBT_OPTS", sbtOpts = "-XX:+UseG1GC -XX:+PrintGC")(
+    "-v"
+  ) { out: List[String] =>
     assert(out.contains[String]("-XX:+UseG1GC"))
     assert(out.contains[String]("-XX:+PrintGC"))
     assert(!out.contains[String]("-XX:+UseG1GC=-XX:+PrintGC"))
@@ -140,7 +164,8 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   test("sbt with -debug in SBT_OPTS appears in sbt commands") {
     if (isWindows) cancel("Test not supported on windows")
 
-    val out: List[String] = sbtProcessWithOpts("compile", "-v")(javaOpts = "", sbtOpts = "-debug").!!.linesIterator.toList
+    val out: List[String] =
+      sbtProcessWithOpts("compile", "-v")(javaOpts = "", sbtOpts = "-debug").!!.linesIterator.toList
     // Debug argument must appear in the 'commands' section (after the sbt-launch.jar argument) to work
     val sbtLaunchMatcher = """^.+sbt-launch.jar["]{0,1}$""".r
     val locationOfSbtLaunchJarArg = out.zipWithIndex.collectFirst {
@@ -155,7 +180,9 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
   }
 
   makeTest("sbt --jvm-debug <port>")("--jvm-debug", "12345", "-v") { out: List[String] =>
-    assert(out.contains[String]("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12345"))
+    assert(
+      out.contains[String]("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12345")
+    )
   }
 
   makeTest("sbt --no-share adds three system properties")("--no-share") { out: List[String] =>
@@ -171,7 +198,7 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
 
   test("sbt --script-version should print sbtVersion") {
     val out = sbtProcess("--script-version").!!.trim
-    val expectedVersion = "^"+SbtRunnerTest.versionRegEx+"$"
+    val expectedVersion = "^" + SbtRunnerTest.versionRegEx + "$"
     assert(out.matches(expectedVersion))
     ()
   }

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -50,6 +50,7 @@ set sbt_args_sbt_dir=
 set sbt_args_sbt_version=
 set sbt_args_mem=
 set sbt_args_client=
+set sbt_args_no_server=
 
 rem users can set SBT_OPTS via .sbtopts
 if exist .sbtopts for /F %%A in (.sbtopts) do (
@@ -202,6 +203,15 @@ if "%~0" == "--no-colors" set _no_colors_arg=true
 if defined _no_colors_arg (
   set _no_colors_arg=
   set sbt_args_no_colors=1
+  goto args_loop
+)
+
+if "%~0" == "-no-server" set _no_server_arg=true
+if "%~0" == "--no-server" set _no_server_arg=true
+
+if defined _no_server_arg (
+  set _no_server_arg=
+  set sbt_args_no_server=1
   goto args_loop
 )
 
@@ -644,6 +654,10 @@ if defined sbt_args_timings (
 
 if defined sbt_args_traces (
   set _SBT_OPTS=-Dsbt.traces=true !_SBT_OPTS!
+)
+
+if defined sbt_args_no_server (
+  set _SBT_OPTS=-Dsbt.io.virtual=false -Dsbt.server.autostart=false !_SBT_OPTS!
 )
 
 rem TODO: _SBT_OPTS needs to be processed as args and diffed against SBT_ARGS

--- a/sbt
+++ b/sbt
@@ -22,6 +22,7 @@ declare sbt_verbose=
 declare sbt_debug=
 declare build_props_sbt_version=
 declare use_sbtn=
+declare no_server=
 declare sbtn_command="$SBTN_CMD"
 declare sbtn_version="1.4.7"
 
@@ -631,6 +632,7 @@ map_args () {
            -traces|--traces) options=( "${options[@]}" "-Dsbt.traces=true" ) && shift ;;
              --supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:13}" ) && shift ;;
               -supershell=*) options=( "${options[@]}" "-Dsbt.supershell=${1:12}" ) && shift ;;
+     -no-server|--no-server) options=( "${options[@]}" "-Dsbt.io.virtual=false" "-Dsbt.server.autostart=false" ) && shift ;;
                   --color=*) options=( "${options[@]}" "-Dsbt.color=${1:8}" ) && shift ;;
                    -color=*) options=( "${options[@]}" "-Dsbt.color=${1:7}" ) && shift ;;
        -no-share|--no-share) options=( "${options[@]}" "${noshare_opts[@]}" ) && shift ;;


### PR DESCRIPTION
Fixes #6530
Ref #6101

Problem
-------
Although having sbt server up by default is beneficial to well-tested
platforms like macOS, on less tested setups various native and/or
native-adjacent techniques we use could end up causing instability.

Solution
--------
This adds `--no-server` as a quick way of telling sbt not to start up
the sbt server or create virtual terminal.