### PR TITLE
Update usage info in sbt for java-home

### DIFF
--- a/sbt
+++ b/sbt
@@ -573,7 +573,6 @@ Usage: `basename "$0"` [options]
   --sbt-version  <version>   use the specified version of sbt
   --sbt-jar      <path>      use the specified jar as the sbt launcher
 
-  # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
   --java-home <path>         alternate JAVA_HOME
 
   # jvm options and output control


### PR DESCRIPTION
I think the usage info for sbt argument java-home is not correct:
```
  # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
  --java-home <path>         alternate JAVA_HOME
```
Actually, I think it is a copy-paste from sbt-version usage info.
```
  # sbt version (default: from project/build.properties if present, else latest release)
  --sbt-version  <version>   use the specified version of sbt
```
So I created this PR to fix the issue.