### PR TITLE
Use native-image 22.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1173,6 +1173,7 @@ lazy val sbtClientProj = (project in file("client"))
     nativeImageReady := { () =>
       ()
     },
+    nativeImageVersion := "22.3.1",
     nativeImageOutput := target.value / "bin" / "sbtn",
     nativeImageOptions ++= Seq(
       "--no-fallback",

--- a/build.sbt
+++ b/build.sbt
@@ -1173,7 +1173,7 @@ lazy val sbtClientProj = (project in file("client"))
     nativeImageReady := { () =>
       ()
     },
-    nativeImageVersion := "22.3.1",
+    nativeImageVersion := "22.2.0",
     nativeImageOutput := target.value / "bin" / "sbtn",
     nativeImageOptions ++= Seq(
       "--no-fallback",


### PR DESCRIPTION
I had to bump the version of native-image to be able to use it in sbt/sbtn-dist#4.