### PR TITLE
[#5219] fix `updateSbtClassifiers` task

### DIFF
--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -185,7 +185,11 @@ private[sbt] object LibraryManagement {
     import config.{ updateConfiguration => c, module => mod }
     import mod.{ id, dependencies => deps, scalaModuleInfo }
     val base = restrictedCopy(id, true).withName(id.name + "$" + label)
-    val module = lm.moduleDescriptor(base, deps, scalaModuleInfo)
+    val moduleSettings = ModuleDescriptorConfiguration(base, ModuleInfo(base.name))
+      .withScalaModuleInfo(scalaModuleInfo)
+      .withDependencies(deps)
+      .withConfigurations(mod.configurations)
+    val module = lm.moduleDescriptor(moduleSettings)
     val report = lm.update(module, c, uwconfig, log) match {
       case Right(r) => r
       case Left(w) =>


### PR DESCRIPTION
[#5219](https://github.com/sbt/sbt/issues/5219)
The problem was caused by the fact that the ModuleIDs of some plugins have `default` configuration, which wasn't passed in the configuration vector to the `sbt.librarymanagement.ModuleDescriptorConfiguration` and as a result, also to the `CoursierDependencyResolution` from the `sbt-coursier` plugin.
The transfer of the `default` configuration to the `CoursierDependencyResolution` is crucial because only dependencies with configurations that are present in the `sbt.librarymanagement.ModuleDescriptorConfiguration#configurations` are taken into account.