### PR TITLE
Include uri in log of `dependencyBrowseTree`

### DIFF
--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -244,7 +244,7 @@ object DependencyTreeSettings {
   def openBrowser(uriKey: TaskKey[URI]) =
     Def.task {
       val uri = uriKey.value
-      streams.value.log.info("Opening in browser...")
+      streams.value.log.info(s"Opening ${uri} in browser...")
       java.awt.Desktop.getDesktop.browse(uri)
       uri
     }


### PR DESCRIPTION
I am running sbt on Arch Linux on a M1 MacBook Pro (therefore arch64 architecture). I will not go into details too much, but I am using Wayland (instead of X11), which is the new thing in the Linux world that manages all the graphics stuff so you can launch windows etc. Everything is switching to Wayland now, however for applications/frameworks which did not switch yet, there is a layer called XWayland which make it possible to run X11 apps in Wayland.
Java does not yet support Wayland, but work is undergoing, specially pushed by JetBrains because they want to make IntelliJ run natively in Wayland. The project page is: https://wiki.openjdk.org/display/wakefield/Pure+Wayland+toolkit+prototype

Anyway.
Because I am running Wayland, but Java does not support it yet, when I run `dependencyBrowseTree` the browser does not open but instead I get:
```
[info] Opening in browser...
[error] java.lang.UnsupportedOperationException: The BROWSE action is not supported on the current platform!
[error]         at java.desktop/java.awt.Desktop.checkActionSupport(Desktop.java:380)
[error]         at java.desktop/java.awt.Desktop.browse(Desktop.java:524)
[error]         at sbt.plugins.DependencyTreeSettings$.$anonfun$openBrowser$1(DependencyTreeSettings.scala:248)
...
```

I will not be able to fix this myself, so instead I just want the log to include the URI that should be opened so I can just open it myself. So with help of this pull request the log will then display:

```
[info] Opening file:/home/mkurz/some-cool-sbt-project/target/tree.html in browser...
```

It's just a stupid workaround which makes my life a bit easier. Thanks!