### PR TITLE
[2.x] Report error if output file of a cached task is not in the output directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             java: 8
             distribution: adopt
             jobtype: 7
-          - os: macos-latest
+          - os: macos-12
             java: 8
             distribution: adopt
             jobtype: 8

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -71,7 +71,6 @@ trait ContextUtil[C <: Quotes & scala.Singleton](val valStart: Int):
   ):
     override def toString: String =
       s"Input($tpe, $qual, $term, $name, $tags)"
-
     def isCacheInput: Boolean = tags.nonEmpty
     lazy val tags = extractTags(qual)
     private def extractTags(tree: Term): List[CacheLevelTag] =

--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -17,7 +17,7 @@ import sbt.librarymanagement.ModuleID
 import sbt.util.{ ActionCacheStore, Level }
 import scala.annotation.nowarn
 import scala.concurrent.duration.FiniteDuration
-import xsbti.VirtualFile
+import xsbti.{ FileConverter, VirtualFile }
 
 object BasicKeys {
   val historyPath = AttributeKey[Option[File]](
@@ -118,6 +118,12 @@ object BasicKeys {
       "Build-wide output directory",
       10000
     )
+
+  val fileConverter = AttributeKey[FileConverter](
+    "fileConverter",
+    "The file converter used to convert between Path and VirtualFile",
+    10000
+  )
 
   // Unlike other BasicKeys, this is not used directly as a setting key,
   // and severLog / logLevel is used instead.

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -23,6 +23,7 @@ import sbt.util.Show
 import xsbti.{ HashedVirtualFileRef, VirtualFile }
 import sjsonnew.JsonFormat
 import scala.reflect.ClassTag
+import xsbti.FileConverter
 
 /** A concrete settings system that uses `sbt.Scope` for the scope type. */
 object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
@@ -233,6 +234,7 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
   private[sbt] var _cacheStore: ActionCacheStore = InMemoryActionCacheStore()
   def cacheStore: ActionCacheStore = _cacheStore
   private[sbt] var _outputDirectory: Option[Path] = None
+  private[sbt] var _fileConverter: Option[FileConverter] = None
   private[sbt] val cacheEventLog: CacheEventLog = CacheEventLog()
   def cacheConfiguration: BuildWideCacheConfiguration =
     BuildWideCacheConfiguration(

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -7,7 +7,6 @@
 
 package sbt
 
-import java.nio.file.Path
 import java.net.URI
 
 import scala.annotation.tailrec
@@ -17,13 +16,12 @@ import sbt.Scope.{ GlobalScope, ThisScope }
 import sbt.internal.util.Types.const
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.{ Terminal => ITerminal, * }
-import sbt.util.{ ActionCacheStore, BuildWideCacheConfiguration, InMemoryActionCacheStore }
+import sbt.util.{ ActionCacheStore, AggregateActionCacheStore, BuildWideCacheConfiguration, cacheLevel , DiskActionCacheStore }
 import Util._
 import sbt.util.Show
 import xsbti.{ HashedVirtualFileRef, VirtualFile }
 import sjsonnew.JsonFormat
 import scala.reflect.ClassTag
-import xsbti.FileConverter
 
 /** A concrete settings system that uses `sbt.Scope` for the scope type. */
 object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
@@ -230,18 +228,40 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
 
   import language.experimental.macros
 
+  private[sbt] val isDummyTask = AttributeKey[Boolean](
+    "is-dummy-task",
+    "Internal: used to identify dummy tasks. sbt injects values for these tasks at the start of task execution.",
+    Invisible
+  )
+
+  private[sbt] val (stateKey: TaskKey[State], dummyState: Task[State]) =
+    dummy[State]("state", "Current build state.")
+
+  private[sbt] val (streamsManagerKey, dummyStreamsManager) =
+    Def.dummy[std.Streams[ScopedKey[?]]](
+      "streams-manager",
+      "Streams manager, which provides streams for different contexts."
+    )
+
   // These are here, as opposed to RemoteCache, since we need them from TaskMacro etc
-  private[sbt] var _cacheStore: ActionCacheStore = InMemoryActionCacheStore()
-  def cacheStore: ActionCacheStore = _cacheStore
-  private[sbt] var _outputDirectory: Option[Path] = None
-  private[sbt] var _fileConverter: Option[FileConverter] = None
   private[sbt] val cacheEventLog: CacheEventLog = CacheEventLog()
-  def cacheConfiguration: BuildWideCacheConfiguration =
+  @cacheLevel(include = Array.empty)
+  val cacheConfiguration: Initialize[Task[BuildWideCacheConfiguration]] = Def.task {
+    val state = stateKey.value
+    val outputDirectory = state.get(BasicKeys.rootOutputDirectory)
+    val cacheStore = state
+      .get(BasicKeys.cacheStores)
+      .collect { case xs if xs.nonEmpty => AggregateActionCacheStore(xs) }
+      .getOrElse(DiskActionCacheStore(state.baseDir.toPath.resolve("target/bootcache")))
+    val fileConverter = state.get(BasicKeys.fileConverter)
     BuildWideCacheConfiguration(
-      _cacheStore,
-      _outputDirectory.getOrElse(sys.error("outputDirectory has not been set")),
+      cacheStore,
+      outputDirectory.getOrElse(sys.error("outputDirectory has not been set")),
+      fileConverter.getOrElse(sys.error("outputDirectory has not been set")),
+      state.log,
       cacheEventLog,
     )
+  }
 
   inline def cachedTask[A1: JsonFormat](inline a1: A1): Def.Initialize[Task[A1]] =
     ${ TaskMacro.taskMacroImpl[A1]('a1, cached = true) }
@@ -403,9 +423,9 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
     (TaskKey[A](name, description, DTask), dummyTask(name))
 
   private[sbt] def dummyTask[T](name: String): Task[T] = {
-    import std.TaskExtra.{ task => newTask, toTaskInfo }
-    val base: Task[T] = newTask(
-      sys.error("Dummy task '" + name + "' did not get converted to a full task.")
+    import TaskExtra.toTaskInfo
+    val base: Task[T] = TaskExtra.task(
+      sys.error(s"Dummy task '$name' did not get converted to a full task.")
     )
       .named(name)
     base.copy(info = base.info.set(isDummyTask, true))
@@ -413,21 +433,6 @@ object Def extends Init[Scope] with TaskMacroExtra with InitializeImplicits:
 
   private[sbt] def isDummy(t: Task[_]): Boolean =
     t.info.attributes.get(isDummyTask) getOrElse false
-
-  private[sbt] val isDummyTask = AttributeKey[Boolean](
-    "is-dummy-task",
-    "Internal: used to identify dummy tasks.  sbt injects values for these tasks at the start of task execution.",
-    Invisible
-  )
-
-  private[sbt] val (stateKey: TaskKey[State], dummyState: Task[State]) =
-    dummy[State]("state", "Current build state.")
-
-  private[sbt] val (streamsManagerKey, dummyStreamsManager) =
-    Def.dummy[std.Streams[ScopedKey[?]]](
-      "streams-manager",
-      "Streams manager, which provides streams for different contexts."
-    )
 end Def
 
 // these need to be mixed into the sbt package object

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -37,7 +37,7 @@ import sbt.librarymanagement.ivy.{ Credentials, IvyConfiguration, IvyPaths, Upda
 import sbt.nio.file.Glob
 import sbt.testing.Framework
 import sbt.util.{ cacheLevel, ActionCacheStore, Level, Logger, LoggerContext }
-import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile, VirtualFileRef }
+import xsbti.{ HashedVirtualFileRef, VirtualFile, VirtualFileRef }
 import xsbti.compile._
 import xsbti.compile.analysis.ReadStamps
 
@@ -283,7 +283,7 @@ object Keys {
   private[sbt] val externalHooks = taskKey[ExternalHooks]("The external hooks used by zinc.")
   val auxiliaryClassFiles = taskKey[Seq[AuxiliaryClassFiles]]("The auxiliary class files that must be managed by Zinc (for instance the TASTy files)")
   @cacheLevel(include = Array.empty)
-  val fileConverter = settingKey[FileConverter]("The file converter used to convert between Path and VirtualFile")
+  val fileConverter = SettingKey(BasicKeys.fileConverter)
   val allowMachinePath = settingKey[Boolean]("Allow machine-specific paths during conversion.")
   val reportAbsolutePath = settingKey[Boolean]("Report absolute paths during compilation.")
   val rootPaths = settingKey[Map[String, NioPath]]("The root paths used to abstract machine-specific paths.")

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -951,7 +951,6 @@ object BuiltinCommands {
   def doLoadProject(s0: State, action: LoadAction): State = {
     welcomeBanner(s0)
     checkSBTVersionChanged(s0)
-    RemoteCache.initializeRemoteCache(s0)
     val (s1, base) = Project.loadAction(SessionVar.clear(s0), action)
     IO.createDirectory(base)
     val s2 = if (s1 has Keys.stateCompilerCache) s1 else registerCompilerCache(s1)
@@ -974,7 +973,6 @@ object BuiltinCommands {
       st => setupGlobalFileTreeRepository(addCacheStoreFactoryFactory(st))
     )
     val s4 = s3.put(Keys.useLog4J.key, Project.extract(s3).get(Keys.useLog4J))
-    RemoteCache.initializeRemoteCache(s4)
     addSuperShellParams(CheckBuildSources.init(LintUnused.lintUnusedFunc(s4)))
   }
 

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -57,6 +57,7 @@ import scala.annotation.targetName
 import scala.concurrent.{ Await, TimeoutException }
 import scala.concurrent.duration.*
 import ClasspathDep.*
+import xsbti.FileConverter
 
 /*
 sealed trait Project extends ProjectDefinition[ProjectReference] with CompositeProject {
@@ -322,6 +323,7 @@ trait ProjectExtra extends Scoped.Syntax:
       val hs: Option[Seq[ServerHandler]] = get(ThisBuild / fullServerHandlers)
       val caches: Option[Seq[ActionCacheStore]] = get(cacheStores)
       val rod: Option[NioPath] = get(rootOutputDirectory)
+      val fileConverter: Option[FileConverter] = get(Keys.fileConverter)
       val commandDefs = allCommands.distinct.flatten[Command].map(_ tag (projectCommand, true))
       val newDefinedCommands = commandDefs ++ BasicCommands.removeTagged(
         s.definedCommands,
@@ -349,6 +351,7 @@ trait ProjectExtra extends Scoped.Syntax:
           .setCond(fullServerHandlers.key, hs)
           .setCond(cacheStores.key, caches)
           .setCond(rootOutputDirectory.key, rod)
+          .setCond(BasicKeys.fileConverter, fileConverter)
       s.copy(
         attributes = newAttrs,
         definedCommands = newDefinedCommands

--- a/main/src/main/scala/sbt/RemoteCache.scala
+++ b/main/src/main/scala/sbt/RemoteCache.scala
@@ -34,7 +34,7 @@ import sbt.nio.FileStamp
 import sbt.nio.Keys.{ inputFileStamps, outputFileStamps }
 import sbt.std.TaskExtra._
 import sbt.util.InterfaceUtil.toOption
-import sbt.util.{ ActionCacheStore, AggregateActionCacheStore, DiskActionCacheStore, Logger }
+import sbt.util.{ ActionCacheStore, DiskActionCacheStore, Logger }
 import sjsonnew.JsonFormat
 import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
 import xsbti.compile.CompileAnalysis
@@ -49,16 +49,6 @@ object RemoteCache {
   // TODO: cap with caffeine
   private[sbt] val analysisStore: mutable.Map[HashedVirtualFileRef, CompileAnalysis] =
     mutable.Map.empty
-
-  // TODO: figure out a good timing to initialize cache
-  // currently this is called twice so metabuild can call compile with a minimal setting
-  private[sbt] def initializeRemoteCache(s: State): Unit =
-    Def._outputDirectory = s.get(BasicKeys.rootOutputDirectory)
-    Def._cacheStore = s
-      .get(BasicKeys.cacheStores)
-      .collect { case xs if xs.nonEmpty => AggregateActionCacheStore(xs) }
-      .getOrElse(DiskActionCacheStore((s.baseDir / "target" / "bootcache").toPath))
-    Def._fileConverter = s.get(Keys.fileConverter.key)
 
   private[sbt] def artifactToStr(art: Artifact): String = {
     import LibraryManagementCodec._

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -98,13 +98,12 @@ object Aggregation {
     val roots = ts.map { case KeyValue(k, _) => k }
     val config = extractedTaskConfig(extracted, structure, s)
     val start = System.currentTimeMillis
-    val cacheEventLog = Def.cacheConfiguration.cacheEventLog
-    cacheEventLog.clear()
+    Def.cacheEventLog.clear()
     val (newS, result) = withStreams(structure, s): str =>
       val transform = nodeView(s, str, roots, extra)
       runTask(toRun, s, str, structure.index.triggers, config)(using transform)
     val stop = System.currentTimeMillis
-    val cacheSummary = cacheEventLog.summary
+    val cacheSummary = Def.cacheEventLog.summary
     Complete(start, stop, result, cacheSummary, newS)
 
   def runTasks[A1](

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -7,7 +7,7 @@ import scala.annotation.{ meta, StaticAnnotation }
 import sjsonnew.{ HashWriter, JsonFormat }
 import sjsonnew.support.murmurhash.Hasher
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser }
-import xsbti.VirtualFile
+import xsbti.{ FileConverter, VirtualFile }
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import scala.quoted.{ Expr, FromExpr, ToExpr, Quotes }
@@ -37,30 +37,47 @@ object ActionCache:
   )(
       config: BuildWideCacheConfiguration
   ): O =
-    val store = config.store
-    val cacheEventLog = config.cacheEventLog
+    import config.*
     val input =
       Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
     val valuePath = s"value/${input}.json"
+
     def organicTask: O =
-      cacheEventLog.append(ActionCacheEvent.NotFound)
       // run action(...) and combine the newResult with outputs
-      val (newResult, outputs) = action(key)
-      val json = Converter.toJsonUnsafe(newResult)
-      val valueFile = StringVirtualFile1(valuePath, CompactPrinter(json))
-      val newOutputs = Vector(valueFile) ++ outputs.toVector
-      store.put(UpdateActionResultRequest(input, newOutputs, exitCode = 0)) match
-        case Right(result) =>
-          store.syncBlobs(result.outputFiles, config.outputDirectory)
-          newResult
-        case Left(e) => throw e
+      val (result, outputs) =
+        try action(key)
+        catch
+          case e: Exception =>
+            cacheEventLog.append(ActionCacheEvent.Error)
+            throw e
+      val json = Converter.toJsonUnsafe(result)
+      val uncacheableOutputs =
+        outputs.filter(f => !fileConverter.toPath(f).startsWith(outputDirectory))
+      if uncacheableOutputs.nonEmpty then
+        cacheEventLog.append(ActionCacheEvent.Error)
+        logger.error(
+          s"Cannot cache task because its output files are outside the output directory: \n" +
+            uncacheableOutputs.mkString("  - ", "\n  - ", "")
+        )
+        result
+      else
+        cacheEventLog.append(ActionCacheEvent.OnsiteTask)
+        val valueFile = StringVirtualFile1(s"value/${input}.json", CompactPrinter(json))
+        val newOutputs = Vector(valueFile) ++ outputs.toVector
+        store.put(UpdateActionResultRequest(input, newOutputs, exitCode = 0)) match
+          case Right(cachedResult) =>
+            store.syncBlobs(cachedResult.outputFiles, config.outputDirectory)
+            result
+          case Left(e) => throw e
+
     def valueFromStr(str: String, origin: Option[String]): O =
       cacheEventLog.append(ActionCacheEvent.Found(origin.getOrElse("unknown")))
       val json = Parser.parseUnsafe(str)
       Converter.fromJsonUnsafe[O](json)
-    store.get(
+
+    val getRequest =
       GetActionResultRequest(input, inlineStdout = false, inlineStderr = false, Vector(valuePath))
-    ) match
+    store.get(getRequest) match
       case Right(result) =>
         // some protocol can embed values into the result
         result.contents.headOption match
@@ -78,6 +95,8 @@ end ActionCache
 class BuildWideCacheConfiguration(
     val store: ActionCacheStore,
     val outputDirectory: Path,
+    val fileConverter: FileConverter,
+    val logger: Logger,
     val cacheEventLog: CacheEventLog,
 ):
   override def toString(): String =

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -41,7 +41,7 @@ object ActionCache:
     val cacheEventLog = config.cacheEventLog
     val input =
       Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
-    val valuePath = config.outputDirectory.resolve(s"value/${input}.json").toString
+    val valuePath = s"value/${input}.json"
     def organicTask: O =
       cacheEventLog.append(ActionCacheEvent.NotFound)
       // run action(...) and combine the newResult with outputs

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -5,13 +5,7 @@ import sbt.internal.util.StringVirtualFile1
 import sbt.io.IO
 import sbt.io.syntax.*
 import verify.BasicTestSuite
-import xsbti.FileConverter
 import xsbti.VirtualFile
-import xsbti.VirtualFileRef
-
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
 
 object ActionCacheTest extends BasicTestSuite:
   val tags = CacheLevelTag.all.toList
@@ -20,10 +14,10 @@ object ActionCacheTest extends BasicTestSuite:
     withDiskCache(testHoldBlob)
 
   def testHoldBlob(cache: ActionCacheStore): Unit =
+    val in = StringVirtualFile1("a.txt", "foo")
+    val hashRefs = cache.putBlobs(in :: Nil)
+    assert(hashRefs.size == 1)
     IO.withTemporaryDirectory: tempDir =>
-      val in = StringVirtualFile1(s"$tempDir/a.txt", "foo")
-      val hashRefs = cache.putBlobs(in :: Nil)
-      assert(hashRefs.size == 1)
       val actual = cache.syncBlobs(hashRefs, tempDir.toPath()).head
       assert(actual.getFileName().toString() == "a.txt")
 
@@ -55,14 +49,14 @@ object ActionCacheTest extends BasicTestSuite:
     withDiskCache(testActionCacheWithBlob)
 
   def testActionCacheWithBlob(cache: ActionCacheStore): Unit =
+    import sjsonnew.BasicJsonProtocol.*
+    var called = 0
+    val action: ((Int, Int)) => (Int, Seq[VirtualFile]) = { case (a, b) =>
+      called += 1
+      val out = StringVirtualFile1("a.txt", (a + b).toString)
+      (a + b, Seq(out))
+    }
     IO.withTemporaryDirectory: (tempDir) =>
-      import sjsonnew.BasicJsonProtocol.*
-      var called = 0
-      val action: ((Int, Int)) => (Int, Seq[VirtualFile]) = { case (a, b) =>
-        called += 1
-        val out = StringVirtualFile1(s"$tempDir/a.txt", (a + b).toString)
-        (a + b, Seq(out))
-      }
       val config = BuildWideCacheConfiguration(cache, tempDir.toPath(), CacheEventLog())
       val v1 =
         ActionCache.cache[(Int, Int), Int]((1, 1), Digest.zero, Digest.zero, tags)(action)(config)
@@ -88,15 +82,9 @@ object ActionCacheTest extends BasicTestSuite:
     IO.withTemporaryDirectory(
       { tempDir0 =>
         val tempDir = tempDir0.toPath
-        val cache = DiskActionCacheStore(tempDir, fileConverter)
+        val cache = DiskActionCacheStore(tempDir)
         f(cache)
       },
       keepDirectory = false
     )
-
-  def fileConverter = new FileConverter:
-    override def toPath(ref: VirtualFileRef): Path = Paths.get(ref.id)
-    override def toVirtualFile(path: Path): VirtualFile =
-      val content = if Files.isRegularFile(path) then new String(Files.readAllBytes(path)) else ""
-      StringVirtualFile1(path.toString, content)
 end ActionCacheTest

--- a/util-cache/src/test/scala/sbt/util/CacheEventLogTest.scala
+++ b/util-cache/src/test/scala/sbt/util/CacheEventLogTest.scala
@@ -25,20 +25,38 @@ object CacheEventLogTest extends BasicTestSuite:
     assertEquals(logger.summary, expectedSummary)
   }
 
-  test("summary of 1 disk, 1 miss event") {
+  test("summary of 1 disk, 1 onsite task") {
     val logger = CacheEventLog()
     logger.append(ActionCacheEvent.Found("disk"))
-    logger.append(ActionCacheEvent.NotFound)
+    logger.append(ActionCacheEvent.OnsiteTask)
     val expectedSummary = "cache 50%, 1 disk cache hit, 1 onsite task"
     assertEquals(logger.summary, expectedSummary)
   }
 
-  test("summary of 1 disk, 2 remote, 1 miss event") {
+  test("summary of 1 disk, 1 onsite task, 1 error") {
+    val logger = CacheEventLog()
+    logger.append(ActionCacheEvent.Found("disk"))
+    logger.append(ActionCacheEvent.OnsiteTask)
+    logger.append(ActionCacheEvent.Error)
+    val expectedSummary = "cache 33%, 1 disk cache hit, 1 onsite task, 1 error"
+    assertEquals(logger.summary, expectedSummary)
+  }
+
+  test("summary of 1 disk, 2 errors") {
+    val logger = CacheEventLog()
+    logger.append(ActionCacheEvent.Found("disk"))
+    logger.append(ActionCacheEvent.Error)
+    logger.append(ActionCacheEvent.Error)
+    val expectedSummary = "cache 33%, 1 disk cache hit, 2 errors"
+    assertEquals(logger.summary, expectedSummary)
+  }
+
+  test("summary of 1 disk, 2 remote, 1 onsite task") {
     val logger = CacheEventLog()
     logger.append(ActionCacheEvent.Found("disk"))
     logger.append(ActionCacheEvent.Found("remote"))
     logger.append(ActionCacheEvent.Found("remote"))
-    logger.append(ActionCacheEvent.NotFound)
+    logger.append(ActionCacheEvent.OnsiteTask)
     val expectedSummary = "cache 75%, 1 disk cache hit, 2 remote cache hits, 1 onsite task"
     assertEquals(logger.summary, expectedSummary)
   }


### PR DESCRIPTION
In the `ActionCache`, we check that all output files are in the output directory. If they are not, we still run the task, but we print an error message saying that the task could not be cached. Also the cache summary details the number of errors.

```
sbt:root> compile
[success] elapsed time: 0 s, cache 0%, 1 onsite task
sbt:root> set root / target := baseDirectory.value / "custom-target"
...
sbt:root> compile
[error] Cannot cache task because its output files are outside the output directory: 
[error]   - ${BASE}/custom-target/zinc/inc_compile_3.zip
[error]   - ${BASE}/custom-target/sbt2-test_3-0.1.0-SNAPSHOT-noresources.jar
[success] elapsed time: 0 s, cache 0%, 1 error
sbt:root>
```