### PR TITLE
Remove `conscriptConfigs` task, not used and needed(?) anymore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,6 @@ lazy val sbtRoot: Project = (project in file("."))
     scalacOptions += "-Ymacro-expand:none", // for both sxr and doc
     Util.publishPomSettings,
     otherRootSettings,
-    Transform.conscriptSettings(bundledLauncherProj),
     publish := {},
     publishLocal := {},
     publish / skip := true,

--- a/project/Transform.scala
+++ b/project/Transform.scala
@@ -2,27 +2,6 @@ import sbt._
 import sbt.Keys._
 
 object Transform {
-  private val conscriptConfigs = taskKey[Unit]("")
-
-  def conscriptSettings(launch: Reference) = Seq(
-    conscriptConfigs := {
-      val sourceFile = (launch / Compile / managedResources).value
-        .find(_.getName == "sbt.boot.properties")
-        .getOrElse(sys.error("No managed boot.properties file."))
-      val source = IO.readLines(sourceFile)
-      val conscriptBase = (Compile / sourceDirectory).value / "conscript"
-      IO.delete(conscriptBase)
-      val pairs = Seq(
-        "sbt.xMain" -> "xsbt",
-        "sbt.ScriptMain" -> "scalas",
-        "sbt.ConsoleMain" -> "screpl",
-      )
-      for ((main, dir) <- pairs) {
-        val lines = source.map(l => if (l.trim.startsWith("class:")) s"  class: $main" else l)
-        IO.writeLines(conscriptBase / dir / "launchconfig", lines)
-      }
-    },
-  )
 
   def configSettings = Seq(
     resourceGenerators += Def.task {


### PR DESCRIPTION
The task was part of the release process, but is not used anymore since the release of sbt 1.5.1: https://github.com/sbt/sbt/commit/43b2f1eb3001d49c8758a7bc80b441082291cd19#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91L1525

Also, the [conscript](https://github.com/foundweekends/conscript) launchconfig files already diverged from the source `sbt.boot.properties` since it does not contain the `local-preloaded[-ivy]` repos anymore: https://github.com/sbt/sbt/commit/181052fddb06fa8bccb01d8548fa61b71d131502, but the conscript launchconfigs do: https://github.com/sbt/sbt/tree/1.9.x/src/main/conscript
It seems those config were and get updated by hand anyway.

Since the task is not used in the release process anymore, I think it's more confusing to keep it (or @eed3si9n did run that task in the last years manually?).
(I stumpled over this because I was looking where/how the default repos are set up (which is https://github.com/sbt/sbt/blob/v1.9.3/launch/src/main/input_resources/sbt/sbt.boot.properties#L13-L19).