### PR TITLE
Fix compilation on JDK21

### DIFF
--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -122,7 +122,7 @@ private[sbt] abstract class AbstractTaskExecuteProgress extends ExecuteProgress[
 object AbstractTaskExecuteProgress {
   private[sbt] class Timer() {
     val startNanos: Long = System.nanoTime()
-    val threadId: Long = Thread.currentThread().getId
+    val threadId: Long = Thread.currentThread().threadId
     var endNanos: Long = 0L
     def stop(): Unit = {
       endNanos = System.nanoTime()

--- a/main/src/main/scala/sbt/internal/GCUtil.scala
+++ b/main/src/main/scala/sbt/internal/GCUtil.scala
@@ -11,7 +11,6 @@ package internal
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 import sbt.util.Logger
 
 private[sbt] object GCUtil {
@@ -27,24 +26,8 @@ private[sbt] object GCUtil {
     // This throttles System.gc calls to interval
     if (now - last > minForcegcInterval.toMillis) {
       lastGcCheck.lazySet(now)
-      forceGc(log)
+      log.debug(s"Trying to force garbage collection (which is a best effort operation)...")
+      System.gc()
     }
   }
-
-  def forceGc(log: Logger): Unit =
-    try {
-      log.debug(s"Forcing garbage collection...")
-      // Force the detection of finalizers for scala.reflect weakhashsets
-      System.gc()
-      // Force finalizers to run.
-      try {
-        System.runFinalization()
-      } catch {
-        case _: NoSuchMethodError =>
-      }
-      // Force actually cleaning the weak hash maps.
-      System.gc()
-    } catch {
-      case NonFatal(_) => // gotta catch em all
-    }
 }


### PR DESCRIPTION
Deprecation warnings combined with "fatal warnings" caused compilation to fail on current JDKs.

This commit removes some attempts to trigger finalization of some objects. However, there are no finalizers defined in the sbt project itself. We can't do more here than remove the deprecated JDK feature, and hope that upstream projects have also replaced their use of finalizers with future-proof alternatives by now.

I think this is the only way forward. Also we're effectively done here as there are no finalizers to migrate.

I'm not sure though what priority it has to be able to compile SBT on newer JDKs.
The build of SBT itself welcomed me with
```
[info] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[info]   Java version is 21. We recommend java 8.
[info] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
which I first didn't notice as it looked like a part of the ASCII art banner directly above.

Than, I thought this is a kind of joke. Like finding a website which recommends Internet Explorer 5.5 for best user experience. :smile: 

I mean, JDK8 is really dated. A lot of projects (also in the Scala build department!) require at least Java 17, and version 21 is the current LTS, which I would actually target for the build environment.