### PR TITLE
[2.x] Use `fileConverter` in `GrpcActionCacheStore`

### DIFF
--- a/sbt-remote-cache/src/main/scala/sbt/plugins/RemoteCachePlugin.scala
+++ b/sbt-remote-cache/src/main/scala/sbt/plugins/RemoteCachePlugin.scala
@@ -25,6 +25,7 @@ object RemoteCachePlugin extends AutoPlugin:
             clientCertChain = remoteCacheTlsClientCertificate.value.map(_.toPath),
             clientPrivateKey = remoteCacheTlsClientKey.value.map(_.toPath),
             remoteHeaders = remoteCacheHeaders.value.toList,
+            converter = fileConverter.value,
             disk = disk,
           )
           orig ++ Seq(r)

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -51,7 +51,7 @@ object ActionCache:
       val newOutputs = Vector(valueFile) ++ outputs.toVector
       store.put(UpdateActionResultRequest(input, newOutputs, exitCode = 0)) match
         case Right(result) =>
-          store.syncBlobs(result.outputFiles, config.outputDirectory)
+          store.syncBlobs(result.outputFiles)
           newResult
         case Left(e) => throw e
     def valueFromStr(str: String, origin: Option[String]): O =
@@ -65,11 +65,11 @@ object ActionCache:
         // some protocol can embed values into the result
         result.contents.headOption match
           case Some(head) =>
-            store.syncBlobs(result.outputFiles, config.outputDirectory)
+            store.syncBlobs(result.outputFiles)
             val str = String(head.array(), StandardCharsets.UTF_8)
             valueFromStr(str, result.origin)
           case _ =>
-            val paths = store.syncBlobs(result.outputFiles, config.outputDirectory)
+            val paths = store.syncBlobs(result.outputFiles)
             if paths.isEmpty then organicTask
             else valueFromStr(IO.read(paths.head.toFile()), result.origin)
       case Left(_) => organicTask

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -45,7 +45,7 @@ trait ActionCacheStore:
   /**
    * Materialize blobs to the output directory.
    */
-  def syncBlobs(refs: Seq[HashedVirtualFileRef], outputDirectory: Path): Seq[Path]
+  def syncBlobs(refs: Seq[HashedVirtualFileRef]): Seq[Path]
 
   /**
    * Find if blobs are present in the storage.
@@ -101,8 +101,8 @@ class AggregateActionCacheStore(stores: Seq[ActionCacheStore]) extends AbstractA
       val xs = store.putBlobs(blobs)
       if res.isEmpty then xs else res
 
-  override def syncBlobs(refs: Seq[HashedVirtualFileRef], outputDirectory: Path): Seq[Path] =
-    stores.collectFirst2(_.syncBlobs(refs, outputDirectory), refs.size)
+  override def syncBlobs(refs: Seq[HashedVirtualFileRef]): Seq[Path] =
+    stores.collectFirst2(_.syncBlobs(refs), refs.size)
 
   override def findBlobs(refs: Seq[HashedVirtualFileRef]): Seq[HashedVirtualFileRef] =
     stores.collectFirst2(_.findBlobs(refs), refs.size)
@@ -154,7 +154,7 @@ class InMemoryActionCacheStore extends AbstractActionCacheStore:
 
   // we won't keep the blobs in-memory so return Nil
   // to implement this correctly, we'd have to grab the content from the original file
-  override def syncBlobs(refs: Seq[HashedVirtualFileRef], outputDirectory: Path): Seq[Path] =
+  override def syncBlobs(refs: Seq[HashedVirtualFileRef]): Seq[Path] =
     Nil
 
   override def findBlobs(refs: Seq[HashedVirtualFileRef]): Seq[HashedVirtualFileRef] =
@@ -241,7 +241,7 @@ class DiskActionCacheStore(base: Path, fileConverter: FileConverter)
             Some(StringVirtualFile1(r.id, content))
       else None
 
-  override def syncBlobs(refs: Seq[HashedVirtualFileRef], outputDirectory: Path): Seq[Path] =
+  override def syncBlobs(refs: Seq[HashedVirtualFileRef]): Seq[Path] =
     refs.flatMap: ref =>
       val casFile = toCasFile(Digest(ref))
       if casFile.toFile().exists then

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -24,7 +24,7 @@ object ActionCacheTest extends BasicTestSuite:
       val in = StringVirtualFile1(s"$tempDir/a.txt", "foo")
       val hashRefs = cache.putBlobs(in :: Nil)
       assert(hashRefs.size == 1)
-      val actual = cache.syncBlobs(hashRefs, tempDir.toPath()).head
+      val actual = cache.syncBlobs(hashRefs).head
       assert(actual.getFileName().toString() == "a.txt")
 
   test("In-memory cache can hold action value"):


### PR DESCRIPTION
Since #7522 I am using the `fileConverter` in `ActionCacheStore` impls to be able to sync files that are outside of the `out` directory. This was needed by some scripted tests. Otherwise the cache would create files such as `target/out/${BASE}/foo`.