### PR TITLE
deprecate config macro

### DIFF
--- a/sbt-app/src/main/scala/package.scala
+++ b/sbt-app/src/main/scala/package.scala
@@ -59,6 +59,7 @@ package object sbt
   final val Global = Scope.Global
   final val GlobalScope = Scope.GlobalScope
 
+  @deprecated("custom config is deprecated; create a separate subproject instead", "1.9.0")
   def config(name: String): Configuration =
     macro sbt.librarymanagement.ConfigurationMacro.configMacroImpl
 }


### PR DESCRIPTION
This deprecates config macro.
See https://eed3si9n.com/sbt-drop-custom-config/ for details.

See also https://github.com/sbt/librarymanagement/pull/412