### PR TITLE
Add dependency-graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,14 @@
+# .github/workflows/dependency-graph.yml
+name: Submit Dependency Graph
+on:
+  push:
+    branches: [1.7.x] # default branch of the project
+jobs:
+  submit-graph:
+    name: Submit Dependency Graph
+    runs-on: ubuntu-latest # or windows-latest, or macOS-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-graph-action@v1
+        with:
+          scala-versions: 2.12.16


### PR DESCRIPTION
Before merging this PR, the `Dependency Graph` feature in `Settings > Code Security and Analysis` must be enabled.

The `Dependabot` feature can also be activated. 

This new workflow will publish the dependency graph of the build to Github, through the [Dependency submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission#about-the-dependency-submission-api).