### PR TITLE
Include ALL sources, and resources in source jar

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1768,17 +1768,17 @@ object Defaults extends BuildCommon {
   // drop base directories, since there are no valid mappings for these
   def sourceMappings: Initialize[Task[Seq[(File, String)]]] =
     Def.task {
-      val sdirs = unmanagedSourceDirectories.value ++ managedSourceDirectories.value
+      val sdirs = sourceDirectories.value
       val base = baseDirectory.value
       val relative = (f: File) => relativeTo(sdirs)(f).orElse(relativeTo(base)(f)).orElse(flat(f))
       val exclude = Set(sdirs, base)
-      (unmanagedSources.value ++ managedSources.value).flatMap {
+      sources.value.flatMap {
         case s if !exclude(s) => relative(s).map(s -> _)
         case _                => None
       }
     }
 
-  def resourceMappings = relativeMappings(unmanagedResources, unmanagedResourceDirectories)
+  def resourceMappings = relativeMappings(resources, resourceDirectories)
 
   def relativeMappings(
       files: Taskable[Seq[File]],


### PR DESCRIPTION
This follows on from #7470, to include all sources, not just managed and unmanaged, in the source jar, along with all resources (previously only unmanaged resources were included).

This means that if, for whatever crazy reason, someone does modify the `sources` task to include additional sources or filter out sources, rather than using the managed or unmanaged source mechanisms, their changes will still be reflected in the source jar. It ensures consistency with both `compile` and `doc`, which both also depend on `sources` rather than manually gathering `unmanagedSources` and `managedSources` themselves.