### PR TITLE
[1.7.x] Fix sbt trying to delete /tmp on ARM Macs

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -310,7 +310,7 @@ public class BootServerSocket implements AutoCloseable {
       return "sbt-load" + hash;
     } else {
       final String alternativeSocketLocation =
-          System.getenv().getOrDefault("XDG_RUNTIME_DIR", "/tmp");
+          System.getenv().getOrDefault("XDG_RUNTIME_DIR", System.getProperty("java.io.tmpdir"));
       final Path alternativeSocketLocationRoot =
           Paths.get(alternativeSocketLocation).resolve(".sbt");
       final Path locationForSocket = alternativeSocketLocationRoot.resolve("sbt-socket" + hash);

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -101,10 +101,8 @@ private[sbt] object Load {
     val delegates = defaultDelegates
     val pluginMgmt = PluginManagement(loader)
     val inject = InjectSettings(injectGlobal(state), Nil, const(Nil))
-    System.setProperty(
-      "swoval.tmpdir",
-      System.getProperty("swoval.tmpdir", globalBase.getAbsolutePath.toString)
-    )
+    SysProp.setSwovalTempDir()
+    SysProp.setIpcSocketTempDir()
     LoadBuildConfiguration(
       stagingDirectory,
       classpath,


### PR DESCRIPTION
Problem
-------
There's a bug in ipcsocket cleanup logic that effectively
tries to wipe out /tmp.

Workaround
----------
We should fix the underlying bug, but we can start by
explicitly configuring the temp directories ipcsocket uses.

Ref https://github.com/sbt/sbt/issues/6931