### PR TITLE
Set socket backlog to default size of 50

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
       shell: bash
       run: |
         # test building sbtn on Windows
+        sbt "commandProj/testOnly xsbt.IPCSpec"
         sbt "-Dsbt.io.virtual=false" nativeImage
         # test launcher script
         echo build using JDK 8, test using JDK 8, on Windows

--- a/main-command/src/main/scala/xsbt/IPC.scala
+++ b/main-command/src/main/scala/xsbt/IPC.scala
@@ -17,6 +17,7 @@ object IPC {
   private val portMin = 1025
   private val portMax = 65536
   private val loopback = InetAddress.getByName(null)
+  private[xsbt] val socketBacklog = 50 // 50 is the default backlog size for the java.net.Socket
 
   def client[T](port: Int)(f: IPC => T): T = ipc(new Socket(loopback, port))(f)
 
@@ -34,7 +35,7 @@ object IPC {
 
     def createServer(attempts: Int): ServerSocket =
       if (attempts > 0) {
-        try new ServerSocket(nextPort, 1, loopback)
+        try new ServerSocket(nextPort, socketBacklog, loopback)
         catch { case NonFatal(_) => createServer(attempts - 1) }
       } else sys.error("Could not connect to socket: maximum attempts exceeded")
 

--- a/main-command/src/test/scala/xsbt/IPCSpec.scala
+++ b/main-command/src/test/scala/xsbt/IPCSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbt
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class IPCSpec extends AnyFlatSpec {
+  "server" should "allow same number of connections as determined in socket backlog" in {
+    noException should be thrownBy {
+      val server = IPC.unmanagedServer
+      (1 until IPC.socketBacklog + 1).foreach { _ =>
+        IPC.client(server.port)(identity)
+      }
+      server.close()
+    }
+  }
+}


### PR DESCRIPTION
My current up to date theory as to what is causing the issues with sbt scripted tests failing in Windows is actually not the method for finding ports (although that should also be improved) but rather using the non conventional `backlog` size of 1.  The reason why I don't think it has anything to do with the port selection method is that its the sbt client that is having its connection refused, not the server when binding the port (in other words the server is not having any issues opening a port even if its calculated by random number generation). This is also ontop of the fact that I have been unable at all to reproduce the `windows-latest` CI image failing with the proper way of finding a free port.

The reasoning behind my theory of it being related to `backlog` is that its behaviour is highly dependant on both the OS and how the OS is configured. Since the backlog is a queueing mechanism along with the fact some OS's can process requests faster than others, you can get differing behaviour (i.e. if something is processed faster than the next request). Normally with a high enough value (i.e. the default which is `50`) this is a non issue in practice however with it currently being set to `1` essentially this is locking the server/client to only have one connection at a time, if there happens to be an extra connection made and the current one is not resolved then you get the `java.net.ConnectException: Connection refused: connect` from the client.

One of the differences between OS's which I have been able to deterministically confirm is that for a `backlog` value of `x`, Windows actually only is able to process `x` - 1 connections at once where as *nix systems can process `x` number of connections but **ONLY** for very low values of `x` (i.e. `1` which is what it is currently). This alone doesn't explain the scripted test failures because on my Windows desktop the sbt-github-actions scripted tests still pass however if we account for the fact that the `windows-latest` CI machines are much slower and/or they are configured differently plus the recursive `createServer` call filling up the backlog this can then explain why scripted tests are failing. So with all of this combined this is my currently most plausible explanation as to why the sbt scripted tests are just failing on `windows-latest` CI image, you can see the result of these findings at https://github.com/sbt/sbt/pull/7084.

Unfortunately testing this conclusively is very hard, from what I can tell there aren't any scripted tests in this sbt project and making some sbt-plugin use a modified version of sbt to test in the `windows-latest` CI image is quite painful/annoying. Hence my current thinking is to set the `backlog` to the default value (which is `50`) as its a very safe change, furthermore I checked the git log and I can't see any evidence of there being a rational reason as to why it was set to `1` in the first place (i.e. it was originally `1` and has never changed since so I think it was just an oversight). The easiest way to confirm this theory would be to make the `backlog` value configurable so that it can be configured in a project such as https://github.com/sbt/sbt-github-actions making the testing/verification easier however I presume that making the `backlog` value configurable can be regarded as excessive/overkill?

@eed3si9n Let me know what you think.

References: https://github.com/sbt/sbt/issues/7082