### PR TITLE
Make sbt new extensible

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -361,6 +361,8 @@ object Defaults extends BuildCommon {
       fork :== false,
       initialize :== {},
       templateResolverInfos :== Nil,
+      templateDescriptions :== TemplateCommandUtil.defaultTemplateDescriptions,
+      templateRunLocal := templateRunLocalInputTask(runLocalTemplate).evaluated,
       forcegc :== sys.props
         .get("sbt.task.forcegc")
         .map(java.lang.Boolean.parseBoolean)
@@ -2644,6 +2646,19 @@ object Defaults extends BuildCommon {
       if (useCoursier.value) CoursierDependencyResolution(csrConfiguration.value)
       else IvyDependencyResolution(ivyConfiguration.value)
     }
+
+  def templateRunLocalInputTask(
+      runLocal: (Seq[String], Logger) => Unit
+  ): Initialize[InputTask[Unit]] =
+    Def.inputTask {
+      import Def._
+      val s = streams.value
+      val args = spaceDelimited().parsed
+      runLocal(args, s.log)
+    }
+
+  def runLocalTemplate(arguments: Seq[String], log: Logger): Unit =
+    TemplateCommandUtil.defaultRunLocalTemplate(arguments.toList, log)
 }
 
 object Classpaths {

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -571,6 +571,8 @@ object Keys {
   val sbtBinaryVersion = settingKey[String]("Defines the binary compatibility version substring.").withRank(BPlusSetting)
   val skip = taskKey[Boolean]("For tasks that support it (currently only 'compile', 'update', 'publish' and 'publishLocal'), setting skip to true will force the task to not to do its work.  The exact semantics may vary depending on the task.").withRank(BSetting)
   val templateResolverInfos = settingKey[Seq[TemplateResolverInfo]]("Template resolvers used for 'new'.").withRank(BSetting)
+  val templateDescriptions = settingKey[Seq[(String, String)]]("List of templates with description used for 'new' / 'init'.")
+  val templateRunLocal = inputKey[Unit]("Runs a local template.").withRank(DTask)
   val interactionService = taskKey[InteractionService]("Service used to ask for user input through the current user interface(s).").withRank(CTask)
   val insideCI = SettingKey[Boolean]("insideCI", "Determines if the sbt is running in a Continuous Integration environment", AMinusSetting)
 

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -149,7 +149,9 @@ private[sbt] class TaskProgress(
       "console",
       "consoleProject",
       "consoleQuick",
-      "state"
+      "state",
+      "streams",
+      "streams-manager",
     )
   private[this] val hiddenTasks = Set(
     "compileEarly",


### PR DESCRIPTION
Feature requested in https://github.com/sbt/sbt/discussions/7292

Problem
-------
`sbt new` (`sbt init`) hardcodes the templates, which I think is ok, but without changing much, we can make it extensible.

Solution
--------
This adds two new keys `templateDescriptions` and `templateRunLocal`, which can customize the behavior for in-house usage etc.