### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,8 +3,12 @@ name: Submit Dependency Graph
 on:
   push:
     branches: [1.7.x] # default branch of the project
+permissions: {}
 jobs:
   submit-graph:
+    permissions:
+      contents: write # to submit the dependency graph
+
     name: Submit Dependency Graph
     runs-on: ubuntu-latest # or windows-latest, or macOS-latest
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
 #    # 08:00 UTC = 03:00 EST
 #    - cron:  '0 8 * * *'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   deploy:
     strategy:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.