### PR TITLE
[1.9.x] Fix #7233: copy artifact files of sbt plugin

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2857,7 +2857,14 @@ object Classpaths {
       val legacyPackages = packaged(defaultPackages).value
 
       def addSuffix(a: Artifact): Artifact = a.withName(crossVersion(a.name))
-      val packages = legacyPackages.map { case (artifact, file) => addSuffix(artifact) -> file }
+      def copyArtifact(artifact: Artifact, file: File): (Artifact, File) = {
+        val nameWithSuffix = crossVersion(artifact.name)
+        val targetFile =
+          new File(file.getParentFile, file.name.replace(artifact.name, nameWithSuffix))
+        IO.copyFile(file, targetFile)
+        artifact.withName(nameWithSuffix) -> targetFile
+      }
+      val packages = legacyPackages.map { case (artifact, file) => copyArtifact(artifact, file) }
       val legacyPackagedArtifacts = Def
         .ifS(sbtPluginPublishLegacyMavenStyle.toTask)(packaged(defaultArtifactTasks))(
           Def.task(Map.empty[Artifact, File])


### PR DESCRIPTION
Since #7096, two artifacts can point to the same file, e.g.
```scala
sbt:sbt-7233> show myPlugin / packagedArtifacts
Map(
  Artifact(myPlugin_2.12_1.0, doc, jar, Some(javadoc), Vector(compile), None, Map(), None, false) ->
    myPlugin/target/scala-2.12/sbt-1.0/myPlugin-0.1.0-SNAPSHOT-javadoc.jar,
 ...
  Artifact(myPlugin, doc, jar, Some(javadoc), Vector(compile), None, Map(), None, false) ->
    myPlugin/target/scala-2.12/sbt-1.0/myPlugin-0.1.0-SNAPSHOT-javadoc.jar,
...
)
```

This was intended to ensure that the artifact contents are identical, and to avoid unnecessary IO.

The problem is that the [raboof/sbt-reproducible-builds](https://github.com/) plugin fails if two artifacts point to the same file. It is possible that other builds or plugins rely on the same assumption. This PR fixes the issue by copying the artifact files when necessary.