### PR TITLE
[1.8.x] Make use of sbtn aarch64 binary where possible

### DIFF
--- a/main/src/main/scala/sbt/internal/InstallSbtn.scala
+++ b/main/src/main/scala/sbt/internal/InstallSbtn.scala
@@ -64,7 +64,11 @@ private[sbt] object InstallSbtn {
       if (Properties.isWin) "pc-win32.exe"
       else if (Properties.isLinux) "pc-linux"
       else "apple-darwin"
-    val sbtnName = s"sbt/bin/sbtn-x86_64-$bin"
+    val isArmArchitecture: Boolean = sys.props
+      .getOrElse("os.arch", "")
+      .toLowerCase(java.util.Locale.ROOT) == "aarch64"
+    val arch = if (Properties.isLinux && isArmArchitecture) "aarch64" else "x86_64"
+    val sbtnName = s"sbt/bin/sbtn-$arch-$bin"
     val fis = new FileInputStream(sbtZip.toFile)
     val zipInputStream = new ZipInputStream(fis)
     var foundBinary = false

--- a/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
+++ b/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
@@ -37,7 +37,7 @@ class InstallSbtnSpec extends AnyFlatSpec {
   "InstallSbtn" should "extract native sbtn" ignore
     withTemp(".zip") { tmp =>
       withTemp(".exe") { sbtn =>
-        InstallSbtn.extractSbtn(term, "1.4.1", tmp, sbtn)
+        InstallSbtn.extractSbtn(term, "1.8.1-M1", tmp, sbtn)
         val tmpDir = Files.createTempDirectory("sbtn-test").toRealPath()
         Files.createDirectories(tmpDir.resolve("project"))
         val foo = tmpDir.resolve("foo")
@@ -46,7 +46,7 @@ class InstallSbtnSpec extends AnyFlatSpec {
         IO.write(tmpDir.resolve("build.sbt").toFile, build)
         IO.write(
           tmpDir.resolve("project").resolve("build.properties").toFile,
-          "sbt.version=1.4.1"
+          "sbt.version=1.8.0"
         )
         try {
           val proc =

--- a/sbt
+++ b/sbt
@@ -24,7 +24,7 @@ declare build_props_sbt_version=
 declare use_sbtn=
 declare no_server=
 declare sbtn_command="$SBTN_CMD"
-declare sbtn_version="1.7.0"
+declare sbtn_version="1.8.1-M1"
 
 ###  ------------------------------- ###
 ###  Helper methods for BASH scripts ###
@@ -172,8 +172,14 @@ acquire_sbtn () {
   local archive_target=
   local url=
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    archive_target="$p/sbtn-x86_64-pc-linux-${sbtn_v}.tar.gz"
-    url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-x86_64-pc-linux-${sbtn_v}.tar.gz"
+    arch=$(uname -m)
+    if [[ "$arch" == "aarch64" ]] || [[ "$arch" == "x86_64" ]]; then
+      archive_target="$p/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
+      url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
+    else
+      echoerr "sbtn is not supported on $arch"
+      exit 2
+    fi
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     archive_target="$p/sbtn-x86_64-apple-darwin-${sbtn_v}.tar.gz"
     url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-x86_64-apple-darwin-${sbtn_v}.tar.gz"
@@ -189,7 +195,7 @@ acquire_sbtn () {
   if [[ -f "$target" ]]; then
     sbtn_command="$target"
   else
-    echoerr "downloading sbtn ${sbtn_v}"
+    echoerr "downloading sbtn ${sbtn_v} for ${arch}"
     download_url "$url" "$archive_target"
     if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
       tar zxf "$archive_target" --directory "$p"
@@ -710,7 +716,8 @@ detectNativeClient() {
   if [[ "$sbtn_command" != "" ]]; then
     :
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-linux"
+    arch=$(uname -m)
+    [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
   elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then

--- a/sbt
+++ b/sbt
@@ -171,6 +171,7 @@ acquire_sbtn () {
   local target="$p/sbtn"
   local archive_target=
   local url=
+  local arch = "x86_64"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     arch=$(uname -m)
     if [[ "$arch" == "aarch64" ]] || [[ "$arch" == "x86_64" ]]; then


### PR DESCRIPTION
Backports
* #7110
* #7111

@eed3si9n I am pretty sure all is done now, how about releasing sbt 1.8.1? Be aware you have to release and upload sbtn 1.8.1 before and change `1.8.1-M1` here in the sbt repo to `1.8.1` in various places before cutting the release.