### PR TITLE
Fix stale BSP diagnostics

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -25,6 +25,7 @@ import xsbti.{
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import java.nio.file.Path
 
 /**
 Provides methods for sending success and failure reports and publishing diagnostics.
@@ -90,7 +91,7 @@ final class BuildServerReporterImpl(
   import sbt.internal.inc.JavaInterfaceUtil._
 
   private lazy val exchange = StandardMain.exchange
-  private val problemsByFile = mutable.Map[VirtualFileRef, Vector[Problem]]()
+  private val problemsByFile = mutable.Map[Path, Vector[Problem]]()
 
   // sometimes the compiler returns a fake position such as <macro>
   // on Windows, this causes InvalidPathException (see #5994 and #6720)
@@ -114,9 +115,10 @@ final class BuildServerReporterImpl(
 
   override def sendFailureReport(sources: Array[VirtualFile]): Unit = {
     for (source <- sources) {
-      val problems = problemsByFile.getOrElse(source, Vector.empty)
+      val problems = problemsByFile.getOrElse(converter.toPath(source), Vector.empty)
       sendReport(source, problems)
     }
+    notifyFirstReport()
   }
 
   private def sendReport(source: VirtualFileRef, problems: Vector[Problem]): Unit = {
@@ -153,7 +155,11 @@ final class BuildServerReporterImpl(
       id <- problem.position.sourcePath.toOption
       (document, diagnostic) <- mapProblemToDiagnostic(problem)
     } {
-      val fileRef = VirtualFileRef.of(id)
+      // Note: We're putting the real path in `fileRef` because the `id` String can take
+      // two forms, either a ${something}/relativePath, or the absolute path of the source.
+      // But where we query this, we always have _only_ a ${something}/relativePath available.
+      // So here we "normalize" to the real path.
+      val fileRef = converter.toPath(VirtualFileRef.of(id))
       problemsByFile(fileRef) = problemsByFile.getOrElse(fileRef, Vector.empty) :+ problem
 
       val params = PublishDiagnosticsParams(

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -236,6 +236,77 @@ object BuildServerTest extends AbstractServerTest {
     )
   }
 
+  test("buildTarget/compile [Java diagnostics] clear stale warnings") { _ =>
+    val buildTarget = buildTargetUri("javaProj", "Compile")
+    val testFile = new File(svr.baseDirectory, s"java-proj/src/main/java/example/Hello.java")
+
+    val otherBuildFile = new File(svr.baseDirectory, "force-java-out-of-process-compiler.sbt")
+    // Setting `javaHome` will force SBT to shell out to an external Java compiler instead
+    // of using the local compilation service offered by the JVM running this SBT instance.
+    IO.write(
+      otherBuildFile,
+      """
+        |lazy val javaProj = project
+        |  .in(file("java-proj"))
+        |  .settings(
+        |    javacOptions += "-Xlint:all",
+        |    javaHome := Some(file(System.getProperty("java.home")))
+        |  )
+        |""".stripMargin
+    )
+    reloadWorkspace()
+
+    compile(buildTarget)
+
+    assertMessage(
+      "build/publishDiagnostics",
+      "Hello.java",
+      """"severity":2""",
+      """found raw type: List"""
+    )(message = "should send publishDiagnostics with severity 2 for Hello.java")
+
+    assertMessage(
+      "build/publishDiagnostics",
+      "Hello.java",
+      """"severity":1""",
+      """incompatible types: int cannot be converted to String"""
+    )(
+      message = "should send publishDiagnostics with severity 1 for Hello.java"
+    )
+    // Note the messages changed slightly in both cases. That's interesting…
+
+    IO.write(
+      testFile,
+      """|package example;
+         |
+         |import java.util.List;
+         |import java.util.ArrayList;
+         |
+         |class Hello {
+         |    public static void main(String[] args) {
+         |        List<String> list = new ArrayList<>();
+         |        String msg = "42";
+         |        System.out.println(msg);
+         |    }
+         |}
+         |""".stripMargin
+    )
+
+    compile(buildTarget)
+
+    assertMessage(
+      "build/publishDiagnostics",
+      "Hello.java",
+      "\"diagnostics\":[]",
+      "\"reset\":true"
+    )(
+      message = "should send publishDiagnostics with empty diagnostics"
+    )
+
+    IO.delete(otherBuildFile)
+    reloadWorkspace()
+  }
+
   test("buildTarget/scalacOptions, buildTarget/javacOptions") { _ =>
     val buildTargets = Seq(
       buildTargetUri("util", "Compile"),


### PR DESCRIPTION
The BSP server didn't reset old diagnostic messages sent to BSP clients under certain circumstances. This commit mitigates this edge case and ensures that diagnostics for files that previously had compilation problems are properly reset when fresh diagnostics messages are sent.

The culprit was a mismatch of map keys: Files with problems were sometimes recorded under an absolute path, but later attempted to be retrieved by virtual path.

That the fix works can be tested end-to-end on a repro project under:
https://github.com/SlowBrainDude/sbt-bsp-bug-reproducer

Clone the repo and open it in VSCode with Metals installed. In case Metals isn't configured to do automatically so, switch to the SBT build server. (Bloop doesn't show any issues with the project). Let Metals import the project and do the initial compilation. Everything should work fine so far. Now navigate to the `JavaClass` file. There is a commented block of code. Delete the `*` as the comment says. SBT will send diagnostics for the now failing build and you'll get a lot of red squiggles in the Java file after compile finishes. Now restore the comment. The errors reported by the SBT BSP will still be shown in the file (and in the problems pane and file explorer). By commenting things in and out you can actually multiply the errors. You can create a few hundred or even more just by commenting things in and out. The reported errors will never go away even when the file compiles fine again.

With my fixed version of SBT the errors get reset properly again and don't get stale.

(Even Metals does some questionable things that may cause sending the reset diagnostic to take quite some time. I've seen compile times of 5 - 15 ms on the Java file, but it could take over 1 minute until the reset diagnostics got sent. But that's a Metals issue which implements some algo that explodes with line count and error count in a file quite quickly, maybe even exponential, at least high polynomial, given that this issue can make a 2 second CLI compile of very large file with only one syntax error into 20 minutes of all CPUs grilling on max when running Metals).

So far so good, but this PR is just a draft as some things aren't clear to me still.

Maybe I've hunted down somethings that shouldn't exist in the first place, and the real bug is even deeper. Because the bug doesn't surface in all cases actually.

I've tried to write a test for the case affected by this code change. But I've failed in doing so; at least so far.

On my repro project the `problem.position.sourcePath` extracted from the `Problem` passed to `publishDiagnostic` is definitively an absolute path. I had log output more or less around every line of code in `BuildServerReporter` and traced the whole BSP communication while debugging. (It took actually quite some time to realize that the cause of the problem is a harmless looking but failing `getOrElse`… And it took even longer to see the difference in file path, as I only looked at the file name at first without paying much attention to what is written before it; also the log output was far apart so I just didn't see the difference between absolute path and something that starts with `${BASE}/` for a long time).

But the test I've written didn't fail in such way. I was wondering why the test gets green no matter my fix is applied or not. It turns out that in the test project `problem.position.sourcePath` is a "virtual path" (with a `${BASE}/` prefix), even for Java files which I thought at first was actually the trigger condition for the bug.

Now I need help to understand why my repro project behaves differently from the test projects in SBT. I've tried to trace how `Problems`s get constructed, and where the source path is initialized, but honestly I wasn't able to look though all this indirection. There is logic in [DiagnosticsReporter](https://github.com/sbt/zinc/blob/14e79143e5906379884142c002eb9861b3f5b9c7/internal/zinc-compile-core/src/main/scala/sbt/internal/inc/javac/DiagnosticsReporter.scala#L183) but I don't understand where and why the source is sometimes feed in as proper file and sometimes as virtual file (which may have a possibly "virtual" path).

The main question is: Why do the "file descriptors" feed into `sendFailureReport` and `publishDiagnostic` differ sometimes in how the path looks like (even they are the same file in the end). Is this something that's expected, or is the actual bug that this differs? Should the `sourcePath` extracted from `Problems` always be a "virtual" one maybe, and is it already wrong that some absolute path ends up there?

In case it's expected that the form of the path may differ between `sendFailureReport` and `publishDiagnostic` I still need a way to write a test that exhibits this behavior, to have a proper negative test (one that fails without the patch applied).

Sorry for the very long description, but the issue wasn't easy to find and understand either. I hope I described it here in a way that can be understood.

### TASKS to make this mergable:
- [x] Investigate whether this is actually the proper fix, and not just "healing symptoms"
- [x] Fix the regression test, or write a proper one in case this is not the right fix