### PR TITLE
[1.9.x] Smooth transition to valid Maven pattern of sbt plugins

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.8.0")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.8.0")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.9.0-M1")
   val zincVersion = nightlyVersion.getOrElse("1.8.0")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompile", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.15"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.0.16"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.9.1") // contrabandSjsonNewVersion.value

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/build.sbt
@@ -1,0 +1,105 @@
+// sbt-plugin-example-diamond is a diamond graph of dependencies of sbt plugins.
+//             sbt-plugin-example-diamond
+//                        / \
+// sbt-plugin-example-left   sbt-plugin-example-right
+//                        \ /
+//             sbt-plugin-example-bottom
+// Depending on the version of sbt-plugin-example-diamond, we test different patterns
+// of dependencies:
+//  * Some dependencies were published using the deprecated Maven paths, some with the new
+//  * Wheter the dependency on sbt-plugin-example-bottom needs conflict resolution or not
+
+inThisBuild(
+  Seq(
+    csrCacheDirectory := baseDirectory.value / "coursier-cache"
+  )
+)
+
+// only deprecated Maven paths
+lazy val v1 = project
+  .in(file("v1"))
+  .settings(
+    localCache,
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.1.0"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-example-diamond-0.1.0.jar",
+      "sbt-plugin-example-left-0.1.0.jar",
+      "sbt-plugin-example-right-0.1.0.jar",
+      "sbt-plugin-example-bottom-0.1.0.jar",
+    ).value
+  )
+
+// diamond and left use the new Maven paths
+lazy val v2 = project
+  .in(file("v2"))
+  .settings(
+    localCache,
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.2.0"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-example-diamond_2.12_1.0-0.2.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.2.0.jar",
+      "sbt-plugin-example-right-0.1.0.jar",
+      "sbt-plugin-example-bottom-0.1.0.jar",
+    ).value
+  )
+
+// conflict resolution on bottom between new and deprecated Maven paths
+lazy val v3 = project
+  .in(file("v3"))
+  .settings(
+    localCache,
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.3.0"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-example-diamond_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right-0.1.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.2.0.jar",
+    ).value
+  )
+
+// right still uses the deprecated Maven path and it depends on bottom
+// which uses the new Maven path
+lazy val v4 = project
+  .in(file("v4"))
+  .settings(
+    localCache,
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.4.0"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-example-diamond_2.12_1.0-0.4.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right-0.2.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.2.0.jar",
+    ).value
+  )
+
+// only new Maven paths with conflict resolution on bottom
+lazy val v5 = project
+  .in(file("v5"))
+  .settings(
+    localCache,
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.5.0"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-example-diamond_2.12_1.0-0.5.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.3.0.jar",
+    ).value
+  )
+
+def localCache =
+  ivyPaths := IvyPaths(baseDirectory.value, Some((ThisBuild / baseDirectory).value / "ivy-cache"))
+
+lazy val checkUpdate = taskKey[Unit]("check the resolved artifacts")
+
+def checkUpdateDef(expected: String*): Def.Initialize[Task[Unit]] = Def.task {
+  val report = update.value
+  val obtainedFiles = report.configurations
+    .find(_.configuration.name == Compile.name)
+    .toSeq
+    .flatMap(_.modules)
+    .flatMap(_.artifacts)
+    .map(_._2)
+  val obtainedSet = obtainedFiles.map(_.getName).toSet
+  val expectedSet = expected.toSet + "scala-library.jar"
+  assert(obtainedSet == expectedSet, obtainedFiles)
+}

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/test
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/test
@@ -1,0 +1,12 @@
+> v1/checkUpdate
+> v2/checkUpdate
+> v3/checkUpdate
+> v4/checkUpdate
+> v5/checkUpdate
+
+> set ThisBuild/useCoursier:=true
+> v1/checkUpdate
+> v2/checkUpdate
+> v3/checkUpdate
+> v4/checkUpdate
+> v5/checkUpdate

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/test
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-diamond/test
@@ -1,12 +1,12 @@
-> v1/checkUpdate
-> v2/checkUpdate
-> v3/checkUpdate
-> v4/checkUpdate
-> v5/checkUpdate
+> v1 / checkUpdate
+> v2 / checkUpdate
+> v3 / checkUpdate
+> v4 / checkUpdate
+> v5 / checkUpdate
 
-> set ThisBuild/useCoursier:=true
-> v1/checkUpdate
-> v2/checkUpdate
-> v3/checkUpdate
-> v4/checkUpdate
-> v5/checkUpdate
+> set ThisBuild / useCoursier:=false
+> v1 / checkUpdate
+> v2 / checkUpdate
+> v3 / checkUpdate
+> v4 / checkUpdate
+> v5 / checkUpdate

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
@@ -1,0 +1,122 @@
+import scala.util.matching.Regex
+
+lazy val repo = file("test-repo")
+lazy val resolver = Resolver.file("test-repo", repo)
+
+lazy val example = project.in(file("example"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    organization := "org.example",
+    addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.5.0"),
+    publishTo := Some(resolver),
+    checkPackagedArtifacts := checkPackagedArtifactsDef.value,
+    checkPublish := checkPublishDef.value
+  )
+
+lazy val testMaven = project.in(file("test-maven"))
+  .settings(
+    addSbtPlugin("org.example" % "example" % "0.1.0-SNAPSHOT"),
+    externalResolvers -= Resolver.defaultLocal,
+    resolvers += {
+      val base = (ThisBuild / baseDirectory).value
+      MavenRepository("test-repo", s"file://$base/test-repo")
+    },
+    checkUpdate := checkUpdateDef(
+      "example_2.12_1.0-0.1.0-SNAPSHOT.jar",
+      "sbt-plugin-example-diamond_2.12_1.0-0.5.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.3.0.jar",
+    ).value
+  )
+
+lazy val testLocal = project.in(file("test-local"))
+  .settings(
+    addSbtPlugin("org.example" % "example" % "0.1.0-SNAPSHOT"),
+    checkUpdate := checkUpdateDef(
+      "example.jar", // resolved from local repository
+      "sbt-plugin-example-diamond_2.12_1.0-0.5.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.3.0.jar",
+    ).value
+  )
+
+lazy val checkPackagedArtifacts = taskKey[Unit]("check the packaged artifacts")
+lazy val checkPublish = taskKey[Unit]("check publish")
+lazy val checkUpdate = taskKey[Unit]("check update")
+
+def checkPackagedArtifactsDef: Def.Initialize[Task[Unit]] = Def.task {
+  val packagedArtifacts = Keys.packagedArtifacts.value
+  val deprecatedArtifacts = packagedArtifacts.keys.filter(a => a.name == "example")
+  assert(deprecatedArtifacts.size == 4)
+
+  val artifactsWithCrossVersion = packagedArtifacts.keys.filter(a => a.name == "example_2.12_1.0")
+  assert(artifactsWithCrossVersion.size == 4)
+
+  val deprecatedPom = deprecatedArtifacts.find(_.`type` == "pom")
+  assert(deprecatedPom.isDefined)
+  val deprecatedPomContent = IO.read(packagedArtifacts(deprecatedPom.get))
+  assert(deprecatedPomContent.contains(s"<artifactId>example</artifactId>"))
+  assert(deprecatedPomContent.contains(s"<artifactId>sbt-plugin-example-diamond</artifactId>"))
+
+  val pomWithCrossVersion = artifactsWithCrossVersion.find(_.`type` == "pom")
+  assert(pomWithCrossVersion.isDefined)
+  val pomContent = IO.read(packagedArtifacts(pomWithCrossVersion.get))
+  assert(pomContent.contains(s"<artifactId>example_2.12_1.0</artifactId>"))
+  assert(pomContent.contains(s"<artifactId>sbt-plugin-example-diamond_2.12_1.0</artifactId>"))
+}
+
+def checkPublishDef: Def.Initialize[Task[Unit]] = Def.task {
+  val _ = publish.value
+  val org = organization.value
+  val files = IO.listFiles(repo / org.replace('.', '/') / "example_2.12_1.0" / "0.1.0-SNAPSHOT")
+
+  assert(files.nonEmpty)
+  
+  val Deprecated = s"example-${Regex.quote("0.1.0-SNAPSHOT")}(-javadoc|-sources)?(\\.jar|\\.pom)".r
+  val WithCrossVersion = s"example${Regex.quote("_2.12_1.0")}-${Regex.quote("0.1.0-SNAPSHOT")}(-javadoc|-sources)?(\\.jar|\\.pom)".r
+  
+  val deprecatedJars = files.map(_.name).collect { case jar @ Deprecated(_, ".jar") => jar }
+  assert(deprecatedJars.size == 3, deprecatedJars.mkString(", ")) // bin, sources and javadoc
+
+  val jarsWithCrossVersion = files.map(_.name).collect { case jar @ WithCrossVersion(_, ".jar") => jar }
+  assert(jarsWithCrossVersion.size == 3, jarsWithCrossVersion.mkString(", ")) // bin, sources and javadoc
+  
+  val deprecatedPom = files
+    .find { file => 
+      file.name match {
+        case pom @ Deprecated(_, ".pom") => true
+        case _ => false
+      }
+    }
+  assert(deprecatedPom.isDefined, "missing deprecated pom")
+  val deprecatedPomContent = IO.read(deprecatedPom.get)
+  assert(deprecatedPomContent.contains(s"<artifactId>example</artifactId>"))
+  assert(deprecatedPomContent.contains(s"<artifactId>sbt-plugin-example-diamond</artifactId>"))
+
+  val pomWithCrossVersion = files
+    .find { file =>
+      file.name match {
+        case pom @ WithCrossVersion(_, ".pom") => true
+        case _ => false
+      }  
+    }
+  assert(pomWithCrossVersion.isDefined, "missing pom with sbt cross-version _2.12_1.0")
+  val pomContent = IO.read(pomWithCrossVersion.get)
+  assert(pomContent.contains(s"<artifactId>example_2.12_1.0</artifactId>"))
+  assert(pomContent.contains(s"<artifactId>sbt-plugin-example-diamond_2.12_1.0</artifactId>"))
+}
+
+def checkUpdateDef(expected: String*): Def.Initialize[Task[Unit]] = Def.task {
+  val report = update.value
+  val obtainedFiles = report.configurations
+    .find(_.configuration.name == Compile.name)
+    .toSeq
+    .flatMap(_.modules)
+    .flatMap(_.artifacts)
+    .map(_._2)
+  val obtainedSet = obtainedFiles.map(_.getName).toSet
+  val expectedSet = expected.toSet + "scala-library.jar"
+  assert(obtainedSet == expectedSet, obtainedFiles)
+}

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
@@ -1,0 +1,11 @@
+> example / checkPackagedArtifacts
+
+> example / checkPublish
+> testMaven / checkUpdate
+> set testMaven / useCoursier := false
+> testMaven / checkUpdate
+
+> example / publishLocal
+> testLocal / checkUpdate
+> set testLocal / useCoursier := false
+> testLocal / checkUpdate


### PR DESCRIPTION
The goal of this PR is to fix https://github.com/sbt/sbt/issues/3410 in sbt 1.x without creating a big-bang in the ecosystem of sbt plugins.

## Summary

The implemented strategy is:
- sbt 1.9 publishes valid poms and old poms
- Coursier 2.1 and sbt 1.9 try first to resolve the valid pom and fallback to the invalid pom if the valid pom is missing (backward compatibility)
- Older versions of Coursier and sbt can still resolve newly published sbt plugins from its old pom (forward compatibility)

Thus the migration of plugins can happen in any order:
- A plugin can migrate to sbt 1.9.x even if it depends on a plugin published by sbt <= 1.8.x.
- A plugin can stay on sbt <= 1.8.x even if it depends on a plugin published by 1.9.x.

It is worth noting that the descriptor of an sbt plugin dependency is still the same: `org.example:example:1.0.0` with extra-attributes `scalaVersion:2.12` and `sbtVersion:1.0`

## Motivation

From the user perspective almost nothing changes, the dependency to a plugin is still declared as:
```scala
addSbtPlugin("org.example" % "example" % "1.0.0")
```

The added value is:
- resolution of an sbt plugin works in enterprise environments
- `mvnrepository.com` starts indexing the sbt plugins
- statistics (downloads) are available on Sonatype for sbt plugins
- `javadoc.io` can find the scaladoc of sbt plugins
- we can fix the linking of sbt plugin dependencies in Scaladex
- we can use Maven to resolve sbt plugins
- (we can use other tools that depends on Maven to resolve sbt plugins)

## Associated PRs

- In Coursier: https://github.com/coursier/coursier/pull/2633 contains the resolution of an sbt plugin based on the valid pattern and the parsing of the valid pom
- In librarymanagement: https://github.com/sbt/librarymanagement/pull/409 contains the resolution of an sbt plugin based on the valid pattern, the parsing of the valid pom and the generation of the valid pom

## In depth

### Generating the valid pom file

We consider a pom file is valid if Maven can resolve it and check its consistency. More precisely, the path of the pom file and the declared `artifactId` in the pom file must be consistent.

Given module `org.example:example:1.0.0` with extra-attributes `scalaVersion:2.12` and `sbtVersion:1.0`, its valid Maven path must be `org/example/example_2.12_1.0/1.0.0/example_2.12_1.0-1.0.0.pom` and the corresponding Maven module ID is:

```xml
<groupId>org.example</groupId>
<artifactId>example_2.12_1.0</artifactId>
<version>1.0.0</version>
<properties>
  <scalaVersion>2.12</scalaVersion>
  <sbtVersion>1.0</sbtVersion>
</properties>
```

Maven must also be able to resolve the sbt plugin dependencies. Thus all declared sbt plugin dependencies in the pom file must contain valid artifact IDs, with the sbt cross-version.

This pom file is generated as if the declared module ID is `org.example:example_2.12_1.0:1.0.0` with no extra attributes. However, in sbt and Coursier, we must maintain the old-style module ID, with extra-attributes, to get the bi-directional compatibilty.

### Resolving an sbt plugin

Given module `org.example:example:1.0.0` with extra-attributes `scalaVersion:2.12` and `sbtVersion:1.0`, we first try to resolve `org/example/example_2.12_1.0/1.0.0/example_2.12_1.0-1.0.0.pom` and we fallback to `org/example/example_2.12_1.0/1.0.0/example-1.0.0.pom`.

Whenever we parse a pom file, we must make sure to remove the cross-version part if it is redundant with the extra-attributes.
So parsing `example_2.12_1.0-1.0.0.pom` returns the same module ID as parsing `example-1.0.0.pom`. That is `org.example:example:1.0.0` with extra-attributes `scalaVersion:2.12` and `sbtVersion:1.0`. All dependencies, in the pom file, are also treated the same. The parsed dependencies of `example_2.12_1.0-1.0.0.pom` are the same as the ones of `example-1.0.0.pom`. Thus the conflict resolution is working well: sbt can resolve conflicts between old and new poms, old and new dependencies.

### Tests

To test these changes thoroughly I created a diamond graph of sbt plugins:
```
            sbt-plugin-example-diamond
                       / \
sbt-plugin-example-left   sbt-plugin-example-right
                       \ /
            sbt-plugin-example-bottom
```

I published the artifacts to Maven Central:
- https://repo1.maven.org/maven2/ch/epfl/scala/sbt-plugin-example-diamond_2.12_1.0/
- https://repo1.maven.org/maven2/ch/epfl/scala/sbt-plugin-example-left_2.12_1.0/
- https://repo1.maven.org/maven2/ch/epfl/scala/sbt-plugin-example-right_2.12_1.0/
- https://repo1.maven.org/maven2/ch/epfl/scala/sbt-plugin-example-bottom_2.12_1.0/

Depending on the version of `sbt-plugin-example-diamond`, from `0.1.0` to `0.5.0`, different parts have migrated to the new pattern, and there can be conflict resolution on `sbt-plugin-example-bottom`. See the scripted `dependency-management/sbt-plugin-diamond` for more details.

`sbt-plugin-example-diamond:0.5.0` is fully migrated to the valid Maven pattern. Hence Maven can resolve its full graph of dependencies, and resolve the conflict on `sbt-plugin-example-bottom`.

The Maven-style publication is tested in the scripted `dependency-management/sbt-plugin-publish`.

## Next Steps

- Once sbt 1.8 is EOL we can drop the publication of the old Maven pom and artifact.
- If ever we drop the support of extra-attributes in Maven, we will still be able to resolve sbt plugins as `org.example:example_2.12_1.0:1.0.0`. We probably still want to resolve older plugins though, so it may not be possible to remove the resolution fallback and the extra-attributes mechanism.
- In sbt 2.x we should drop all this complexity and use the `CrossVersion` mechanism to publish sbt plugin, similarly to Scala.js or Scala Native artifacts. The cross version would then be something like `_sbt2_3`.
- After sbt 1.x in EOL we can drop the support of extra-attributes in Coursier