### PR TITLE
deps: bump the default semanticdb version used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 Global / semanticdbEnabled := !(Global / insideCI).value
 // Change main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala too, if you change this.
-Global / semanticdbVersion := "4.5.13"
+Global / semanticdbVersion := "4.7.8"
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
 Global / excludeLint := (Global / excludeLint).?.value.getOrElse(Set.empty)
 Global / excludeLint += componentID

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -26,7 +26,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.5.13"
+    semanticdbVersion := "4.7.8"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
This updates semanticdb from 4.5.13 to 4.7.8.