### PR TITLE
add a Scala 3 seed to the sbt new menu

### DIFF
--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -172,6 +172,7 @@ private[sbt] object TemplateCommandUtil {
     ScalaToolkitSlug -> "Scala Toolkit (beta) by Scala Center and VirtusLab",
     TypelevelToolkitSlug -> "Toolkit to start building Typelevel apps",
     SbtCrossPlatformSlug -> "A cross-JVM/JS/Native project",
+    "scala/scala3.g8" -> "Scala 3 seed template",
     "scala/scala-seed.g8" -> "Scala 2 seed template",
     "playframework/play-scala-seed.g8" -> "A Play project in Scala",
     "playframework/play-java-seed.g8" -> "A Play project in Java",


### PR DESCRIPTION
seems like probably just an oversight that this wasn't included in the first place