### PR TITLE
Resolve `scripted-sbt-redux` to run scripted

### DIFF
--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -79,6 +79,7 @@ object ScriptedPlugin extends AutoPlugin {
         )
       case Some((2, _)) =>
         Seq(
+          "org.scala-sbt" %% "scripted-sbt-redux" % scriptedSbt.value % ScriptedConf,
           "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % ScriptedLaunchConf
         )
       case Some((x, y)) => sys error s"Unknown sbt version ${scriptedSbt.value} ($x.$y)"


### PR DESCRIPTION
Previously, in sbt 2, the Scripted plugin was not resolving any module that would provide it with the `ScriptedTests` object, and could therefore not run scripted tests.

With this patch, `scripted-sbt-redux` will be resolved and added to the classloader that's used to load `sbt.scriptedtest.ScriptedTests`.