### PR TITLE
includePluginResolvers should work for coursier resolutions

### DIFF
--- a/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
@@ -57,16 +57,7 @@ object CoursierRepositoriesTasks {
   private final val keepPreloaded = false // coursierKeepPreloaded.value
 
   def coursierResolversTask: Def.Initialize[sbt.Task[Seq[Resolver]]] = Def.task {
-    val bootResOpt = bootResolvers.value
-    val overrideFlag = overrideBuildResolvers.value
-    val result0 = bootResOpt.filter(_ => overrideFlag) match {
-      case Some(r) => r
-      case None =>
-        val extRes = externalResolvers.value
-        val isSbtPlugin = sbtPlugin.value
-        if (isSbtPlugin) sbtResolvers.value ++ extRes
-        else extRes
-    }
+    val result0 = fullResolvers.value.filterNot(_ == projectResolver.value)
     val reorderResolvers = true // coursierReorderResolvers.value
 
     val paths = ivyPaths.value

--- a/sbt-app/src/sbt-test/dependency-management/resolvers-plugin/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/resolvers-plugin/build.sbt
@@ -2,6 +2,9 @@ lazy val check = taskKey[Unit]("")
 ThisBuild / includePluginResolvers := true
 
 check := {
-  val rs = fullResolvers.value
-  assert(rs exists (_.name == "bintray-eed3si9n-sbt-plugins"), s"$rs does not include bintray")
+  val ivy = fullResolvers.value
+  assert(ivy exists (_.name == "bintray-eed3si9n-sbt-plugins"), s"$ivy does not include bintray")
+
+  val cs = csrResolvers.value
+  assert(cs exists (_.name == "bintray-eed3si9n-sbt-plugins"), s"$cs does not include bintray")
 }


### PR DESCRIPTION
It looks like https://github.com/sbt/sbt/pull/5094 didn't really address https://github.com/sbt/sbt/issues/5070 as the coursier behavior was not updated (only ivy which relies on `fullResolvers`).

I haven't found any active usage of `includePluginResolvers` in open-source, but https://github.com/gitter-badger/bqtest/commit/aa75c2b7c9bd624f97fdb157ae38f742048a4747 seems to confirm it does not work as expected.