### PR TITLE
add debugProvider and canDebug in BSP contra

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -50,6 +50,7 @@ object BuildServerProtocol {
     CompileProvider(BuildServerConnection.languages),
     TestProvider(BuildServerConnection.languages),
     RunProvider(BuildServerConnection.languages),
+    DebugProvider(Vector.empty),
     dependencySourcesProvider = true,
     resourcesProvider = true,
     outputPathsProvider = true,
@@ -609,7 +610,8 @@ object BuildServerProtocol {
       config <- configs
       if dep != thisProjectRef || config.name != thisConfig.name
     } yield (dep / config / Keys.bspTargetIdentifier)
-    val capabilities = BuildTargetCapabilities(canCompile = true, canTest = true, canRun = true)
+    val capabilities =
+      BuildTargetCapabilities(canCompile = true, canTest = true, canRun = true, canDebug = false)
     val tags = BuildTargetTag.fromConfig(configuration.name)
     Def.task {
       BuildTarget(
@@ -655,7 +657,12 @@ object BuildServerProtocol {
       toSbtTargetIdName(loadedUnit),
       projectStandard(loadedUnit.unit.localBase).toURI,
       Vector(),
-      BuildTargetCapabilities(canCompile = false, canTest = false, canRun = false),
+      BuildTargetCapabilities(
+        canCompile = false,
+        canTest = false,
+        canRun = false,
+        canDebug = false
+      ),
       BuildServerConnection.languages,
       Vector(),
       "sbt",

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildServerCapabilities.scala
@@ -15,6 +15,7 @@ final class BuildServerCapabilities private (
   val compileProvider: Option[sbt.internal.bsp.CompileProvider],
   val testProvider: Option[sbt.internal.bsp.TestProvider],
   val runProvider: Option[sbt.internal.bsp.RunProvider],
+  val debugProvider: Option[sbt.internal.bsp.DebugProvider],
   val dependencySourcesProvider: Option[Boolean],
   val resourcesProvider: Option[Boolean],
   val outputPathsProvider: Option[Boolean],
@@ -25,17 +26,17 @@ final class BuildServerCapabilities private (
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.testProvider == x.testProvider) && (this.runProvider == x.runProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.resourcesProvider == x.resourcesProvider) && (this.outputPathsProvider == x.outputPathsProvider) && (this.canReload == x.canReload) && (this.jvmRunEnvironmentProvider == x.jvmRunEnvironmentProvider) && (this.jvmTestEnvironmentProvider == x.jvmTestEnvironmentProvider)
+    case x: BuildServerCapabilities => (this.compileProvider == x.compileProvider) && (this.testProvider == x.testProvider) && (this.runProvider == x.runProvider) && (this.debugProvider == x.debugProvider) && (this.dependencySourcesProvider == x.dependencySourcesProvider) && (this.resourcesProvider == x.resourcesProvider) && (this.outputPathsProvider == x.outputPathsProvider) && (this.canReload == x.canReload) && (this.jvmRunEnvironmentProvider == x.jvmRunEnvironmentProvider) && (this.jvmTestEnvironmentProvider == x.jvmTestEnvironmentProvider)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + testProvider.##) + runProvider.##) + dependencySourcesProvider.##) + resourcesProvider.##) + outputPathsProvider.##) + canReload.##) + jvmRunEnvironmentProvider.##) + jvmTestEnvironmentProvider.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildServerCapabilities".##) + compileProvider.##) + testProvider.##) + runProvider.##) + debugProvider.##) + dependencySourcesProvider.##) + resourcesProvider.##) + outputPathsProvider.##) + canReload.##) + jvmRunEnvironmentProvider.##) + jvmTestEnvironmentProvider.##)
   }
   override def toString: String = {
-    "BuildServerCapabilities(" + compileProvider + ", " + testProvider + ", " + runProvider + ", " + dependencySourcesProvider + ", " + resourcesProvider + ", " + outputPathsProvider + ", " + canReload + ", " + jvmRunEnvironmentProvider + ", " + jvmTestEnvironmentProvider + ")"
+    "BuildServerCapabilities(" + compileProvider + ", " + testProvider + ", " + runProvider + ", " + debugProvider + ", " + dependencySourcesProvider + ", " + resourcesProvider + ", " + outputPathsProvider + ", " + canReload + ", " + jvmRunEnvironmentProvider + ", " + jvmTestEnvironmentProvider + ")"
   }
-  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, testProvider: Option[sbt.internal.bsp.TestProvider] = testProvider, runProvider: Option[sbt.internal.bsp.RunProvider] = runProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, resourcesProvider: Option[Boolean] = resourcesProvider, outputPathsProvider: Option[Boolean] = outputPathsProvider, canReload: Option[Boolean] = canReload, jvmRunEnvironmentProvider: Option[Boolean] = jvmRunEnvironmentProvider, jvmTestEnvironmentProvider: Option[Boolean] = jvmTestEnvironmentProvider): BuildServerCapabilities = {
-    new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
+  private[this] def copy(compileProvider: Option[sbt.internal.bsp.CompileProvider] = compileProvider, testProvider: Option[sbt.internal.bsp.TestProvider] = testProvider, runProvider: Option[sbt.internal.bsp.RunProvider] = runProvider, debugProvider: Option[sbt.internal.bsp.DebugProvider] = debugProvider, dependencySourcesProvider: Option[Boolean] = dependencySourcesProvider, resourcesProvider: Option[Boolean] = resourcesProvider, outputPathsProvider: Option[Boolean] = outputPathsProvider, canReload: Option[Boolean] = canReload, jvmRunEnvironmentProvider: Option[Boolean] = jvmRunEnvironmentProvider, jvmTestEnvironmentProvider: Option[Boolean] = jvmTestEnvironmentProvider): BuildServerCapabilities = {
+    new BuildServerCapabilities(compileProvider, testProvider, runProvider, debugProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
   }
   def withCompileProvider(compileProvider: Option[sbt.internal.bsp.CompileProvider]): BuildServerCapabilities = {
     copy(compileProvider = compileProvider)
@@ -54,6 +55,12 @@ final class BuildServerCapabilities private (
   }
   def withRunProvider(runProvider: sbt.internal.bsp.RunProvider): BuildServerCapabilities = {
     copy(runProvider = Option(runProvider))
+  }
+  def withDebugProvider(debugProvider: Option[sbt.internal.bsp.DebugProvider]): BuildServerCapabilities = {
+    copy(debugProvider = debugProvider)
+  }
+  def withDebugProvider(debugProvider: sbt.internal.bsp.DebugProvider): BuildServerCapabilities = {
+    copy(debugProvider = Option(debugProvider))
   }
   def withDependencySourcesProvider(dependencySourcesProvider: Option[Boolean]): BuildServerCapabilities = {
     copy(dependencySourcesProvider = dependencySourcesProvider)
@@ -94,6 +101,6 @@ final class BuildServerCapabilities private (
 }
 object BuildServerCapabilities {
   
-  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], testProvider: Option[sbt.internal.bsp.TestProvider], runProvider: Option[sbt.internal.bsp.RunProvider], dependencySourcesProvider: Option[Boolean], resourcesProvider: Option[Boolean], outputPathsProvider: Option[Boolean], canReload: Option[Boolean], jvmRunEnvironmentProvider: Option[Boolean], jvmTestEnvironmentProvider: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
-  def apply(compileProvider: sbt.internal.bsp.CompileProvider, testProvider: sbt.internal.bsp.TestProvider, runProvider: sbt.internal.bsp.RunProvider, dependencySourcesProvider: Boolean, resourcesProvider: Boolean, outputPathsProvider: Boolean, canReload: Boolean, jvmRunEnvironmentProvider: Boolean, jvmTestEnvironmentProvider: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(testProvider), Option(runProvider), Option(dependencySourcesProvider), Option(resourcesProvider), Option(outputPathsProvider), Option(canReload), Option(jvmRunEnvironmentProvider), Option(jvmTestEnvironmentProvider))
+  def apply(compileProvider: Option[sbt.internal.bsp.CompileProvider], testProvider: Option[sbt.internal.bsp.TestProvider], runProvider: Option[sbt.internal.bsp.RunProvider], debugProvider: Option[sbt.internal.bsp.DebugProvider], dependencySourcesProvider: Option[Boolean], resourcesProvider: Option[Boolean], outputPathsProvider: Option[Boolean], canReload: Option[Boolean], jvmRunEnvironmentProvider: Option[Boolean], jvmTestEnvironmentProvider: Option[Boolean]): BuildServerCapabilities = new BuildServerCapabilities(compileProvider, testProvider, runProvider, debugProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
+  def apply(compileProvider: sbt.internal.bsp.CompileProvider, testProvider: sbt.internal.bsp.TestProvider, runProvider: sbt.internal.bsp.RunProvider, debugProvider: sbt.internal.bsp.DebugProvider, dependencySourcesProvider: Boolean, resourcesProvider: Boolean, outputPathsProvider: Boolean, canReload: Boolean, jvmRunEnvironmentProvider: Boolean, jvmTestEnvironmentProvider: Boolean): BuildServerCapabilities = new BuildServerCapabilities(Option(compileProvider), Option(testProvider), Option(runProvider), Option(debugProvider), Option(dependencySourcesProvider), Option(resourcesProvider), Option(outputPathsProvider), Option(canReload), Option(jvmRunEnvironmentProvider), Option(jvmTestEnvironmentProvider))
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildTargetCapabilities.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/BuildTargetCapabilities.scala
@@ -8,26 +8,28 @@ package sbt.internal.bsp
  * @param canCompile This target can be compiled by the BSP server.
  * @param canTest This target can be tested by the BSP server.
  * @param canRun This target can be run by the BSP server.
+ * @param canDebug This target can be debugged by the BSP server.
  */
 final class BuildTargetCapabilities private (
   val canCompile: Boolean,
   val canTest: Boolean,
-  val canRun: Boolean) extends Serializable {
+  val canRun: Boolean,
+  val canDebug: Boolean) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: BuildTargetCapabilities => (this.canCompile == x.canCompile) && (this.canTest == x.canTest) && (this.canRun == x.canRun)
+    case x: BuildTargetCapabilities => (this.canCompile == x.canCompile) && (this.canTest == x.canTest) && (this.canRun == x.canRun) && (this.canDebug == x.canDebug)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildTargetCapabilities".##) + canCompile.##) + canTest.##) + canRun.##)
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.bsp.BuildTargetCapabilities".##) + canCompile.##) + canTest.##) + canRun.##) + canDebug.##)
   }
   override def toString: String = {
-    "BuildTargetCapabilities(" + canCompile + ", " + canTest + ", " + canRun + ")"
+    "BuildTargetCapabilities(" + canCompile + ", " + canTest + ", " + canRun + ", " + canDebug + ")"
   }
-  private[this] def copy(canCompile: Boolean = canCompile, canTest: Boolean = canTest, canRun: Boolean = canRun): BuildTargetCapabilities = {
-    new BuildTargetCapabilities(canCompile, canTest, canRun)
+  private[this] def copy(canCompile: Boolean = canCompile, canTest: Boolean = canTest, canRun: Boolean = canRun, canDebug: Boolean = canDebug): BuildTargetCapabilities = {
+    new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
   }
   def withCanCompile(canCompile: Boolean): BuildTargetCapabilities = {
     copy(canCompile = canCompile)
@@ -38,8 +40,11 @@ final class BuildTargetCapabilities private (
   def withCanRun(canRun: Boolean): BuildTargetCapabilities = {
     copy(canRun = canRun)
   }
+  def withCanDebug(canDebug: Boolean): BuildTargetCapabilities = {
+    copy(canDebug = canDebug)
+  }
 }
 object BuildTargetCapabilities {
   
-  def apply(canCompile: Boolean, canTest: Boolean, canRun: Boolean): BuildTargetCapabilities = new BuildTargetCapabilities(canCompile, canTest, canRun)
+  def apply(canCompile: Boolean, canTest: Boolean, canRun: Boolean, canDebug: Boolean): BuildTargetCapabilities = new BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugProvider.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/DebugProvider.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp
+final class DebugProvider private (
+  val languageIds: Vector[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: DebugProvider => (this.languageIds == x.languageIds)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.bsp.DebugProvider".##) + languageIds.##)
+  }
+  override def toString: String = {
+    "DebugProvider(" + languageIds + ")"
+  }
+  private[this] def copy(languageIds: Vector[String] = languageIds): DebugProvider = {
+    new DebugProvider(languageIds)
+  }
+  def withLanguageIds(languageIds: Vector[String]): DebugProvider = {
+    copy(languageIds = languageIds)
+  }
+}
+object DebugProvider {
+  
+  def apply(languageIds: Vector[String]): DebugProvider = new DebugProvider(languageIds)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildServerCapabilitiesFormats.scala
@@ -5,7 +5,7 @@
 // DO NOT EDIT MANUALLY
 package sbt.internal.bsp.codec
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
-trait BuildServerCapabilitiesFormats { self: sbt.internal.bsp.codec.CompileProviderFormats with sbt.internal.bsp.codec.TestProviderFormats with sbt.internal.bsp.codec.RunProviderFormats with sjsonnew.BasicJsonProtocol =>
+trait BuildServerCapabilitiesFormats { self: sbt.internal.bsp.codec.CompileProviderFormats with sbt.internal.bsp.codec.TestProviderFormats with sbt.internal.bsp.codec.RunProviderFormats with sbt.internal.bsp.codec.DebugProviderFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.BuildServerCapabilities] = new JsonFormat[sbt.internal.bsp.BuildServerCapabilities] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.BuildServerCapabilities = {
     __jsOpt match {
@@ -14,6 +14,7 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
       val compileProvider = unbuilder.readField[Option[sbt.internal.bsp.CompileProvider]]("compileProvider")
       val testProvider = unbuilder.readField[Option[sbt.internal.bsp.TestProvider]]("testProvider")
       val runProvider = unbuilder.readField[Option[sbt.internal.bsp.RunProvider]]("runProvider")
+      val debugProvider = unbuilder.readField[Option[sbt.internal.bsp.DebugProvider]]("debugProvider")
       val dependencySourcesProvider = unbuilder.readField[Option[Boolean]]("dependencySourcesProvider")
       val resourcesProvider = unbuilder.readField[Option[Boolean]]("resourcesProvider")
       val outputPathsProvider = unbuilder.readField[Option[Boolean]]("outputPathsProvider")
@@ -21,7 +22,7 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
       val jvmRunEnvironmentProvider = unbuilder.readField[Option[Boolean]]("jvmRunEnvironmentProvider")
       val jvmTestEnvironmentProvider = unbuilder.readField[Option[Boolean]]("jvmTestEnvironmentProvider")
       unbuilder.endObject()
-      sbt.internal.bsp.BuildServerCapabilities(compileProvider, testProvider, runProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
+      sbt.internal.bsp.BuildServerCapabilities(compileProvider, testProvider, runProvider, debugProvider, dependencySourcesProvider, resourcesProvider, outputPathsProvider, canReload, jvmRunEnvironmentProvider, jvmTestEnvironmentProvider)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -31,6 +32,7 @@ implicit lazy val BuildServerCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
     builder.addField("compileProvider", obj.compileProvider)
     builder.addField("testProvider", obj.testProvider)
     builder.addField("runProvider", obj.runProvider)
+    builder.addField("debugProvider", obj.debugProvider)
     builder.addField("dependencySourcesProvider", obj.dependencySourcesProvider)
     builder.addField("resourcesProvider", obj.resourcesProvider)
     builder.addField("outputPathsProvider", obj.outputPathsProvider)

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildTargetCapabilitiesFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/BuildTargetCapabilitiesFormats.scala
@@ -14,8 +14,9 @@ implicit lazy val BuildTargetCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
       val canCompile = unbuilder.readField[Boolean]("canCompile")
       val canTest = unbuilder.readField[Boolean]("canTest")
       val canRun = unbuilder.readField[Boolean]("canRun")
+      val canDebug = unbuilder.readField[Boolean]("canDebug")
       unbuilder.endObject()
-      sbt.internal.bsp.BuildTargetCapabilities(canCompile, canTest, canRun)
+      sbt.internal.bsp.BuildTargetCapabilities(canCompile, canTest, canRun, canDebug)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -25,6 +26,7 @@ implicit lazy val BuildTargetCapabilitiesFormat: JsonFormat[sbt.internal.bsp.Bui
     builder.addField("canCompile", obj.canCompile)
     builder.addField("canTest", obj.canTest)
     builder.addField("canRun", obj.canRun)
+    builder.addField("canDebug", obj.canDebug)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugProviderFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/DebugProviderFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.bsp.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait DebugProviderFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val DebugProviderFormat: JsonFormat[sbt.internal.bsp.DebugProvider] = new JsonFormat[sbt.internal.bsp.DebugProvider] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.bsp.DebugProvider = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val languageIds = unbuilder.readField[Vector[String]]("languageIds")
+      unbuilder.endObject()
+      sbt.internal.bsp.DebugProvider(languageIds)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.bsp.DebugProvider, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("languageIds", obj.languageIds)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/bsp/codec/JsonProtocol.scala
@@ -21,6 +21,7 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.bsp.codec.CompileProviderFormats
   with sbt.internal.bsp.codec.TestProviderFormats
   with sbt.internal.bsp.codec.RunProviderFormats
+  with sbt.internal.bsp.codec.DebugProviderFormats
   with sbt.internal.bsp.codec.BuildServerCapabilitiesFormats
   with sbt.internal.bsp.codec.InitializeBuildResultFormats
   with sbt.internal.bsp.codec.PublishDiagnosticsParamsFormats

--- a/protocol/src/main/contraband/bsp.contra
+++ b/protocol/src/main/contraband/bsp.contra
@@ -61,6 +61,9 @@ type BuildTargetCapabilities {
 
   ## This target can be run by the BSP server.
   canRun: Boolean!
+
+  ## This target can be debugged by the BSP server.
+  canDebug: Boolean!
 }
 
 type DebugSessionAddress {
@@ -190,6 +193,9 @@ type BuildServerCapabilities {
   # The languages the server supports run via method buildTarget/run
   runProvider: sbt.internal.bsp.RunProvider
 
+  # The languages the server supports debugging via method debugSession/start
+  debugProvider: sbt.internal.bsp.DebugProvider
+
   # The server can provide a list of targets that contain a
   # single text document via the method buildTarget/inverseSources
   # inverseSourcesProvider: Boolean
@@ -232,6 +238,10 @@ type TestProvider {
 }
 
 type RunProvider {
+  languageIds: [String]
+}
+
+type DebugProvider {
   languageIds: [String]
 }
 


### PR DESCRIPTION
I believe this was just an oversight that it's not marked as true since sbt can handle `debugSession/start`. This change just ensures that during the initialization process sbt says it's a `debugProvider` for the same languages as `runProvider` and `testProvider`. It also correctly marks the build targets as `canDebug`, unless they are sbt targets.