### PR TITLE
[1.7.x] feat: start forwarding diagnosticCode via BSP

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -201,7 +201,7 @@ final class BuildServerReporterImpl(
       Diagnostic(
         range,
         Option(toDiagnosticSeverity(problem.severity)),
-        None,
+        problem.diagnosticCode().toOption.map(_.code),
         Option("sbt"),
         problem.message
       )


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/6998 by @ckipp01 

## original description

This change is a continuation of the work that was done in
https://github.com/sbt/sbt/pull/6874 to allow the Scala 3 compiler to
forward the `diagnosticCode` of an error as well as the other normal
things. This change in dotty was merged in
https://github.com/lampepfl/dotty/pull/15565 and also backported so it
will be in the 3.2.x series release. This change captures the
`diagnosticCode` and forwards it on via BSP so that tools like Metals
can can use this code.

You can see this in the BSP trace now for a diagnostic:

For example with some code that contains the following:

```scala
val x: Int = "hi"
```

You'll see the code in the BSP diagnostic:
```  "diagnostics": [
    {
      "range": {
        "start": {
          "line": 9,
          "character": 15
        },
        "end": {
          "line": 9,
          "character": 19
        }
      },
      "severity": 1,
      "code": "7",
      "source": "sbt",
      "message": "Found:    (\u001b[32m\"hi\"\u001b[0m : String)\nRequired: Int\n\nThe following import might make progress towards fixing the problem:\n\n  import sourcecode.Text.generate\n\n"
    }
  ]
```

Co-authored-by: Adrien Piquerez <adrien.piquerez@gmail.com>
Refs: https://github.com/lampepfl/dotty/issues/14904