### PR TITLE
launcher: debian package to depend on curl | wget

### DIFF
--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -191,7 +191,7 @@ val root = (project in file(".")).
     },
     // Used to have "openjdk-8-jdk" but that doesn't work on Ubuntu 14.04 https://github.com/sbt/sbt/issues/3105
     // before that we had java6-runtime-headless" and that was pulling in JDK9 on Ubuntu 16.04 https://github.com/sbt/sbt/issues/2931
-    debianPackageDependencies in Debian ++= Seq("bash (>= 3.2)"),
+    debianPackageDependencies in Debian ++= Seq("bash (>= 3.2)", "curl | wget"),
     debianPackageRecommends in Debian += "git",
     linuxPackageMappings in Debian += {
       val bd = sourceDirectory.value

--- a/sbt
+++ b/sbt
@@ -123,6 +123,9 @@ download_url () {
       curl --silent -L "$url" --output "$jar"
     elif command -v wget > /dev/null; then
       wget --quiet -O "$jar" "$url"
+    else
+      echoerr "failed to download $url: Neither curl nor wget is avaialble"
+      exit 2
     fi
   } && [[ -f "$jar" ]]
 }


### PR DESCRIPTION
also give informative error message when neither is available, rather than

```
$ sbt                                                                                      
downloading sbt launcher 1.6.1
/bin/mv: cannot stat '/root/.cache/sbt/boot/sbt-launch/1.6.1/sbt-launch-1.6.1.jar.temp': No such file or directory
failed to download launcher jar: https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.6.1/sbt-launch-1.6.1.jar
```