### PR TITLE
[1.7.x] Filter incompatible Scala 3 projects in cross switch commands, take 2

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -339,16 +339,18 @@ object Cross {
                 )
             }
         }
-      } else {
-        val binaryVersion = CrossVersion.binaryScalaVersion(version)
+      } else
+        // This is the default implementation for ++ <sv> <command1>
+        // It checks that <sv> is backward compatible with one of the Scala versions listed
+        // in crossScalaVersions setting. Note this must account for the fact that in Scala 3.x
+        // 3.1.0 is not compatible with 3.0.0.
         projectScalaVersions.map {
           case (project, scalaVersions) =>
-            if (scalaVersions.exists(v => CrossVersion.binaryScalaVersion(v) == binaryVersion))
+            if (scalaVersions.exists(CrossVersion.isScalaBinaryCompatibleWith(version, _)))
               (project, Some(version), scalaVersions)
             else
               (project, None, scalaVersions)
         }
-      }
     }
 
     val included = projects.collect {

--- a/notes/1.7.0/cross-strict-aggregation-scala-3.md
+++ b/notes/1.7.0/cross-strict-aggregation-scala-3.md
@@ -1,0 +1,8 @@
+[@ruippeixotog]: https://github.com/ruippeixotog
+
+[#6915]: https://github.com/sbt/sbt/issues/6915
+[#6926]: https://github.com/sbt/sbt/pull/6926
+
+### Bug Fixes
+
+- Make `++ <scala-version> <command>` run `<command>` only on compatible Scala 3 subprojects. [#6915][]/[#6926][] by [@ruippeixotog][]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.6.0")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.7.0-M1")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.7.0-M3")
   val zincVersion = nightlyVersion.getOrElse("1.7.0-M2")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/build.sbt
@@ -1,0 +1,14 @@
+scalaVersion := "2.12.16"
+
+lazy val core = project
+  .settings(
+    crossScalaVersions := Seq("2.12.16", "3.0.2", "3.1.2")
+  )
+
+lazy val subproj = project
+  .dependsOn(core)
+  .settings(
+    crossScalaVersions := Seq("2.12.16", "3.1.2"),
+    // a random library compiled against Scala 3.1
+    libraryDependencies += "org.http4s" %% "http4s-core" % "0.23.12"
+  )

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/subproj/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/subproj/src/main/scala/A.scala
@@ -1,0 +1,6 @@
+import org.http4s.Uri
+
+object A {
+  // Just using something from http4s 
+  Uri.fromString("example.com")
+}

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/test
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/test
@@ -1,0 +1,14 @@
+> ++3.0.2 compile
+
+$ exists core/target/scala-3.0.2
+-$ exists core/target/scala-3.1.2
+-$ exists subproj/target/scala-3.0.2
+-$ exists subproj/target/scala-3.1.2
+
+> clean
+> ++3.1.2 compile
+
+-$ exists core/target/scala-3.0.2
+$ exists core/target/scala-3.1.2
+-$ exists subproj/target/scala-3.0.2
+$ exists subproj/target/scala-3.1.2


### PR DESCRIPTION
This is a modified resend of https://github.com/sbt/sbt/pull/6926 by @ruippeixotog
Fixes #6915

Usage
------

```scala
ThisBuild / scalaVersion := "2.12.16"

lazy val core = project
  .settings(
    crossScalaVersions := Seq("2.12.16", "3.0.2", "3.1.2")
  )

lazy val sub2 = project
  .dependsOn(core)
  .settings(
    crossScalaVersions := Seq("2.12.16", "3.1.2"),
    // a random library compiled against Scala 3.1
    libraryDependencies += "org.http4s" %% "http4s-core" % "0.23.12"
  )
```

```
++3.0.2 test
```

Explanation
-----------
In sbt 1.7.0 `++3.0.2 test` tests `core` subprojects, but skips `sub2`.
Previously, `++ <sv> <command1>` used the ABI suffix (`_3`) to filter the `crossScalaVersion`, which was a fine strategy for Scala 2.x releases that maintained both backward and forward version compatibility. Since Scala 3 only maintains backward compatibility, we should use backward compatibility check instead of checking if the ABI suffix would be the same.
