### PR TITLE
feat: add in `actions()` to `Problem`

### DIFF
--- a/internal/util-interface/src/main/java/xsbti/Action.java
+++ b/internal/util-interface/src/main/java/xsbti/Action.java
@@ -1,0 +1,32 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbti;
+
+import java.util.Optional;
+
+/**
+ * An Action is very miminal representation of a `CodeAction` in the LSP protocol.
+ *
+ * <p>However it only focuses on the actual title, description, and edit, leaving it up to the
+ * language server to communicate with the client and put together a proper codeAction in accordance
+ * to client capabilities.
+ *
+ * @see <a href=
+ *     "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction">`CodeAction`</a>
+ */
+public interface Action {
+
+  /** Title of the action that will be shown to the user client side. */
+  String title();
+
+  /** Optional description that may be shown to the user client side to explain the action. */
+  Optional<String> description();
+
+  /** The actual edit contained in the action. */
+  WorkspaceEdit edit();
+}

--- a/internal/util-interface/src/main/java/xsbti/FileChanges.java
+++ b/internal/util-interface/src/main/java/xsbti/FileChanges.java
@@ -1,0 +1,21 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbti;
+
+import java.net.URI;
+import java.util.List;
+
+/** A collection of TextEdits that belong to a given URI. */
+public interface FileChanges {
+
+  /** The URI that the edits belong to. */
+  URI uri();
+
+  /** The edits belonging to the URI. */
+  List<TextEdit> edits();
+}

--- a/internal/util-interface/src/main/java/xsbti/Problem.java
+++ b/internal/util-interface/src/main/java/xsbti/Problem.java
@@ -48,4 +48,29 @@ public interface Problem {
   default List<DiagnosticRelatedInformation> diagnosticRelatedInforamation() {
     return Collections.emptyList();
   }
+
+  /**
+   * Actions (aka quick fixes) that are able to either fix or address the issue that is causing this
+   * Problem.
+   *
+   * <p>For example given the following code:
+   *
+   * <pre>
+   *  trait Example:
+   *    def foo(): Unit
+   *    def bar(): Unit
+   *
+   *  class MyExample extends Example
+   * </pre>
+   *
+   * You could expect this to have multiple actions attatched:
+   *
+   * <ul>
+   *   <li>An option to implement a stub method for `foo()` and `bar()`
+   *   <li>An option to make `MyExample` abstract
+   * </ul>
+   */
+  default List<Action> actions() {
+    return Collections.emptyList();
+  }
 }

--- a/internal/util-interface/src/main/java/xsbti/TextEdit.java
+++ b/internal/util-interface/src/main/java/xsbti/TextEdit.java
@@ -1,0 +1,25 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbti;
+
+/**
+ * A representation of the `TextEdit` found in the LSP protocol.
+ *
+ * <p>NOTE: That instead of a `Range` we use the internal [[xsbti.Position]].
+ *
+ * @see <a
+ *     href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit">`TextEdit`</a>
+ */
+public interface TextEdit {
+
+  /** The position this edit will be applied to. */
+  Position position();
+
+  /** The next text that will be inserted into the given [[TextEdit.position]]. */
+  String newText();
+}

--- a/internal/util-interface/src/main/java/xsbti/WorkspaceEdit.java
+++ b/internal/util-interface/src/main/java/xsbti/WorkspaceEdit.java
@@ -1,0 +1,27 @@
+/*
+ * sbt
+ * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package xsbti;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * A minimal representatin of the `WorkspaceEdit` found in the LSP protocol.
+ *
+ * <p>However it only supports the minimal `changes` to ensure the fixes will work with all clients.
+ *
+ * <p>NOTE: In the future this may be expanded to handle resource operations via `documentChanges`.
+ *
+ * @see <a href=
+ *     "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit">`WorkspaceEdit`</a>
+ */
+public interface WorkspaceEdit {
+
+  /** List of [[xsbti.FileChanges]] that belong to this WorkspaceEdit. */
+  List<FileChanges> changes();
+}


### PR DESCRIPTION
This adds a new field into `xsbti.Problem` allowing for the compiler to forward "actions" that can address diagnostics. The idea largely mimics a very minimal `CodeAction` that can be found in the [LSP Spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction) in order to ensure it will work with a variety of difference clients that use LSP, and those that don't. In the future the `WorkspaceEdit` that was created here could also be expanded to handle more advanced changes, aka resource operations, like creating/moving/deleting files. For now we only focus on a small subset of these features.

This relates to the discussion in https://contributors.scala-lang.org/t/roadmap-for-actionable-diagnostics/6172