### PR TITLE
[1.7.x] ipcsocket 1.5.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"
-  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.3.1"
+  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.5.0"
 
   private val compilerInterface = "org.scala-sbt" % "compiler-interface" % zincVersion
   private val compilerClasspath = "org.scala-sbt" %% "zinc-classpath" % zincVersion


### PR DESCRIPTION
This bumps to ipcsocket 1.5.0, which fixes the temp directory cleanup
bug.
Fixes https://github.com/sbt/sbt/issues/6931
Fixes https://github.com/sbt/sbt/issues/6173