### PR TITLE
fix: deprecate mispelled diagnosticRelatedInforamation

### DIFF
--- a/internal/util-interface/src/main/java/xsbti/Problem.java
+++ b/internal/util-interface/src/main/java/xsbti/Problem.java
@@ -39,13 +39,19 @@ public interface Problem {
     return Optional.empty();
   }
 
+  /** @deprecated use {@link #diagnosticRelatedInformation()} instead. */
+  @Deprecated
+  default List<DiagnosticRelatedInformation> diagnosticRelatedInforamation() {
+    return diagnosticRelatedInformation();
+  }
+
   /**
    * The possible releated information for the diagnostic being reported.
    *
    * <p>NOTE: To avoid breaking compatibility we provide a default to account for older Scala
    * versions that do not have the concept of "related information".
    */
-  default List<DiagnosticRelatedInformation> diagnosticRelatedInforamation() {
+  default List<DiagnosticRelatedInformation> diagnosticRelatedInformation() {
     return Collections.emptyList();
   }
 }


### PR DESCRIPTION
This also adds in a new one.

Relates to https://github.com/sbt/sbt/discussions/7063