### PR TITLE
Add `releaseNotesURL` setting

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3347,7 +3347,7 @@ object Classpaths {
     }
     val p3 = releaseNotesURL.value match {
       case Some(u) =>
-        p1.extra("info.releaseNotesUrl" -> u.toExternalForm)
+        p2.extra("info.releaseNotesUrl" -> u.toExternalForm)
       case _ => p2
     }
     p3

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3347,7 +3347,7 @@ object Classpaths {
     }
     val p3 = releaseNotesURL.value match {
       case Some(u) =>
-        p2.extra("info.releaseNotesUrl" -> u.toExternalForm)
+        p2.extra(SbtPomExtraProperties.POM_RELEASE_NOTES_KEY -> u.toExternalForm)
       case _ => p2
     }
     p3

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -200,7 +200,8 @@ object Defaults extends BuildCommon {
       autoCompilerPlugins :== true,
       scalaHome :== None,
       apiURL := None,
-      javaHome :== None,
+      releaseNotesURL := None
+        javaHome :== None,
       discoveredJavaHomes := CrossJava.discoverJavaHomes,
       javaHomes :== ListMap.empty,
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
@@ -3344,7 +3345,12 @@ object Classpaths {
         p1.extra(SbtPomExtraProperties.VERSION_SCHEME_KEY -> x)
       case _ => p1
     }
-    p2
+    val p3 = releaseNotesURL.value match {
+      case Some(u) =>
+        p1.extra("info.releaseNotesUrl" -> u.toExternalForm)
+      case _ => p2
+    }
+    p3
   }
   def pluginProjectID: Initialize[ModuleID] =
     Def.setting {

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -200,8 +200,8 @@ object Defaults extends BuildCommon {
       autoCompilerPlugins :== true,
       scalaHome :== None,
       apiURL := None,
-      releaseNotesURL := None
-        javaHome :== None,
+      releaseNotesURL := None,
+      javaHome :== None,
       discoveredJavaHomes := CrossJava.discoverJavaHomes,
       javaHomes :== ListMap.empty,
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -346,6 +346,7 @@ object Keys {
   val entryApiURL = AttributeKey[URL]("entryApiURL", "Base URL for the API documentation for a classpath entry.")
   val apiMappings = taskKey[Map[File, URL]]("Mappings from classpath entry to API documentation base URL.").withRank(BMinusSetting)
   val autoAPIMappings = settingKey[Boolean]("If true, automatically manages mappings to the API doc URL.").withRank(BMinusSetting)
+  val releaseNotesURL = settingKey[Option[URL]]("URL for release notes.").withRank(BMinusSetting)
   val scmInfo = settingKey[Option[ScmInfo]]("Basic SCM information for the project.").withRank(BMinusSetting)
   val projectInfo = settingKey[ModuleInfo]("Addition project information like formal name, homepage, licenses etc.").withRank(CSetting)
   val defaultConfiguration = settingKey[Option[Configuration]]("Defines the configuration used when none is specified for a dependency in ivyXML.").withRank(CSetting)

--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -45,6 +45,7 @@ object CoursierInputsTasks {
       sv: String,
       sbv: String,
       auOpt: Option[URL],
+      rnOpt: Option[URL],
       description: String,
       homepage: Option[URL],
       vsOpt: Option[String],
@@ -70,8 +71,15 @@ object CoursierInputsTasks {
         proj1.withProperties(proj1.properties :+ (SbtPomExtraProperties.VERSION_SCHEME_KEY -> vs))
       case _ => proj1
     }
-    proj2.withInfo(
-      proj2.info.withDescription(description).withHomePage(homepage.fold("")(_.toString))
+    val proj3 = rnOpt match {
+      case Some(rn) =>
+        proj2.withProperties(
+          proj2.properties :+ (SbtPomExtraProperties.POM_RELEASE_NOTES_KEY -> rn.toString)
+        )
+      case _ => proj2
+    }
+    proj3.withInfo(
+      proj3.info.withDescription(description).withHomePage(homepage.fold("")(_.toString))
     )
   }
 
@@ -84,6 +92,7 @@ object CoursierInputsTasks {
         scalaVersion.value,
         scalaBinaryVersion.value,
         apiURL.value,
+        releaseNotesURL.value,
         description.value,
         homepage.value,
         versionScheme.value,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.8.0")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.8.0")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.9.0-M1")
   val zincVersion = nightlyVersion.getOrElse("1.8.0")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -5,8 +5,10 @@ lazy val root = (project in file(".")) settings (
   TaskKey[Unit]("checkPom") := checkPom.value,
   TaskKey[Unit]("checkExtra") := checkExtra.value,
   TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
+  TaskKey[Unit]("checkAPIURL") := checkAPIURL.value,
   TaskKey[Unit]("checkReleaseNotesURL") := checkReleaseNotesURL.value,
   resolvers += Resolver.sonatypeRepo("snapshots"),
+  apiURL := Some(url("https://www.scala-sbt.org/1.x/api/")),
   releaseNotesURL := Some(url("https://github.com/sbt/sbt/releases")),
   makePomConfiguration := {
     val p = makePomConfiguration.value
@@ -46,6 +48,11 @@ lazy val checkVersionPlusMapping = (readPom) map { (pomXml) =>
     if (dep \ "version").text != "[1.3,1.4)"
   } sys.error(s"Found dependency with invalid maven version: $dep")
   ()
+}
+
+lazy val checkAPIURL = (readPom) map { (pomXml) =>
+  val notes = pomXml \ "properties" \ "info.apiURL"
+  if (notes.isEmpty) sys.error("'apiURL' not found in generated pom.xml.") else ()
 }
 
 lazy val checkReleaseNotesURL = (readPom) map { (pomXml) =>

--- a/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -5,7 +5,9 @@ lazy val root = (project in file(".")) settings (
   TaskKey[Unit]("checkPom") := checkPom.value,
   TaskKey[Unit]("checkExtra") := checkExtra.value,
   TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
+  TaskKey[Unit]("checkReleaseNotesURL") := checkReleaseNotesURL.value,
   resolvers += Resolver.sonatypeRepo("snapshots"),
+  releaseNotesURL := Some(url("https://github.com/sbt/sbt/releases")),
   makePomConfiguration := {
     val p = makePomConfiguration.value
     p.withExtra(<extra-tag/>)
@@ -44,6 +46,11 @@ lazy val checkVersionPlusMapping = (readPom) map { (pomXml) =>
     if (dep \ "version").text != "[1.3,1.4)"
   } sys.error(s"Found dependency with invalid maven version: $dep")
   ()
+}
+
+lazy val checkReleaseNotesURL = (readPom) map { (pomXml) =>
+  val notes = pomXml \ "properties" \ "info.releaseNotesUrl"
+  if (notes.isEmpty) sys.error("'releaseNotesUrl' not found in generated pom.xml.") else ()
 }
 
 lazy val checkPom = Def task {

--- a/sbt-app/src/sbt-test/dependency-management/make-pom/test
+++ b/sbt-app/src/sbt-test/dependency-management/make-pom/test
@@ -1,3 +1,4 @@
 > checkPom
 > checkExtra
 > checkVersionPlusMapping
+> checkReleaseNotesURL

--- a/sbt-app/src/sbt-test/dependency-management/make-pom/test
+++ b/sbt-app/src/sbt-test/dependency-management/make-pom/test
@@ -1,4 +1,5 @@
 > checkPom
 > checkExtra
 > checkVersionPlusMapping
+> checkAPIURL
 > checkReleaseNotesURL


### PR DESCRIPTION
Closes https://github.com/sbt/sbt/issues/7125

Scala Steward has adopted a `info.releaseNotesUrl` property for the POM.

https://contributors.scala-lang.org/t/add-release-notes-urls-to-your-poms/6059

Can we add a setting `releaseNotesURL` to populate it?