### PR TITLE
[1.8.x] Protect against missing edges in graph by using map get vs apply

### DIFF
--- a/main/src/main/scala/sbt/internal/graph/GraphTransformations.scala
+++ b/main/src/main/scala/sbt/internal/graph/GraphTransformations.scala
@@ -32,7 +32,7 @@ object GraphTransformations {
     val nodes =
       edges
         .foldLeft(Set.empty[GraphModuleId])((set, edge) => set + edge._1 + edge._2)
-        .map(graph.module)
+        .flatMap(graph.module)
     ModuleGraph(nodes.toSeq, edges)
   }
 

--- a/main/src/main/scala/sbt/internal/graph/model.scala
+++ b/main/src/main/scala/sbt/internal/graph/model.scala
@@ -67,7 +67,7 @@ private[sbt] case class ModuleGraph(nodes: Seq[Module], edges: Seq[Edge]) {
   lazy val modules: Map[GraphModuleId, Module] =
     nodes.map(n => (n.id, n)).toMap
 
-  def module(id: GraphModuleId): Module = modules(id)
+  def module(id: GraphModuleId): Option[Module] = modules.get(id)
 
   lazy val dependencyMap: Map[GraphModuleId, Seq[Module]] =
     createMap(identity)
@@ -81,7 +81,7 @@ private[sbt] case class ModuleGraph(nodes: Seq[Module], edges: Seq[Edge]) {
     val m = new HashMap[GraphModuleId, Set[Module]] with MultiMap[GraphModuleId, Module]
     edges.foreach { entry =>
       val (f, t) = bindingFor(entry)
-      m.addBinding(f, module(t))
+      module(t).foreach(m.addBinding(f, _))
     }
     m.toMap.mapValues(_.toSeq.sortBy(_.id.idString)).toMap.withDefaultValue(Nil)
   }

--- a/main/src/main/scala/sbt/internal/graph/rendering/Statistics.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/Statistics.scala
@@ -28,7 +28,7 @@ object Statistics {
       val directDependencies = graph.dependencyMap(moduleId).filterNot(_.isEvicted).map(_.id)
       val dependencyStats =
         directDependencies.map(statsFor).flatMap(_.transitiveStatsWithSelf).toMap
-      val selfSize = graph.module(moduleId).jarFile.filter(_.exists).map(_.length)
+      val selfSize = graph.module(moduleId).flatMap(_.jarFile).filter(_.exists).map(_.length)
       val numDirectDependencies = directDependencies.size
       val numTransitiveDependencies = dependencyStats.size
       val transitiveSize = selfSize.getOrElse(0L) + dependencyStats


### PR DESCRIPTION
This backports https://github.com/sbt/sbt/pull/6978

## original description

Connects to #6976 

It's possible for there to be orphaned edges in the constructed graph. Using `map.apply` to retrieve the edge will then fail  with `NoSuchElementException`. This PR updates to using `get` that safely returns an `Option` instead of throwing. 

This does _not_ fix the underlying issue. The produced dependency graph will likely be incorrect if the edges aren't present. This will only prevent an exception from being thrown. 