### PR TITLE
bsp: add JVM test/run env capabilities to BSP

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -65,7 +65,9 @@ object BuildServerProtocol {
     RunProvider(BuildServerConnection.languages),
     dependencySourcesProvider = true,
     resourcesProvider = true,
-    canReload = true
+    canReload = true,
+    jvmRunEnvironmentProvider = true,
+    jvmTestEnvironmentProvider = true,
   )
 
   private val bspReload = "bspReload"

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
@@ -17,22 +17,24 @@ final class BuildServerCapabilities private (
   val runProvider: Option[sbt.internal.bsp.RunProvider],
   val dependencySourcesProvider: Option[Boolean],
   val resourcesProvider: Option[Boolean],
-  val canReload: Option[Boolean]) extends Serializable {
+  val canReload: Option[Boolean],
+  val jvmRunEnvironmentProvider: Option[Boolean],
+  val jvmTestEnvironmentProvider: Option[Boolean]) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.testProvider == x.testProvider) && (this.runProvider == x.runProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.resourcesProvider == x.resourcesProvider) && (this.canReload == x.canReload)
+    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.testProvider == x.testProvider) && (this.runProvider == x.runProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.resourcesProvider == x.resourcesProvider) && (this.canReload == x.canReload) && (this.jvmRunEnvironmentProvider == x.jvmRunEnvironmentProvider) && (this.jvmTestEnvironmentProvider == x.jvmTestEnvironmentProvider)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + testProvider.##) + runProvider.##) + dependencySourcesProvider.##) + resourcesProvider.##) + canReload.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + testProvider.##) + runProvider.##) + dependencySourcesProvider.##) + resourcesProvider.##) + canReload.##) + jvmRunEnvironmentProvider.##) + jvmTestEnvironmentProvider.##)
   }
   override def toString: String = {
-    "BuildServerCapabilities(" + compileProvider + ", " + testProvider + ", " + runProvider + ", " + dependencySourcesProvider + ", " + resourcesProvider + ", " + canReload + ")"
+    "BuildServerCapabilities(" + compileProvider + ", " + testProvider + ", " + runProvider + ", " + dependencySourcesProvider + ", " + resourcesProvider + ", " + canReload + ", " + jvmRunEnvironmentProvider + ", " + jvmTestEnvironmentProvider + ")"
   }
-  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, testProvider: Option[sbt.internal.bsp.TestProvider] = testProvider, runProvider: Option[sbt.internal.bsp.RunProvider] = runProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, resourcesProvider: Option[Boolean] = resourcesProvider, canReload: Option[Boolean] = canReload): BuildServerCapabilities = {
-    new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload)
+  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, testProvider: Option[sbt.internal.bsp.TestProvider] = testProvider, runProvider: Option[sbt.internal.bsp.RunProvider] = runProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, resourcesProvider: Option[Boolean] = resourcesProvider, canReload: Option[Boolean] = canReload, jvmRunEnvironmentProvider: Option[Boolean] = jvmRunEnvironmentProvider, jvmTestEnvironmentProvider: Option[Boolean] = jvmTestEnvironmentProvider): BuildServerCapabilities = {
+    new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
   }
   def withCompileProvider(compileProvider: Option[sbt.internal.bsp.CompileProvider]): BuildServerCapabilities = {
     copy(compileProvider = compileProvider)
@@ -70,9 +72,21 @@ final class BuildServerCapabilities private (
   def withCanReload(canReload: Boolean): BuildServerCapabilities = {
     copy(canReload = Option(canReload))
   }
+  def withJvmRunEnvironmentProvider(jvmRunEnvironmentProvider: Option[Boolean]): BuildServerCapabilities = {
+    copy(jvmRunEnvironmentProvider = jvmRunEnvironmentProvider)
+  }
+  def withJvmRunEnvironmentProvider(jvmRunEnvironmentProvider: Boolean): BuildServerCapabilities = {
+    copy(jvmRunEnvironmentProvider = Option(jvmRunEnvironmentProvider))
+  }
+  def withJvmTestEnvironmentProvider(jvmTestEnvironmentProvider: Option[Boolean]): BuildServerCapabilities = {
+    copy(jvmTestEnvironmentProvider = jvmTestEnvironmentProvider)
+  }
+  def withJvmTestEnvironmentProvider(jvmTestEnvironmentProvider: Boolean): BuildServerCapabilities = {
+    copy(jvmTestEnvironmentProvider = Option(jvmTestEnvironmentProvider))
+  }
 }
 object BuildServerCapabilities {
   
-  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], testProvider: Option[sbt.internal.bsp.TestProvider], runProvider: Option[sbt.internal.bsp.RunProvider], dependencySourcesProvider: Option[Boolean], resourcesProvider: Option[Boolean], canReload: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload)
-  def apply(compileProvider: sbt.internal.bsp.CompileProvider, testProvider: sbt.internal.bsp.TestProvider, runProvider: sbt.internal.bsp.RunProvider, dependencySourcesProvider: Boolean, resourcesProvider: Boolean, canReload: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(testProvider), Option(runProvider), Option(dependencySourcesProvider), Option(resourcesProvider), Option(canReload))
+  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], testProvider: Option[sbt.internal.bsp.TestProvider], runProvider: Option[sbt.internal.bsp.RunProvider], dependencySourcesProvider: Option[Boolean], resourcesProvider: Option[Boolean], canReload: Option[Boolean], jvmRunEnvironmentProvider: Option[Boolean], jvmTestEnvironmentProvider: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
+  def apply(compileProvider: sbt.internal.bsp.CompileProvider, testProvider: sbt.internal.bsp.TestProvider, runProvider: sbt.internal.bsp.RunProvider, dependencySourcesProvider: Boolean, resourcesProvider: Boolean, canReload: Boolean, jvmRunEnvironmentProvider: Boolean, jvmTestEnvironmentProvider: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(testProvider), Option(runProvider), Option(dependencySourcesProvider), Option(resourcesProvider), Option(canReload), Option(jvmRunEnvironmentProvider), Option(jvmTestEnvironmentProvider))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
@@ -17,8 +17,10 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
       val dependencySourcesProvider = unbuilder.readField[Option[Boolean]]("dependencySourcesProvider")
       val resourcesProvider = unbuilder.readField[Option[Boolean]]("resourcesProvider")
       val canReload = unbuilder.readField[Option[Boolean]]("canReload")
+      val jvmRunEnvironmentProvider = unbuilder.readField[Option[Boolean]]("jvmRunEnvironmentProvider")
+      val jvmTestEnvironmentProvider = unbuilder.readField[Option[Boolean]]("jvmTestEnvironmentProvider")
       unbuilder.endObject()
-      sbt.internal.bsp.BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload)
+      sbt.internal.bsp.BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -31,6 +33,8 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
     builder.addField("dependencySourcesProvider", obj.dependencySourcesProvider)
     builder.addField("resourcesProvider", obj.resourcesProvider)
     builder.addField("canReload", obj.canReload)
+    builder.addField("jvmRunEnvironmentProvider", obj.jvmRunEnvironmentProvider)
+    builder.addField("jvmTestEnvironmentProvider", obj.jvmTestEnvironmentProvider)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -208,6 +208,15 @@ type BuildServerCapabilities {
   # The server sends notifications to the client on build
   # target change events via buildTarget/didChange
   # buildTargetChangedProvider: Boolean
+
+
+  # The JVM run/test environment request is sent from the client to the server 
+  # in order to gather information required to launch a Java process. 
+  # This is useful when the client wants to control the Java process execution, 
+  # for example to enable custom Java agents or launch a custom main class during 
+  # unit testing or debugging
+  jvmRunEnvironmentProvider: Boolean
+  jvmTestEnvironmentProvider: Boolean
 }
 
 type CompileProvider {


### PR DESCRIPTION
I forgot to do this in https://github.com/sbt/sbt/pull/6858 or https://github.com/sbt/sbt/pull/6875 @adpi2 

Should I create another PR that targets `develop` or will `1.7.x` be merged into it?