### PR TITLE
Fix logging of raw strings

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.{ Level => XLevel }
 import sbt.internal.util.ConsoleAppender._
 import sbt.util._
 import org.apache.logging.log4j.core.AbstractLogEvent
-import org.apache.logging.log4j.message.StringFormatterMessageFactory
+import org.apache.logging.log4j.message.SimpleMessageFactory
 import java.util.concurrent.atomic.AtomicReference
 
 object ConsoleLogger {
@@ -598,7 +598,7 @@ private[sbt] class ConsoleAppenderFromLog4J(
     delegate.append(new AbstractLogEvent {
       override def getLevel(): XLevel = ConsoleAppender.toXLevel(level)
       override def getMessage(): Message =
-        StringFormatterMessageFactory.INSTANCE.newMessage(message.toString, Array.empty)
+        SimpleMessageFactory.INSTANCE.newMessage(message.toString, Array.empty)
     })
   }
 }


### PR DESCRIPTION
sbt passes raw string messages in `ConsoleAppenderFromLog4J` to `StringFormatterMessageFactory`. This is wrong because these strings are pre-formatted and should not be processed again for formatting. There is no way to pass parameters to them anyway. This causes problems when the raw strings contain characters that `StringFormatterMessageFactory` wants to interpret.

For example, when using `-Ystatistics`:

```
ERROR StatusConsoleListener Unable to format msg:   nscprofiling                : 1 spans, ()7.543ms (0.3%)
java.util.UnknownFormatConversionException: Conversion = ')'
at java.base/java.util.Formatter.checkText(Formatter.java:2732)
at java.base/java.util.Formatter.parse(Formatter.java:2718)
at java.base/java.util.Formatter.format(Formatter.java:2655)
at java.base/java.util.Formatter.format(Formatter.java:2609)
at java.base/java.lang.String.format(String.java:2938)
at org.apache.logging.log4j.message.StringFormattedMessage.formatMessage(StringFormattedMessage.java:121)
at org.apache.logging.log4j.message.StringFormattedMessage.getFormattedMessage(StringFormattedMessage.java:89)
at sbt.internal.util.Appender.$anonfun$appendMessage$1(ConsoleAppender.scala:522)
...
```