### PR TITLE
[1.9.x] Add `sbtPluginPublishLegacyMavenStyle` to publish to Artifactory

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -491,6 +491,7 @@ object Keys {
   val makeIvyXmlLocalConfiguration = taskKey[PublishConfiguration]("Configuration for generating ivy.xml.").withRank(DSetting)
   val packagedArtifacts = taskKey[Map[Artifact, File]]("Packages all artifacts for publishing and maps the Artifact definition to the generated file.").withRank(CTask)
   val publishMavenStyle = settingKey[Boolean]("Configures whether to generate and publish a pom (true) or Ivy file (false).").withRank(BSetting)
+  val sbtPluginPublishLegacyMavenStyle = settingKey[Boolean]("Configuration for generating the legacy pom of sbt plugins, to publish to Maven").withRank(CSetting)
   val credentials = taskKey[Seq[Credentials]]("The credentials to use for updating and publishing.").withRank(BMinusTask)
   val allCredentials = taskKey[Seq[Credentials]]("Aggregated credentials across current and root subprojects. Do not rewire this task.").withRank(DTask)
 

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
@@ -1,11 +1,19 @@
-> example / checkPackagedArtifacts
+> sbtPlugin1 / checkPackagedArtifacts
 
-> example / checkPublish
-> testMaven / checkUpdate
-> set testMaven / useCoursier := false
-> testMaven / checkUpdate
+> sbtPlugin1 / checkPublish
+> testMaven1 / checkUpdate
+> set testMaven1 / useCoursier := false
+> testMaven1 / checkUpdate
 
-> example / publishLocal
-> testLocal / checkUpdate
-> set testLocal / useCoursier := false
-> testLocal / checkUpdate
+> sbtPlugin1 / publishLocal
+> testLocal1 / checkUpdate
+> set testLocal1 / useCoursier := false
+> testLocal1 / checkUpdate
+
+> sbtPlugin2 / checkPackagedArtifacts
+
+# test publish without legacy artifacts and resolve
+> sbtPlugin2 / checkPublish
+> testMaven2 / checkUpdate
+> set testMaven2 / useCoursier := false
+> testMaven2 / checkUpdate


### PR DESCRIPTION
Solves https://github.com/sbt/sbt/issues/3410#issuecomment-1491092368

Artifactory has a feature that rejects any non-constitent POM, including legacy sbt plugins' POM. By turning `sbtPluginPublishLegacyMavenStyle` off, we can publish only the valid artifacts and not the legacy ones.

Does anyone think of a better name instead of `sbtPluginPublishLegacyMavenStyle`?
