### PR TITLE
Upgrade sbt plugins to avoid deprecated repo.scala-sbt.org

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,10 @@ ThisBuild / useCoursier := false
 
 scalacOptions ++= Seq("-feature", "-language:postfixOps", "-Ywarn-unused:_,-imports")
 
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.1")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.5.3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.5")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`.

See
- https://github.com/sbt/sbt/issues/7202

this repo could go down again.

Unfortunately you still pull in outdated versions of [sbt-contraband](https://github.com/sbt/contraband/) and [sbt-dynver](https://github.com/sbt/sbt-dynver) which are only hosted on repo.scala-sbt.org.

This PR allows me to published sbt 1.10.x publish locally.