### PR TITLE
[sbt 2.x] Forward version as the sbt version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -639,6 +639,7 @@ lazy val dependencyTreeProj = (project in file("dependency-tree"))
     sbtPlugin := true,
     baseSettings,
     name := "sbt-dependency-tree",
+    pluginCrossBuild / sbtVersion := version.value,
     publishMavenStyle := true,
     // mimaSettings,
     mimaPreviousArtifacts := Set.empty,


### PR DESCRIPTION
For sbt plugins that's part of sbt/sbt, we actually need to forward `version` as the `pluginCrossBuild / sbtVersion`.
This hasn't really caused the problem previously since we've been using close enough versions.