### PR TITLE
Temporary fix for #7371

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -110,6 +110,11 @@ object LineReader {
       override def readLine(prompt: String, mask: Option[Char]): Option[String] = {
         val term = JLine3(terminal)
         val reader = LineReaderBuilder.builder().terminal(term).completer(completer(parser)).build()
+
+        if (Util.isEmacs) {
+          reader.setKeyMap(JLineReader.SAFE)
+        }
+
         try {
           inputrcFileContents.foreach { bytes =>
             InputRC.configure(


### PR DESCRIPTION
This fix disables vi-style effects (most notably parenthesis matching) if the terminal is inside emacs.

The proper fix is to update to JLine 3.24.0 where this check has been implemented in JLine proper.