### PR TITLE
Fix installSbtn for apple silicon

### DIFF
--- a/main/src/main/scala/sbt/internal/InstallSbtn.scala
+++ b/main/src/main/scala/sbt/internal/InstallSbtn.scala
@@ -65,10 +65,16 @@ private[sbt] object InstallSbtn {
       if (Properties.isWin) "pc-win32.exe"
       else if (Properties.isLinux) "pc-linux"
       else "apple-darwin"
-    val isArmArchitecture: Boolean = sys.props
-      .getOrElse("os.arch", "")
-      .toLowerCase(java.util.Locale.ROOT) == "aarch64"
-    val arch = if (Properties.isLinux && isArmArchitecture) "aarch64" else "x86_64"
+
+    val isArmArchitecture: Boolean = {
+      val prop = sys.props
+        .getOrElse("os.arch", "")
+        .toLowerCase(java.util.Locale.ROOT)
+
+      prop == "arm64" || prop == "aarch64"
+    }
+
+    val arch = if (isArmArchitecture) "aarch64" else "x86_64"
     val sbtnName = s"sbt/bin/sbtn-$arch-$bin"
     val fis = new FileInputStream(sbtZip.toFile)
     val zipInputStream = new ZipInputStream(fis)

--- a/main/src/main/scala/sbt/internal/InstallSbtn.scala
+++ b/main/src/main/scala/sbt/internal/InstallSbtn.scala
@@ -117,7 +117,9 @@ private[sbt] object InstallSbtn {
       val sbtnAlternativeMsg = alternativeArch.map(name => s" (or $name)")
       nativeArchFound.orElse(alternativeArchFound) match {
         case None =>
-          throw new IllegalStateException(s"couldn't find $sbtnName$sbtnAlternativeMsg in $sbtZip")
+          throw new IllegalStateException(
+            s"couldn't find $nativeArch$sbtnAlternativeMsg in $sbtZip"
+          )
         case Some(value) =>
           write(value)
       }


### PR DESCRIPTION
1. Handle ARM architecture for non-Linux architectures
2. Provide a Rosetta fallback if the ARM binary is not available for Apple Silicon

(2) is possibly controversial, because using sbtn through rosetta is always problematic.
But I'm just replicating current behaviour