### PR TITLE
Bump sbt-dependency-submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,6 +9,4 @@ jobs:
     runs-on: ubuntu-latest # or windows-latest, or macOS-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: scalacenter/sbt-dependency-graph-action@v1
-        with:
-          scala-versions: 2.12.16
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/build.sbt
+++ b/build.sbt
@@ -622,6 +622,7 @@ lazy val scriptedSbtReduxProj = (project in file("scripted-sbt-redux"))
   .dependsOn(sbtProj % "compile;test->test", commandProj, utilLogging, utilScripted)
   .settings(
     baseSettings,
+    crossScalaVersions := Seq(baseScalaVersion),
     name := "Scripted sbt Redux",
     libraryDependencies ++= Seq(launcherInterface % "provided"),
     mimaSettings,
@@ -633,6 +634,7 @@ lazy val scriptedSbtOldProj = (project in file("scripted-sbt-old"))
   .dependsOn(scriptedSbtReduxProj)
   .settings(
     baseSettings,
+    crossScalaVersions := Seq(baseScalaVersion),
     name := "Scripted sbt",
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
@@ -660,6 +662,7 @@ lazy val dependencyTreeProj = (project in file("dependency-tree"))
   .settings(
     sbtPlugin := true,
     baseSettings,
+    crossScalaVersions := Seq(baseScalaVersion),
     name := "sbt-dependency-tree",
     publishMavenStyle := true,
     // mimaSettings,


### PR DESCRIPTION
It submits the graphs on 2.12 and 2.13.

Remove 2.13 in the crossScalaVersions of sbt-dependency-graph, scripted-sbt-redux and scripted-sbt because they depend on sbtProj (only on 2.12).

Tested [here](https://github.com/adpi2/sbt/actions/runs/2675847663) and it produced [a snapshot](https://github.com/adpi2/sbt/network/dependencies) of 205 deps (82 extra deps).