### PR TITLE
Use binary compiler bridge

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -715,7 +715,9 @@ object Defaults extends BuildCommon {
     clean := clean.dependsOn(cleanIvy).value,
     scalaCompilerBridgeBinaryJar := Def.settingDyn {
       val sv = scalaVersion.value
-      if (ScalaArtifacts.isScala3(sv)) fetchBridgeBinaryJarTask(sv)
+      if (ScalaArtifacts.isScala3(sv) || VersionNumber(sv)
+            .matchesSemVer(SemanticSelector(s"=2.13 >=${ZincLmUtil.scala2SbtBridgeStart}")))
+        fetchBridgeBinaryJarTask(sv)
       else Def.task[Option[File]](None)
     }.value,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),

--- a/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
@@ -1,6 +1,7 @@
 lazy val check = taskKey[Unit]("")
 lazy val compile2 = taskKey[Unit]("")
 lazy val scala212 = "2.12.18"
+lazy val scala213 = "2.13.12"
 
 lazy val root = (project in file("."))
   .aggregate(foo, bar, client)
@@ -11,7 +12,7 @@ lazy val root = (project in file("."))
 
 lazy val foo = project
   .settings(
-    crossScalaVersions := Seq(scala212, "2.13.11"),
+    crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0",
 
     check := {
@@ -43,7 +44,7 @@ lazy val bar = project
 
 lazy val baz = project
   .settings(
-    crossScalaVersions := Seq("2.13.11"),
+    crossScalaVersions := Seq(scala213),
     check := {
       // This tests that +baz/check will respect bar's crossScalaVersions and not switch
       val x = (LocalProject("bar") / scalaVersion).value
@@ -54,7 +55,7 @@ lazy val baz = project
 
 lazy val client = project
   .settings(
-    crossScalaVersions := Seq(scala212, "2.13.11"),
+    crossScalaVersions := Seq(scala212, scala213),
     check := (Compile / compile).value,
     compile2 := (Compile / compile).value,
   )

--- a/sbt-app/src/sbt-test/actions/cross-advanced/test
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/test
@@ -17,7 +17,7 @@
 ## test + with command or alias
 > clean
 ## for command cross building you do need crossScalaVerions on root
-> set root/crossScalaVersions := Seq("2.12.18", "2.13.11")
+> set root/crossScalaVersions := Seq("2.12.18", "2.13.12")
 > + build
 $ exists foo/target/scala-2.12
 $ exists foo/target/scala-2.13

--- a/sbt-app/src/sbt-test/actions/cross-incremental/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-incremental/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.12.18"
-crossScalaVersions := List("2.12.18", "2.13.11")
+crossScalaVersions := List("2.12.18", "2.13.12")
 
 val setLastModified = taskKey[Unit]("Sets the last modified time for classfiles")
 setLastModified := {

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala212 = "2.12.18"
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.12"
 
 ThisBuild / crossScalaVersions := Seq(scala212, scala213)
 ThisBuild / scalaVersion       := scala212

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/test
@@ -36,7 +36,7 @@ $ exists extras/target/scala-2.12
 
 # test safe switching
 > clean
-> ++ 2.13.11 -v compile
+> ++ 2.13.12 -v compile
 $ exists lib/target/scala-2.13
 -$ exists lib/target/scala-2.12
 # -$ exists sbt-foo/target/scala-2.12

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala212 = "2.12.18"
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.12"
 
 ThisBuild / scalaVersion := scala212
 

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation/test
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation/test
@@ -4,7 +4,7 @@
 
 > clean
 
-> ++2.13.11 compile
+> ++2.13.12 compile
 
 $ exists core/target/scala-2.13
 -$ exists module/target/scala-2.13

--- a/sbt-app/src/sbt-test/actions/doc/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc/build.sbt
@@ -5,7 +5,7 @@ import Parsers._
 lazy val root = (project in file("."))
   .settings(
     crossPaths := false,
-    crossScalaVersions := Seq("2.12.18", "2.13.11"),
+    crossScalaVersions := Seq("2.12.18", "2.13.12"),
     scalaVersion := "2.12.18",
     Compile / doc / scalacOptions += "-Xfatal-warnings",
     commands += Command.command("excludeB") { s =>

--- a/sbt-app/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala212 = "2.12.18"
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.12"
 ThisBuild / scalaVersion := scala212
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/console/project-compiler-bridge/build.sbt
+++ b/sbt-app/src/sbt-test/console/project-compiler-bridge/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 
 // Send some bogus initial command so that it doesn't get stuck.
 // The task itself will still succeed.

--- a/sbt-app/src/sbt-test/dependency-graph/asciiGraphWidth/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/asciiGraphWidth/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 name := "asciiGraphWidthSpecs"
 

--- a/sbt-app/src/sbt-test/dependency-graph/whatDependsOn-without-previous-initialization/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/whatDependsOn-without-previous-initialization/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 name := "whatDependsOn"
 

--- a/sbt-app/src/sbt-test/dependency-graph/whatDependsOn/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/whatDependsOn/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 name := "whatDependsOn"
 

--- a/sbt-app/src/sbt-test/dependency-management/cp-order/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/cp-order/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 csrConfiguration := csrConfiguration.value.withCache(target.value / "coursier-cache")
 
 libraryDependencies += "com.typesafe.play" %% "play-test" % "2.8.0-RC1" % Test // worked around in 2.8.0

--- a/sbt-app/src/sbt-test/dependency-management/credentials/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/credentials/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 ivyPaths := IvyPaths(baseDirectory.value, Some(target.value / "ivy-cache"))
 

--- a/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
@@ -1,7 +1,7 @@
 import xsbti.AppConfiguration
 // ThisBuild / useCoursier := false
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / versionScheme := Some("semver-spec")
 ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 

--- a/sbt-app/src/sbt-test/dependency-management/missingok/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/missingok/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 libraryDependencies ++= Seq(
   "com.chuusai" %% "shapeless" % "2.3.3",
   // non-existing

--- a/sbt-app/src/sbt-test/plugins/dotty-sandwich-sjs/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/dotty-sandwich-sjs/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / scalacOptions += "-Ytasty-reader"
 
 lazy val scala3code = project

--- a/sbt-app/src/sbt-test/plugins/dotty-sandwich/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/dotty-sandwich/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "3.1.3"
 ThisBuild / scalacOptions += "-Ytasty-reader"
 
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.12"
 
 lazy val root = (project in file("."))
   .aggregate(fooApp, fooCore, barApp, barCore)

--- a/sbt-app/src/sbt-test/project/val-order/build.sbt
+++ b/sbt-app/src/sbt-test/project/val-order/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion     := "2.13.11"
+ThisBuild / scalaVersion     := "2.13.12"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 
 lazy val check = taskKey[Unit]("")

--- a/sbt-app/src/sbt-test/source-dependencies/constants/test
+++ b/sbt-app/src/sbt-test/source-dependencies/constants/test
@@ -8,7 +8,7 @@ $ copy-file changes/A2.scala A.scala
 > run 2
 
 > clean
-> ++2.13.11!
+> ++2.13.12!
 
 $ copy-file changes/A1.scala A.scala
 > run 1

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / usePipelining := true
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / usePipelining := true
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/tests/hedgehog/build.sbt
+++ b/sbt-app/src/sbt-test/tests/hedgehog/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 val hedgehogVersion = "0.10.0"
 

--- a/sbt-app/src/sbt-test/tests/scalatest/build.sbt
+++ b/sbt-app/src/sbt-test/tests/scalatest/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion     := "2.13.11"
+ThisBuild / scalaVersion     := "2.13.12"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"

--- a/sbt-app/src/sbt-test/tests/weaver-cats/build.sbt
+++ b/sbt-app/src/sbt-test/tests/weaver-cats/build.sbt
@@ -1,3 +1,3 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "0.8.3" % Test

--- a/sbt-app/src/sbt-test/tests/zio-test/build.sbt
+++ b/sbt-app/src/sbt-test/tests/zio-test/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.12"
 
 libraryDependencies += "dev.zio" %% "zio-test" % "2.0.2" % Test
 libraryDependencies += "dev.zio" %% "zio-test-sbt" % "2.0.2" % Test

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -15,8 +15,10 @@ import sbt.librarymanagement.{
   DependencyResolution,
   ModuleID,
   ScalaArtifacts,
+  SemanticSelector,
   UnresolvedWarningConfiguration,
-  UpdateConfiguration
+  UpdateConfiguration,
+  VersionNumber,
 }
 import sbt.librarymanagement.syntax._
 import xsbti.ArtifactInfo.SbtOrganization
@@ -24,6 +26,8 @@ import xsbti._
 import xsbti.compile.{ ClasspathOptions, ScalaInstance => XScalaInstance }
 
 object ZincLmUtil {
+
+  final val scala2SbtBridgeStart = "2.13.12"
 
   /**
    * Instantiate a Scala compiler that is instrumented to analyze dependencies.
@@ -85,6 +89,11 @@ object ZincLmUtil {
   def getDefaultBridgeModule(scalaVersion: String): ModuleID = {
     if (ScalaArtifacts.isScala3(scalaVersion)) {
       ModuleID(ScalaArtifacts.Organization, "scala3-sbt-bridge", scalaVersion)
+        .withConfigurations(Some(Compile.name))
+    } else if (VersionNumber(scalaVersion).matchesSemVer(
+                 SemanticSelector(s"=2.13 >=$scala2SbtBridgeStart")
+               )) {
+      ModuleID(ScalaArtifacts.Organization, "scala2-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
     } else {
       val compilerBridgeId = scalaVersion match {


### PR DESCRIPTION
Problem
-------
Starting Scala 2.13.12, Scala 2 has in-sourced the compiler bridge imple (https://github.com/scala/scala/pull/10472), which hopefully will be kept up to date more than the ones in Zinc.

Solution
--------
This switches to using the pre-compiled compiler bridge for >=2.13.12 /cc @lrytz 