### PR TITLE
Fix bug of unmanagedResourceDirectories

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2535,7 +2535,7 @@ object Defaults extends BuildCommon {
   def copyResourcesTask =
     Def.task {
       val t = classDirectory.value
-      val dirs = resourceDirectories.value.toSet
+      val dirs = collection.SortedSet(resourceDirectories.value: _*)
       val s = streams.value
       val syncDir = crossTarget.value / (prefix(configuration.value.name) + "sync")
       val factory = CacheStoreFactory(syncDir)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2542,7 +2542,8 @@ object Defaults extends BuildCommon {
       val cacheStore = factory.make("copy-resource")
       val converter = fileConverter.value
       val flt: File => Option[File] = flat(t)
-      val transform: File => Option[File] = (f: File) => rebase(dirs, t)(f).orElse(flt(f))
+      val transform: File => Option[File] =
+        (f: File) => rebase(resourceDirectories.value.sorted, t)(f).orElse(flt(f))
       val mappings: Seq[(File, File)] = resources.value.flatMap {
         case r if !dirs(r) => transform(r).map(r -> _)
         case _             => None

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2535,7 +2535,7 @@ object Defaults extends BuildCommon {
   def copyResourcesTask =
     Def.task {
       val t = classDirectory.value
-      val dirs = collection.SortedSet(resourceDirectories.value: _*)
+      val dirs = resourceDirectories.value.toSet
       val s = streams.value
       val syncDir = crossTarget.value / (prefix(configuration.value.name) + "sync")
       val factory = CacheStoreFactory(syncDir)


### PR DESCRIPTION
I found that sometimes files in directories added to `unmanagedResourceDirectories` are ignored.

This was because the `resourcesDirectories` are managed as a `Set` like below

``` scala
  def copyResourcesTask =
    Def.task {
      val t = classDirectory.value
      val dirs = resourceDirectories.value.toSet
      ...
```

But, you know, the default `Set` in `scala` is implemented as a `HashSet`, which does not guarantee ordering of elements.

For example, When I added my config directory `src/main/resources/conf` to `unmanagedResourceDirectories` in order to include a file called `src/main/resources/conf/my-conf.json` as a resource, but my config file was compiled as `target/scala/classes/conf/my-conf.json`, not `target/scala/classes/my-conf.json`.

When I printed out the variable `dirs` mentioned above, I got the following result. (For convenience, represent the project path as `~`)

``` scala
Set(~/src/main/resources/conf, ~/src/main/resources)
```

When I improved it using `SortedSet` and printed out the variable `dirs`, It looks fine! 

``` scala
TreeSet(~/src/main/resources,~/src/main/resources/conf)
```