### PR TITLE
Fix #7297: Convert `OffsetPosition` to BSP range

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -185,11 +185,15 @@ final class BuildServerReporterImpl(
     val startColumnOpt = pos.startColumn.toOption.map(_.toLong)
     val endLineOpt = pos.endLine.toOption.map(_.toLong - 1)
     val endColumnOpt = pos.endColumn.toOption.map(_.toLong)
+    val lineOpt = pos.line.toOption.map(_.toLong - 1)
+    val columnOpt = pos.pointer.toOption.map(_.toLong)
 
     def toPosition(lineOpt: Option[Long], columnOpt: Option[Long]): Option[Position] =
       lineOpt.map(line => Position(line, columnOpt.getOrElse(0L)))
 
-    val startPos = toPosition(startLineOpt, startColumnOpt).getOrElse(Position(0L, 0L))
+    val startPos = toPosition(startLineOpt, startColumnOpt)
+      .orElse(toPosition(lineOpt, columnOpt))
+      .getOrElse(Position(0L, 0L))
     val endPosOpt = toPosition(endLineOpt, endColumnOpt)
     Range(startPos, endPosOpt.getOrElse(startPos))
   }


### PR DESCRIPTION
Fixes #7297 

An `OffsetPosition` contains a `line` and a `pointer` in the line. We use them to compute the `startPos` of the BSP range.

```scala
package example

class A {
  def foo: String = ""
}

class AA extends A {
  val foo: String = ""
//    ^^^
// overriding method foo in class A of type => String;
//  value foo needs `override' modifier
}
```