### PR TITLE
Transfer copyright to the Scala Center

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,24 @@
+name: Scala CLA
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check CLA
+      env:
+        AUTHOR: ${{ github.event.pull_request.user.login }}
+      run: |
+        echo "Pull request submitted by $AUTHOR";
+        signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");
+        if [ "$signed" = "true" ] ; then
+          echo "CLA check for $AUTHOR successful";
+        else
+          echo "CLA check for $AUTHOR failed";
+          echo "Please sign the Scala CLA to contribute to the Scala compiler.";
+          echo "Go to https://www.lightbend.com/contribute/cla/scala and then";
+          echo "comment on the pull request to ask for a new check.";
+          echo "";
+          echo "Check if CLA is signed: https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR";
+          exit 1;
+        fi;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ $ vsce publish
 ## Signing the CLA
 
 Contributing to sbt requires you or your employer to sign the
-[Lightbend Contributor License Agreement](https://www.lightbend.com/contribute/cla).
+[Scala Contributor License Agreement](https://www.lightbend.com/contribute/cla/scala).
 
 To make it easier to respect our license agreements, we have added an sbt task
 that takes care of adding the LICENSE headers to new files. Run `headerCreate`

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2011 - 2018, Lightbend, Inc.
+   Copyright (c) 2023, Scala Center
+   Copyright (c) 2011 - 2022, Lightbend, Inc.
    Copyright (c) 2008 - 2010, Mark Harrah
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
 sbt
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under Apache v2 license (see LICENSE)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,20 +1,10 @@
   [ask]: https://stackoverflow.com/questions/ask?tags=sbt
-  [Lightbend]: https://www.lightbend.com/
-  [subscriptions]: https://www.lightbend.com/platform/subscription
   [gitter]: https://gitter.im/sbt/sbt
 
 Support
 =======
 
-[Lightbend] sponsors sbt and encourages contributions from the active community. Enterprises can adopt it for mission critical systems with confidence because Lightbend stands behind sbt with commercial support and services.
-
 For community support please [ask] on StackOverflow with the tag "sbt" (and the name of the sbt plugin(s) if any).
 
 - State the problem or question clearly and provide enough context. Code examples and `build.sbt` are often useful when appropriately edited.
 - There's also [Gitter sbt/sbt room][gitter], but Stackoverflow is recommended so others can benefit from the answers.
-
-For professional support, for instance if you need faster response times, [Lightbend], the maintainer of Scala compiler and sbt, provides:
-
-- [Lightbend Subscriptions][subscriptions], which includes Expert Support
-- Training
-- Consulting

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ def commonBaseSettings: Seq[Setting[_]] = Def.settings(
   headerLicense := Some(
     HeaderLicense.Custom(
       """|sbt
-       |Copyright 2011 - 2018, Lightbend, Inc.
+       |Copyright 2023, Scala center
+       |Copyright 2011 - 2022, Lightbend, Inc.
        |Copyright 2008 - 2010, Mark Harrah
        |Licensed under Apache License 2.0 (see LICENSE)
        |""".stripMargin

--- a/client/src/main/java/sbt/client/Client.java
+++ b/client/src/main/java/sbt/client/Client.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Instance.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/KListBuilder.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/LinterDSL.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/LinterDSL.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/MixedBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/MixedBuilder.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/StringTypeTag.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleBuilder.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleNBuilder.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/TupleNBuilder.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/dependency-tree/src/main/scala/sbt/plugins/DependencyTreePlugin.scala
+++ b/dependency-tree/src/main/scala/sbt/plugins/DependencyTreePlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/NOTICE
+++ b/internal/util-collection/NOTICE
@@ -1,4 +1,5 @@
 sbt: Collection Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/internal/util-collection/src/main/scala-2.12/sbt/internal/util/Par.scala
+++ b/internal/util-collection/src/main/scala-2.12/sbt/internal/util/Par.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala-2.12/sbt/internal/util/WrappedMap.scala
+++ b/internal/util-collection/src/main/scala-2.12/sbt/internal/util/WrappedMap.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/AList.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Classes.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Classes.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Dag.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Dag.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/HList.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/HListFormats.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/HListFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/INode.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/INode.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/KList.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/KList.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/PMap.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/PMap.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Signal.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Signal.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Types.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Types.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/util/OptJsonWriter.scala
+++ b/internal/util-collection/src/main/scala/sbt/util/OptJsonWriter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/main/scala/sbt/util/Show.scala
+++ b/internal/util-collection/src/main/scala/sbt/util/Show.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/DagSpecification.scala
+++ b/internal/util-collection/src/test/scala/DagSpecification.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/HListFormatSpec.scala
+++ b/internal/util-collection/src/test/scala/HListFormatSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/KeyTest.scala
+++ b/internal/util-collection/src/test/scala/KeyTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/PMapTest.scala
+++ b/internal/util-collection/src/test/scala/PMapTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/SettingsExample.scala
+++ b/internal/util-collection/src/test/scala/SettingsExample.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/SettingsTest.scala
+++ b/internal/util-collection/src/test/scala/SettingsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-collection/src/test/scala/UnitSpec.scala
+++ b/internal/util-collection/src/test/scala/UnitSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/NOTICE
+++ b/internal/util-complete/NOTICE
@@ -1,4 +1,5 @@
 sbt: Completion Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Completions.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Completions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/EditDistance.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/EditDistance.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/ExampleSource.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/ExampleSource.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/History.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/History.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/HistoryCommands.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/HistoryCommands.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/ProcessError.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/ProcessError.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/SizeParser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/SizeParser.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/TokenCompletions.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/TokenCompletions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/TypeString.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/TypeString.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/UpperBound.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/UpperBound.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/DefaultParsersSpec.scala
+++ b/internal/util-complete/src/test/scala/DefaultParsersSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/ParserTest.scala
+++ b/internal/util-complete/src/test/scala/ParserTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/UnitSpec.scala
+++ b/internal/util-complete/src/test/scala/UnitSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/sbt/complete/FileExamplesTest.scala
+++ b/internal/util-complete/src/test/scala/sbt/complete/FileExamplesTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/sbt/complete/FixedSetExamplesTest.scala
+++ b/internal/util-complete/src/test/scala/sbt/complete/FixedSetExamplesTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
+++ b/internal/util-complete/src/test/scala/sbt/complete/ParserWithExamplesTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-control/src/main/scala/sbt/internal/util/ErrorHandling.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/ErrorHandling.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-control/src/main/scala/sbt/internal/util/ExitHook.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/ExitHook.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-control/src/main/scala/sbt/internal/util/MessageOnlyException.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/MessageOnlyException.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/Action.java
+++ b/internal/util-interface/src/main/java/xsbti/Action.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/DiagnosticCode.java
+++ b/internal/util-interface/src/main/java/xsbti/DiagnosticCode.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/DiagnosticRelatedInformation.java
+++ b/internal/util-interface/src/main/java/xsbti/DiagnosticRelatedInformation.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/Logger.java
+++ b/internal/util-interface/src/main/java/xsbti/Logger.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/Position.java
+++ b/internal/util-interface/src/main/java/xsbti/Position.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/Problem.java
+++ b/internal/util-interface/src/main/java/xsbti/Problem.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/Severity.java
+++ b/internal/util-interface/src/main/java/xsbti/Severity.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/T2.java
+++ b/internal/util-interface/src/main/java/xsbti/T2.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/TextEdit.java
+++ b/internal/util-interface/src/main/java/xsbti/TextEdit.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-interface/src/main/java/xsbti/WorkspaceEdit.java
+++ b/internal/util-interface/src/main/java/xsbti/WorkspaceEdit.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/java/sbt/internal/util/DeprecatedJLine.java
+++ b/internal/util-logging/src/main/java/sbt/internal/util/DeprecatedJLine.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/com/github/ghik/silencer/silent.scala
+++ b/internal/util-logging/src/main/scala/com/github/ghik/silencer/silent.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/BasicLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/BasicLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/EscHelpers.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/EscHelpers.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/FilterLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/FilterLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/FullLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/FullLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/GlobalLogging.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/GlobalLogging.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/LoggerWriter.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/LoggerWriter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/MainAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/MainAppender.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/MultiLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/MultiLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ObjectEvent.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ObjectEvent.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ProgressState.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Prompt.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Prompt.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StringTypeTag.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/Terminal.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/JValueFormats.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/JValueFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/PositionFormats.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/PositionFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/ProblemFormats.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/ProblemFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/SeverityFormats.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/SeverityFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/ThrowableShowLines.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/ThrowableShowLines.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/AbstractLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/AbstractLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/Level.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/Level.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/LogEvent.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogEvent.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/Logger.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/Logger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/main/scala/sbt/util/ShowLines.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/ShowLines.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/Escapes.scala
+++ b/internal/util-logging/src/test/scala/Escapes.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/LogExchangeSpec.scala
+++ b/internal/util-logging/src/test/scala/LogExchangeSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/LogWriterTest.scala
+++ b/internal/util-logging/src/test/scala/LogWriterTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/ProblemTest.scala
+++ b/internal/util-logging/src/test/scala/ProblemTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/TestLogger.scala
+++ b/internal/util-logging/src/test/scala/TestLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/sbt/internal/util/CleanStringSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/CleanStringSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logging/src/test/scala/sbt/internal/util/UTF8DecoderSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/UTF8DecoderSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logic/src/main/scala/sbt/internal/util/logic/Logic.scala
+++ b/internal/util-logic/src/main/scala/sbt/internal/util/logic/Logic.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-logic/src/test/scala/sbt/logic/Test.scala
+++ b/internal/util-logic/src/test/scala/sbt/logic/Test.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-position/src/main/scala-2/sbt/internal/util/SourcePositionMacro.scala
+++ b/internal/util-position/src/main/scala-2/sbt/internal/util/SourcePositionMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-position/src/main/scala/sbt/internal/util/Positions.scala
+++ b/internal/util-position/src/main/scala/sbt/internal/util/Positions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-position/src/test/scala/sbt/internal/util/SourcePositionSpec.scala
+++ b/internal/util-position/src/test/scala/sbt/internal/util/SourcePositionSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */
@@ -12,7 +13,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 class SourcePositionSpec extends AnyFlatSpec {
   "SourcePosition()" should "return a sane SourcePosition" in {
     val filename = "SourcePositionSpec.scala"
-    val lineNumber = 16
+    val lineNumber = 17
     SourcePosition.fromEnclosing() match {
       case LinePosition(path, startLine) => assert(path === filename && startLine === lineNumber)
       case RangePosition(path, range)    => assert(path === filename && inRange(range, lineNumber))

--- a/internal/util-relation/src/main/scala/sbt/internal/util/Relation.scala
+++ b/internal/util-relation/src/main/scala/sbt/internal/util/Relation.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-relation/src/test/scala/RelationTest.scala
+++ b/internal/util-relation/src/test/scala/RelationTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/java/sbt/internal/scripted/ScriptConfig.java
+++ b/internal/util-scripted/src/main/java/sbt/internal/scripted/ScriptConfig.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/CommentHandler.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/CommentHandler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FilteredLoader.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FilteredLoader.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/HandlersProvider.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/HandlersProvider.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptRunner.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptRunner.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/StatementHandler.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/StatementHandler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/TestScriptParser.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/TestScriptParser.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/launch/NOTICE
+++ b/launch/NOTICE
@@ -1,5 +1,6 @@
 sbt Launcher
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah, David MacIver
 Licensed under BSD-3-Clause license (see LICENSE)
 

--- a/launcher-package/NOTICE
+++ b/launcher-package/NOTICE
@@ -1,6 +1,7 @@
 sbt
 https://www.scala-sbt.org/
-Copyright 2011 - 2019, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under Apache v2 license (see LICENSE)
 

--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -185,7 +185,7 @@ val root = (project in file(".")).
     },
 
     // GENERAL LINUX PACKAGING STUFFS
-    maintainer := "Eugene Yokota <eugene.yokota@lightbend.com>",
+    maintainer := "Eugene Yokota <eed3si9n@gmail.com>",
     packageSummary := "sbt, the interactive build tool",
     packageDescription := """This script provides a native way to run sbt,
   a build tool for Scala and more.""",
@@ -240,7 +240,7 @@ val root = (project in file(".")).
         case (x, p) => p.contains("sbtn-x86_64") || p.contains("sbtn-aarch64")
       }))
     },
-    rpmVendor := "lightbend",
+    rpmVendor := "scalacenter",
     rpmUrl := Some("http://github.com/sbt/sbt-launcher-package"),
     rpmLicense := Some("Apache-2.0"),
     // This is intentionally empty. java-devel could bring in JDK 9-ea on Fedora,
@@ -262,7 +262,7 @@ val root = (project in file(".")).
         case Array(major) => Seq(major, "0", "0", bid.toString) mkString "."
       }
     },
-    maintainer in Windows := "Lightbend, Inc.",
+    maintainer in Windows := "Scala Center",
     packageSummary in Windows := "sbt " + (version in Windows).value,
     packageDescription in Windows := "The interactive build tool.",
     wixProductId := "ce07be71-510d-414a-92d4-dff47631848a",

--- a/main-actions/src/main/scala/sbt/Console.scala
+++ b/main-actions/src/main/scala/sbt/Console.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/Doc.scala
+++ b/main-actions/src/main/scala/sbt/Doc.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/DotGraph.scala
+++ b/main-actions/src/main/scala/sbt/DotGraph.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/RawCompileLike.scala
+++ b/main-actions/src/main/scala/sbt/RawCompileLike.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/Sync.scala
+++ b/main-actions/src/main/scala/sbt/Sync.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/compiler/Eval.scala
+++ b/main-actions/src/main/scala/sbt/compiler/Eval.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/main/scala/sbt/compiler/EvalReporter.scala
+++ b/main-actions/src/main/scala/sbt/compiler/EvalReporter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/test/scala/sbt/CacheIvyTest.scala
+++ b/main-actions/src/test/scala/sbt/CacheIvyTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-actions/src/test/scala/sbt/compiler/EvalTest.scala
+++ b/main-actions/src/test/scala/sbt/compiler/EvalTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/java/sbt/internal/ServerAlreadyBootingException.java
+++ b/main-command/src/main/java/sbt/internal/ServerAlreadyBootingException.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/java/sbt/internal/classpath/WrappedLoader.java
+++ b/main-command/src/main/java/sbt/internal/classpath/WrappedLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/CommandUtil.scala
+++ b/main-command/src/main/scala/sbt/CommandUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/ExceptionCategory.scala
+++ b/main-command/src/main/scala/sbt/ExceptionCategory.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/Highlight.scala
+++ b/main-command/src/main/scala/sbt/Highlight.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/MainControl.scala
+++ b/main-command/src/main/scala/sbt/MainControl.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/State.scala
+++ b/main-command/src/main/scala/sbt/State.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/Watched.scala
+++ b/main-command/src/main/scala/sbt/Watched.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/CommandChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/CommandChannel.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/ConsoleChannel.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/LabeledFunctions.scala
+++ b/main-command/src/main/scala/sbt/internal/LabeledFunctions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/LegacyWatched.scala
+++ b/main-command/src/main/scala/sbt/internal/LegacyWatched.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/classpath/ClassLoaderCache.scala
+++ b/main-command/src/main/scala/sbt/internal/classpath/ClassLoaderCache.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/client/BspClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/BspClient.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/client/ServerConnection.scala
+++ b/main-command/src/main/scala/sbt/internal/client/ServerConnection.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/ui/UITask.scala
+++ b/main-command/src/main/scala/sbt/internal/ui/UITask.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/ui/UserThread.scala
+++ b/main-command/src/main/scala/sbt/internal/ui/UserThread.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
+++ b/main-command/src/main/scala/sbt/internal/util/JoinThread.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/sbt/internal/util/ReadJsonFromInputStream.scala
+++ b/main-command/src/main/scala/sbt/internal/util/ReadJsonFromInputStream.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/main/scala/xsbt/IPC.scala
+++ b/main-command/src/main/scala/xsbt/IPC.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
+++ b/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Append.scala
+++ b/main-settings/src/main/scala/sbt/Append.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/ConfigKey.scala
+++ b/main-settings/src/main/scala/sbt/ConfigKey.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/DelegateIndex.scala
+++ b/main-settings/src/main/scala/sbt/DelegateIndex.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/InputTask.scala
+++ b/main-settings/src/main/scala/sbt/InputTask.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/KeyRanks.scala
+++ b/main-settings/src/main/scala/sbt/KeyRanks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/PromiseWrap.scala
+++ b/main-settings/src/main/scala/sbt/PromiseWrap.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Remove.scala
+++ b/main-settings/src/main/scala/sbt/Remove.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/ScopeMask.scala
+++ b/main-settings/src/main/scala/sbt/ScopeMask.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/dsl/LinterLevel.scala
+++ b/main-settings/src/main/scala/sbt/dsl/LinterLevel.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/InputConvert.scala
+++ b/main-settings/src/main/scala/sbt/std/InputConvert.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main-settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/KeyMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/KeyMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/SettingMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/SettingMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskLinterDSL.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/main/scala/sbt/unchecked.scala
+++ b/main-settings/src/main/scala/sbt/unchecked.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/AppendSpec.scala
+++ b/main-settings/src/test/scala/sbt/AppendSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
+++ b/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/ScopeDisplaySpec.scala
+++ b/main-settings/src/test/scala/sbt/ScopeDisplaySpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/ScopedSpec.scala
+++ b/main-settings/src/test/scala/sbt/ScopedSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/TupleSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/TupleSyntaxTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/std/TaskConfigSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskConfigSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/TaskPosSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/std/TestUtil.scala
+++ b/main-settings/src/test/scala/sbt/std/TestUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/std/UsageTest.scala
+++ b/main-settings/src/test/scala/sbt/std/UsageTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main-settings/src/test/scala/sbt/std/neg/TaskNegSpec.scala
+++ b/main-settings/src/test/scala/sbt/std/neg/TaskNegSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/NOTICE
+++ b/main/NOTICE
@@ -1,4 +1,5 @@
 sbt: Main integration component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/main/src/main/java/sbt/internal/BottomClassLoader.java
+++ b/main/src/main/java/sbt/internal/BottomClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ClassLoaderClose.java
+++ b/main/src/main/java/sbt/internal/ClassLoaderClose.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ClassLoadingLock.java
+++ b/main/src/main/java/sbt/internal/ClassLoadingLock.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/FlatLoader.java
+++ b/main/src/main/java/sbt/internal/FlatLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/FullScalaLoader.java
+++ b/main/src/main/java/sbt/internal/FullScalaLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/JLineLoader.java
+++ b/main/src/main/java/sbt/internal/JLineLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/LayeredClassLoader.java
+++ b/main/src/main/java/sbt/internal/LayeredClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ManagedClassLoader.java
+++ b/main/src/main/java/sbt/internal/ManagedClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/MetaBuildLoader.java
+++ b/main/src/main/java/sbt/internal/MetaBuildLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ReverseLookupClassLoader.java
+++ b/main/src/main/java/sbt/internal/ReverseLookupClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/SbtInterfaceLoader.java
+++ b/main/src/main/java/sbt/internal/SbtInterfaceLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ScalaLibraryClassLoader.java
+++ b/main/src/main/java/sbt/internal/ScalaLibraryClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/ScalaReflectClassLoader.java
+++ b/main/src/main/java/sbt/internal/ScalaReflectClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/XMainClassLoader.java
+++ b/main/src/main/java/sbt/internal/XMainClassLoader.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/java/sbt/internal/XMainConfiguration.java
+++ b/main/src/main/java/sbt/internal/XMainConfiguration.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/BuildPaths.scala
+++ b/main/src/main/scala/sbt/BuildPaths.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/BuildSyntax.scala
+++ b/main/src/main/scala/sbt/BuildSyntax.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/ClassLoaderLayeringStrategy.scala
+++ b/main/src/main/scala/sbt/ClassLoaderLayeringStrategy.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/CommandLineUIService.scala
+++ b/main/src/main/scala/sbt/CommandLineUIService.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/InteractionService.scala
+++ b/main/src/main/scala/sbt/InteractionService.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/OptionSyntax.scala
+++ b/main/src/main/scala/sbt/OptionSyntax.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Opts.scala
+++ b/main/src/main/scala/sbt/Opts.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Plugins.scala
+++ b/main/src/main/scala/sbt/Plugins.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Project.scala
+++ b/main/src/main/scala/sbt/Project.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Resolvers.scala
+++ b/main/src/main/scala/sbt/Resolvers.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/RichURI.scala
+++ b/main/src/main/scala/sbt/RichURI.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/ScopeFilter.scala
+++ b/main/src/main/scala/sbt/ScopeFilter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/ScopedKeyData.scala
+++ b/main/src/main/scala/sbt/ScopedKeyData.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/ScriptedRun.scala
+++ b/main/src/main/scala/sbt/ScriptedRun.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/SessionVar.scala
+++ b/main/src/main/scala/sbt/SessionVar.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/StateTransform.scala
+++ b/main/src/main/scala/sbt/StateTransform.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/Terminal.scala
+++ b/main/src/main/scala/sbt/Terminal.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/UpperStateOps.scala
+++ b/main/src/main/scala/sbt/UpperStateOps.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/VersionScheme.scala
+++ b/main/src/main/scala/sbt/VersionScheme.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/APIMappings.scala
+++ b/main/src/main/scala/sbt/internal/APIMappings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/AddSettings.scala
+++ b/main/src/main/scala/sbt/internal/AddSettings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Banner.scala
+++ b/main/src/main/scala/sbt/internal/Banner.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/BuildDef.scala
+++ b/main/src/main/scala/sbt/internal/BuildDef.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/BuildDependencies.scala
+++ b/main/src/main/scala/sbt/internal/BuildDependencies.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/BuildLoader.scala
+++ b/main/src/main/scala/sbt/internal/BuildLoader.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/BuildUtil.scala
+++ b/main/src/main/scala/sbt/internal/BuildUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ClassLoaderWarmup.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaderWarmup.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/CompatParColls.scala
+++ b/main/src/main/scala/sbt/internal/CompatParColls.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/DefaultRunProfiler.scala
+++ b/main/src/main/scala/sbt/internal/DefaultRunProfiler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/DeprecatedContinuous.scala
+++ b/main/src/main/scala/sbt/internal/DeprecatedContinuous.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/DslEntry.scala
+++ b/main/src/main/scala/sbt/internal/DslEntry.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/DynamicInput.scala
+++ b/main/src/main/scala/sbt/internal/DynamicInput.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/main/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/FastTrackCommands.scala
+++ b/main/src/main/scala/sbt/internal/FastTrackCommands.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/FileChangesMacro.scala
+++ b/main/src/main/scala/sbt/internal/FileChangesMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/GCMonitor.scala
+++ b/main/src/main/scala/sbt/internal/GCMonitor.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/GCUtil.scala
+++ b/main/src/main/scala/sbt/internal/GCUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/GroupedAutoPlugins.scala
+++ b/main/src/main/scala/sbt/internal/GroupedAutoPlugins.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/InMemoryCacheStore.scala
+++ b/main/src/main/scala/sbt/internal/InMemoryCacheStore.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Inspect.scala
+++ b/main/src/main/scala/sbt/internal/Inspect.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/InstallSbtn.scala
+++ b/main/src/main/scala/sbt/internal/InstallSbtn.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/InternalDependencies.scala
+++ b/main/src/main/scala/sbt/internal/InternalDependencies.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/JarClassPath.scala
+++ b/main/src/main/scala/sbt/internal/JarClassPath.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/KeyIndex.scala
+++ b/main/src/main/scala/sbt/internal/KeyIndex.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/LayeredClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/LayeredClassLoaders.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/LoadedSbtFile.scala
+++ b/main/src/main/scala/sbt/internal/LoadedSbtFile.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Output.scala
+++ b/main/src/main/scala/sbt/internal/Output.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/PluginManagement.scala
+++ b/main/src/main/scala/sbt/internal/PluginManagement.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/PluginsDebug.scala
+++ b/main/src/main/scala/sbt/internal/PluginsDebug.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/PrettyPrint.scala
+++ b/main/src/main/scala/sbt/internal/PrettyPrint.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ProjectNavigation.scala
+++ b/main/src/main/scala/sbt/internal/ProjectNavigation.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/RelayAppender.scala
+++ b/main/src/main/scala/sbt/internal/RelayAppender.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/RemoteCache.scala
+++ b/main/src/main/scala/sbt/internal/RemoteCache.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Resolve.scala
+++ b/main/src/main/scala/sbt/internal/Resolve.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/RetrieveUnit.scala
+++ b/main/src/main/scala/sbt/internal/RetrieveUnit.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/SessionSettings.scala
+++ b/main/src/main/scala/sbt/internal/SessionSettings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/SettingGraph.scala
+++ b/main/src/main/scala/sbt/internal/SettingGraph.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/ShutdownHooks.scala
+++ b/main/src/main/scala/sbt/internal/ShutdownHooks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/TaskName.scala
+++ b/main/src/main/scala/sbt/internal/TaskName.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/TaskSequential.scala
+++ b/main/src/main/scala/sbt/internal/TaskSequential.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/VirtualFileValueCache.scala
+++ b/main/src/main/scala/sbt/internal/VirtualFileValueCache.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
+++ b/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/GraphTransformations.scala
+++ b/main/src/main/scala/sbt/internal/graph/GraphTransformations.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/backend/IvyReport.scala
+++ b/main/src/main/scala/sbt/internal/graph/backend/IvyReport.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/backend/SbtUpdateReport.scala
+++ b/main/src/main/scala/sbt/internal/graph/backend/SbtUpdateReport.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/model.scala
+++ b/main/src/main/scala/sbt/internal/graph/model.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/package.scala
+++ b/main/src/main/scala/sbt/internal/graph/package.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/AsciiTree.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/AsciiTree.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/DOT.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/DOT.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/DagreHTML.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/DagreHTML.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/FlatList.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/FlatList.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/GraphML.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/GraphML.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/LicenseInfo.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/LicenseInfo.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/Statistics.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/Statistics.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/graph/rendering/TreeView.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/TreeView.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/librarymanagement/FakeRawRepository.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/FakeRawRepository.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/internal/nio/CheckBuildSources.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/parser/SbtRefactorings.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtRefactorings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileProgress.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/BuildServerEvalReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerEvalReporter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/Definition.scala
+++ b/main/src/main/scala/sbt/internal/server/Definition.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/LanguageServerProtocol.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/SettingQuery.scala
+++ b/main/src/main/scala/sbt/internal/server/SettingQuery.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/internal/server/VirtualTerminal.scala
+++ b/main/src/main/scala/sbt/internal/server/VirtualTerminal.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/nio/FileChanges.scala
+++ b/main/src/main/scala/sbt/nio/FileChanges.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/nio/FileStamp.scala
+++ b/main/src/main/scala/sbt/nio/FileStamp.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/nio/Keys.scala
+++ b/main/src/main/scala/sbt/nio/Keys.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/nio/Watch.scala
+++ b/main/src/main/scala/sbt/nio/Watch.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/CorePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/CorePlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/Giter8TemplatePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/Giter8TemplatePlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/IvyPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/IvyPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JUnitXmlReportPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/JvmPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/JvmPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/MiniDependencyTreePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/MiniDependencyTreePlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/SbtPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SbtPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/BuildPathsTest.scala
+++ b/main/src/test/scala/BuildPathsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/ClasspathsTest.scala
+++ b/main/src/test/scala/ClasspathsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/DefaultsTest.scala
+++ b/main/src/test/scala/DefaultsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/Delegates.scala
+++ b/main/src/test/scala/Delegates.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/ParseKey.scala
+++ b/main/src/test/scala/ParseKey.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/ParserSpec.scala
+++ b/main/src/test/scala/ParserSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/PluginCommandTest.scala
+++ b/main/src/test/scala/PluginCommandTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/PluginsTest.scala
+++ b/main/src/test/scala/PluginsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/ProjectMacro.scala
+++ b/main/src/test/scala/ProjectMacro.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/ProjectSpec.scala
+++ b/main/src/test/scala/ProjectSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/TagsTest.scala
+++ b/main/src/test/scala/TagsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/AggregationSpec.scala
+++ b/main/src/test/scala/sbt/internal/AggregationSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/CrossJavaTest.scala
+++ b/main/src/test/scala/sbt/internal/CrossJavaTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/FileStampJsonSpec.scala
+++ b/main/src/test/scala/sbt/internal/FileStampJsonSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/GCMonitorTest.scala
+++ b/main/src/test/scala/sbt/internal/GCMonitorTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
+++ b/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/StressGCMonitor.scala
+++ b/main/src/test/scala/sbt/internal/StressGCMonitor.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/TestBuild.scala
+++ b/main/src/test/scala/sbt/internal/TestBuild.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/graph/rendering/TreeViewTest.scala
+++ b/main/src/test/scala/sbt/internal/graph/rendering/TreeViewTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/AbstractSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/AbstractSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/CheckIfParsedSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/CheckIfParsedSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/CommentedXmlSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/CommentedXmlSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/EmbeddedXmlSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/EmbeddedXmlSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/ErrorSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/ErrorSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/NewFormatSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/NewFormatSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/SessionSettingsSpec.scala
+++ b/main/src/test/scala/sbt/internal/parser/SessionSettingsSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/SplitExpressions.scala
+++ b/main/src/test/scala/sbt/internal/parser/SplitExpressions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/SplitExpressionsBehavior.scala
+++ b/main/src/test/scala/sbt/internal/parser/SplitExpressionsBehavior.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/parser/SplitExpressionsTest.scala
+++ b/main/src/test/scala/sbt/internal/parser/SplitExpressionsTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/server/DefinitionTest.scala
+++ b/main/src/test/scala/sbt/internal/server/DefinitionTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
+++ b/main/src/test/scala/sbt/internal/server/SettingQueryTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/main/src/test/scala/testpkg/CompletionSpec.scala
+++ b/main/src/test/scala/testpkg/CompletionSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerConnection.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildServerTasks.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildServerTasks.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildTargetName.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildTargetName.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/BuildTargetTag.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/BuildTargetTag.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/DiagnosticSeverity.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/DiagnosticSeverity.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/OutputPathItemKind.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/OutputPathItemKind.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/ScalaPlatform.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/ScalaPlatform.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/SourceItemKind.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/SourceItemKind.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/bsp/StatusCode.scala
+++ b/protocol/src/main/scala/sbt/internal/bsp/StatusCode.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/langserver/DiagnosticSeverity.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/DiagnosticSeverity.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/ErrorCodes.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
+++ b/protocol/src/main/scala/sbt/internal/langserver/MessageType.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRPCProtocol.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRPCProtocol.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcNotificationMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcNotificationMessageFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcRequestMessageFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseErrorFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseErrorFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseMessageFormats.scala
+++ b/protocol/src/main/scala/sbt/internal/protocol/codec/JsonRpcResponseMessageFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/protocol/ClientSocket.scala
+++ b/protocol/src/main/scala/sbt/protocol/ClientSocket.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/protocol/src/main/scala/sbt/protocol/Serialization.scala
+++ b/protocol/src/main/scala/sbt/protocol/Serialization.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/NOTICE
+++ b/run/NOTICE
@@ -1,5 +1,6 @@
 sbt: Run Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)
 

--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/main/scala/sbt/OutputStrategy.scala
+++ b/run/src/main/scala/sbt/OutputStrategy.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/main/scala/sbt/SelectMainClass.scala
+++ b/run/src/main/scala/sbt/SelectMainClass.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/main/scala/sbt/TrapExit.scala
+++ b/run/src/main/scala/sbt/TrapExit.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/main/scala/sbt/TrapExitSecurityException.scala
+++ b/run/src/main/scala/sbt/TrapExitSecurityException.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/test/scala/sbt/ForkTest.scala
+++ b/run/src/test/scala/sbt/ForkTest.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/run/src/test/scala/sbt/TestLogger.scala
+++ b/run/src/test/scala/sbt/TestLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/main/scala/package.scala
+++ b/sbt-app/src/main/scala/package.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/main/scala/sbt/AllSyntax.scala
+++ b/sbt-app/src/main/scala/sbt/AllSyntax.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/main/scala/sbt/Import.scala
+++ b/sbt-app/src/main/scala/sbt/Import.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/test/scala/sbt/IllegalReferenceSpec.scala
+++ b/sbt-app/src/test/scala/sbt/IllegalReferenceSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/sbt-app/src/test/scala/sbt/internal/scriptedtest/ScriptedLauncher.java
+++ b/sbt-app/src/test/scala/sbt/internal/scriptedtest/ScriptedLauncher.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-plugin/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/scripted-plugin/src/main/scala/sbt/ScriptedPlugin.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-sbt-old/src/main/scala/sbt/test/OldScriptedTests.scala
+++ b/scripted-sbt-old/src/main/scala/sbt/test/OldScriptedTests.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-sbt-redux/NOTICE
+++ b/scripted-sbt-redux/NOTICE
@@ -1,4 +1,5 @@
 sbt: Scripted Testing
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/BatchScriptRunner.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/BatchScriptRunner.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/RemoteSbtCreator.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/RemoteSbtCreator.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/SbtHandler.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/SbtHandler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt-redux/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/NOTICE
+++ b/tasks-standard/NOTICE
@@ -1,4 +1,5 @@
 sbt: Standard Tasks Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/tasks-standard/src/main/scala/sbt/Action.scala
+++ b/tasks-standard/src/main/scala/sbt/Action.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/main/scala/sbt/std/Streams.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Streams.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
+++ b/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/main/scala/sbt/std/Transform.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Transform.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/Execute.scala
+++ b/tasks-standard/src/test/scala/Execute.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TaskGen.scala
+++ b/tasks-standard/src/test/scala/TaskGen.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TaskRunnerCircular.scala
+++ b/tasks-standard/src/test/scala/TaskRunnerCircular.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TaskRunnerFork.scala
+++ b/tasks-standard/src/test/scala/TaskRunnerFork.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TaskSerial.scala
+++ b/tasks-standard/src/test/scala/TaskSerial.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/Test.scala
+++ b/tasks-standard/src/test/scala/Test.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TestRunnerCall.scala
+++ b/tasks-standard/src/test/scala/TestRunnerCall.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/TestRunnerSort.scala
+++ b/tasks-standard/src/test/scala/TestRunnerSort.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks-standard/src/test/scala/checkResult.scala
+++ b/tasks-standard/src/test/scala/checkResult.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/NOTICE
+++ b/tasks/NOTICE
@@ -1,4 +1,5 @@
 sbt: Task Engine Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/ExecuteProgress.scala
+++ b/tasks/src/main/scala/sbt/ExecuteProgress.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/Incomplete.scala
+++ b/tasks/src/main/scala/sbt/Incomplete.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/Node.scala
+++ b/tasks/src/main/scala/sbt/Node.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/tasks/src/main/scala/sbt/Result.scala
+++ b/tasks/src/main/scala/sbt/Result.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/NOTICE
+++ b/testing/NOTICE
@@ -1,4 +1,5 @@
 sbt: Testing Component
-Copyright 2011 - 2017, Lightbend, Inc.
+Copyright 2023, Scala center
+Copyright 2011 - 2022, Lightbend, Inc.
 Copyright 2008 - 2010, Mark Harrah, Steven Blundy, Josh Cough
 Licensed under BSD-3-Clause license (see LICENSE)

--- a/testing/agent/src/main/java/sbt/ForkConfiguration.java
+++ b/testing/agent/src/main/java/sbt/ForkConfiguration.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/agent/src/main/java/sbt/ForkMain.java
+++ b/testing/agent/src/main/java/sbt/ForkMain.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/agent/src/main/java/sbt/ForkTags.java
+++ b/testing/agent/src/main/java/sbt/ForkTags.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/agent/src/main/java/sbt/FrameworkWrapper.java
+++ b/testing/agent/src/main/java/sbt/FrameworkWrapper.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/TestFramework.scala
+++ b/testing/src/main/scala/sbt/TestFramework.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/TestReportListener.scala
+++ b/testing/src/main/scala/sbt/TestReportListener.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/TestStatusReporter.scala
+++ b/testing/src/main/scala/sbt/TestStatusReporter.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/internal/testing/StatusFormats.scala
+++ b/testing/src/main/scala/sbt/internal/testing/StatusFormats.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
+++ b/testing/src/main/scala/sbt/internal/testing/TestLogger.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/internal/util/EmptyCacheError.scala
+++ b/util-cache/src/main/scala/sbt/internal/util/EmptyCacheError.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/BasicCacheImplicits.scala
+++ b/util-cache/src/main/scala/sbt/util/BasicCacheImplicits.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/Cache.scala
+++ b/util-cache/src/main/scala/sbt/util/Cache.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
+++ b/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/CacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/CacheStore.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/Input.scala
+++ b/util-cache/src/main/scala/sbt/util/Input.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/Output.scala
+++ b/util-cache/src/main/scala/sbt/util/Output.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/SeparatedCache.scala
+++ b/util-cache/src/main/scala/sbt/util/SeparatedCache.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/main/scala/sbt/util/StampedFormat.scala
+++ b/util-cache/src/main/scala/sbt/util/StampedFormat.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/test/scala/CacheSpec.scala
+++ b/util-cache/src/test/scala/CacheSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-cache/src/test/scala/SingletonCacheSpec.scala
+++ b/util-cache/src/test/scala/SingletonCacheSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-tracking/src/main/scala/sbt/util/ChangeReport.scala
+++ b/util-tracking/src/main/scala/sbt/util/ChangeReport.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-tracking/src/main/scala/sbt/util/FileFunction.scala
+++ b/util-tracking/src/main/scala/sbt/util/FileFunction.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-tracking/src/main/scala/sbt/util/Tracked.scala
+++ b/util-tracking/src/main/scala/sbt/util/Tracked.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/util-tracking/src/test/scala/sbt/util/TrackedSpec.scala
+++ b/util-tracking/src/test/scala/sbt/util/TrackedSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/java/xsbti/compile/ZincBridgeProvider.java
+++ b/zinc-lm-integration/src/main/java/xsbti/compile/ZincBridgeProvider.java
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/Errors.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/Errors.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/IfMissing.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/IfMissing.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ResourceLoader.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ResourceLoader.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentManager.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentManager.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
@@ -1,6 +1,7 @@
 /*
  * sbt
- * Copyright 2011 - 2018, Lightbend, Inc.
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
  * Copyright 2008 - 2010, Mark Harrah
  * Licensed under Apache License 2.0 (see LICENSE)
  */


### PR DESCRIPTION
- Added “Copyright 2023, Scala Center” to the top of the copyright mentions
- Updated the CLA to use the Scala CLA instead of the Lightbend CLA