### PR TITLE
Fix background job logging

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -126,11 +126,12 @@ object ConsoleAppender {
     def out: ConsoleOut
   }
   private[sbt] object Properties {
-    def from(terminal: Terminal): Properties = new Properties {
-      override def isAnsiSupported: Boolean = terminal.isAnsiSupported
-      override def isColorEnabled: Boolean = terminal.isColorEnabled
-      override def out = ConsoleOut.terminalOut(terminal)
-    }
+    def from(terminal: Terminal): Properties =
+      from(ConsoleOut.terminalOut(terminal), terminal.isAnsiSupported, terminal.isColorEnabled)
+
+    def safelyFrom(terminal: Terminal): Properties =
+      from(ConsoleOut.safeTerminalOut(terminal), terminal.isAnsiSupported, terminal.isColorEnabled)
+
     def from(o: ConsoleOut, ansi: Boolean, color: Boolean): Properties = new Properties {
       override def isAnsiSupported: Boolean = ansi
       override def isColorEnabled: Boolean = color
@@ -244,6 +245,18 @@ object ConsoleAppender {
    */
   def apply(name: String, terminal: Terminal): Appender = {
     new ConsoleAppender(name, Properties.from(terminal), noSuppressedMessage)
+  }
+
+  /**
+   * A new `ConsoleAppender` identified by `name`, and that writes to `terminal`.
+   * Printing to this Appender will not throw if the Terminal has been closed.
+   *
+   * @param name      An identifier for the `ConsoleAppender`.
+   * @param terminal  The terminal to which this appender corresponds
+   * @return A new `ConsoleAppender` that writes to `terminal`.
+   */
+  def safe(name: String, terminal: Terminal): Appender = {
+    new ConsoleAppender(name, Properties.safelyFrom(terminal), noSuppressedMessage)
   }
 
   /**

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -438,6 +438,7 @@ object Terminal {
     override def toString: String = s"ProxyTerminal(current = $t)"
   }
   private[sbt] def get: Terminal = ProxyTerminal
+  private[sbt] def current: Terminal = activeTerminal.get
 
   private[sbt] def withIn[T](in: InputStream)(f: => T): T = {
     val original = inputStream.get

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -182,7 +182,8 @@ object LoggerContext {
       }
     }
     def close(): Unit = {
-      loggers.forEach((name, l) => l.clearAppenders())
+      closed.set(true)
+      loggers.forEach((_, l) => l.clearAppenders())
       loggers.clear()
     }
   }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -149,7 +149,7 @@ object LogManager {
         task: ScopedKey[_],
         context: LoggerContext
     ): ManagedLogger = {
-      val console = screen(task, state)
+      val console = ConsoleAppender("bg-" + ConsoleAppender.generateName(), ITerminal.current)
       LogManager.backgroundLog(data, state, task, console, relay(()), context)
     }
   }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -73,15 +73,23 @@ object LogManager {
       manager(data, state, task, to, context)
     }
 
-  @nowarn
+  @deprecated("Use alternate constructBackgroundLog that provides a LoggerContext", "1.8.0")
   def constructBackgroundLog(
       data: Settings[Scope],
       state: State
+  ): ScopedKey[_] => ManagedLogger = {
+    val context = state.get(Keys.loggerContext).getOrElse(LoggerContext.globalContext)
+    constructBackgroundLog(data, state, context)
+  }
+
+  def constructBackgroundLog(
+      data: Settings[Scope],
+      state: State,
+      context: LoggerContext
   ): (ScopedKey[_]) => ManagedLogger =
     (task: ScopedKey[_]) => {
       val manager: LogManager =
         (logManager in task.scope).get(data) getOrElse defaultManager(state.globalLogging.console)
-      val context = state.get(Keys.loggerContext).getOrElse(LoggerContext.globalContext)
       manager.backgroundLog(data, state, task, context)
     }
 

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -149,7 +149,7 @@ object LogManager {
         task: ScopedKey[_],
         context: LoggerContext
     ): ManagedLogger = {
-      val console = ConsoleAppender("bg-" + ConsoleAppender.generateName(), ITerminal.current)
+      val console = ConsoleAppender.safe("bg-" + ConsoleAppender.generateName(), ITerminal.current)
       LogManager.backgroundLog(data, state, task, console, relay(()), context)
     }
   }


### PR DESCRIPTION
Fixes #6842 

## Description

In order of commits

### Use BackgroundJobService context instead of MainLoop context

Use the `LoggerContext` of the `BackgroundJobService` to create and clean the loggers of the jobs. This is to avoid using the `LoggerContext` of the `MainLoop` which is closed after each command: the logger must stay alive after the execution of the command until the job is done.

### Don't use ProxyTerminal in background job

Do not use the `ProxyTerminal` in the `ConsoleAppender` of a job, so that the logs do not switch from active client to active client. Instead we get the current active terminal at the time the logger is created, and we stick to it until the job is done. So if the job is started by client network 1, the logs will be redirected to client network 1 until the end of the job.

### Catch `ClosedChannelException` in background job logger

If the terminal is closed before the end of the job we catch the `ClosedChannelException` thrown by the `ConsoleOut`, otherwise the job would crash.

## Results

The logs of a background job are only redirected to the clients that started the job.

![bg-run](https://user-images.githubusercontent.com/13123162/183081673-924e00b0-86e7-48be-83f7-e86ecf442ef9.gif)

 If a terminal is killed the job keeps running in the background and the logs are not displayed anywhere.

![bg-run-exit](https://user-images.githubusercontent.com/13123162/183082186-69ccae9c-f97b-4101-a196-a0e7576c1468.gif)

## Limitation

### Getting the log of background job whose terminal is closed

Currently the logs of a job whose terminal is closed are lost. It would be nice to get them back when running `bgWait` on that job.

### Call to `println` in a background job

A call to `println` in a background job will always print to the terminal that is active, the ones that is running a task. In particular, if we run the main class of a project without forking, its standard output will move from one active terminal to the other active terminal.

![bg-run-println](https://user-images.githubusercontent.com/13123162/183083897-c66ba86e-acf3-458b-bc8b-f781f74412ce.gif)

Unfortunately I don't think there is a solution for this.

###  `RelayAppender`

Currently the logger of a background job contains a relay appender and all BSP clients receive all logs of all background jobs.

This kind-of pollutes the logs of BSP clients. For instance in Metals:
![bgRun-metals](https://user-images.githubusercontent.com/13123162/183085822-e2a5f1a6-48b7-4512-b440-67e904d189a2.gif)

It would be better if a BSP client only receives the logs of the background jobs that it started.