### PR TITLE
Raise error for undiscovered mainClass

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -360,6 +360,7 @@ object Defaults extends BuildCommon {
       aggregate :== true,
       maxErrors :== 100,
       fork :== false,
+      allowUndiscoveredMainClass :== false,
       initialize :== {},
       templateResolverInfos :== Nil,
       forcegc :== sys.props
@@ -990,7 +991,6 @@ object Defaults extends BuildCommon {
     discoveredSbtPlugins := discoverSbtPluginNames.value,
     // This fork options, scoped to the configuration is used for tests
     forkOptions := forkOptionsTask.value,
-    allowUndiscoveredMainClass :== false,
     selectMainClass :=
       errorForUndiscoveredMainClass(
         mainClass.value,
@@ -1680,7 +1680,11 @@ object Defaults extends BuildCommon {
           val ver = version.value
           val org = organization.value
           val orgName = organizationName.value
-          val main = mainClass.value
+          val main = errorForUndiscoveredMainClass(
+            mainClass.value,
+            discoveredMainClasses.value,
+            allowUndiscoveredMainClass.value
+          )
           val ts = packageTimestamp.value
           val old = packageOptions.value
 
@@ -1902,6 +1906,8 @@ object Defaults extends BuildCommon {
       discoveredMainClasses: Seq[String],
       allowUndiscoveredMainClass: Boolean
   ): Option[String] = {
+    // TODO: remove println before merge!
+    println(s"$mainClass | ${discoveredMainClasses.mkString(",")} | $allowUndiscoveredMainClass")
     mainClass match {
       case None                                                                         => mainClass
       case Some(mc) if discoveredMainClasses.contains(mc) || allowUndiscoveredMainClass => mainClass

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -256,7 +256,6 @@ object Keys {
   val rootPaths = settingKey[Map[String, NioPath]]("The root paths used to abstract machine-specific paths.")
   private[sbt] val timeWrappedStamper = settingKey[ReadStamps]("The stamper to create timestamp or hash.")
   private[sbt] val reusableStamper = taskKey[ReadStamps]("The stamper can be reused across subprojects and sessions.")
-  val allowUndiscoveredMainClass = settingKey[Boolean]("Toggles whether or not to allow a mainClass that is not in the list of discovered main classes")
 
   // package keys
   val packageBin = taskKey[File]("Produces a main artifact, such as a binary jar.").withRank(ATask)
@@ -274,6 +273,7 @@ object Keys {
   val artifactName = settingKey[(ScalaVersion, ModuleID, Artifact) => String]("Function that produces the artifact name from its definition.").withRank(CSetting)
   val mappings = taskKey[Seq[(File, String)]]("Defines the mappings from a file to a path, used by packaging, for example.").withRank(BTask)
   val fileMappings = taskKey[Seq[(File, File)]]("Defines the mappings from a file to a file, used for copying files, for example.").withRank(BMinusTask)
+  val allowUndiscoveredMainClass = settingKey[Boolean]("Toggles whether or not to allow a mainClass that is missing in the list of discovered main classes")
 
   // Run Keys
   val selectMainClass = taskKey[Option[String]]("Selects the main class to run.").withRank(BMinusTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -256,6 +256,7 @@ object Keys {
   val rootPaths = settingKey[Map[String, NioPath]]("The root paths used to abstract machine-specific paths.")
   private[sbt] val timeWrappedStamper = settingKey[ReadStamps]("The stamper to create timestamp or hash.")
   private[sbt] val reusableStamper = taskKey[ReadStamps]("The stamper can be reused across subprojects and sessions.")
+  val allowUndiscoveredMainClass = settingKey[Boolean]("Toggles whether or not to allow a mainClass that is not in the list of discovered main classes")
 
   // package keys
   val packageBin = taskKey[File]("Produces a main artifact, such as a binary jar.").withRank(ATask)

--- a/sbt-app/src/sbt-test/package/main-class/build.sbt
+++ b/sbt-app/src/sbt-test/package/main-class/build.sbt
@@ -1,0 +1,12 @@
+lazy val ok = project.settings(
+  Compile / mainClass := Some("jartest.Main")
+)
+
+lazy val missing = project.settings(
+  Compile / mainClass := Some("does.not.exist")
+)
+
+lazy val suppressed = project.settings(
+  Compile / mainClass := Some("does.not.exist"),
+  Compile / allowUndiscoveredMainClass := true
+)

--- a/sbt-app/src/sbt-test/package/main-class/src/main/scala/jartest/Main.scala
+++ b/sbt-app/src/sbt-test/package/main-class/src/main/scala/jartest/Main.scala
@@ -1,0 +1,6 @@
+package jartest
+
+object Main
+{
+	def main(args: Array[String]): Unit = ()
+}

--- a/sbt-app/src/sbt-test/package/main-class/test
+++ b/sbt-app/src/sbt-test/package/main-class/test
@@ -1,0 +1,7 @@
+> ok/package
+
+# an undiscovered main-class should fail package task
+-> missing/package
+
+# an undiscovered main-class with suppressed error should succeed package task
+> suppressed/package


### PR DESCRIPTION
This PR lets SBT raise a build error when the `mainClass` is not in the list of discovered main classes.
For those rare cases where the main class comes from somewhere else, this also includes an option to suppress the error.

This is a follow up of https://github.com/sbt/sbt/discussions/6867 which describes the rationale.

There are a few open questions:
 - Is this the correct way to raise a build error?
 - Does this require a unit test? If so, where should it be added?