### PR TITLE
[1.5.x] log4j 2.17.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,7 +106,7 @@ object Dependencies {
   val scalaPar = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0"
 
   // specify all of log4j modules to prevent misalignment
-  def log4jModule = (n: String) => "org.apache.logging.log4j" % n % "2.17.0"
+  def log4jModule = (n: String) => "org.apache.logging.log4j" % n % "2.17.1"
   val log4jApi = log4jModule("log4j-api")
   val log4jCore = log4jModule("log4j-core")
   val log4jSlf4jImpl = log4jModule("log4j-slf4j-impl")


### PR DESCRIPTION
Similar to sbt#6755, bumping log4j to the latest patch release to address CVE-2021-44832