### PR TITLE
[1.10.x] Fix declaring `Optional` inter-project dependency in BSP

### DIFF
--- a/main/src/main/scala/sbt/internal/InternalDependencies.scala
+++ b/main/src/main/scala/sbt/internal/InternalDependencies.scala
@@ -13,7 +13,9 @@ import sbt.Keys._
 
 private[sbt] object InternalDependencies {
   def configurations: Def.Initialize[Seq[(ProjectRef, Set[String])]] = Def.setting {
-    val allConfigs = Classpaths.allConfigs(configuration.value).map(_.name).toSet
+    val configMap = internalConfigurationMap.value
+    val config = configMap(configuration.value)
+    val allConfigs = Classpaths.allConfigs(config).map(_.name).toSet
     val ref = thisProjectRef.value
     val projectDependencies = buildDependencies.value.classpath.get(ref).toSeq.flatten
     val applicableConfigs = allConfigs + "*"

--- a/sbt-app/src/sbt-test/project/internal-dependency-configurations/build.sbt
+++ b/sbt-app/src/sbt-test/project/internal-dependency-configurations/build.sbt
@@ -23,31 +23,31 @@ def getConfigs(key: SettingKey[Seq[(ProjectRef, Set[String])]]):
 val checkA = taskKey[Unit]("Verify that project a's internal dependencies are as expected")
 checkA := {
   val compileDeps = getConfigs(a / Compile / internalDependencyConfigurations).value
-  assert(compileDeps == Map("a" -> Set("compile")))
+  assert(compileDeps == Map("a" -> Set("compile", "optional", "provided", "compile-internal")))
   val testDeps = getConfigs(a / Test / internalDependencyConfigurations).value
-  assert(testDeps == Map("a" -> Set("compile", "runtime", "test")))
+  assert(testDeps == Map("a" -> Set("compile", "optional", "provided", "runtime", "test", "test-internal")), testDeps.mkString(", "))
 }
 
 val checkB = taskKey[Unit]("Verify that project b's internal dependencies are as expected")
 checkB := {
   val compileDeps = getConfigs(b / Compile / internalDependencyConfigurations).value
-  assert(compileDeps == Map("b" -> Set("compile"), "a" -> Set("compile")))
+  assert(compileDeps == Map("b" -> Set("compile",  "optional", "provided", "compile-internal"), "a" -> Set("compile")))
   val testDeps = getConfigs(b / Test / internalDependencyConfigurations).value
-  assert(testDeps == Map("b" -> Set("compile", "runtime", "test"), "a" -> Set("compile")))
+  assert(testDeps == Map("b" -> Set("compile", "optional", "provided", "runtime", "test", "test-internal"), "a" -> Set("compile")))
 }
 
 val checkC = taskKey[Unit]("Verify that project c's internal dependencies are as expected")
 checkC := {
   val compileDeps = getConfigs(c / Compile / internalDependencyConfigurations).value
-  assert(compileDeps == Map("c" -> Set("compile")))
+  assert(compileDeps == Map("c" -> Set("compile",  "optional", "provided", "compile-internal")))
   val testDeps = getConfigs(c / Test / internalDependencyConfigurations).value
-  assert(testDeps == Map("c" -> Set("compile", "runtime", "test")))
+  assert(testDeps == Map("c" -> Set("compile", "optional", "provided", "runtime", "test", "test-internal")))
 }
 
 val checkD = taskKey[Unit]("Verify that project d's internal dependencies are as expected")
 checkD := {
   val compileDeps = getConfigs(d / Compile / internalDependencyConfigurations).value
-  assert(compileDeps == Map("d" -> Set("compile"), "c" -> Set("compile")))
+  assert(compileDeps == Map("d" -> Set("compile",  "optional", "provided", "compile-internal"), "c" -> Set("compile")))
   val testDeps = getConfigs(d / Test / internalDependencyConfigurations).value
-  assert(testDeps == Map("d" -> Set("compile", "runtime", "test"), "c" -> Set("compile", "test")))
+  assert(testDeps == Map("d" -> Set("compile", "optional", "provided", "runtime", "test", "test-internal"), "c" -> Set("compile", "test")))
 }

--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -12,7 +12,7 @@ lazy val runAndTest = project.in(file("run-and-test"))
     Test / javaOptions := Vector("Xmx512M"),
     Test / envVars := Map("KEY_TEST" -> "VALUE_TEST"),
   )
-  .dependsOn(util)
+  .dependsOn(util % Optional)
 
 lazy val reportError = project.in(file("report-error"))
 


### PR DESCRIPTION
```scala
val a = project.in(file("a"))

val b = project.in(file("b")).dependsOn(a % Optional)
```

In BSP there is no notion of `Optional` or `Provided` dependencies. But the `b#Compile` build target should contain a dependency to `a#Compile` because it needs it to compile. (The classphath configuration is `CompileInternal` which extends `Optional` and `Provided`).

To fix this we use the `internalConfigurationMap` to compute the internal dependencies of a configuration.

@unkarjedy  This PR should fix https://youtrack.jetbrains.com/issue/SCL-22476/SBTBSP-build-with-an-optional-inter-project-dependency-results-in-cannot-resolve-symbol-errors 