### PR TITLE
Remove spurious whitespace in the launcher script

### DIFF
--- a/sbt
+++ b/sbt
@@ -171,7 +171,7 @@ acquire_sbtn () {
   local target="$p/sbtn"
   local archive_target=
   local url=
-  local arch = "x86_64"
+  local arch="x86_64"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     arch=$(uname -m)
     if [[ "$arch" == "aarch64" ]] || [[ "$arch" == "x86_64" ]]; then


### PR DESCRIPTION
It causes an error in (at least) fish shell: "sbt: line 174: local: `=': not a valid identifier"