### PR TITLE
JLine 3.24.1 and JAnsi 2.4.0.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,14 +86,14 @@ object Dependencies {
 
   // JLine 3 version must be coordinated together with JAnsi version
   // and the JLine 2 fork version, which uses the same JAnsi
-  val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-a1b0ffbb8f64bb820f4f84a0c07a0c0964507493"
-  val jline3Version = "3.19.0"
+  val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79"
+  val jline3Version = "3.24.1"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
   val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val jansi = "org.fusesource.jansi" % "jansi" % "2.1.0"
+  val jansi = "org.fusesource.jansi" % "jansi" % "2.4.0"
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   val junit = "junit" % "junit" % "4.13.1"


### PR DESCRIPTION
Fix #7371

- https://github.com/fusesource/jansi/releases/tag/jansi-2.4.1
- https://github.com/jline/jline3/releases/tag/jline-parent-3.24.1