### PR TITLE
Fix #7285: stick to legacy Maven style on `publishLocal`

### DIFF
--- a/sbt-app/src/sbt-test/actions/external-doc/build.sbt
+++ b/sbt-app/src/sbt-test/actions/external-doc/build.sbt
@@ -2,23 +2,23 @@
 ThisBuild / useCoursier := false
 
 Seq(
-	autoAPIMappings in ThisBuild := true,
-	publishArtifact in (ThisBuild, packageDoc) := false,
-	publishArtifact in packageSrc := false,
-	organization in ThisBuild := "org.example",
+	ThisBuild / autoAPIMappings := true,
+	ThisBuild / packageDoc / publishArtifact := false,
+	packageSrc / publishArtifact := false,
+	ThisBuild / organization := "org.example",
 	version := "1.0"
 )
 
 val aPublishResolver = Def.setting {
-	Resolver.file("a-resolver", baseDirectory.in(ThisBuild).value / "a-repo")
+	Resolver.file("a-resolver", (ThisBuild / baseDirectory).value / "a-repo")
 }
 val aResolver = Def.setting {
-	val dir = baseDirectory.in(ThisBuild).value
+	val dir = (ThisBuild / baseDirectory).value
 	"a-resolver" at s"file://${dir.getAbsolutePath}/a-repo"
 }
 
 val bResolver = Def.setting {
-	val dir = baseDirectory.in(ThisBuild).value / "b-repo"
+	val dir = (ThisBuild / baseDirectory).value / "b-repo"
 	Resolver.file("b-resolver", dir)(Resolver.defaultIvyPatterns)
 }
 
@@ -68,7 +68,7 @@ val d = project.dependsOn( c ).settings(
 	addDep("a"),
 	addDep("b"),
 	checkApiMappings := {
-		val actual = apiMappings.in(Compile,doc).value
+		val actual = (Compile / doc / apiMappings).value
 		println("Actual API Mappings: " + actual.mkString("\n\t", "\n\t", ""))
 		val expected = expectedMappings.value
 		println("Expected API Mappings: " + expected.mkString("\n\t", "\n\t", ""))

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
@@ -73,6 +73,18 @@ lazy val testMaven2 = project.in(file("test-maven-2"))
     ).value
   )
 
+lazy val testLocal2 = project.in(file("test-local-2"))
+  .settings(
+    addSbtPlugin("org.example" % "sbt-plugin-2" % "0.1.0-SNAPSHOT"),
+    checkUpdate := checkUpdateDef(
+      "sbt-plugin-2.jar", // resolved from local repository
+      "sbt-plugin-example-diamond_2.12_1.0-0.5.0.jar",
+      "sbt-plugin-example-left_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-right_2.12_1.0-0.3.0.jar",
+      "sbt-plugin-example-bottom_2.12_1.0-0.3.0.jar",
+    ).value
+  )
+
 lazy val checkPackagedArtifacts = taskKey[Unit]("check the packaged artifacts")
 lazy val checkPublish = taskKey[Unit]("check publish")
 lazy val checkUpdate = taskKey[Unit]("check update")

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/test
@@ -17,3 +17,8 @@
 > testMaven2 / checkUpdate
 > set testMaven2 / useCoursier := false
 > testMaven2 / checkUpdate
+
+> sbtPlugin2 / publishLocal
+> testLocal2 / checkUpdate
+> set testLocal2 / useCoursier := false
+> testLocal2 / checkUpdate


### PR DESCRIPTION
Fixes #7285 by adding the legacy Maven artifacts to `publishLocal` if missing.