### PR TITLE
fix: publish BSP diagnostics when it's necessary

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2307,11 +2307,10 @@ object Defaults extends BuildCommon {
     val ci = (compile / compileInputs).value
     val ping = earlyOutputPing.value
     val reporter = (compile / bspReporter).value
-    val prevAnalysis = previousCompile.value.analysis.toOption.getOrElse(Analysis.empty)
     BspCompileTask.compute(bspTargetIdentifier.value, thisProjectRef.value, configuration.value) {
       task =>
         // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
-        compileIncrementalTaskImpl(task, s, ci, ping, reporter, prevAnalysis)
+        compileIncrementalTaskImpl(task, s, ci, ping, reporter)
     }
   }
   private val incCompiler = ZincUtil.defaultIncrementalCompiler
@@ -2326,7 +2325,7 @@ object Defaults extends BuildCommon {
         val result0 = incCompiler
           .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
           .compileAllJava(in, s.log)
-        reporter.sendSuccessReport(result0.analysis(), Analysis.empty, false)
+        reporter.sendSuccessReport(result0.analysis())
         result0.withHasModified(result0.hasModified || r.hasModified)
       } else r
     } catch {
@@ -2341,7 +2340,6 @@ object Defaults extends BuildCommon {
       ci: Inputs,
       promise: PromiseWrap[Boolean],
       reporter: BuildServerReporter,
-      prev: CompileAnalysis
   ): CompileResult = {
     lazy val x = s.text(ExportStream)
     def onArgs(cs: Compilers) = {
@@ -2363,11 +2361,7 @@ object Defaults extends BuildCommon {
       .withSetup(onProgress(setup))
     try {
       val result = incCompiler.compile(i, s.log)
-      reporter.sendSuccessReport(
-        result.getAnalysis,
-        prev,
-        BuildServerProtocol.shouldReportAllPreviousProblems(task.targetId)
-      )
+      reporter.sendSuccessReport(result.getAnalysis)
       result
     } catch {
       case e: Throwable =>

--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -32,6 +32,8 @@ lazy val respondError = project.in(file("respond-error"))
 
 lazy val util = project
 
+lazy val diagnostics = project
+
 def somethingBad = throw new MessageOnlyException("I am a bad build target")
 // other build targets should not be affected by this bad build target
 lazy val badBuildTarget = project.in(file("bad-build-target"))

--- a/server-test/src/server-test/buildserver/diagnostics/src/main/scala/Diagnostics.scala
+++ b/server-test/src/server-test/buildserver/diagnostics/src/main/scala/Diagnostics.scala
@@ -1,0 +1,3 @@
+object Diagnostics {
+  private val a: Int = 5
+}

--- a/server-test/src/server-test/buildserver/diagnostics/src/main/scala/PatternMatch.scala
+++ b/server-test/src/server-test/buildserver/diagnostics/src/main/scala/PatternMatch.scala
@@ -1,0 +1,7 @@
+
+class PatternMatch {
+  val opt: Option[Int] = None
+  opt match {
+    case Some(value) => ()
+  }
+}


### PR DESCRIPTION
* do not publish bsp diagnostics if there were and there are no problems
* publish diagnostics if problems needs to be updated

continues effort of https://github.com/sbt/sbt/pull/6847, closes https://github.com/sbt/sbt/issues/6896

@adpi2 do you have an idea how to write test for this PR which will cover https://github.com/sbt/sbt/issues/6896?