### PR TITLE
Using common Scala 2.12 version for the sbtn subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1165,7 +1165,6 @@ lazy val sbtClientProj = (project in file("client"))
   .dependsOn(commandProj)
   .settings(
     commonBaseSettings,
-    scalaVersion := "2.12.11", // The thin client does not build with 2.12.12
     publish / skip := true,
     name := "sbt-client",
     mimaPreviousArtifacts := Set.empty,


### PR DESCRIPTION
The old, hardcoded Scala 2.12 version previously used for the sbtn project (as a kind of workaround?) was no longer supported by Scala IDE tooling. But sbtn builds just fine when using the current global setting for the Scala 2.12 version, so this commit removes the hardcoded version.

Metals complained, so I tried to fix it. I think the change is harmless as the "client" project contains just a Java file, which gets build anyway by Graal Native Image and not by Scala.

I've actually run the native build and verified that the resulting binary starts up. (Didn't do any further testing with it though as I don't see what could go wrong besides the build when changing that setting in the build description).