### PR TITLE
Fix old Dotty plugin compat

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -735,6 +735,10 @@ object Defaults extends BuildCommon {
     Seq(
       auxiliaryClassFiles :== Nil,
       incOptions := IncOptions.of(),
+      // TODO: Kept for old Dotty plugin. Remove on sbt 2.x
+      classpathOptions :== ClasspathOptionsUtil.boot,
+      // TODO: Kept for old Dotty plugin. Remove on sbt 2.x
+      console / classpathOptions :== ClasspathOptionsUtil.repl,
       compileOrder :== CompileOrder.Mixed,
       javacOptions :== Nil,
       scalacOptions :== Nil,


### PR DESCRIPTION
**Problem**
https://github.com/scala/scala3/pull/20157 identified that `sbt-dotty/dotty-knowledge.i17` scripted test fails on sbt 1.10.0-RC2. The regression happened in https://github.com/sbt/sbt/pull/7480/files#diff-6d9589bfb3f1247d2eace99bab7e928590337680d1aebd087d9da286586fba77L739-L740 where global setting was removed, and moved to project level.

**Solution**
This restores the global setting that is apparently referenced by now defunct Dotty plugin.