### PR TITLE
[2.x] Fix `dependency-management/force-update-period`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3990,7 +3990,7 @@ object Classpaths {
           fup match
             case None => false
             case Some(period) =>
-              val fullUpdateOutput = cacheDirectory / "out"
+              val fullUpdateOutput = cacheDirectory / "output"
               val now = System.currentTimeMillis
               val diff = now - IO.getModifiedTimeOrZero(fullUpdateOutput)
               val elapsedDuration = new FiniteDuration(diff, TimeUnit.MILLISECONDS)

--- a/sbt-app/src/sbt-test/dependency-management/force-update-period/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/force-update-period/build.sbt
@@ -1,17 +1,19 @@
 ThisBuild / useCoursier := false
 
+name := "force-update-period"
+scalaVersion := "2.12.18"
 libraryDependencies += "log4j" % "log4j" % "1.2.16" % "compile"
-
 autoScalaLibrary := false
 
-crossPaths := false
-
-TaskKey[Unit]("check-last-update-time") := (streams map { (s) =>
-  val fullUpdateOutput = s.cacheDirectory / "out"
-  val timeDiff = System.currentTimeMillis()-fullUpdateOutput.lastModified()
-  val exists = fullUpdateOutput.exists()
-  s.log.info(s"Amount of time since last full update: $timeDiff")
-  if (exists && timeDiff > 5000) {
-    sys.error("Full update not performed")
+TaskKey[Unit]("check-last-update-time") := {
+  val s = streams.value
+  val updateOutput = target.value / "update" / updateCacheName.value / "output"
+  if (!updateOutput.exists()) {
+    sys.error("Update cache does not exist")
   }
-}).value
+  val timeDiff = System.currentTimeMillis() - updateOutput.lastModified()
+  s.log.info(s"Amount of time since last full update: $timeDiff")
+  if (timeDiff > 5000) {
+    sys.error("Update not performed")
+  }
+}

--- a/sbt-app/src/sbt-test/dependency-management/force-update-period/test
+++ b/sbt-app/src/sbt-test/dependency-management/force-update-period/test
@@ -1,8 +1,8 @@
-$ absent target/resolution-cache
+$ absent target/out/jvm/scala-2.12.18/force-update-period/resolution-cache
 > compile
-$ exists target/resolution-cache
+$ exists target/out/jvm/scala-2.12.18/force-update-period/resolution-cache
 > checkLastUpdateTime
-$ sleep 10000
+$ sleep 5000
 > compile
 # This is expected to fail
 -> checkLastUpdateTime


### PR DESCRIPTION
This scripted test was actually not testing what it was supposed to test. And so the `forceUpdatePeriod` is also broken in sbt 1.x (https://github.com/sbt/sbt/issues/6512). I'll backport the fix.