### PR TITLE
[2.x] Reduce abstraction in `Execute` and around (bis)

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -25,7 +25,7 @@ import Scope.GlobalScope
 import sbt.SlashSyntax0.*
 import sbt.internal.parser.SbtParser
 import sbt.io.IO
-import scala.collection.JavaConverters.*
+import scala.jdk.CollectionConverters.*
 import xsbti.VirtualFile
 import xsbti.VirtualFileRef
 
@@ -403,14 +403,14 @@ object Index {
       )
   }
 
-  private[this] type TriggerMap = collection.mutable.HashMap[Task[Any], Seq[Task[Any]]]
+  private[this] type TriggerMap = collection.mutable.HashMap[TaskId[?], Seq[TaskId[?]]]
 
-  def triggers(ss: Settings[Scope]): Triggers[Task] = {
+  def triggers(ss: Settings[Scope]): Triggers = {
     val runBefore = new TriggerMap
     val triggeredBy = new TriggerMap
     ss.data.values foreach (
       _.entries foreach {
-        case AttributeEntry(_, value: Task[Any]) =>
+        case AttributeEntry(_, value: Task[?]) =>
           val as = value.info.attributes
           update(runBefore, value, as.get(Def.runBefore.asInstanceOf))
           update(triggeredBy, value, as.get(Def.triggeredBy.asInstanceOf))
@@ -418,13 +418,13 @@ object Index {
       }
     )
     val onComplete = (GlobalScope / Def.onComplete) get ss getOrElse (() => ())
-    new Triggers[Task](runBefore, triggeredBy, map => { onComplete(); map })
+    new Triggers(runBefore, triggeredBy, map => { onComplete(); map })
   }
 
   private[this] def update(
       map: TriggerMap,
-      base: Task[Any],
-      tasksOpt: Option[Seq[Task[Any]]]
+      base: Task[?],
+      tasksOpt: Option[Seq[Task[?]]]
   ): Unit =
     for {
       tasks <- tasksOpt

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -382,10 +382,11 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
     (TaskKey[A](name, description, DTask), dummyTask(name))
 
   private[sbt] def dummyTask[T](name: String): Task[T] = {
-    import std.TaskExtra.{ task => newTask, _ }
+    import std.TaskExtra.{ task => newTask, toTaskInfo }
     val base: Task[T] = newTask(
       sys.error("Dummy task '" + name + "' did not get converted to a full task.")
-    ) named name
+    )
+      .named(name)
     base.copy(info = base.info.set(isDummyTask, true))
   }
 

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -115,7 +115,7 @@ object Previous {
   /** Persists values of tasks t where there is some task referencing it via t.previous. */
   private[sbt] def complete(
       referenced: References,
-      results: RMap[Task, Result],
+      results: RMap[TaskId, Result],
       streams: Streams
   ): Unit = {
     val map = referenced.getReferences
@@ -124,7 +124,7 @@ object Previous {
     // We first collect all of the successful tasks and write their scoped key into a map
     // along with their values.
     val successfulTaskResults = (for
-      case results.TPair(task, Result.Value(v)) <- results.toTypedSeq
+      results.TPair(task: Task[?], Result.Value(v)) <- results.toTypedSeq
       key <- task.info.attributes.get(Def.taskDefinitionKey).asInstanceOf[Option[AnyTaskKey]]
     yield key -> v).toMap
     // We then traverse the successful results and look up all of the referenced values for

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -534,7 +534,7 @@ object Scoped:
         .apply(deps => nop.dependsOn(deps: _*))
   }
 
-  sealed abstract class RichTaskables[K[L[x]]](final val keys: K[Taskable])(using
+  sealed abstract class RichTaskables[K[+L[x]]](final val keys: K[Taskable])(using
       a: AList[K]
   ):
 

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -590,9 +590,9 @@ object Keys {
   val state = Def.stateKey
   val streamsManager = Def.streamsManagerKey
   // wrapper to work around SI-2915
-  final class TaskProgress(val progress: ExecuteProgress[Task])
+  final class TaskProgress(val progress: ExecuteProgress)
   object TaskProgress {
-    def apply(progress: ExecuteProgress[Task]): TaskProgress = new TaskProgress(progress)
+    def apply(progress: ExecuteProgress): TaskProgress = new TaskProgress(progress)
   }
   private[sbt] val currentTaskProgress = AttributeKey[TaskProgress]("current-task-progress")
   private[sbt] val taskProgress = AttributeKey[sbt.internal.TaskProgress]("active-task-progress")

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -71,7 +71,7 @@ final class BuildStructure(
 final class StructureIndex(
     val keyMap: Map[String, AttributeKey[_]],
     val taskToKey: Map[Task[_], ScopedKey[Task[_]]],
-    val triggers: Triggers[Task],
+    val triggers: Triggers,
     val keyIndex: KeyIndex,
     val aggregateKeyIndex: KeyIndex,
 )

--- a/main/src/main/scala/sbt/internal/TaskName.scala
+++ b/main/src/main/scala/sbt/internal/TaskName.scala
@@ -12,11 +12,11 @@ import Def.{ displayFull, ScopedKey }
 import Keys.taskDefinitionKey
 
 private[sbt] object TaskName {
-  def name(node: Task[_]): String = definedName(node) getOrElse anonymousName(node)
+  def name(node: Task[_]): String = definedName(node).getOrElse(anonymousName(node))
   def definedName(node: Task[_]): Option[String] =
-    node.info.name orElse transformNode(node).map(displayFull)
-  def anonymousName(node: Task[_]): String =
+    node.info.name.orElse(transformNode(node).map(displayFull))
+  def anonymousName(node: TaskId[_]): String =
     "<anon-" + System.identityHashCode(node).toHexString + ">"
   def transformNode(node: Task[_]): Option[ScopedKey[_]] =
-    node.info.attributes get taskDefinitionKey
+    node.info.attributes.get(taskDefinitionKey)
 }

--- a/main/src/main/scala/sbt/internal/TaskTimings.scala
+++ b/main/src/main/scala/sbt/internal/TaskTimings.scala
@@ -23,7 +23,7 @@ import sbt.util.{ Level, Logger }
  */
 private[sbt] final class TaskTimings(reportOnShutdown: Boolean, logger: Logger)
     extends AbstractTaskExecuteProgress
-    with ExecuteProgress[Task] {
+    with ExecuteProgress {
   @deprecated("Use the constructor that takes an sbt.util.Logger parameter.", "1.3.3")
   def this(reportOnShutdown: Boolean) =
     this(
@@ -50,9 +50,9 @@ private[sbt] final class TaskTimings(reportOnShutdown: Boolean, logger: Logger)
       start = System.nanoTime
   }
 
-  override def afterReady(task: Task[Any]): Unit = ()
-  override def afterCompleted[T](task: Task[T], result: Result[T]): Unit = ()
-  override def afterAllCompleted(results: RMap[Task, Result]): Unit =
+  override def afterReady(task: TaskId[?]): Unit = ()
+  override def afterCompleted[T](task: TaskId[T], result: Result[T]): Unit = ()
+  override def afterAllCompleted(results: RMap[TaskId, Result]): Unit =
     if (!reportOnShutdown) {
       report()
     }

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -21,17 +21,15 @@ import sjsonnew.support.scalajson.unsafe.CompactPrinter
  * as Chrome Trace Event Format.
  * This class is activated by adding -Dsbt.traces=true to the JVM options.
  */
-private[sbt] final class TaskTraceEvent
-    extends AbstractTaskExecuteProgress
-    with ExecuteProgress[Task] {
+private[sbt] final class TaskTraceEvent extends AbstractTaskExecuteProgress with ExecuteProgress {
   import AbstractTaskExecuteProgress.Timer
   private[this] var start = 0L
   private[this] val console = ConsoleOut.systemOut
 
   override def initial(): Unit = ()
-  override def afterReady(task: Task[Any]): Unit = ()
-  override def afterCompleted[T](task: Task[T], result: Result[T]): Unit = ()
-  override def afterAllCompleted(results: RMap[Task, Result]): Unit = ()
+  override def afterReady(task: TaskId[?]): Unit = ()
+  override def afterCompleted[T](task: TaskId[T], result: Result[T]): Unit = ()
+  override def afterAllCompleted(results: RMap[TaskId, Result]): Unit = ()
   override def stop(): Unit = ()
 
   start = System.nanoTime

--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -66,7 +66,7 @@ object BspCompileTask {
 case class BspCompileTask private (
     targetId: BuildTargetIdentifier,
     targetName: String,
-    id: TaskId,
+    id: sbt.internal.bsp.TaskId,
     startTimeMillis: Long
 ) {
   import sbt.internal.bsp.codec.JsonProtocol._

--- a/tasks-standard/src/main/scala/sbt/Task.scala
+++ b/tasks-standard/src/main/scala/sbt/Task.scala
@@ -16,7 +16,7 @@ import sbt.util.Monad
 /**
  * Combines metadata `info` and a computation `work` to define a task.
  */
-final case class Task[A](info: Info[A], work: Action[A]):
+final case class Task[A](info: Info[A], work: Action[A]) extends TaskId[A]:
   override def toString = info.name getOrElse ("Task(" + info + ")")
   override def hashCode = info.hashCode
 
@@ -28,7 +28,10 @@ final case class Task[A](info: Info[A], work: Action[A]):
     withInfo(info = nextInfo)
   }
 
-  def tags: TagMap = info get tagsKey getOrElse TagMap.empty
+  def tags: TagMap = info.get(tagsKey).getOrElse(TagMap.empty)
+  def name: Option[String] = info.name
+
+  def attributes: AttributeMap = info.attributes
 
   private[sbt] def withInfo(info: Info[A]): Task[A] =
     Task(info = info, work = this.work)

--- a/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
+++ b/tasks-standard/src/main/scala/sbt/std/TaskExtra.scala
@@ -144,7 +144,7 @@ trait TaskExtra extends TaskExtra0 {
       : Conversion[(Task[A1], Task[A2]), MultiInTask[[F[_]] =>> Tuple.Map[(A1, A2), F]]] =
     multT2Task(_)
 
-  final implicit def multInputTask[K[F[_]]: AList](tasks: K[Task]): MultiInTask[K] =
+  final implicit def multInputTask[K[+F[_]]: AList](tasks: K[Task]): MultiInTask[K] =
     new MultiInTask[K]:
       override def flatMapN[A](f: K[Id] => Task[A]): Task[A] =
         Task(Info(), Action.FlatMapped[A, K](tasks, f compose allM, AList[K]))

--- a/tasks-standard/src/test/scala/TaskGen.scala
+++ b/tasks-standard/src/test/scala/TaskGen.scala
@@ -22,15 +22,15 @@ object TaskGen extends std.TaskExtra {
   val TaskListGen = MaxTasksGen.flatMap(size => Gen.listOfN(size, Arbitrary.arbInt.arbitrary))
 
   def run[T](root: Task[T], checkCycles: Boolean, maxWorkers: Int): Result[T] = {
-    val (service, shutdown) = CompletionService[Task[_], Completed](maxWorkers)
+    val (service, shutdown) = CompletionService(maxWorkers)
     val dummies = std.Transform.DummyTaskMap(Nil)
-    val x = new Execute[Task](
+    val x = new Execute(
       Execute.config(checkCycles),
       Execute.noTriggers,
-      ExecuteProgress.empty[Task]
+      ExecuteProgress.empty
     )(using std.Transform(dummies))
     try {
-      x.run(root)(using service.asInstanceOf)
+      x.run(root)(using service)
     } finally {
       shutdown()
     }

--- a/tasks-standard/src/test/scala/TaskRunnerCircular.scala
+++ b/tasks-standard/src/test/scala/TaskRunnerCircular.scala
@@ -50,5 +50,5 @@ object TaskRunnerCircularTest extends Properties("TaskRunner Circular") {
   def cyclic(i: Incomplete) =
     Incomplete
       .allExceptions(i)
-      .exists(_.isInstanceOf[Execute[({ type A[_] <: AnyRef })#A @unchecked]#CyclicException[_]])
+      .exists(_.isInstanceOf[Execute#CyclicException])
 }

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -7,19 +7,19 @@
 
 package sbt
 
-trait CompletionService[A, R]:
+trait CompletionService:
 
   /**
    * Submits a work node A with work that returns R. In Execute this is used for tasks returning
    * sbt.Completed.
    */
-  def submit(node: A, work: () => R): Unit
+  def submit(node: TaskId[?], work: () => Completed): Unit
 
   /**
    * Retrieves and removes the result from the next completed task, waiting if none are yet present.
    * In Execute this is used for tasks returning sbt.Completed.
    */
-  def take(): R
+  def take(): Completed
 end CompletionService
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -35,35 +35,40 @@ import java.util.concurrent.{
 
 object CompletionService {
   val poolID = new AtomicInteger(1)
-  def apply[A, T](poolSize: Int): (CompletionService[A, T], () => Unit) = {
+  def apply(poolSize: Int): (CompletionService, () => Unit) = {
     val i = new AtomicInteger(1)
     val id = poolID.getAndIncrement()
     val pool = Executors.newFixedThreadPool(
       poolSize,
       (r: Runnable) => new Thread(r, s"sbt-completion-thread-$id-${i.getAndIncrement}")
     )
-    (apply[A, T](pool), () => { pool.shutdownNow(); () })
+    (apply(pool), () => { pool.shutdownNow(); () })
   }
 
-  def apply[A, T](x: Executor): CompletionService[A, T] =
-    apply(new ExecutorCompletionService[T](x))
+  def apply(x: Executor): CompletionService =
+    apply(new ExecutorCompletionService[Completed](x))
 
-  def apply[A, T](completion: JCompletionService[T]): CompletionService[A, T] =
-    new CompletionService[A, T] {
-      def submit(node: A, work: () => T) = { CompletionService.submit(work, completion); () }
+  def apply(completion: JCompletionService[Completed]): CompletionService =
+    new CompletionService {
+      def submit(node: TaskId[?], work: () => Completed) = {
+        CompletionService.submit(work, completion); ()
+      }
       def take() = completion.take().get()
     }
 
-  def submit[T](work: () => T, completion: JCompletionService[T]): () => T = {
-    val future = submitFuture[T](work, completion)
+  def submit(work: () => Completed, completion: JCompletionService[Completed]): () => Completed = {
+    val future = submitFuture(work, completion)
     () => future.get
   }
 
-  private[sbt] def submitFuture[A](work: () => A, completion: JCompletionService[A]): JFuture[A] = {
+  private[sbt] def submitFuture(
+      work: () => Completed,
+      completion: JCompletionService[Completed]
+  ): JFuture[Completed] = {
     val future =
       try
         completion.submit {
-          new Callable[A] {
+          new Callable[Completed] {
             def call =
               try {
                 work()
@@ -79,9 +84,9 @@ object CompletionService {
       }
     future
   }
-  def manage[A, T](
-      service: CompletionService[A, T]
-  )(setup: A => Unit, cleanup: A => Unit): CompletionService[A, T] =
+  def manage(
+      service: CompletionService
+  )(setup: TaskId[?] => Unit, cleanup: TaskId[?] => Unit): CompletionService =
     wrap(service) { (node, work) => () =>
       setup(node)
       try {
@@ -90,11 +95,11 @@ object CompletionService {
         cleanup(node)
       }
     }
-  def wrap[A, T](
-      service: CompletionService[A, T]
-  )(w: (A, () => T) => (() => T)): CompletionService[A, T] =
-    new CompletionService[A, T] {
-      def submit(node: A, work: () => T) = service.submit(node, w(node, work))
+  def wrap(
+      service: CompletionService
+  )(w: (TaskId[?], () => Completed) => (() => Completed)): CompletionService =
+    new CompletionService {
+      def submit(node: TaskId[?], work: () => Completed) = service.submit(node, w(node, work))
       def take() = service.take()
     }
 }

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -13,14 +13,12 @@ import sbt.internal.util.AttributeKey
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ Future => JFuture, RejectedExecutionException }
 import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
 
 /**
  * Describes restrictions on concurrent execution for a set of tasks.
- *
- * @tparam A
- *   the type of a task
  */
-trait ConcurrentRestrictions[A] {
+trait ConcurrentRestrictions {
 
   /** Internal state type used to describe a set of tasks. */
   type G
@@ -29,10 +27,10 @@ trait ConcurrentRestrictions[A] {
   def empty: G
 
   /** Updates the description `g` to include a new task `a`. */
-  def add(g: G, a: A): G
+  def add(g: G, a: TaskId[?]): G
 
   /** Updates the description `g` to remove a previously added task `a`. */
-  def remove(g: G, a: A): G
+  def remove(g: G, a: TaskId[?]): G
 
   /**
    * Returns true if the tasks described by `g` are allowed to execute concurrently. The methods in
@@ -54,8 +52,7 @@ import java.util.concurrent.{ Executor, Executors, ExecutorCompletionService }
 import annotation.tailrec
 
 object ConcurrentRestrictions {
-  private[this] val completionServices = new java.util.WeakHashMap[CompletionService[_, _], Boolean]
-  import scala.collection.JavaConverters._
+  private[this] val completionServices = new java.util.WeakHashMap[CompletionService, Boolean]
   def cancelAll() = completionServices.keySet.asScala.toVector.foreach {
     case a: AutoCloseable => a.close()
     case _                =>
@@ -71,22 +68,22 @@ object ConcurrentRestrictions {
    * @param zero
    *   the constant placeholder used for t
    */
-  def unrestricted[A]: ConcurrentRestrictions[A] =
-    new ConcurrentRestrictions[A] {
+  def unrestricted: ConcurrentRestrictions =
+    new ConcurrentRestrictions {
       type G = Unit
       def empty = ()
-      def add(g: G, a: A) = ()
-      def remove(g: G, a: A) = ()
+      def add(g: G, a: TaskId[?]) = ()
+      def remove(g: G, a: TaskId[?]) = ()
       def valid(g: G) = true
     }
 
-  def limitTotal[A](i: Int): ConcurrentRestrictions[A] = {
+  def limitTotal(i: Int): ConcurrentRestrictions = {
     assert(i >= 1, "Maximum must be at least 1 (was " + i + ")")
-    new ConcurrentRestrictions[A] {
+    new ConcurrentRestrictions {
       type G = Int
       def empty = 0
-      def add(g: Int, a: A) = g + 1
-      def remove(g: Int, a: A) = g - 1
+      def add(g: Int, a: TaskId[?]) = g + 1
+      def remove(g: Int, a: TaskId[?]) = g - 1
       def valid(g: Int) = g <= i
     }
   }
@@ -108,26 +105,25 @@ object ConcurrentRestrictions {
 
   /**
    * Implements concurrency restrictions on tasks based on Tags.
-   * @tparam A
-   *   type of a task
    * @param get
    *   extracts tags from a task
    * @param validF
    *   defines whether a set of tasks are allowed to execute concurrently based on their merged tags
    */
-  def tagged[A](get: A => TagMap, validF: TagMap => Boolean): ConcurrentRestrictions[A] =
-    new ConcurrentRestrictions[A] {
+  def tagged(validF: TagMap => Boolean): ConcurrentRestrictions =
+    new ConcurrentRestrictions {
       type G = TagMap
       def empty = Map.empty
-      def add(g: TagMap, a: A) = merge(g, a, get)(_ + _)
-      def remove(g: TagMap, a: A) = merge(g, a, get)(_ - _)
+      def add(g: TagMap, a: TaskId[?]) = merge(g, a)(_ + _)
+      def remove(g: TagMap, a: TaskId[?]) = merge(g, a)(_ - _)
       def valid(g: TagMap) = validF(g)
     }
 
-  private[this] def merge[A](m: TagMap, a: A, get: A => TagMap)(f: (Int, Int) => Int): TagMap = {
-    val aTags = get(a)
-    val base = merge(m, aTags)(f)
-    val un = if (aTags.isEmpty) update(base, Untagged, 1)(f) else base
+  private[this] def merge(m: TagMap, a: TaskId[?])(
+      f: (Int, Int) => Int
+  ): TagMap = {
+    val base = merge(m, a.tags)(f)
+    val un = if (a.tags.isEmpty) update(base, Untagged, 1)(f) else base
     update(un, All, 1)(f)
   }
 
@@ -154,26 +150,26 @@ object ConcurrentRestrictions {
    * @tparam R
    *   the type of data that will be computed by the CompletionService.
    */
-  def completionService[A, R](
-      tags: ConcurrentRestrictions[A],
+  def completionService(
+      tags: ConcurrentRestrictions,
       warn: String => Unit
-  ): (CompletionService[A, R], () => Unit) = {
+  ): (CompletionService, () => Unit) = {
     val id = poolID.getAndIncrement
     val i = new AtomicInteger(1)
     val pool = Executors.newCachedThreadPool { r =>
       new Thread(r, s"sbt-completion-service-pool-$id-${i.getAndIncrement()}")
     }
-    val service = completionService[A, R](pool, tags, warn)
+    val service = completionService(pool, tags, warn)
     (service, () => { pool.shutdownNow(); () })
   }
 
-  def completionService[A, R](
-      tags: ConcurrentRestrictions[A],
+  def completionService(
+      tags: ConcurrentRestrictions,
       warn: String => Unit,
-      isSentinel: A => Boolean
-  ): (CompletionService[A, R], () => Unit) = {
+      isSentinel: TaskId[?] => Boolean
+  ): (CompletionService, () => Unit) = {
     val pool = Executors.newCachedThreadPool()
-    val service = completionService[A, R](pool, tags, warn, isSentinel)
+    val service = completionService(pool, tags, warn, isSentinel)
     (
       service,
       () => {
@@ -183,13 +179,13 @@ object ConcurrentRestrictions {
     )
   }
 
-  def cancellableCompletionService[A, R](
-      tags: ConcurrentRestrictions[A],
+  def cancellableCompletionService(
+      tags: ConcurrentRestrictions,
       warn: String => Unit,
-      isSentinel: A => Boolean
-  ): (CompletionService[A, R], Boolean => Unit) = {
+      isSentinel: TaskId[?] => Boolean
+  ): (CompletionService, Boolean => Unit) = {
     val pool = Executors.newCachedThreadPool()
-    val service = completionService[A, R](pool, tags, warn, isSentinel)
+    val service = completionService(pool, tags, warn, isSentinel)
     (
       service,
       force => {
@@ -200,12 +196,12 @@ object ConcurrentRestrictions {
     )
   }
 
-  def completionService[A, R](
+  def completionService(
       backing: Executor,
-      tags: ConcurrentRestrictions[A],
+      tags: ConcurrentRestrictions,
       warn: String => Unit
-  ): CompletionService[A, R] with AutoCloseable = {
-    completionService[A, R](backing, tags, warn, (_: A) => false)
+  ): CompletionService with AutoCloseable = {
+    completionService(backing, tags, warn, _ => false)
   }
 
   /**
@@ -213,17 +209,17 @@ object ConcurrentRestrictions {
    * restrictions on concurrent task execution and using the provided Executor to manage execution
    * on threads.
    */
-  def completionService[A, R](
+  def completionService(
       backing: Executor,
-      tags: ConcurrentRestrictions[A],
+      tags: ConcurrentRestrictions,
       warn: String => Unit,
-      isSentinel: A => Boolean,
-  ): CompletionService[A, R] with CancelSentiels with AutoCloseable = {
+      isSentinel: TaskId[?] => Boolean,
+  ): CompletionService with CancelSentiels with AutoCloseable = {
 
     // Represents submitted work for a task.
-    final class Enqueue(val node: A, val work: () => R)
+    final class Enqueue(val node: TaskId[?], val work: () => Completed)
 
-    new CompletionService[A, R] with CancelSentiels with AutoCloseable {
+    new CompletionService with CancelSentiels with AutoCloseable {
       completionServices.put(this, true)
       private[this] val closed = new AtomicBoolean(false)
       override def close(): Unit = if (closed.compareAndSet(false, true)) {
@@ -232,7 +228,7 @@ object ConcurrentRestrictions {
       }
 
       /** Backing service used to manage execution on threads once all constraints are satisfied. */
-      private[this] val jservice = new ExecutorCompletionService[R](backing)
+      private[this] val jservice = new ExecutorCompletionService[Completed](backing)
 
       /** The description of the currently running tasks, used by `tags` to manage restrictions. */
       private[this] var tagState = tags.empty
@@ -255,7 +251,7 @@ object ConcurrentRestrictions {
         sentinels.clear()
       }
 
-      def submit(node: A, work: () => R): Unit = synchronized {
+      def submit(node: TaskId[?], work: () => Completed): Unit = synchronized {
         if (closed.get) throw new RejectedExecutionException
         else if (isSentinel(node)) {
           // skip all checks for sentinels
@@ -276,7 +272,7 @@ object ConcurrentRestrictions {
         }
         ()
       }
-      private[this] def submitValid(node: A, work: () => R): Unit = {
+      private[this] def submitValid(node: TaskId[?], work: () => Completed): Unit = {
         running += 1
         val wrappedWork = () =>
           try work()
@@ -284,7 +280,7 @@ object ConcurrentRestrictions {
         CompletionService.submitFuture(wrappedWork, jservice)
         ()
       }
-      private[this] def cleanup(node: A): Unit = synchronized {
+      private[this] def cleanup(node: TaskId[?]): Unit = synchronized {
         running -= 1
         tagState = tags.remove(tagState, node)
         if (!tags.valid(tagState)) {
@@ -320,7 +316,7 @@ object ConcurrentRestrictions {
           submitValid(tried)
         }
 
-      def take(): R = {
+      def take(): Completed = {
         if (closed.get)
           throw new RejectedExecutionException(
             "Tried to get values for a closed completion service"

--- a/tasks/src/main/scala/sbt/ExecuteProgress.scala
+++ b/tasks/src/main/scala/sbt/ExecuteProgress.scala
@@ -14,7 +14,7 @@ import sbt.internal.util.RMap
  * except `started` and `finished`, which is called from the executing task's thread. All methods
  * should return quickly to avoid task execution overhead.
  */
-trait ExecuteProgress[F[_]] {
+trait ExecuteProgress {
   def initial(): Unit
 
   /**
@@ -22,20 +22,24 @@ trait ExecuteProgress[F[_]] {
    * `task` are `allDeps` and the subset of those dependencies that have not completed are
    * `pendingDeps`.
    */
-  def afterRegistered(task: F[Any], allDeps: Iterable[F[Any]], pendingDeps: Iterable[F[Any]]): Unit
+  def afterRegistered(
+      task: TaskId[?],
+      allDeps: Iterable[TaskId[?]],
+      pendingDeps: Iterable[TaskId[?]]
+  ): Unit
 
   /**
    * Notifies that all of the dependencies of `task` have completed and `task` is therefore ready to
    * run. The task has not been scheduled on a thread yet.
    */
-  def afterReady(task: F[Any]): Unit
+  def afterReady(task: TaskId[?]): Unit
 
   /**
    * Notifies that the work for `task` is starting after this call returns. This is called from the
    * thread the task executes on, unlike most other methods in this callback. It is called
    * immediately before the task's work starts with minimal intervening executor overhead.
    */
-  def beforeWork(task: F[Any]): Unit
+  def beforeWork(task: TaskId[?]): Unit
 
   /**
    * Notifies that the work for `task` work has finished. The task may have computed the next task
@@ -45,16 +49,16 @@ trait ExecuteProgress[F[_]] {
    * executes on, unlike most other methods in this callback. It is immediately called after the
    * task's work is complete with minimal intervening executor overhead.
    */
-  def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit
+  def afterWork[A](task: TaskId[A], result: Either[TaskId[A], Result[A]]): Unit
 
   /**
    * Notifies that `task` has completed. The task's work is done with a final `result`. Any tasks
    * called by `task` have completed.
    */
-  def afterCompleted[A](task: F[A], result: Result[A]): Unit
+  def afterCompleted[A](task: TaskId[A], result: Result[A]): Unit
 
   /** All tasks have completed with the final `results` provided. */
-  def afterAllCompleted(results: RMap[F, Result]): Unit
+  def afterAllCompleted(results: RMap[TaskId, Result]): Unit
 
   /** Notifies that either all tasks have finished or cancelled. */
   def stop(): Unit
@@ -64,46 +68,46 @@ trait ExecuteProgress[F[_]] {
  * This module is experimental and subject to binary and source incompatible changes at any time.
  */
 object ExecuteProgress {
-  def empty[F[_]]: ExecuteProgress[F] = new ExecuteProgress[F] {
+  def empty: ExecuteProgress = new ExecuteProgress {
     override def initial(): Unit = ()
     override def afterRegistered(
-        task: F[Any],
-        allDeps: Iterable[F[Any]],
-        pendingDeps: Iterable[F[Any]]
+        task: TaskId[?],
+        allDeps: Iterable[TaskId[?]],
+        pendingDeps: Iterable[TaskId[?]]
     ): Unit =
       ()
-    override def afterReady(task: F[Any]): Unit = ()
-    override def beforeWork(task: F[Any]): Unit = ()
-    override def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit = ()
-    override def afterCompleted[A](task: F[A], result: Result[A]): Unit = ()
-    override def afterAllCompleted(results: RMap[F, Result]): Unit = ()
+    override def afterReady(task: TaskId[?]): Unit = ()
+    override def beforeWork(task: TaskId[?]): Unit = ()
+    override def afterWork[A](task: TaskId[A], result: Either[TaskId[A], Result[A]]): Unit = ()
+    override def afterCompleted[A](task: TaskId[A], result: Result[A]): Unit = ()
+    override def afterAllCompleted(results: RMap[TaskId, Result]): Unit = ()
     override def stop(): Unit = ()
   }
 
-  def aggregate[F[_]](reporters: Seq[ExecuteProgress[F]]) = new ExecuteProgress[F] {
+  def aggregate(reporters: Seq[ExecuteProgress]) = new ExecuteProgress {
     override def initial(): Unit = {
       reporters foreach { _.initial() }
     }
     override def afterRegistered(
-        task: F[Any],
-        allDeps: Iterable[F[Any]],
-        pendingDeps: Iterable[F[Any]]
+        task: TaskId[?],
+        allDeps: Iterable[TaskId[?]],
+        pendingDeps: Iterable[TaskId[?]]
     ): Unit = {
       reporters foreach { _.afterRegistered(task, allDeps, pendingDeps) }
     }
-    override def afterReady(task: F[Any]): Unit = {
+    override def afterReady(task: TaskId[?]): Unit = {
       reporters foreach { _.afterReady(task) }
     }
-    override def beforeWork(task: F[Any]): Unit = {
+    override def beforeWork(task: TaskId[?]): Unit = {
       reporters foreach { _.beforeWork(task) }
     }
-    override def afterWork[A](task: F[A], result: Either[F[A], Result[A]]): Unit = {
+    override def afterWork[A](task: TaskId[A], result: Either[TaskId[A], Result[A]]): Unit = {
       reporters foreach { _.afterWork(task, result) }
     }
-    override def afterCompleted[A](task: F[A], result: Result[A]): Unit = {
+    override def afterCompleted[A](task: TaskId[A], result: Result[A]): Unit = {
       reporters foreach { _.afterCompleted(task, result) }
     }
-    override def afterAllCompleted(results: RMap[F, Result]): Unit = {
+    override def afterAllCompleted(results: RMap[TaskId, Result]): Unit = {
       reporters foreach { _.afterAllCompleted(results) }
     }
     override def stop(): Unit = {

--- a/tasks/src/main/scala/sbt/Incomplete.scala
+++ b/tasks/src/main/scala/sbt/Incomplete.scala
@@ -11,6 +11,7 @@ import scala.collection.mutable.ListBuffer
 
 import sbt.internal.util.IDSet
 import Incomplete.{ Error, Value => IValue }
+import scala.jdk.CollectionConverters.*
 
 /**
  * Describes why a task did not complete.
@@ -45,7 +46,6 @@ object Incomplete extends Enumeration {
   def transformTD(i: Incomplete)(f: Incomplete => Incomplete): Incomplete = transform(i, true)(f)
   def transformBU(i: Incomplete)(f: Incomplete => Incomplete): Incomplete = transform(i, false)(f)
   def transform(i: Incomplete, topDown: Boolean)(f: Incomplete => Incomplete): Incomplete = {
-    import collection.JavaConverters._
     val visited: collection.mutable.Map[Incomplete, Incomplete] =
       (new java.util.IdentityHashMap[Incomplete, Incomplete]).asScala
     def visit(inc: Incomplete): Incomplete =

--- a/tasks/src/main/scala/sbt/Node.scala
+++ b/tasks/src/main/scala/sbt/Node.scala
@@ -17,11 +17,11 @@ import sbt.internal.util.AList
  * @tparam A
  *   the type computed by this node
  */
-private[sbt] trait Node[Effect[_], A]:
+private[sbt] trait Node[A]:
   type K[L[x]]
-  def in: K[Effect]
+  def in: K[TaskId]
   def alist: AList[K]
 
   /** Computes the result of this task given the results from the inputs. */
-  def work(inputs: K[Result]): Either[Effect[A], A]
+  def work(inputs: K[Result]): Either[TaskId[A], A]
 end Node

--- a/tasks/src/main/scala/sbt/TaskId.scala
+++ b/tasks/src/main/scala/sbt/TaskId.scala
@@ -1,0 +1,6 @@
+package sbt
+
+import sbt.internal.util.AttributeMap
+
+trait TaskId[A]:
+  def tags: ConcurrentRestrictions.TagMap


### PR DESCRIPTION
This is an alternative of #7442 that should address https://github.com/sbt/sbt/pull/7442#discussion_r1406643948

Instead of using `Task[A]` directly, `Execute` uses a newly introduced `trait TaskId[A]`. So `Task[A]` is still not accessible from `Execute`.