### PR TITLE
Include `managedSources` in `packageSrc`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1719,11 +1719,11 @@ object Defaults extends BuildCommon {
   // drop base directories, since there are no valid mappings for these
   def sourceMappings: Initialize[Task[Seq[(File, String)]]] =
     Def.task {
-      val sdirs = unmanagedSourceDirectories.value
+      val sdirs = unmanagedSourceDirectories.value ++ managedSourceDirectories.value
       val base = baseDirectory.value
       val relative = (f: File) => relativeTo(sdirs)(f).orElse(relativeTo(base)(f)).orElse(flat(f))
       val exclude = Set(sdirs, base)
-      unmanagedSources.value.flatMap {
+      (unmanagedSources.value ++ managedSources.value).flatMap {
         case s if !exclude(s) => relative(s).map(s -> _)
         case _                => None
       }


### PR DESCRIPTION
Fixes #2205, https://github.com/sbt/zinc/issues/140

### Validating the PR

Before the fix
```
❯ jar tf /Users/jiahuitan/.ivy2/local/org.scala-sbt/compiler-interface/1.9.0-SNAPSHOT/srcs/compiler-interface-sources.jar
META-INF/MANIFEST.MF
xsbti/
xsbti/api/
xsbti/compile/
xsbti/compile/analysis/
xsbti/AnalysisCallback.java
xsbti/AnalysisCallback2.java
xsbti/ArtifactInfo.java
xsbti/BasicVirtualFileRef.java
xsbti/CompileCancelled.java
xsbti/CompileFailed.java
xsbti/FileConverter.java
xsbti/InteractiveConsoleFactory.java
xsbti/InteractiveConsoleInterface.java
xsbti/InteractiveConsoleResponse.java
xsbti/InteractiveConsoleResult.java
xsbti/PathBasedFile.java
xsbti/Reporter.java
xsbti/UseScope.java
xsbti/VirtualDirectory.java
xsbti/VirtualFile.java
xsbti/VirtualFileRef.java
xsbti/VirtualFileWrite.java
xsbti/api/AbstractLazy.java
xsbti/api/Lazy.java
xsbti/api/Modifiers.java
xsbti/api/SafeLazy.java
xsbti/compile/APIChange.java
xsbti/compile/AnalysisContents.java
xsbti/compile/AnalysisStore.java
xsbti/compile/AuxiliaryClassFiles.java
xsbti/compile/CachedCompiler.java
xsbti/compile/CachedCompilerProvider.java
xsbti/compile/Changes.java
xsbti/compile/ClassFileManager.java
xsbti/compile/CompileAnalysis.java
xsbti/compile/CompileOrder.java
xsbti/compile/CompileProgress.java
xsbti/compile/CompilerBridgeProvider.java
xsbti/compile/CompilerInterface2.java
xsbti/compile/ConsoleInterface1.java
xsbti/compile/DefaultExternalHooks.java
xsbti/compile/DefinesClass.java
xsbti/compile/DependencyChanges.java
xsbti/compile/ExternalHooks.java
xsbti/compile/GlobalsCache.java
xsbti/compile/IncToolOptionsUtil.java
xsbti/compile/IncrementalCompiler.java
xsbti/compile/InitialChanges.java
xsbti/compile/InvalidationProfiler.java
xsbti/compile/JavaCompiler.java
xsbti/compile/JavaTool.java
xsbti/compile/JavaTools.java
xsbti/compile/Javadoc.java
xsbti/compile/MultipleOutput.java
xsbti/compile/Output.java
xsbti/compile/OutputGroup.java
xsbti/compile/PerClasspathEntryLookup.java
xsbti/compile/RunProfiler.java
xsbti/compile/ScalaCompiler.java
xsbti/compile/ScalaInstance.java
xsbti/compile/ScaladocInterface1.java
xsbti/compile/ScaladocInterface2.java
xsbti/compile/SingleOutput.java
xsbti/compile/UsedName.java
xsbti/compile/WrappedClassFileManager.java
xsbti/compile/analysis/Compilation.java
xsbti/compile/analysis/ReadCompilations.java
xsbti/compile/analysis/ReadSourceInfos.java
xsbti/compile/analysis/ReadStamps.java
xsbti/compile/analysis/SourceInfo.java
xsbti/compile/analysis/Stamp.java
```

After the fix (tested via using a snapshot version of sbt build against the PR branch, then running `publishLocal` on zinc repo.)

```
jar tf /Users/jiahuitan/.ivy2/local/org.scala-sbt/compiler-interface/1.9.0-SNAPSHOT/srcs/compiler-interface-sources.jar
META-INF/MANIFEST.MF
xsbti/
xsbti/api/
xsbti/compile/
xsbti/compile/analysis/
xsbti/AnalysisCallback.java
xsbti/AnalysisCallback2.java
xsbti/ArtifactInfo.java
xsbti/BasicVirtualFileRef.java
xsbti/CompileCancelled.java
xsbti/CompileFailed.java
xsbti/FileConverter.java
xsbti/InteractiveConsoleFactory.java
xsbti/InteractiveConsoleInterface.java
xsbti/InteractiveConsoleResponse.java
xsbti/InteractiveConsoleResult.java
xsbti/PathBasedFile.java
xsbti/Reporter.java
xsbti/UseScope.java
xsbti/VirtualDirectory.java
xsbti/VirtualFile.java
xsbti/VirtualFileRef.java
xsbti/VirtualFileWrite.java
xsbti/api/AbstractLazy.java
xsbti/api/Access.java
xsbti/api/AnalyzedClass.java
xsbti/api/Annotated.java
xsbti/api/Annotation.java
xsbti/api/AnnotationArgument.java
xsbti/api/ClassDefinition.java
xsbti/api/ClassLike.java
xsbti/api/ClassLikeDef.java
xsbti/api/Companions.java
xsbti/api/Constant.java
xsbti/api/Def.java
xsbti/api/Definition.java
xsbti/api/DefinitionType.java
xsbti/api/DependencyContext.java
xsbti/api/EmptyType.java
xsbti/api/Existential.java
xsbti/api/ExternalDependency.java
xsbti/api/FieldLike.java
xsbti/api/Id.java
xsbti/api/IdQualifier.java
xsbti/api/InternalDependency.java
xsbti/api/Lazy.java
xsbti/api/MethodParameter.java
xsbti/api/Modifiers.java
xsbti/api/NameHash.java
xsbti/api/Package.java
xsbti/api/ParameterList.java
xsbti/api/ParameterModifier.java
xsbti/api/ParameterRef.java
xsbti/api/Parameterized.java
xsbti/api/ParameterizedDefinition.java
xsbti/api/Path.java
xsbti/api/PathComponent.java
xsbti/api/Polymorphic.java
xsbti/api/Private.java
xsbti/api/Projection.java
xsbti/api/Protected.java
xsbti/api/Public.java
xsbti/api/Qualified.java
xsbti/api/Qualifier.java
xsbti/api/SafeLazy.java
xsbti/api/Singleton.java
xsbti/api/Structure.java
xsbti/api/Super.java
xsbti/api/This.java
xsbti/api/ThisQualifier.java
xsbti/api/Type.java
xsbti/api/TypeAlias.java
xsbti/api/TypeDeclaration.java
xsbti/api/TypeMember.java
xsbti/api/TypeParameter.java
xsbti/api/Unqualified.java
xsbti/api/Val.java
xsbti/api/Var.java
xsbti/api/Variance.java
xsbti/compile/APIChange.java
xsbti/compile/AnalysisContents.java
xsbti/compile/AnalysisStore.java
xsbti/compile/AuxiliaryClassFiles.java
xsbti/compile/CachedCompiler.java
xsbti/compile/CachedCompilerProvider.java
xsbti/compile/Changes.java
xsbti/compile/ClassFileManager.java
xsbti/compile/ClassFileManagerType.java
xsbti/compile/ClasspathOptions.java
xsbti/compile/CompileAnalysis.java
xsbti/compile/CompileOptions.java
xsbti/compile/CompileOrder.java
xsbti/compile/CompileProgress.java
xsbti/compile/CompileResult.java
xsbti/compile/CompilerBridgeProvider.java
xsbti/compile/CompilerInterface2.java
xsbti/compile/Compilers.java
xsbti/compile/ConsoleInterface1.java
xsbti/compile/DefaultExternalHooks.java
xsbti/compile/DefinesClass.java
xsbti/compile/DeleteImmediatelyManagerType.java
xsbti/compile/DependencyChanges.java
xsbti/compile/ExternalHooks.java
xsbti/compile/FileHash.java
xsbti/compile/GlobalsCache.java
xsbti/compile/IncOptions.java
xsbti/compile/IncToolOptions.java
xsbti/compile/IncToolOptionsUtil.java
xsbti/compile/IncrementalCompiler.java
xsbti/compile/InitialChanges.java
xsbti/compile/Inputs.java
xsbti/compile/InvalidationProfiler.java
xsbti/compile/JavaCompiler.java
xsbti/compile/JavaTool.java
xsbti/compile/JavaTools.java
xsbti/compile/Javadoc.java
xsbti/compile/MiniOptions.java
xsbti/compile/MiniSetup.java
xsbti/compile/MultipleOutput.java
xsbti/compile/Output.java
xsbti/compile/OutputGroup.java
xsbti/compile/PerClasspathEntryLookup.java
xsbti/compile/PreviousResult.java
xsbti/compile/RunProfiler.java
xsbti/compile/ScalaCompiler.java
xsbti/compile/ScalaInstance.java
xsbti/compile/ScaladocInterface1.java
xsbti/compile/ScaladocInterface2.java
xsbti/compile/Setup.java
xsbti/compile/SingleOutput.java
xsbti/compile/TransactionalManagerType.java
xsbti/compile/UsedName.java
xsbti/compile/WrappedClassFileManager.java
xsbti/compile/analysis/Compilation.java
xsbti/compile/analysis/ReadCompilations.java
xsbti/compile/analysis/ReadSourceInfos.java
xsbti/compile/analysis/ReadStamps.java
xsbti/compile/analysis/SourceInfo.java
xsbti/compile/analysis/Stamp.java
```