### PR TITLE
Add support for wildcards in Scala version switch (fuzzy switch)

### DIFF
--- a/main/src/test/scala/sbt/CrossSpec.scala
+++ b/main/src/test/scala/sbt/CrossSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+object CrossSpec extends verify.BasicTestSuite {
+  import Cross._
+
+  test("glob filter should work as expected") {
+    assert(globFilter("2.13.*", Seq("2.12.8", "2.13.16", "3.0.1")) == Seq("2.13.16"))
+    assert(globFilter("3.*", Seq("2.12.8", "2.13.16", "3.0.1")) == Seq("3.0.1"))
+    assert(globFilter("3.*", Seq("3.0.1", "30.1")) == Seq("3.0.1"))
+    assert(globFilter("2.*", Seq("2.12.8", "2.13.16", "3.0.1")) == Seq("2.12.8", "2.13.16"))
+    assert(globFilter("4.*", Seq("2.12.8", "2.13.16", "3.0.1")) == Nil)
+  }
+}

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/test
@@ -41,3 +41,24 @@ $ exists lib/target/scala-2.13
 -$ exists lib/target/scala-2.12
 # -$ exists sbt-foo/target/scala-2.12
 -$ exists sbt-foo/target/scala-2.13
+
+# test wildcard switching (2.12)
+> clean
+> ++ 2.12.* -v compile
+$ exists lib/target/scala-2.12
+-$ exists lib/target/scala-2.13
+$ exists sbt-foo/target/scala-2.12
+-$ exists sbt-foo/target/scala-2.13
+
+# test wildcard switching (2.13)
+> clean
+> ++ 2.13.* -v compile
+$ exists lib/target/scala-2.13
+-$ exists lib/target/scala-2.12
+# -$ exists sbt-foo/target/scala-2.12
+-$ exists sbt-foo/target/scala-2.13
+
+# test wildcard switching (no matches)
+-> ++ 3.*
+# test wildcard switching (multiple matches)
+-> ++ 2.*


### PR DESCRIPTION
This adds the ability to use semantic version selector expression (such as `2.13.x` and `3.x`) in `++` command as discussed in https://github.com/sbt/sbt/discussions/6893. The following description includes the patch in https://github.com/sbt/sbt/pull/6936.

## Usage

```
++ 2.13.x test
```

## Explanation

This is an extension of existing `++ <sv> <command1>` where the given `<command1>` will be executed only within the subprojects listing `<sv>` in their respective `crossScalaVersions` setting.

sbt 1.7.0 now allows the `<sv>` part to be a semantic version selector expression, implemented originally by @tanishiking in https://github.com/sbt/librarymanagement/pull/239 based on [npm-semver](https://www.npmjs.com/package/semver#Ranges). Note that the semantic version selector expression may match at most one Scala version within `crossScalaVersions` per subproject. This is because `++` remains to be a _switch_ command.