### PR TITLE
Show a more useful log message when doing a flexible version switch

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -294,7 +294,14 @@ object Cross {
       if (switch.version.force) {
         state.log.info(s"Forcing Scala version to $version on all projects.")
       } else {
-        state.log.info(s"Setting Scala version to $version on ${included.size} projects.")
+        included
+          .groupBy(_._2)
+          .foreach {
+            case (selectedVersion, projects) =>
+              state.log.info(
+                s"Setting Scala version to $selectedVersion on ${projects.size} projects."
+              )
+          }
       }
       if (excluded.nonEmpty && !switch.verbose) {
         state.log.info(s"Excluded ${excluded.size} projects, run ++ $version -v for more details.")


### PR DESCRIPTION
Suggested by @SethTisue in https://github.com/sbt/sbt/pull/6894#issuecomment-1168042209

Will show multiple lines when different versions are selected for different subprojects.

When no subprojects have a matching Scala version you will get a
'Switch failed' exception anyway, so in that case there is no
change in behavior.