### PR TITLE
Keep logger names in hash set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -428,6 +428,7 @@ lazy val utilLogging = (project in file("internal") / "util-logging")
       exclude[MissingTypesProblem]("sbt.internal.util.ConsoleAppender"),
       exclude[MissingTypesProblem]("sbt.internal.util.BufferedAppender"),
       exclude[MissingClassProblem]("sbt.internal.util.Terminal$BlockingInputStream$"),
+      exclude[IncompatibleResultTypeProblem]("sbt.util.LoggerContext#Log4JLoggerContext.loggers"),
     ),
   )
   .configure(addSbtIO)

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -46,7 +46,7 @@ object LoggerContext {
       case a: AbstractConfiguration => a
       case _                        => throw new IllegalStateException("")
     }
-    val loggers = new java.util.Vector[String]
+    val loggers = new java.util.HashSet[String]
     private[this] val closed = new AtomicBoolean(false)
     override def logger(
         name: String,


### PR DESCRIPTION
Previously, the list of logger names that have been created in a given context with Log4J was being kept in a `Vector`. As a result, subsequent calls to `logger` on a `Log4JLoggerContext` with the same logger name would introduce duplicates in the list. Note that Log4J's logger configuration would not allow duplicates, and only one configuration object for a given logger name will exist. The duplicates in the list of logger names are therefore unnecessary.

With this patch, the logger names will be kept in a `HashSet`.

Since the logger names are only used to remove the logger configurations after the logger context is closed, and the logger configurations contain no duplicates, removing duplicate logger names should not cause any issue.