### PR TITLE
[sbt 2] Remove usage of Manifest in Structure.scala

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -388,18 +388,15 @@ object Index {
   )(label: AttributeKey[_] => String): Map[String, AttributeKey[_]] = {
     val multiMap = settings.groupBy(label)
     val duplicates = multiMap.iterator
-      .collect { case (k, xs) if xs.size > 1 => (k, xs.map(_.manifest)) }
-      .collect {
-        case (k, xs) if xs.size > 1 => (k, xs)
-      }
+      .collect { case (k, xs) if xs.size > 1 => (k, xs.map(_.tag)) }
+      .collect { case (k, xs) if xs.size > 1 => (k, xs) }
       .toVector
     if duplicates.isEmpty then multiMap.collect { case (k, v) if validID(k) => (k, v.head) }.toMap
     else
-      sys.error(
-        duplicates map { case (k, tps) =>
-          "'" + k + "' (" + tps.mkString(", ") + ")"
-        } mkString ("Some keys were defined with the same name but different types: ", ", ", "")
-      )
+      val duplicateStr = duplicates
+        .map { case (k, tps) => s"'$k' (${tps.mkString(", ")})" }
+        .mkString(",")
+      sys.error(s"Some keys were defined with the same name but different types: $duplicateStr")
   }
 
   private[this] type TriggerMap = collection.mutable.HashMap[TaskId[?], Seq[TaskId[?]]]

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -56,7 +56,7 @@ object Previous {
     // private[sbt] def task: ScopedKey[Task[T]] = key.task
 
     lazy val stamped: JsonFormat[T] =
-      StampedFormat.withStamp(key.task.key.manifest.toString)(format)
+      StampedFormat.withStamp(key.task.key.tag.toString)(format)
 
     def setTask(newTask: ScopedKey[Task[T]]) = new Referenced(newTask, format)
     private[sbt] def read(streams: Streams): Option[T] =

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -736,7 +736,7 @@ import Scoped.extendScoped
 /** Constructs InputKeys, which are associated with input tasks to define a setting. */
 object InputKey:
   private given [A: ClassTag]: KeyTag[InputTask[A]] =
-    KeyTag.Task(summon[ClassTag[A]].runtimeClass)
+    KeyTag.InputTask(summon[ClassTag[A]].runtimeClass)
 
   def apply[A1: ClassTag](label: String): InputKey[A1] =
     apply[A1](label, "", KeyRanks.DefaultInputRank)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -440,14 +440,14 @@ object BuiltinCommands {
 
   private[this] def quiet[T](t: => T): Option[T] =
     try Some(t)
-    catch { case _: Exception => None }
+    catch case _: Exception => None
 
   def settingsCommand: Command =
     showSettingLike(
       SettingsCommand,
       settingsPreamble,
       KeyRanks.MainSettingCutoff,
-      key => !isTask(key.manifest)
+      key => key.tag.isSetting
     )
 
   def tasks: Command =
@@ -455,7 +455,7 @@ object BuiltinCommands {
       TasksCommand,
       tasksPreamble,
       KeyRanks.MainTaskCutoff,
-      key => isTask(key.manifest)
+      key => key.tag.isTaskOrInputTask
     )
 
   def showSettingLike(
@@ -517,11 +517,6 @@ object BuiltinCommands {
   def sortByRank(keys: Seq[AttributeKey[_]]): Seq[AttributeKey[_]] = keys.sortBy(_.rank)
   def withDescription(keys: Seq[AttributeKey[_]]): Seq[AttributeKey[_]] =
     keys.filter(_.description.isDefined)
-
-  def isTask(
-      mf: ClassTag[_]
-  )(using taskMF: ClassTag[Task[_]], inputMF: ClassTag[InputTask[_]]): Boolean =
-    mf.runtimeClass == taskMF.runtimeClass || mf.runtimeClass == inputMF.runtimeClass
 
   def topNRanked(n: Int) = (keys: Seq[AttributeKey[_]]) => sortByRank(keys).take(n)
 

--- a/main/src/main/scala/sbt/internal/server/SettingQuery.scala
+++ b/main/src/main/scala/sbt/internal/server/SettingQuery.scala
@@ -104,7 +104,7 @@ object SettingQuery {
   def getJsonWriter[A](key: AttributeKey[A]): Either[String, JsonWriter[A]] =
     key.optJsonWriter match {
       case SomeJsonWriter(jw) => Right(jw)
-      case NoJsonWriter()     => Left(s"JsonWriter for ${key.manifest} not found")
+      case NoJsonWriter()     => Left(s"JsonWriter for ${key.tag} not found")
     }
 
   def toJson[A: JsonWriter](x: A): JValue = Converter toJsonUnsafe x
@@ -128,7 +128,7 @@ object SettingQuery {
     for {
       key <- key
       json <- getSettingJsonValue(structure, key)
-    } yield SettingQuerySuccess(json, key.key.manifest.toString)
+    } yield SettingQuerySuccess(json, key.key.tag.toString)
   }
 
   def handleSettingQuery(req: SettingQuery, structure: BuildStructure): SettingQueryResponse =


### PR DESCRIPTION
I introduce `KeyTag` to convey information about the nature of the attribute - a setting, a task, an input task - and its type argument. We don't need to coerce any `scala.reflect.Manifest` anymore.