### PR TITLE
catch `NoSuchMethodError` when call `runFinalization`

### DIFF
--- a/main/src/main/scala/sbt/internal/GCUtil.scala
+++ b/main/src/main/scala/sbt/internal/GCUtil.scala
@@ -37,7 +37,11 @@ private[sbt] object GCUtil {
       // Force the detection of finalizers for scala.reflect weakhashsets
       System.gc()
       // Force finalizers to run.
-      System.runFinalization()
+      try {
+        System.runFinalization()
+      } catch {
+        case _: NoSuchMethodError =>
+      }
       // Force actually cleaning the weak hash maps.
       System.gc()
     } catch {


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/System.html#runFinalization()

> [@Deprecated](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Deprecated.html)([since](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Deprecated.html#since())="18", [forRemoval](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Deprecated.html#forRemoval())=true)
public static void runFinalization()
Deprecated, for removal: This API element is subject to removal in a future version.
Finalization has been deprecated for removal. See [Object.finalize()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Object.html#finalize()) for background information and details about migration options.
When running in a JVM in which finalization has been disabled or removed, no objects will be pending finalization, so this method does nothing.
