### PR TITLE
Extend supershell close timeout

### DIFF
--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -70,8 +70,9 @@ private[sbt] class TaskProgress(
     pending.clear()
     scheduler.shutdownNow()
     executor.shutdownNow()
-    if (!executor.awaitTermination(1, TimeUnit.SECONDS) ||
-        !scheduler.awaitTermination(1, TimeUnit.SECONDS)) {
+    if (!executor.awaitTermination(30, TimeUnit.SECONDS) ||
+        !scheduler.awaitTermination(30, TimeUnit.SECONDS)) {
+      scala.Console.err.println("timed out closing the executor of supershell")
       throw new TimeoutException
     }
   }


### PR DESCRIPTION
Fixes #6592

Problem
-------
On Heroku there's timeout.

Solution
--------
This seems to be coming from supershell closing the executor.
Extend the timeout to 30s.