### PR TITLE
Use the publisher interface for publishing as default

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3665,7 +3665,8 @@ object Classpaths {
           val conf = config.value
           val log = streams.value.log
           val module = ivyModule.value
-          IvyActions.publish(module, conf, log)
+          val publisherInterface = publisher.value
+          publisherInterface.publish(module, conf, log)
         }
       }
       .tag(Tags.Publish, Tags.Network)


### PR DESCRIPTION
Today I realized, that just configuring a publisher is not enough to actually use it. So I wanted to propose, to use always the configured one, which defaults to the same, so nobody has to overwrite the publish task itself, to use a custom PublisherInterface.

Please leave some feedback, because I am not sure, if this is wanted or if the PR is correctly set up.