### PR TITLE
"oldshell" command should use `OldShell` on failure instead of `Shell`

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -406,7 +406,7 @@ object BasicCommands {
       case Some(line) =>
         val newState = s
           .copy(
-            onFailure = Some(Exec(Shell, None)),
+            onFailure = Some(Exec(OldShell, None)),
             remainingCommands = Exec(line, s.source) +: Exec(OldShell, None) +: s.remainingCommands
           )
           .setInteractive(true)


### PR DESCRIPTION
following up https://github.com/sbt/sbt/pull/3098

Otherwise it will return to `shell` (server) behavior:

![image](https://user-images.githubusercontent.com/3989292/169872093-80da392f-adce-4ee3-b049-1f8a78502910.png)

(by "it's removed in 1.6.2" on the screenshot I meant that `sbt oldshell` command is wiped out from terminal once it's started)