### PR TITLE
add output when boot server socket fails to create

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -141,13 +141,17 @@ private[sbt] object xMain {
 
   private def getSocketOrExit(
       configuration: xsbti.AppConfiguration
-  ): (Option[BootServerSocket], Option[Exit]) =
-    try (Some(new BootServerSocket(configuration)) -> None)
+  ): (Option[BootServerSocket], Option[Exit]) = {
+    def printThrowable(e: Throwable): Unit = {
+      println("sbt thinks that server is already booting because of this exception:")
+      e.printStackTrace()
+    }
+
+    try Some(new BootServerSocket(configuration)) -> None
     catch {
       case e: ServerAlreadyBootingException
           if System.console != null && !ITerminal.startedByRemoteClient =>
-        println("sbt thinks that server is already booting because of this exception:")
-        e.printStackTrace()
+        printThrowable(e)
         println("Create a new server? y/n (default y)")
         val exit =
           if (ITerminal.get.withRawInput(System.in.read) == 'n'.toInt) Some(Exit(1))
@@ -156,12 +160,12 @@ private[sbt] object xMain {
       case e: ServerAlreadyBootingException =>
         if (SysProp.forceServerStart) (None, None)
         else {
-          println("Boot server failed to create socket")
-          e.printStackTrace()
+          printThrowable(e)
           (None, Some(Exit(2)))
         }
       case _: UnsatisfiedLinkError => (None, None)
     }
+  }
 }
 
 final class ScriptMain extends xsbti.AppMain {

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -153,9 +153,13 @@ private[sbt] object xMain {
           if (ITerminal.get.withRawInput(System.in.read) == 'n'.toInt) Some(Exit(1))
           else None
         (None, exit)
-      case _: ServerAlreadyBootingException =>
+      case e: ServerAlreadyBootingException =>
         if (SysProp.forceServerStart) (None, None)
-        else (None, Some(Exit(2)))
+        else {
+          println("Boot server failed to create socket")
+          e.printStackTrace()
+          (None, Some(Exit(2)))
+        }
       case _: UnsatisfiedLinkError => (None, None)
     }
 }


### PR DESCRIPTION
Small change to add some output when Boot Server Socket fails to be created in a non-interactive environment. I and a couple team members spent more than a day trying to figure out why sbt was exiting without any output in our CI/CD pipelines. Some output here would have help us isolate the issue much quicker.

This change seem too small to warrant a note but if that is not the case I can and will create one. Let me know. 

If there are use-cases where sbt is expected to exit and this output would be clutter, I can understand why this output might be undesirable. If that is the case, maybe someone can point me to a better way. Also if the text is not normative to the project, guide me and I'll update it too.