### PR TITLE
Improve log for not found remote cache artifact

### DIFF
--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -303,7 +303,8 @@ object RemoteCache {
                       }
                       found = true
                     case Left(e) =>
-                      log.info(s"remote cache not found for ${v}")
+                      val classifier = seqa.map(_.classifier).mkString(" ")
+                      log.info(s"remote cache artifact not found for $p $classifier")
                       log.debug(e.getMessage)
                   }
                 }


### PR DESCRIPTION
When a remote cache artifact isn't found, prints a more specific log with the project and the classifier:

```diff
-remote cache not found for 0.0.0-7c40144bd1c774e6
+remote cache artifact not found for org.gontard:sbt-test:0.0.0-7c40144bd1c774e6 Some(cached-compile)
```

It also aligned with other logs:
```diff
remote cache artifact extracted for org.gontard:sbt-test:0.0.0-7c40144bd1c774e6 Some(cached-compile)
```