### PR TITLE
[2.x] Miscellaneous cleanup

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
@@ -76,7 +76,9 @@ trait Cont:
       given qctx.type = qctx
       Expr
         .summon[Applicative[F]]
-        .getOrElse(sys.error(s"Applicative[F] not found for ${TypeRepr.of[F].typeSymbol}"))
+        .getOrElse(
+          report.errorAndAbort(s"Applicative[F] not found for ${TypeRepr.of[F].typeSymbol}")
+        )
 
     /**
      * Implementation of a macro that provides a direct syntax for applicative functors and monads.

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala
@@ -377,6 +377,7 @@ trait ParserMain {
 
   implicit def literalRichCharParser(c: Char): RichParser[Char] = richParser(c)
   implicit def literalRichStringParser(s: String): RichParser[String] = richParser(s)
+  extension (s: String) def *(n: Int): String = augmentString(s).*(n)
 
   /**
    * Construct a parser that is valid, but has no valid result. This is used as a way to provide a

--- a/internal/util-complete/src/test/scala/ParserTest.scala
+++ b/internal/util-complete/src/test/scala/ParserTest.scala
@@ -8,8 +8,6 @@
 package sbt.internal.util
 package complete
 
-import scala.collection.StringOps
-
 object JLineTest {
   import DefaultParsers._
 
@@ -155,12 +153,12 @@ object ParserExample {
     val an = repeat(a, min = n, max = n)
     val ann = aqn ~ an
 
-    def r = apply(ann)(new StringOps("a") * (n * 2)).resultEmpty
+    def r = apply(ann)("a" * (n * 2)).resultEmpty
     println(r.isValid)
   }
   def run2(n: Int): Unit = {
     val ab = "ab".?.*
-    val r = apply(ab)(new StringOps("a") * n).resultEmpty
+    val r = apply(ab)("a" * n).resultEmpty
     println(r)
   }
 }

--- a/main-command/src/main/scala/sbt/CommandUtil.scala
+++ b/main-command/src/main/scala/sbt/CommandUtil.scala
@@ -9,7 +9,6 @@ package sbt
 
 import java.io.File
 import java.util.regex.{ Pattern, PatternSyntaxException }
-import scala.collection.immutable.StringOps
 
 import sbt.internal.util.AttributeKey
 import sbt.internal.util.complete.Parser
@@ -43,7 +42,7 @@ object CommandUtil {
       for ((a, b) <- in) yield pre + fill(a, width) + sep + b
     }
 
-  def fill(s: String, size: Int): String = s + StringOps(" ") * math.max(size - s.length, 0)
+  def fill(s: String, size: Int): String = s + " " * math.max(size - s.length, 0)
 
   def withAttribute[T](s: State, key: AttributeKey[T], ifMissing: String)(f: T => State): State =
     s get key match {

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -13,13 +13,12 @@ import sbt.internal.util.complete.Parser
 
 object MultiParserSpec {
   val parser: Parser[Seq[String]] = BasicCommands.multiParserImpl(None)
-  implicit class StringOps(val s: String) {
+  extension (s: String)
     def parse: Seq[String] = Parser.parse(s, parser) match {
       case Right(x) => x
       case Left(x)  => sys.error(s)
     }
     def parseEither: Either[String, Seq[String]] = Parser.parse(s, parser)
-  }
 }
 import sbt.MultiParserSpec._
 class MultiParserSpec extends AnyFlatSpec {

--- a/main-settings/src/main/scala/sbt/InputTask.scala
+++ b/main-settings/src/main/scala/sbt/InputTask.scala
@@ -10,7 +10,7 @@ package sbt
 import sbt.internal.util.complete.Parser
 import Def.{ Initialize, ScopedKey }
 import std.TaskExtra._
-import sbt.internal.util.{ ~>, AttributeKey, Types }
+import sbt.internal.util.{ AttributeKey, Types }
 import sbt.internal.util.Types._
 import sbt.internal.util.Util._
 import sbt.util.Applicative

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -92,15 +92,12 @@ sealed abstract class SettingKey[A1]
   final inline def ++=[A2](inline vs: A2)(using Append.Values[A1, A2]): Setting[A1] =
     appendN(settingMacro[A2](vs))
 
-  final def appendN[V](vs: Initialize[V])(using
-      ev: Append.Values[A1, V]
-  ): Setting[A1] = make(vs)(ev.appendValues)
+  final def appendN[V](vs: Initialize[V])(using ev: Append.Values[A1, V]): Setting[A1] =
+    make(vs)(ev.appendValues)
 
-  final inline def <+=[A2](inline v: Initialize[A2]): Setting[A1] =
-    ${ TaskMacro.fakeSettingAppend1Position[A1, A2]('v) }
+  final inline def <+=[A2](v: Initialize[A2]): Setting[A1] = ${ TaskMacro.fakeAppend1Impl }
 
-  final inline def <++=[A2](inline vs: Initialize[A2]): Setting[A1] =
-    ${ TaskMacro.fakeSettingAppendNPosition[A1, A2]('vs) }
+  final inline def <++=[A2](vs: Initialize[A2]): Setting[A1] = ${ TaskMacro.fakeAppendNImpl }
 
   final inline def -=[A2](inline v: A2)(using Remove.Value[A1, A2]): Setting[A1] =
     remove1(settingMacro[A2](v))
@@ -172,11 +169,11 @@ sealed abstract class TaskKey[A1]
       ev: Append.Values[A1, A2]
   ): Setting[Task[A1]] = make(vs)(ev.appendValues)
 
-  inline def <+=[A2](inline v: Initialize[Task[A2]]): Setting[Task[A1]] =
-    ${ TaskMacro.fakeTaskAppend1Position[A1, A2]('v) }
+  inline def <+=[A2](v: Initialize[Task[A2]]): Setting[Task[A1]] =
+    ${ TaskMacro.fakeAppend1Impl }
 
-  inline def <++=[A2](inline vs: Initialize[Task[A2]]): Setting[Task[A1]] =
-    ${ TaskMacro.fakeTaskAppendNPosition[A1, A2]('vs) }
+  inline def <++=[A2](vs: Initialize[Task[A2]]): Setting[Task[A1]] =
+    ${ TaskMacro.fakeAppendNImpl }
 
   final inline def -=[A2](v: A2)(using Remove.Value[A1, A2]): Setting[Task[A1]] =
     remove1[A2](taskMacro[A2](v))
@@ -334,8 +331,7 @@ object Scoped:
     private[sbt] final inline def :==(inline app: A1): Setting[A1] =
       set(Def.valueStrict(app))
 
-    inline def <<=(inline app: Initialize[A1]): Setting[A1] =
-      ${ TaskMacro.fakeSettingAssignImpl('app) }
+    inline def <<=(app: Initialize[A1]): Setting[A1] = ${ TaskMacro.fakeAssignImpl }
 
     /** In addition to creating Def.setting(...), this captures the source position. */
     inline def set(inline app: Initialize[A1]): Setting[A1] =
@@ -479,8 +475,7 @@ object Scoped:
     inline def :=(inline a: A1): Setting[Task[A1]] =
       set(taskMacro(a))
 
-    inline def <<=(inline app: Initialize[Task[A1]]): Setting[Task[A1]] =
-      ${ TaskMacro.fakeItaskAssignPosition[A1]('app) }
+    inline def <<=(app: Initialize[Task[A1]]): Setting[Task[A1]] = ${ TaskMacro.fakeAssignImpl }
 
     /** In addition to creating Def.setting(...), this captures the source position. */
     inline def set(inline app: Initialize[Task[A1]]): Setting[Task[A1]] =

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -10,7 +10,7 @@ package sbt
 import scala.annotation.targetName
 
 import sbt.internal.util.Types.*
-import sbt.internal.util.{ ~>, AttributeKey, Settings, SourcePosition }
+import sbt.internal.util.{ AttributeKey, Settings, SourcePosition }
 import sbt.internal.util.TupleMapExtension.*
 import sbt.util.OptJsonWriter
 import sbt.ConcurrentRestrictions.Tag

--- a/main-settings/src/main/scala/sbt/std/InputConvert.scala
+++ b/main-settings/src/main/scala/sbt/std/InputConvert.scala
@@ -12,7 +12,6 @@ import sbt.internal.util.appmacro.{ Convert, ContextUtil }
 import sbt.internal.util.complete.Parser
 import Def.Initialize
 import sbt.util.Applicative
-import sbt.internal.util.Types.Compose
 import scala.quoted.*
 
 class InputInitConvert[C <: Quotes & scala.Singleton](override val qctx: C, valStart: Int)
@@ -94,7 +93,7 @@ class FullConvert[C <: Quotes & scala.Singleton](override val qctx: C, valStart:
     }
     Converted.success(t.asTerm)
 
-  def appExpr: Expr[Applicative[Compose[Initialize, Task]]] =
+  def appExpr: Expr[Applicative[[a] =>> Initialize[Task[a]]]] =
     '{ FullInstance.initializeTaskMonad }
 end FullConvert
 

--- a/main-settings/src/main/scala/sbt/std/Instances.scala
+++ b/main-settings/src/main/scala/sbt/std/Instances.scala
@@ -10,7 +10,7 @@ package std
 
 import Def.Initialize
 import sbt.util.{ Applicative, Monad }
-import sbt.internal.util.Types.{ const, Compose }
+import sbt.internal.util.Types.const
 import sbt.internal.util.complete.{ DefaultParsers, Parser }
 
 object InitializeInstance:
@@ -28,8 +28,8 @@ end InitializeInstance
 private[std] object ComposeInstance:
   import InitializeInstance.initializeMonad
   val InitInstance = summon[Applicative[Initialize]]
-  val F1F2: Applicative[Compose[Initialize, Task]] =
-    summon[Applicative[Compose[Initialize, Task]]]
+  val F1F2: Applicative[[a] =>> Initialize[Task[a]]] =
+    summon[Applicative[[a] =>> Initialize[Task[a]]]]
 end ComposeInstance
 
 object ParserInstance:
@@ -60,8 +60,8 @@ object FullInstance:
   )
 
   given Monad[Initialize] = InitializeInstance.initializeMonad
-  val F1F2: Applicative[Compose[Initialize, Task]] = ComposeInstance.F1F2
-  given initializeTaskMonad: Monad[Compose[Initialize, Task]] with
+  val F1F2: Applicative[[a] =>> Initialize[Task[a]]] = ComposeInstance.F1F2
+  given initializeTaskMonad: Monad[[a] =>> Initialize[Task[a]]] with
     type F[x] = Initialize[Task[x]]
     override def pure[A1](x: () => A1): Initialize[Task[A1]] = F1F2.pure(x)
     override def ap[A1, A2](ff: Initialize[Task[A1 => A2]])(

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -43,7 +43,7 @@ object TaskMacro:
   final val appendNMigration =
     "`<++=` operator is removed. Try `lhs ++= { x.value }`\n  or see https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html."
   final val assignMigration =
-    """`<<=` operator is removed. Use `key := { x.value }` or `key ~= (old => { newValue })`.
+    """`<<=` operator is removed. Use `key := { x.value }` or `key ~= {old => newValue }`.
       |See https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html""".stripMargin
 
   type F[x] = Initialize[Task[x]]
@@ -105,49 +105,17 @@ object TaskMacro:
   // Error macros (Restligeist)
   // These macros are there just so we can fail old operators like `<<=` and provide useful migration information.
 
-  def fakeSettingAssignImpl[A1: Type](app: Expr[Initialize[A1]])(using
-      qctx: Quotes
-  ): Expr[Setting[A1]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.assignMigration)
+  def errorAndAbort(message: String)(using quotes: Quotes): Nothing =
+    quotes.reflect.report.errorAndAbort(message)
 
-  def fakeSettingAppend1Position[A1: Type, A2: Type](
-      @deprecated("unused", "") v: Expr[Initialize[A2]]
-  )(using
-      qctx: Quotes
-  ): Expr[Setting[A1]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.append1Migration)
+  def fakeAssignImpl(using qctx: Quotes): Nothing =
+    qctx.reflect.report.errorAndAbort(assignMigration)
 
-  def fakeSettingAppendNPosition[A1: Type, A2: Type](
-      @deprecated("unused", "") vs: Expr[Initialize[A2]]
-  )(using
-      qctx: Quotes
-  ): Expr[Setting[A1]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.appendNMigration)
+  def fakeAppend1Impl(using qctx: Quotes): Nothing =
+    qctx.reflect.report.errorAndAbort(append1Migration)
 
-  def fakeItaskAssignPosition[A1: Type](
-      @deprecated("unused", "") app: Expr[Initialize[Task[A1]]]
-  )(using qctx: Quotes): Expr[Setting[Task[A1]]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.assignMigration)
-
-  def fakeTaskAppend1Position[A1: Type, A2: Type](
-      @deprecated("unused", "") v: Expr[Initialize[Task[A2]]]
-  )(using
-      qctx: Quotes
-  ): Expr[Setting[Task[A1]]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.append1Migration)
-
-  def fakeTaskAppendNPosition[A1: Type, A2: Type](
-      @deprecated("unused", "") vs: Expr[Initialize[Task[A2]]]
-  )(using
-      qctx: Quotes
-  ): Expr[Setting[Task[A1]]] =
-    import qctx.reflect.*
-    report.errorAndAbort(TaskMacro.appendNMigration)
+  def fakeAppendNImpl(using qctx: Quotes): Nothing =
+    qctx.reflect.report.errorAndAbort(appendNMigration)
 
   // Implementations of <<= macro variations for tasks and settings.
   // These just get the source position of the call site.

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -21,7 +21,7 @@ import sbt.internal.util.appmacro.{
   // MonadInstance
 }
 // import Instance.Transform
-import sbt.internal.util.{ LinePosition, NoPosition, SourcePosition, ~> }
+import sbt.internal.util.{ LinePosition, NoPosition, SourcePosition }
 
 import language.experimental.macros
 import scala.annotation.tailrec

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -46,8 +46,8 @@ import sbt.internal.{
   SettingCompletions,
   SessionSettings
 }
-import sbt.internal.util.{ AttributeKey, AttributeMap, Dag, Relation, Settings, ~> }
-import sbt.internal.util.Types.const // , idFun }
+import sbt.internal.util.{ AttributeKey, AttributeMap, Dag, Relation, Settings }
+import sbt.internal.util.Types.const
 import sbt.internal.util.complete.DefaultParsers
 import sbt.internal.server.ServerHandler
 import sbt.librarymanagement.Configuration

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -22,7 +22,7 @@ import sbt.internal.inc.{ MappedFileConverter, ScalaInstance, ZincLmUtil, ZincUt
 import sbt.internal.server.BuildServerEvalReporter
 import sbt.internal.util.Attributed.data
 import sbt.internal.util.Types.const
-import sbt.internal.util.{ Attributed, Settings, ~> }
+import sbt.internal.util.{ Attributed, Settings }
 import sbt.io.{ GlobFilter, IO, Path }
 import sbt.librarymanagement.ivy.{ InlineIvyConfiguration, IvyDependencyResolution, IvyPaths }
 import sbt.librarymanagement.{ Configuration, Configurations, Resolver }

--- a/main/src/main/scala/sbt/nio/Watch.scala
+++ b/main/src/main/scala/sbt/nio/Watch.scala
@@ -26,7 +26,6 @@ import sbt.util.{ Level, Logger }
 
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.collection.immutable.StringOps
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
@@ -506,9 +505,7 @@ object Watch {
     val opts = distinctOptions(options).sortBy(_.input)
     val alignmentLength = opts.map(_.display.length).max + 1
     val formatted =
-      opts.map(o =>
-        s"${o.display}${StringOps(" ") * (alignmentLength - o.display.length)}: ${o.description}"
-      )
+      opts.map(o => s"${o.display}${" " * (alignmentLength - o.display.length)}: ${o.description}")
     s"Options:\n${formatted.mkString("  ", "\n  ", "")}"
   }
   private def distinctOptions(options: Seq[InputOption]): Seq[InputOption] = {
@@ -539,7 +536,7 @@ object Watch {
       {
         val countStr = s"$count. "
         Some(s"$countStr${waitMessage(project, commands)
-            .mkString(s"\n${StringOps(" ") * countStr.length}")}")
+            .mkString(s"\n${" " * countStr.length}")}")
       }
   }.label("Watched.defaultStartWatch")
 

--- a/sbt-app/src/main/scala/sbt/Import.scala
+++ b/sbt-app/src/main/scala/sbt/Import.scala
@@ -206,7 +206,7 @@ trait Import {
   type UnprintableException = sbt.internal.util.UnprintableException
   val Util = sbt.internal.util.Util
   // val ~> = sbt.internal.util.~>
-  type ~>[-K[_], +V[_]] = sbt.internal.util.~>[K, V]
+  // type ~>[-K[_], +V[_]] = sbt.internal.util.~>[K, V]
 
   // sbt.internal.util.complete
   object complete {

--- a/tasks-standard/src/main/scala/sbt/Task.scala
+++ b/tasks-standard/src/main/scala/sbt/Task.scala
@@ -9,7 +9,7 @@ package sbt
 
 import sbt.internal.Action
 import sbt.internal.util.Types.const
-import sbt.internal.util.{ ~>, AttributeKey, AttributeMap }
+import sbt.internal.util.{ AttributeKey, AttributeMap }
 import ConcurrentRestrictions.{ Tag, TagMap, tagsKey }
 import sbt.util.Monad
 

--- a/tasks-standard/src/main/scala/sbt/std/Transform.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Transform.scala
@@ -9,7 +9,7 @@ package sbt
 package std
 
 import sbt.internal.Action
-import sbt.internal.util.{ ~>, DelegatingPMap, RMap }
+import sbt.internal.util.{ DelegatingPMap, RMap }
 import sbt.internal.util.TupleMapExtension.*
 import TaskExtra.{ all, existToAny }
 import sbt.internal.util.Types.*

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -10,7 +10,7 @@ package sbt
 import java.util.concurrent.ExecutionException
 
 import sbt.internal.util.ErrorHandling.wideConvert
-import sbt.internal.util.{ DelegatingPMap, IDSet, PMap, RMap, ~> }
+import sbt.internal.util.{ DelegatingPMap, IDSet, PMap, RMap }
 import sbt.internal.util.Types.const
 import sbt.internal.util.Util.nilSeq
 

--- a/tasks/src/main/scala/sbt/Result.scala
+++ b/tasks/src/main/scala/sbt/Result.scala
@@ -7,8 +7,6 @@
 
 package sbt
 
-import sbt.internal.util.~>
-
 // used instead of Either[Incomplete, T] for type inference
 
 /** Result of completely evaluating a task. */

--- a/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -89,7 +89,7 @@ trait Init[ScopeType]:
    * This can be useful when dealing with dynamic Initialize values.
    */
   lazy val capturedTransformations: Initialize[[x] => Initialize[x] => Initialize[x]] =
-    TransformCapture(idK[Initialize])
+    TransformCapture([a] => (init: Initialize[a]) => init)
 
   def setting[A1](
       key: ScopedKey[A1],

--- a/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -11,7 +11,6 @@ trait TypeFunctions:
   type Id[X] = X
   type NothingK[X] = Nothing
 
-  sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
   private type AnyLeft[A] = Left[A, Nothing]
   private type AnyRight[A] = Right[Nothing, A]
   final val left: [A] => A => AnyLeft[A] = [A] => (a: A) => Left(a)
@@ -55,16 +54,6 @@ object TypeFunctions extends TypeFunctions:
 
 end TypeFunctions
  */
-
-trait ~>[-F1[_], +F2[_]] { outer =>
-  def apply[A](f1: F1[A]): F2[A]
-  // directly on ~> because of type inference limitations
-  final def ∙[F3[_]](g: F3 ~> F1): F3 ~> F2 = new ~>[F3, F2] {
-    override def apply[A](f3: F3[A]) = outer.apply(g(f3))
-  }
-  final def ∙[C, D](g: C => D)(implicit ev: D <:< F1[D]): C => F2[D] = i => apply(ev(g(i)))
-  lazy val fn: [A] => F1[A] => F2[A] = [A] => (f1: F1[A]) => outer.apply[A](f1)
-}
 
 /*
 object ~> {

--- a/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -11,15 +11,6 @@ trait TypeFunctions:
   type Id[X] = X
   type NothingK[X] = Nothing
 
-  /*
-  import TypeFunctions._
-  sealed trait Const[A] { type Apply[B] = A }
-  sealed trait ConstK[A] { type l[L[x]] = A }
-  type ConstK[A] = [F[_]] =>> A
-   */
-
-  type Compose[F1[_], F2[_]] = [a] =>> F1[F2[a]]
-
   sealed trait ∙[A[_], B[_]] { type l[T] = A[B[T]] }
   private type AnyLeft[A] = Left[A, Nothing]
   private type AnyRight[A] = Right[Nothing, A]
@@ -40,10 +31,6 @@ trait TypeFunctions:
   final def idK[F[_]]: [a] => F[a] => F[a] = [a] =>
     (fa: F[a]) => fa // .setToString("TypeFunctions.idK")
 
-  inline def nestCon[F1[_], F2[_], F3[_]](
-      f: [a] => F1[a] => F2[a]
-  ): [a] => Compose[F1, F3][a] => Compose[F2, F3][a] =
-    f.asInstanceOf[[a] => Compose[F1, F3][a] => Compose[F2, F3][a]]
 end TypeFunctions
 
 /*

--- a/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -11,54 +11,13 @@ trait TypeFunctions:
   type Id[X] = X
   type NothingK[X] = Nothing
 
-  private type AnyLeft[A] = Left[A, Nothing]
-  private type AnyRight[A] = Right[Nothing, A]
-  final val left: [A] => A => AnyLeft[A] = [A] => (a: A) => Left(a)
+  final val left: [A] => A => Left[A, Nothing] = [A] => (a: A) => Left(a)
 
-  final val right: [A] => A => AnyRight[A] = [A] => (a: A) => Right(a)
+  final val right: [A] => A => Right[Nothing, A] = [A] => (a: A) => Right(a)
 
   final val some: [A] => A => Some[A] = [A] => (a: A) => Some(a)
-  // Id ~> Left[*, Nothing] =
-  // λ[Id ~> AnyLeft](Left(_)).setToString("TypeFunctions.left")
-  // final val right: Id ~> Right[Nothing, *] =
-  //   λ[Id ~> AnyRight](Right(_)).setToString("TypeFunctions.right")
-  // final val some: Id ~> Some[*] = λ[Id ~> Some](Some(_)).setToString("TypeFunctions.some")
 
-  final def idFun[A]: A => A = ((a: A) => a) // .setToString("TypeFunctions.id")
-  final def const[A, B](b: B): A => B = ((_: A) => b) // .setToString(s"TypeFunctions.const($b)")
-
-  final def idK[F[_]]: [a] => F[a] => F[a] = [a] =>
-    (fa: F[a]) => fa // .setToString("TypeFunctions.idK")
+  final def idFun[A]: A => A = ((a: A) => a)
+  final def const[A, B](b: B): A => B = ((_: A) => b)
 
 end TypeFunctions
-
-/*
-object TypeFunctions extends TypeFunctions:
-
-  private implicit class Ops[T[_], R[_]](val underlying: T ~> R) extends AnyVal {
-    def setToString(string: String): T ~> R = new (T ~> R) {
-      override def apply[U](a: T[U]): R[U] = underlying(a)
-      override def toString: String = string
-      override def equals(o: Any): Boolean = underlying.equals(o)
-      override def hashCode: Int = underlying.hashCode
-    }
-  }
-  private implicit class FunctionOps[A, B](val f: A => B) extends AnyVal {
-    def setToString(string: String): A => B = new (A => B) {
-      override def apply(a: A): B = f(a)
-      override def toString: String = string
-      override def equals(o: Any): Boolean = f.equals(o)
-      override def hashCode: Int = f.hashCode
-    }
-  }
-
-end TypeFunctions
- */
-
-/*
-object ~> {
-  import TypeFunctions._
-  val Id: Id ~> Id = idK[Id]
-  implicit def tcIdEquals: Id ~> Id = Id
-}
- */

--- a/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/TypeFunctions.scala
@@ -44,12 +44,6 @@ trait TypeFunctions:
       f: [a] => F1[a] => F2[a]
   ): [a] => Compose[F1, F3][a] => Compose[F2, F3][a] =
     f.asInstanceOf[[a] => Compose[F1, F3][a] => Compose[F2, F3][a]]
-
-  /*
-  type Endo[T] = T => T
-  type ~>|[A[_], B[_]] = A ~> Compose[Option, B]#Apply
-   */
-  type ~>|[F1[_], F2[_]] = [A] => F1[A] => Option[F2[A]]
 end TypeFunctions
 
 /*


### PR DESCRIPTION
1. Remove unnecessary definitions in `TypeFunctions`: `~>|`, `Composite`, ` ~>`, `idK`
2. Fix resolution of `*` on `String`
3. Use `report.errorAndAbort` instead of `sys.error`
4. Shorten fake task macro impl