### PR TITLE
Launcher 1.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   private val libraryManagementCore = "org.scala-sbt" %% "librarymanagement-core" % lmVersion
   private val libraryManagementIvy = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion
 
-  val launcherVersion = "1.3.3"
+  val launcherVersion = "1.4.1"
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"


### PR DESCRIPTION
Launcher 1.4.1 is capable of launching Scala 3 apps. In other words, launchers prior to 1.4.1 are not capable of launching Scala 3 apps, including tests for sbt 2.x.