### PR TITLE
Fixes M1 support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"
-  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.6.1"
+  val ipcSocket = "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.6.2"
 
   private val compilerInterface = "org.scala-sbt" % "compiler-interface" % zincVersion
   private val compilerClasspath = "org.scala-sbt" %% "zinc-classpath" % zincVersion


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7117

Problem
-------
sbt no longer works on a Mac with M1 (aarch64) chips because it fails on ipcsocket library, which we maintain.
This was caused by architecture detection that was added in 1.6.1, which did not take in account for macOS universal binary.

Solution
--------
Update to ipcsocket 1.6.2.