### PR TITLE
Use XDG_RUNTIME_DIR environment variable to choose the path used for the creation of sockets

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -313,7 +313,8 @@ public class BootServerSocket implements AutoCloseable {
 
   public static String socketLocation(final Path base)
       throws UnsupportedEncodingException, IOException {
-    boolean usingAlternativeSocketLocation = System.getProperty("sbt.altSockLocation", "") != "";
+    String alternativeSocketLocation = System.getenv().getOrDefault("XDG_RUNTIME_DIR", "");
+    boolean usingAlternativeSocketLocation = alternativeSocketLocation != "";
 
     final Path target = base.resolve("project").resolve("target");
     if (isWindows) {
@@ -321,8 +322,7 @@ public class BootServerSocket implements AutoCloseable {
       return "sbt-load" + hash;
     } else if (usingAlternativeSocketLocation) {
       long hash = LongHashFunction.farmNa().hashBytes(target.toString().getBytes("UTF-8"));
-      final Path alternativeSocketLocationRoot =
-          Paths.get(System.getProperty("sbt.altSockLocation", "/"));
+      final Path alternativeSocketLocationRoot = Paths.get(alternativeSocketLocation);
       final Path locationForSocket = alternativeSocketLocationRoot.resolve("socket" + hash);
       final Path pathForSocket = locationForSocket.resolve("sbt-load.sock");
       return pathForSocket.toString();

--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -313,8 +313,8 @@ public class BootServerSocket implements AutoCloseable {
 
   public static String socketLocation(final Path base)
       throws UnsupportedEncodingException, IOException {
-    String alternativeSocketLocation = System.getenv().getOrDefault("XDG_RUNTIME_DIR", "");
-    boolean usingAlternativeSocketLocation = alternativeSocketLocation != "";
+    final String alternativeSocketLocation = System.getenv().getOrDefault("XDG_RUNTIME_DIR", "/tmp/.sbt");
+    final boolean usingAlternativeSocketLocation = alternativeSocketLocation != "";
 
     final Path target = base.resolve("project").resolve("target");
     if (isWindows) {

--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -313,21 +313,16 @@ public class BootServerSocket implements AutoCloseable {
 
   public static String socketLocation(final Path base)
       throws UnsupportedEncodingException, IOException {
-    final String alternativeSocketLocation = System.getenv().getOrDefault("XDG_RUNTIME_DIR", "/tmp/.sbt");
-    final boolean usingAlternativeSocketLocation = alternativeSocketLocation != "";
-
     final Path target = base.resolve("project").resolve("target");
+      long hash = LongHashFunction.farmNa().hashBytes(target.toString().getBytes("UTF-8"));
     if (isWindows) {
-      long hash = LongHashFunction.farmNa().hashBytes(target.toString().getBytes("UTF-8"));
       return "sbt-load" + hash;
-    } else if (usingAlternativeSocketLocation) {
-      long hash = LongHashFunction.farmNa().hashBytes(target.toString().getBytes("UTF-8"));
-      final Path alternativeSocketLocationRoot = Paths.get(alternativeSocketLocation);
-      final Path locationForSocket = alternativeSocketLocationRoot.resolve("socket" + hash);
+    } else {
+      final String alternativeSocketLocation = System.getenv().getOrDefault("XDG_RUNTIME_DIR", "/tmp");
+      final Path alternativeSocketLocationRoot = Paths.get(alternativeSocketLocation).resolve(".sbt");
+      final Path locationForSocket = alternativeSocketLocationRoot.resolve("sbt-socket" + hash);
       final Path pathForSocket = locationForSocket.resolve("sbt-load.sock");
       return pathForSocket.toString();
-    } else {
-      return base.relativize(target.resolve("sbt-load.sock")).toString();
     }
   }
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -329,7 +329,6 @@ object BuiltinCommands {
       startServer,
       eval,
       last,
-      oldLastGrep,
       lastGrep,
       export,
       boot,


### PR DESCRIPTION
The `XDG_RUNTIME_DIR` environment variable will be used to choose the base directory in which the sockets will be created by **sbt**. This can help when issues such as #6777 appear. There are other related issues, such as #6101, [Metals issue #2235](https://github.com/scalameta/metals/issues/2235), [Che issue #18394](https://github.com/eclipse/che/issues/18394). Those are closed issues, but there are some cases in which the solution does not work (such as the case in #6777). Furthermore, the solution given seems more like a workaround than an actual fix.

**What causes this issue?**
At least in my case, the **ServerAlreadyBootingException** is thrown after **sbt** tries to create a Unix domain socket and fails. In my specific environment, I was not able to create the sockets in some directories because they were mounted on an NFS. This prevented me from using any automated sbt command on any of those directories (Metals uses sbt under the hood, and it was not able to start because of the ServerAlreadyBootingException), which in turn resulted in me not being able to use Metals on a project that was created on any of those directories. 

**How is the issue solved in this PR?**
If the `XDG_RUNTIME_DIR` environment variable is set, then sockets will be created in a folder with a hashed name, inside the directory `XDG_RUNTIME_DIR/.sbt/`. If this variable is not set, everything works exactly the same as always.

Let's see an example:

1. My environment variable `XDG_RUNTIME_DIR` is set to /home/alonso/.runtime-dir`
2. I create my project in `/home/alonso/workspace/hello-world`
3. I run `sbt compile`
4. The socket is created in `/home/alonso/.runtime-dir/.sbt/sbt-socket102030405060/sbt-load.sock`. The number **102030405060** is a hash that is computed from the base directory of the project (it is actually the same hash that is produced in order to create sockets in Windows) and it will be different depending on the location of the project
5. The sbt command executed correctly, which would not have happened if the socket had been created in the `home/alonso/workspace` directory or any of its subdirectories (in this example, `/home/BlackDiamond/workspace` corresponds to a network file share)