### PR TITLE
Add `public` modifier to the SubclassFingerscan and AnnotatedFingerscan.

### DIFF
--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -27,12 +27,12 @@ public final class ForkMain {
   // serializables
   // -----------------------------------------------------------------------------
 
-  static final class SubclassFingerscan implements SubclassFingerprint, Serializable {
+  public static final class SubclassFingerscan implements SubclassFingerprint, Serializable {
     private final boolean isModule;
     private final String superclassName;
     private final boolean requireNoArgConstructor;
 
-    SubclassFingerscan(final SubclassFingerprint print) {
+    public SubclassFingerscan(final SubclassFingerprint print) {
       isModule = print.isModule();
       superclassName = print.superclassName();
       requireNoArgConstructor = print.requireNoArgConstructor();
@@ -51,11 +51,11 @@ public final class ForkMain {
     }
   }
 
-  static final class AnnotatedFingerscan implements AnnotatedFingerprint, Serializable {
+  public static final class AnnotatedFingerscan implements AnnotatedFingerprint, Serializable {
     private final boolean isModule;
     private final String annotationName;
 
-    AnnotatedFingerscan(final AnnotatedFingerprint print) {
+    public AnnotatedFingerscan(final AnnotatedFingerprint print) {
       isModule = print.isModule();
       annotationName = print.annotationName();
     }


### PR DESCRIPTION
Currently, both `SubclassFingerscan` and `AnnotatedFingerscan` are package-private within the `sbt` package. This forces for example [bloop](https://github.com/scalacenter/bloop/blob/master/frontend/src/main/scala/sbt/SerializableFingerprints.scala) and [scala-debug-adapter](https://github.com/scalacenter/scala-debug-adapter/blob/989106082776015999c2c6f631d415a3544ce108/sbt/test-agent/src/main/java/ch/epfl/scala/debugadapter/sbtplugin/internal/SubclassFingerscan.java) to have some workaround about this.

Adding `public` modifier will solve mentioned problem.