### PR TITLE
fix: propagate `InterruptedException` from JLine.readLine

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -178,13 +178,7 @@ abstract class JLine extends LineReader {
   protected[this] lazy val in: InputStream = Terminal.wrappedSystemIn
 
   override def readLine(prompt: String, mask: Option[Char] = None): Option[String] =
-    try {
-      unsynchronizedReadLine(prompt, mask)
-    } catch {
-      case _: InterruptedException =>
-        // println("readLine: InterruptedException")
-        Option("")
-    }
+    unsynchronizedReadLine(prompt, mask)
 
   private[this] def unsynchronizedReadLine(prompt: String, mask: Option[Char]): Option[String] =
     readLineWithHistory(prompt, mask) map { x =>


### PR DESCRIPTION
**Motivation:**
Cannot exit from InteractionService.readLine

**Modification:**
Remove try/catch of InterruptedException mapped to None in JLine.readLine