### PR TITLE
[1.6.x] Throw when test framework cannot be loaded due to MatchError or NoClassDefFoundError

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import scala.util.Try
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 ThisBuild / version := {
-  val v = "1.6.0-SNAPSHOT"
+  val v = "1.6.2-SNAPSHOT"
   nightlyVersion.getOrElse(v)
 }
 ThisBuild / version2_13 := "2.0.0-SNAPSHOT"

--- a/sbt
+++ b/sbt
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set +e
-declare builtin_sbt_version="1.6.0"
+declare builtin_sbt_version="1.6.1"
 declare -a residual_args
 declare -a java_args
 declare -a scalac_args


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6805
Ref https://github.com/lampepfl/dotty/issues/14391
Ref https://github.com/sbt/sbt/pull/6480

Problem
-------
In some situations like Dotty Community Build, sbt version is
mechanically upgraded on an old commit without humans checking the log.
For reasons we're not completely sure (likely change in ClassLoader
structure) sbt 1.6.x started to fail to load test frameworks during
tests, but since the failure of the test framework loading doesn't fail
the task, this silently succeeded the builds.

Solution
--------
On MatchError and NoClassDefFound Error, rethrow the exception.
Note that ClassNotFoundException is considered ok since we have
predefined test frameworks listed in sbt, which often are not included
in the users' classpath.