### PR TITLE
Update jansi dep to match the one that's included in the jline dep

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,7 +93,7 @@ object Dependencies {
   val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val jansi = "org.fusesource.jansi" % "jansi" % "2.4.0"
+  val jansi = "org.fusesource.jansi" % "jansi" % "2.4.1"
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   val junit = "junit" % "junit" % "4.13.1"


### PR DESCRIPTION
This also allows sbt to work on ARM64 Windows without needing to specify things like, e.g. `jline.terminal=jline.UnsupportedTerminal` or `TERM=dumb`.

Jline3 has been using jansi 2.4.1 since version 3.24.0 and sbt current Jline3 version is 3.24.1 (https://github.com/jline/jline3/commit/0f01e4ce2ecd12c883681f9c23000f2817217736)
