### PR TITLE
[1.7.x] Backport #6929: Fix publishing BSP diagnostics

### DIFF
--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -32,6 +32,8 @@ lazy val respondError = project.in(file("respond-error"))
 
 lazy val util = project
 
+lazy val diagnostics = project
+
 def somethingBad = throw new MessageOnlyException("I am a bad build target")
 // other build targets should not be affected by this bad build target
 lazy val badBuildTarget = project.in(file("bad-build-target"))

--- a/server-test/src/server-test/buildserver/diagnostics/src/main/scala/Diagnostics.scala
+++ b/server-test/src/server-test/buildserver/diagnostics/src/main/scala/Diagnostics.scala
@@ -1,0 +1,3 @@
+object Diagnostics {
+  private val a: Int = 5
+}

--- a/server-test/src/server-test/buildserver/diagnostics/src/main/scala/PatternMatch.scala
+++ b/server-test/src/server-test/buildserver/diagnostics/src/main/scala/PatternMatch.scala
@@ -1,0 +1,7 @@
+
+class PatternMatch {
+  val opt: Option[Int] = None
+  opt match {
+    case Some(value) => ()
+  }
+}


### PR DESCRIPTION
Backport of #6929 

* do not publish bsp diagnostics if there were and there are no problems
* publish diagnostics if problems needs to be updated