### PR TITLE
[1.8.x] Make `Keys.loggerContext` and `LoggerContext()` public

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -187,6 +187,6 @@ object LoggerContext {
       loggers.clear()
     }
   }
-  private[sbt] def apply(useLog4J: Boolean) =
+  def apply(useLog4J: Boolean) =
     if (useLog4J) new Log4JLoggerContext(LogExchange.context) else new LoggerContextImpl
 }

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -181,8 +181,7 @@ object LoggerContext {
         case l    => l.clearAppenders()
       }
     }
-    def close(): Unit = {
-      closed.set(true)
+    def close(): Unit = if (closed.compareAndSet(false, true)) {
       loggers.forEach((_, l) => l.clearAppenders())
       loggers.clear()
     }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -64,7 +64,7 @@ object Keys {
   val extraAppenders = settingKey[AppenderSupplier]("A function that provides additional loggers for a given setting.").withRank(DSetting)
   val useLog4J = settingKey[Boolean]("Toggles whether or not to use log4j for sbt internal loggers.").withRank(Invisible)
   val logManager = settingKey[LogManager]("The log manager, which creates Loggers for different contexts.").withRank(DSetting)
-  private[sbt] val loggerContext = AttributeKey[LoggerContext]("sbt-logger-context", "The logger config which creates Loggers for different contexts.", Int.MaxValue)
+  val loggerContext = AttributeKey[LoggerContext]("sbt-logger-context", "The logger config which creates Loggers for different contexts.", Int.MaxValue)
   val logBuffered = settingKey[Boolean]("True if logging should be buffered until work completes.").withRank(CSetting)
   val sLog = settingKey[Logger]("Logger usable by settings during project loading.").withRank(CSetting)
   val serverLog = taskKey[Unit]("A dummy task to set server log level using Global / serverLog / logLevel.").withRank(CTask)


### PR DESCRIPTION
Starting with sbt 1.8.0-RC1 a `LoggerContext` will set its internal `closed` status to `true`:

https://github.com/sbt/sbt/blob/f974cd3bab0b8d09d031414c0741035ceba221b2/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala#L184-L188

The line `closed.set(true)` was introduced in #6992.

Because this `AtomicBoolean` is true now, it of course is not possible to re use a LoggerContext anymore:

https://github.com/sbt/sbt/blob/ec770668c924432d017204610390b102fa5b7f3d/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala#L142-L149

So far so good, this seems correct.

However this is causing problems with the Play Framework, which now runs into that exception with sbt 1.8, see https://github.com/playframework/playframework/issues/11527

So basically Play has a special `NonBlockingInteractionMode` which causes an app to continue to run in the background when calling `run` in a sbt console. That means, when `run` is "finished", there is still a (server) thread running that can serve requests. We use that for scripted tests. It's actually the same mechanism that sbt's `bgRun` is using, only that `NonBlockingInteractionMode` was implemented long time before `bgRun` was introduced in sbt 1.0.
Until sbt 1.7.x this was working fine, even though the background thread was using a state's loggercontext that, in theory, was closed already, but wasn't marked as closed (even thought the close method ran).

To test things out, I also came up with a clean room `bgRun` implementation in Play, that resembled what the `NonBlockingInteractionMode` is doing and I was running in the exact same exception. That `bgRun` looked somehow like this:

```sbt
// Not the full code, just for demonstration purposes
bgRun: Initialize[InputTask[JobHandle]] = Def.inputTask {
    val service = bgJobService.value
    service.runInBackground(resolvedScoped.value, state.value) { (logger, workingDir) =>
      // At some point later, triggered by the Play server when a request comes in and the app has code changes:
      Project.runTask(Compile / compile, state) // re-compile the project
    }
}.evaluated
```

The problem is that the body of `runInBackground`, which at some point may calls `Project.runTask`, is not running in the `bgRun` lifetime anymore, but in a background thread, so after the `bgRun` task finishes the loggercontext gets closed. `Project.runTask(...)` however tries to access the loggercontext of the passed `state` which of course is closed now.

I tried _a lot_ to workaround that or to come up with another solution. However the only solution that I found and IMHO think is the only one to be able to resolve that (right now) is to "wrap" `Project.runTask(...)` calls with an open loggercontext, which needs to be attached to the `state`. To do that, I need to be able to 

1. initialized a `LoggerContext` - but the `apply` method is private right now
1. attach that loggerContext to the `state` with `state.put(Keys.loggerContext,..)`. - but `Keys.loggerContext` is private right now

Using this patch here I was able to make both, Play's `NonBlockingInteractionMode` and sbt's `bgRun`, work in Play.
[These lines](https://github.com/playframework/playframework/pull/11441/commits/1f28b99880703f8a8642952e83a32b3ef2c605f4#diff-be42fe9ca2ca80fab032ee36d2f376f1f021c0e30c3f04c60029a2a1634c4afdR74-R87) of https://github.com/playframework/playframework/pull/11441 create a loggercontext and closes it afterwards. I also finally was able to implement `bgRun` in Play in the [last commit](https://github.com/playframework/playframework/pull/11441/commits/d6431b0ee8684e7f5e91eb0117da3118d7bb5de8) of that PR.

@eed3si9n If there is nothing that speaks against opening up this key and method I would be happy if you can merge this, I will provide PRs for the `1.9.x` and `develop` branch afterwards.