### PR TITLE
fix: bspConfig sbt.script - use `Path` env variable as a fallback for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 .bsp/
 metals.sbt
 launcher-package/citest/freshly-baked
+.vscode

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -63,8 +63,10 @@ object BuildServerConnection {
     // For those who use an old sbt script, the -Dsbt.script is not set
     // As a fallback we try to find the sbt script in $PATH
     val fileName = if (Properties.isWin) "sbt.bat" else "sbt"
-    val envPath = sys.env.getOrElse("PATH", "")
-    val allPaths = envPath.split(File.pathSeparator).map(Paths.get(_))
+    val envPath = sys.env.collectFirst {
+      case (k, v) if k.toUpperCase() == "PATH" => v
+    }
+    val allPaths = envPath.map(_.split(File.pathSeparator).map(Paths.get(_))).getOrElse(Array.empty)
     allPaths
       .map(_.resolve(fileName))
       .find(file => Files.exists(file) && Files.isExecutable(file))


### PR DESCRIPTION
Originally reported in https://github.com/scalameta/metals/issues/4702#issuecomment-1339137772