### PR TITLE
[BSP]Do not fire `build/publishDiagnostics` if there are (and were) no problems 

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2310,10 +2310,11 @@ object Defaults extends BuildCommon {
     val ci = (compile / compileInputs).value
     val ping = earlyOutputPing.value
     val reporter = (compile / bspReporter).value
+    val prevAnalysis = previousCompile.value.analysis.toOption.getOrElse(Analysis.empty)
     BspCompileTask.compute(bspTargetIdentifier.value, thisProjectRef.value, configuration.value) {
       task =>
         // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
-        compileIncrementalTaskImpl(task, s, ci, ping, reporter)
+        compileIncrementalTaskImpl(task, s, ci, ping, reporter, prevAnalysis)
     }
   }
   private val incCompiler = ZincUtil.defaultIncrementalCompiler
@@ -2342,7 +2343,8 @@ object Defaults extends BuildCommon {
       s: TaskStreams,
       ci: Inputs,
       promise: PromiseWrap[Boolean],
-      reporter: BuildServerReporter
+      reporter: BuildServerReporter,
+      prev: CompileAnalysis
   ): CompileResult = {
     lazy val x = s.text(ExportStream)
     def onArgs(cs: Compilers) = {
@@ -2364,7 +2366,7 @@ object Defaults extends BuildCommon {
       .withSetup(onProgress(setup))
     try {
       val result = incCompiler.compile(i, s.log)
-      reporter.sendSuccessReport(result.getAnalysis)
+      reporter.sendSuccessReport(result.getAnalysis, prev)
       result
     } catch {
       case e: Throwable =>

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2329,7 +2329,7 @@ object Defaults extends BuildCommon {
         val result0 = incCompiler
           .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
           .compileAllJava(in, s.log)
-        reporter.sendSuccessReport(result0.analysis())
+        reporter.sendSuccessReport(result0.analysis(), Analysis.empty, false)
         result0.withHasModified(result0.hasModified || r.hasModified)
       } else r
     } catch {
@@ -2366,7 +2366,11 @@ object Defaults extends BuildCommon {
       .withSetup(onProgress(setup))
     try {
       val result = incCompiler.compile(i, s.log)
-      reporter.sendSuccessReport(result.getAnalysis, prev)
+      reporter.sendSuccessReport(
+        result.getAnalysis,
+        prev,
+        BuildServerProtocol.shouldReportAllPreviousProblems(task.targetId)
+      )
       result
     } catch {
       case e: Throwable =>

--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -38,7 +38,7 @@ sealed trait BuildServerReporter extends Reporter {
 
   protected def publishDiagnostic(problem: Problem): Unit
 
-  def sendSuccessReport(analysis: CompileAnalysis): Unit
+  def sendSuccessReport(analysis: CompileAnalysis, prev: CompileAnalysis): Unit
 
   def sendFailureReport(sources: Array[VirtualFile]): Unit
 
@@ -86,20 +86,26 @@ final class BuildServerReporterImpl(
     if (ref.id().contains("<")) None
     else Some(converter.toPath(ref))
 
-  override def sendSuccessReport(analysis: CompileAnalysis): Unit = {
+  override def sendSuccessReport(analysis: CompileAnalysis, prev: CompileAnalysis): Unit = {
+    val prevInfos = prev.readSourceInfos().getAllSourceInfos().asScala
     for {
       (source, infos) <- analysis.readSourceInfos.getAllSourceInfos.asScala
       filePath <- toSafePath(source)
     } {
-      val diagnostics = infos.getReportedProblems.toSeq.flatMap(toDiagnostic)
-      val params = PublishDiagnosticsParams(
-        textDocument = TextDocumentIdentifier(filePath.toUri),
-        buildTarget,
-        originId = None,
-        diagnostics.toVector,
-        reset = true
-      )
-      exchange.notifyEvent("build/publishDiagnostics", params)
+      val prevProblems = prevInfos.get(source).map(_.getReportedProblems()).getOrElse(Array.empty)
+      val dontPublish = prevProblems.length == 0 && infos.getReportedProblems().length == 0
+
+      if (!dontPublish) {
+        val diagnostics = infos.getReportedProblems.toSeq.flatMap(toDiagnostic)
+        val params = PublishDiagnosticsParams(
+          textDocument = TextDocumentIdentifier(filePath.toUri),
+          buildTarget,
+          originId = None,
+          diagnostics.toVector,
+          reset = true
+        )
+        exchange.notifyEvent("build/publishDiagnostics", params)
+      }
     }
   }
 
@@ -179,7 +185,7 @@ final class BuildServerForwarder(
     protected override val underlying: Reporter
 ) extends BuildServerReporter {
 
-  override def sendSuccessReport(analysis: CompileAnalysis): Unit = ()
+  override def sendSuccessReport(analysis: CompileAnalysis, prev: CompileAnalysis): Unit = ()
 
   override def sendFailureReport(sources: Array[VirtualFile]): Unit = ()
 

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -126,9 +126,24 @@ object BuildServerTest extends AbstractServerTest {
     })
 
     assert(svr.waitForString(60.seconds) { s =>
+      s.contains("build/publishDiagnostics")
+      s.contains(""""diagnostics":[]""")
+    })
+
+    assert(svr.waitForString(60.seconds) { s =>
       s.contains("build/taskFinish") &&
       s.contains(""""message":"Compiled runAndTest"""")
     })
+
+    svr.sendJsonRpc(
+      s"""{ "jsonrpc": "2.0", "id": "34", "method": "buildTarget/compile", "params": {
+         |  "targets": [{ "uri": "$buildTarget" }]
+         |} }""".stripMargin
+    )
+
+    assert(!svr.waitForString(30.seconds) { s =>
+      s.contains("build/publishDiagnostics")
+    }, "shouldn't send publishDiagnostics if there's no change in diagnostics")
   }
 
   test("buildTarget/scalacOptions") { _ =>


### PR DESCRIPTION
As a first step for fixing https://github.com/sbt/sbt/issues/6844, this PR suppress the sbt server from sending `build/publishDiagnostics` if

- there were no problems with the previous build &&
- there are no problems with the current build

---

While `bloop` doesn't send notifications if problems are the same as the previous ones, I have a concern about comparing all the problems may slow down the server performance a bit (Is there a good way to profile build?)
Therefore, this PR suppresses the diagnostics only when there are (and were) no problems, for the time being. (I believe this is still pretty effective for reducing the message load between BSP client-server, assuming most of the programs have no problems).

### example
For example, when we edit a file in [this repository](https://github.com/tanishiking/sbt-multi-project/tree/20a3d476dc874db295fb3af3450873f8f211f1ea), (after a full compilation, edit doesn't contain any problems) sbt BSP sends the following requests/notifications

<details>

<summary>sbt 1.6.2 </summary>

```
[Trace - 09:46:34 PM] Sending request 'buildTarget/compile - (11)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:46:35 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/compile"
}


[Trace - 09:46:35 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "24",
    "parents": []
  },
  "eventTime": 1647866795052,
  "message": "Compiling proj1",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj1/src/main/scala/A.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "24",
    "parents": []
  },
  "eventTime": 1647866795057,
  "message": "Compiled proj1",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 5
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795061,
  "message": "Compiling proj2",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/logMessage'
Params: {
  "type": 3,
  "message": "compiling 1 Scala source to /Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/target/scala-2.12/classes ..."
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795204,
  "message": "Compiling proj2 (10%)",
  "total": 28,
  "progress": 10,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795204,
  "message": "Compiling proj2 (10%)",
  "total": 28,
  "progress": 10,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795707,
  "message": "Compiling proj2 (25%)",
  "total": 28,
  "progress": 25,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795707,
  "message": "Compiling proj2 (25%)",
  "total": 28,
  "progress": 25,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795718,
  "message": "Compiling proj2 (35%)",
  "total": 28,
  "progress": 35,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795719,
  "message": "Compiling proj2 (35%)",
  "total": 28,
  "progress": 35,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795737,
  "message": "Compiling proj2 (50%)",
  "total": 28,
  "progress": 50,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795737,
  "message": "Compiling proj2 (50%)",
  "total": 28,
  "progress": 50,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795848,
  "message": "Compiling proj2 (60%)",
  "total": 28,
  "progress": 60,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795849,
  "message": "Compiling proj2 (60%)",
  "total": 28,
  "progress": 60,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795858,
  "message": "Compiling proj2 (75%)",
  "total": 28,
  "progress": 75,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795859,
  "message": "Compiling proj2 (75%)",
  "total": 28,
  "progress": 75,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795860,
  "message": "Compiling proj2 (85%)",
  "total": 28,
  "progress": 85,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795860,
  "message": "Compiling proj2 (85%)",
  "total": 28,
  "progress": 85,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795896,
  "message": "Compiling proj2 (100%)",
  "total": 28,
  "progress": 100,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795896,
  "message": "Compiling proj2 (100%)",
  "total": 28,
  "progress": 100,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/logMessage'
Params: {
  "type": 3,
  "message": "done compiling"
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/src/main/scala/B.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/src/main/scala/C.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "25",
    "parents": []
  },
  "eventTime": 1647866795903,
  "message": "Compiled proj2",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 842
  }
}


[Trace - 09:46:35 PM] Received response 'buildTarget/compile - (11)' in 912ms
Result: {
  "statusCode": 1
}
Error: null


[Trace - 09:46:35 PM] Sending request 'buildTarget/scalaMainClasses - (12)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:46:35 PM] Sending request 'buildTarget/scalaTestClasses - (13)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:46:35 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/scalaMainClasses"
}


[Trace - 09:46:35 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "26",
    "parents": []
  },
  "eventTime": 1647866795950,
  "message": "Compiling proj1",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj1/src/main/scala/A.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "26",
    "parents": []
  },
  "eventTime": 1647866795956,
  "message": "Compiled proj1",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 6
  }
}


[Trace - 09:46:35 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "27",
    "parents": []
  },
  "eventTime": 1647866795959,
  "message": "Compiling proj2",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/src/main/scala/B.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/publishDiagnostics'
Params: {
  "textDocument": {
    "uri": "file:///Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/src/main/scala/C.scala"
  },
  "buildTarget": {
    "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
  },
  "diagnostics": [],
  "reset": true
}


[Trace - 09:46:35 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "27",
    "parents": []
  },
  "eventTime": 1647866795966,
  "message": "Compiled proj2",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 7
  }
}


[Trace - 09:46:35 PM] Received response 'buildTarget/scalaMainClasses - (12)' in 60ms
Result: {
  "items": [
    {
      "target": {
        "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
      },
      "classes": []
    }
  ]
}
Error: null


[Trace - 09:46:35 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/scalaTestClasses"
}


[Trace - 09:46:35 PM] Received response 'buildTarget/scalaTestClasses - (13)' in 83ms
Result: {
  "items": [
    {
      "target": {
        "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
      },
      "classes": []
    }
  ]
}
Error: null
```

</details>

<details>

<summary>this SNAPSHOT</summary>

```

[Trace - 09:52:06 PM] Sending request 'buildTarget/compile - (14)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:52:06 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/compile"
}


[Trace - 09:52:06 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "28",
    "parents": []
  },
  "eventTime": 1647867126276,
  "message": "Compiling proj1",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    }
  }
}


[Trace - 09:52:06 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "28",
    "parents": []
  },
  "eventTime": 1647867126281,
  "message": "Compiled proj1",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 5
  }
}


[Trace - 09:52:06 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867126287,
  "message": "Compiling proj2",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:06 PM] Received notification 'build/logMessage'
Params: {
  "type": 3,
  "message": "compiling 1 Scala source to /Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/proj2/target/scala-2.12/classes ..."
}


[Trace - 09:52:08 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867128167,
  "message": "Compiling proj2 (10%)",
  "total": 28,
  "progress": 10,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:08 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867128170,
  "message": "Compiling proj2 (10%)",
  "total": 28,
  "progress": 10,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:08 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867128945,
  "message": "Compiling proj2 (25%)",
  "total": 28,
  "progress": 25,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:08 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867128945,
  "message": "Compiling proj2 (25%)",
  "total": 28,
  "progress": 25,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129043,
  "message": "Compiling proj2 (35%)",
  "total": 28,
  "progress": 35,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129048,
  "message": "Compiling proj2 (35%)",
  "total": 28,
  "progress": 35,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129398,
  "message": "Compiling proj2 (50%)",
  "total": 28,
  "progress": 50,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129398,
  "message": "Compiling proj2 (50%)",
  "total": 28,
  "progress": 50,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129843,
  "message": "Compiling proj2 (60%)",
  "total": 28,
  "progress": 60,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129844,
  "message": "Compiling proj2 (60%)",
  "total": 28,
  "progress": 60,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129901,
  "message": "Compiling proj2 (75%)",
  "total": 28,
  "progress": 75,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129901,
  "message": "Compiling proj2 (75%)",
  "total": 28,
  "progress": 75,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129913,
  "message": "Compiling proj2 (85%)",
  "total": 28,
  "progress": 85,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:09 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867129913,
  "message": "Compiling proj2 (85%)",
  "total": 28,
  "progress": 85,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:10 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867130068,
  "message": "Compiling proj2 (100%)",
  "total": 28,
  "progress": 100,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:10 PM] Received notification 'build/taskProgress'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867130069,
  "message": "Compiling proj2 (100%)",
  "total": 28,
  "progress": 100,
  "dataKind": "compile-progress",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:10 PM] Received notification 'build/logMessage'
Params: {
  "type": 3,
  "message": "done compiling"
}


[Trace - 09:52:10 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "29",
    "parents": []
  },
  "eventTime": 1647867130082,
  "message": "Compiled proj2",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 3795
  }
}


[Trace - 09:52:10 PM] Received response 'buildTarget/compile - (14)' in 3914ms
Result: {
  "statusCode": 1
}
Error: null


[Trace - 09:52:10 PM] Sending request 'buildTarget/scalaMainClasses - (15)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:52:10 PM] Sending request 'buildTarget/scalaTestClasses - (16)'
Params: {
  "targets": [
    {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  ]
}


[Trace - 09:52:10 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/scalaMainClasses"
}


[Trace - 09:52:10 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "30",
    "parents": []
  },
  "eventTime": 1647867130194,
  "message": "Compiling proj1",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    }
  }
}


[Trace - 09:52:10 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "30",
    "parents": []
  },
  "eventTime": 1647867130199,
  "message": "Compiled proj1",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj1/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 5
  }
}


[Trace - 09:52:10 PM] Received notification 'build/taskStart'
Params: {
  "taskId": {
    "id": "31",
    "parents": []
  },
  "eventTime": 1647867130206,
  "message": "Compiling proj2",
  "dataKind": "compile-task",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    }
  }
}


[Trace - 09:52:10 PM] Received notification 'build/taskFinish'
Params: {
  "taskId": {
    "id": "31",
    "parents": []
  },
  "eventTime": 1647867130214,
  "message": "Compiled proj2",
  "status": 1,
  "dataKind": "compile-report",
  "data": {
    "target": {
      "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
    },
    "errors": 0,
    "warnings": 0,
    "time": 8
  }
}


[Trace - 09:52:10 PM] Received response 'buildTarget/scalaMainClasses - (15)' in 70ms
Result: {
  "items": [
    {
      "target": {
        "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
      },
      "classes": []
    }
  ]
}
Error: null


[Trace - 09:52:10 PM] Received notification 'build/logMessage'
Params: {
  "type": 4,
  "message": "Processing buildTarget/scalaTestClasses"
}


[Trace - 09:52:10 PM] Received response 'buildTarget/scalaTestClasses - (16)' in 97ms
Result: {
  "items": [
    {
      "target": {
        "uri": "file:/Users/tanishiking/src/github.com/tanishiking/sbt-multi-project/#proj2/Compile"
      },
      "classes": []
    }
  ]
}
Error: null

```

</details>

Point is, there's no `publishDiagnostics` notifications anymore :)