### PR TITLE
[1.8.x] Prepare aarch64 support for sbtn binary

### DIFF
--- a/client/src/main/resources/META-INF/native-image/resource-config.json
+++ b/client/src/main/resources/META-INF/native-image/resource-config.json
@@ -16,6 +16,7 @@
 	{"pattern":"org/jline/utils/screen.caps"},
 	{"pattern":"library.properties"},
         {"pattern":"darwin/x86_64/libsbtipcsocket.dylib"},
+        {"pattern":"linux/aarch64/libsbtipcsocket.so"},
         {"pattern":"linux/x86_64/libsbtipcsocket.so"},
         {"pattern":"win32/x86_64/sbtipcsocket.dll"}
     ]


### PR DESCRIPTION
In https://github.com/mkurz/sbtn-dist/commits/aarch64-support I am setting up a GitHub actions job to build a `sbtn` binary for Linux aarch64. To make this happen, the changes in this PR are necessary. I am almost done, binary can be downloaded here already: https://github.com/mkurz/sbtn-dist/actions/runs/3825258120