### PR TITLE
Remove deprecated command last-grep

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -626,11 +626,6 @@ object BuiltinCommands {
       s
   }
 
-  @deprecated("Use `lastGrep` instead.", "1.2.0")
-  def oldLastGrep: Command =
-    lastGrepCommand(OldLastGrepCommand, oldLastGrepBrief, oldLastGrepDetailed, { s =>
-      lastGrepParser(s)
-    })
 
   def lastGrep: Command =
     lastGrepCommand(LastGrepCommand, lastGrepBrief, lastGrepDetailed, lastGrepParser)
@@ -643,9 +638,6 @@ object BuiltinCommands {
   ): Command =
     Command(name, briefHelp, detail)(parser) { (s: State, sks: (String, Option[AnyKeys])) =>
       {
-        if (name == OldLastGrepCommand)
-          s.log.warn(deprecationWarningText(OldLastGrepCommand, LastGrepCommand))
-
         (s, sks) match {
           case (s, (pattern, Some(sks))) =>
             val (str, _, display) = extractLast(s)

--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -70,22 +70,9 @@ $PrintCommand <task>
   def pluginsDetailed = pluginsBrief // TODO: expand
 
   val LastCommand = "last"
-  val OldLastGrepCommand = "last-grep"
   val LastGrepCommand = "lastGrep"
   val ExportCommand = "export"
   val ExportStream = "export"
-
-  val oldLastGrepBrief =
-    (OldLastGrepCommand, "Shows lines from the last output for 'key' that match 'pattern'.")
-  val oldLastGrepDetailed =
-    s"""$OldLastGrepCommand <pattern>
-	Displays lines from the logging of previous commands that match `pattern`.
-
-$OldLastGrepCommand <pattern> [key]
-	Displays lines from logging associated with `key` that match `pattern`.  The key typically refers to a task (for example, test:compile).  The logging that is displayed is restricted to the logging for that particular task.
-
-	<pattern> is a regular expression interpreted by java.util.Pattern.  Matching text is highlighted (when highlighting is supported and enabled).
-	See also '$LastCommand'."""
 
   val lastGrepBrief =
     (LastGrepCommand, "Shows lines from the last output for 'key' that match 'pattern'.")


### PR DESCRIPTION
This PR removes  the 'last-grep'  command, deprecated-marked  back in 2018. 
