### PR TITLE
[sbt2] Reactivate checkTargets in Load

### DIFF
--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -357,31 +357,6 @@ trait ProjectExtra extends Scoped.Syntax:
     def setCond[T](key: AttributeKey[T], vopt: Option[T], attributes: AttributeMap): AttributeMap =
       attributes.setCond(key, vopt)
 
-    private[sbt] def checkTargets(data: Settings[Scope]): Option[String] =
-      val dups = overlappingTargets(allTargets(data))
-      if (dups.isEmpty) None
-      else {
-        val dupStrs = dups map { case (dir, scopes) =>
-          s"${dir.getAbsolutePath}:\n\t${scopes.mkString("\n\t")}"
-        }
-        Some(s"Overlapping output directories:${dupStrs.mkString}")
-      }
-
-    private[this] def overlappingTargets(
-        targets: Seq[(ProjectRef, File)]
-    ): Map[File, Seq[ProjectRef]] =
-      targets.groupBy(_._2).view.filter(_._2.size > 1).mapValues(_.map(_._1)).toMap
-
-    private[this] def allTargets(data: Settings[Scope]): Seq[(ProjectRef, File)] = {
-      import ScopeFilter._
-      val allProjects = ScopeFilter(Make.inAnyProject)
-      val targetAndRef = Def.setting { (Keys.thisProjectRef.value, Keys.target.value) }
-      new SettingKeyAll(Def.optional(targetAndRef)(identity))
-        .all(allProjects)
-        .evaluate(data)
-        .flatMap(x => x)
-    }
-
     private[sbt] def equalKeys(a: ScopedKey[_], b: ScopedKey[_], mask: ScopeMask): Boolean =
       a.key == b.key && Scope.equal(a.scope, b.scope, mask)
 

--- a/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/build.sbt
@@ -13,22 +13,13 @@ def commonSettings: Seq[Def.Setting[_]] =
     resolvers += MavenCache("local-maven", (LocalRootProject / target).value / "local-maven"),
   )
 
-lazy val root = (project in file("."))
-  .settings(commonSettings)
-
-val `v1-0-0` = (project in file("v1.0.0"))
+val semverSpecTest = project
   .settings(commonSettings)
   .settings(
     name := "semver-spec-test",
     version := "1.0.0",
   )
 
-val `v1-1-0` = (project in file("v1.1.0"))
-  .settings(commonSettings)
-  .settings(
-    name := "semver-spec-test",
-    version := "1.1.0",
-  )
 
 val middle = project
   .settings(commonSettings)

--- a/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/test
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/test
@@ -1,5 +1,6 @@
-> v1-0-0/publish
-> v1-1-0/publish
+> semverSpecTest/publish
+> set semverSpecTest/version := "1.1.0"
+> semverSpecTest/publish
 > middle/publish
 
 > use/check

--- a/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/v1.0.0/LibraryTest.scala
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/v1.0.0/LibraryTest.scala
@@ -1,3 +1,0 @@
-package example
-
-trait Foo {}

--- a/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/v1.1.0/LibraryTest.scala
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-semver-spec/v1.1.0/LibraryTest.scala
@@ -1,3 +1,0 @@
-package example
-
-trait Foo {}


### PR DESCRIPTION
`checkTargets` verifies that the target directories of all sub-projects do not overlap.