### PR TITLE
JLine 3.27.0 (was 3.24.1) for sbt 1.10.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,7 +87,7 @@ object Dependencies {
   // JLine 3 version must be coordinated together with JAnsi version
   // and the JLine 2 fork version, which uses the same JAnsi
   val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79"
-  val jline3Version = "3.24.1"
+  val jline3Version = "3.26.3"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
   val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,7 +87,7 @@ object Dependencies {
   // JLine 3 version must be coordinated together with JAnsi version
   // and the JLine 2 fork version, which uses the same JAnsi
   val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79"
-  val jline3Version = "3.26.3"
+  val jline3Version = "3.27.0"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
   val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version


### PR DESCRIPTION
wdyt @eed3si9n might it be this simple?

at https://github.com/jline/jline3/releases/tag/jline-parent-3.25.0 it says: "Merge Jansi library into JLine" and I'm unclear on whether that's somehow problematic for us here.

fyi @hamzaremmal

if this works out I can forward-port to `develop` branch, of course.