### PR TITLE
Fix compile error in `VirtualFileValueCache`

### DIFF
--- a/main/src/main/scala/sbt/internal/VirtualFileValueCache.scala
+++ b/main/src/main/scala/sbt/internal/VirtualFileValueCache.scala
@@ -32,8 +32,10 @@ object VirtualFileValueCache {
     }
   }
   def apply[A](converter: FileConverter)(f: VirtualFile => A): VirtualFileValueCache[A] = {
-    import collection.mutable.{ HashMap, Map }
-    val stampCache: Map[VirtualFileRef, (Long, XStamp)] = new HashMap
+    import collection.concurrent.Map
+    import java.util.concurrent.ConcurrentHashMap
+    import scala.collection.JavaConverters._
+    val stampCache: Map[VirtualFileRef, (Long, XStamp)] = new ConcurrentHashMap().asScala
     make(
       Stamper.timeWrap(stampCache, converter, {
         case (vf: VirtualFile) => Stamper.forContentHash(vf)


### PR DESCRIPTION
Fix the [CI failure](https://github.com/sbt/sbt/actions/runs/7381647063/job/20080415216?pr=7470) due to https://github.com/sbt/zinc/pull/1317

