### PR TITLE
Scala 2.12.20 (was .19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     env:
       JAVA_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
-      SCALA_212: 2.12.19
+      SCALA_212: 2.12.20
       SCALA_3: 3.1.0
       UTIL_TESTS: "utilCache/test utilControl/test utilInterface/test utilLogging/test utilPosition/test utilRelation/test utilScripted/test utilTracking/test"
       SBT_LOCAL: false

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" 
 
 Global / semanticdbEnabled := !(Global / insideCI).value
 // Change main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala too, if you change this.
-Global / semanticdbVersion := "4.7.8"
+Global / semanticdbVersion := "4.9.9"
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
 Global / excludeLint := (Global / excludeLint).?.value.getOrElse(Set.empty)
 Global / excludeLint += componentID

--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -26,7 +26,7 @@ lazy val sbtVersionToRelease = sys.props.getOrElse("sbt.build.version", sys.env.
       }))
 
 lazy val scala210 = "2.10.7"
-lazy val scala212 = "2.12.19"
+lazy val scala212 = "2.12.20"
 lazy val scala210Jline = "org.scala-lang" % "jline" % scala210
 lazy val jansi = {
   if (sbtVersionToRelease startsWith "1.") "org.fusesource.jansi" % "jansi" % "1.12"
@@ -34,7 +34,7 @@ lazy val jansi = {
 }
 lazy val scala212Compiler = "org.scala-lang" % "scala-compiler" % scala212
 lazy val scala212Jline = "jline" % "jline" % "2.14.6"
-// use the scala-xml version used by the compiler not the latest: https://github.com/scala/scala/blob/v2.12.19/versions.properties
+// use the scala-xml version used by the compiler not the latest: https://github.com/scala/scala/blob/v2.12.20/versions.properties
 lazy val scala212Xml = "org.scala-lang.modules" % "scala-xml_2.12" % "2.2.0"
 lazy val sbtActual = "org.scala-sbt" % "sbt" % sbtVersionToRelease
 

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -100,7 +100,7 @@ private[sbt] object PluginCross {
     VersionNumber(sv) match {
       case VersionNumber(Seq(0, 12, _*), _, _) => "2.9.2"
       case VersionNumber(Seq(0, 13, _*), _, _) => "2.10.7"
-      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.19"
+      case VersionNumber(Seq(1, 0, _*), _, _)  => "2.12.20"
       case _                                   => sys.error(s"Unsupported sbt binary version: $sv")
     }
 }

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -27,7 +27,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.7.8"
+    semanticdbVersion := "4.9.9"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
-  val scala212 = "2.12.19"
+  val scala212 = "2.12.20"
   val scala213 = "2.13.14"
   val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala212

--- a/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/build.sbt
@@ -1,6 +1,6 @@
 lazy val check = taskKey[Unit]("")
 lazy val compile2 = taskKey[Unit]("")
-lazy val scala212 = "2.12.19"
+lazy val scala212 = "2.12.20"
 lazy val scala213 = "2.13.12"
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/actions/cross-advanced/test
+++ b/sbt-app/src/sbt-test/actions/cross-advanced/test
@@ -17,7 +17,7 @@
 ## test + with command or alias
 > clean
 ## for command cross building you do need crossScalaVerions on root
-> set root/crossScalaVersions := Seq("2.12.19", "2.13.12")
+> set root/crossScalaVersions := Seq("2.12.20", "2.13.12")
 > + build
 $ exists foo/target/scala-2.12
 $ exists foo/target/scala-2.13

--- a/sbt-app/src/sbt-test/actions/cross-incremental/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-incremental/build.sbt
@@ -1,5 +1,5 @@
-scalaVersion := "2.12.19"
-crossScalaVersions := List("2.12.19", "2.13.12")
+scalaVersion := "2.12.20"
+crossScalaVersions := List("2.12.20", "2.13.12")
 
 val setLastModified = taskKey[Unit]("Sets the last modified time for classfiles")
 setLastModified := {

--- a/sbt-app/src/sbt-test/actions/cross-multi-parser/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-multi-parser/build.sbt
@@ -1,1 +1,1 @@
-crossScalaVersions := Seq[String]("2.11.12", "2.12.19")
+crossScalaVersions := Seq[String]("2.11.12", "2.12.20")

--- a/sbt-app/src/sbt-test/actions/cross-multi-parser/test
+++ b/sbt-app/src/sbt-test/actions/cross-multi-parser/test
@@ -1,5 +1,5 @@
 > ++2.11.12; compile
 
-> ++ 2.12.19  ; compile;
+> ++ 2.12.20  ; compile;
 
-> ++ 2.12.19 ; compile
+> ++ 2.12.20 ; compile

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.19"
+lazy val scala212 = "2.12.20"
 lazy val scala213 = "2.13.12"
 
 ThisBuild / crossScalaVersions := Seq(scala212, scala213)

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/ref/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/ref/build.sbt
@@ -1,4 +1,4 @@
 lazy val external = (project in file("."))
   .settings(
-    scalaVersion := "2.12.19"
+    scalaVersion := "2.12.20"
   )

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/test
@@ -13,7 +13,7 @@ $ exists lib/target/scala-2.13
 
 # test safe switching
 > clean
-> ++ 2.12.19 -v compile
+> ++ 2.12.20 -v compile
 $ exists lib/target/scala-2.12
 -$ exists lib/target/scala-2.13
 $ exists sbt-foo/target/scala-2.12
@@ -31,7 +31,7 @@ $ exists ref/target/scala-2.12
 
 # Test ++ leaves crossScalaVersions unchanged
 > clean
-> ++2.12.19
+> ++2.12.20
 > +extrasProj/compile
 $ exists extras/target/scala-2.13
 $ exists extras/target/scala-2.12

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation-scala-3/build.sbt
@@ -1,14 +1,14 @@
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"
 
 lazy val core = project
   .settings(
-    crossScalaVersions := Seq("2.12.19", "3.0.2", "3.1.2")
+    crossScalaVersions := Seq("2.12.20", "3.0.2", "3.1.2")
   )
 
 lazy val subproj = project
   .dependsOn(core)
   .settings(
-    crossScalaVersions := Seq("2.12.19", "3.1.2"),
+    crossScalaVersions := Seq("2.12.20", "3.1.2"),
     // a random library compiled against Scala 3.1
     libraryDependencies += "org.http4s" %% "http4s-core" % "0.23.12"
   )

--- a/sbt-app/src/sbt-test/actions/cross-strict-aggregation/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-strict-aggregation/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.19"
+lazy val scala212 = "2.12.20"
 lazy val scala213 = "2.13.12"
 
 ThisBuild / scalaVersion := scala212

--- a/sbt-app/src/sbt-test/actions/doc-file-options/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc-file-options/build.sbt
@@ -2,7 +2,7 @@ val newContents = "bbbbbbbbb"
 
 val rootContentFile = "root.txt"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/actions/doc/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc/build.sbt
@@ -5,8 +5,8 @@ import Parsers._
 lazy val root = (project in file("."))
   .settings(
     crossPaths := false,
-    crossScalaVersions := Seq("2.12.19", "2.13.12"),
-    scalaVersion := "2.12.19",
+    crossScalaVersions := Seq("2.12.20", "2.13.12"),
+    scalaVersion := "2.12.20",
     Compile / doc / scalacOptions += "-Xfatal-warnings",
     commands += Command.command("excludeB") { s =>
       val impl = """val src = (sources in Compile).value; src.filterNot(_.getName.contains("B"))"""

--- a/sbt-app/src/sbt-test/actions/generator/build.sbt
+++ b/sbt-app/src/sbt-test/actions/generator/build.sbt
@@ -1,6 +1,6 @@
 val buildInfo = taskKey[Seq[File]]("generates the build info")
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/actions/multi-command/build.sbt
+++ b/sbt-app/src/sbt-test/actions/multi-command/build.sbt
@@ -19,4 +19,4 @@ val dynamicTask = taskKey[Unit]("dynamic input task")
 
 dynamicTask := { println("not yet et") }
 
-crossScalaVersions := "2.11.12" :: "2.12.19" :: Nil
+crossScalaVersions := "2.11.12" :: "2.12.20" :: Nil

--- a/sbt-app/src/sbt-test/actions/multi-command/test
+++ b/sbt-app/src/sbt-test/actions/multi-command/test
@@ -37,4 +37,4 @@
 
 > ++ 2.11.12 compile; setStringValue bar; checkStringValue bar
 
-> ++2.12.19 compile; setStringValue foo; checkStringValue foo
+> ++2.12.20 compile; setStringValue foo; checkStringValue foo

--- a/sbt-app/src/sbt-test/actions/package-delete-target/build.sbt
+++ b/sbt-app/src/sbt-test/actions/package-delete-target/build.sbt
@@ -1,5 +1,5 @@
 lazy val root = (project in file("."))
   .settings(
     name := "delete-target",
-    scalaVersion := "2.12.19"
+    scalaVersion := "2.12.20"
   )

--- a/sbt-app/src/sbt-test/actions/remote-cache-semanticdb/build.sbt
+++ b/sbt-app/src/sbt-test/actions/remote-cache-semanticdb/build.sbt
@@ -1,6 +1,6 @@
 name := "my-project"
 
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"
 
 semanticdbIncludeInJar := true
 

--- a/sbt-app/src/sbt-test/actions/remote-cache/build.sbt
+++ b/sbt-app/src/sbt-test/actions/remote-cache/build.sbt
@@ -8,7 +8,7 @@ lazy val CustomArtifact = config("custom-artifact")
 val recordPreviousIterations = taskKey[Unit]("Record previous iterations.")
 val checkIterations = inputKey[Unit]("Verifies the accumulated number of iterations of incremental compilation.")
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / pushRemoteCacheTo := Some(
   MavenCache("local-cache", (ThisBuild / baseDirectory).value / "r")
 )

--- a/sbt-app/src/sbt-test/classloader-cache/akka-actor-system/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/akka-actor-system/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val akkaTest = (project in file(".")).settings(
   name := "akka-test",
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.5.16",
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"

--- a/sbt-app/src/sbt-test/classloader-cache/jni/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/jni/build.sbt
@@ -13,7 +13,7 @@ def wrap(task: InputKey[Unit]): Def.Initialize[Task[Unit]] =
 ThisBuild / turbo := true
 
 val root = (project in file(".")).settings(
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-h",
   sourceDirectory.value.toPath.resolve("main/native/include").toString),
   libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.6" % "test",

--- a/sbt-app/src/sbt-test/classloader-cache/library-mismatch/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/library-mismatch/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val snapshot = (project in file(".")).settings(
   name := "mismatched-libraries",
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   libraryDependencies ++= Seq("com.lihaoyi" %% "utest" % "0.6.6" % "test"),
   testFrameworks := Seq(TestFramework("utest.runner.Framework")),
   resolvers += "Local Maven" at file("libraries/ivy").toURI.toURL.toString,

--- a/sbt-app/src/sbt-test/classloader-cache/runtime-layers/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/runtime-layers/build.sbt
@@ -1,6 +1,6 @@
 val layeringStrategyTest = (project in file(".")).settings(
   name := "layering-strategy-test",
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   organization := "sbt",
   libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.16",
 )

--- a/sbt-app/src/sbt-test/classloader-cache/snapshot/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/snapshot/build.sbt
@@ -9,7 +9,7 @@ ThisBuild / useCoursier := false
 
 val snapshot = (project in file(".")).settings(
   name := "akka-test",
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"
   ),

--- a/sbt-app/src/sbt-test/classloader-cache/snapshot/libraries/library-1/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
+++ b/sbt-app/src/sbt-test/classloader-cache/snapshot/libraries/library-1/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.19</version>
+            <version>2.12.20</version>
         </dependency>
     </dependencies>
 </project>

--- a/sbt-app/src/sbt-test/classloader-cache/snapshot/libraries/library-2/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
+++ b/sbt-app/src/sbt-test/classloader-cache/snapshot/libraries/library-2/ivy/sbt/foo-lib_2.12/0.1.0-SNAPSHOT/foo-lib_2.12-0.1.0-SNAPSHOT.pom
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.19</version>
+            <version>2.12.20</version>
         </dependency>
     </dependencies>
 </project>

--- a/sbt-app/src/sbt-test/classloader-cache/spark/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/spark/build.sbt
@@ -2,7 +2,7 @@ name := "Simple Project"
 
 version := "1.0"
 
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3"
 

--- a/sbt-app/src/sbt-test/classloader-cache/utest/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/utest/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / turbo := true
 
 val utestTest = (project in file(".")).settings(
   name := "utest-test",
-  scalaVersion := "2.12.19",
+  scalaVersion := "2.12.20",
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "utest" % "0.6.6" % "test"
   ),

--- a/sbt-app/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/error-in-invalidated/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt-app/src/sbt-test/compiler-project/macro-config/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/macro-config/build.sbt
@@ -5,7 +5,7 @@ val Macro = config("macro").hide.extend(Compile)
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.12.19",
+    scalaVersion := "2.12.20",
 
     // Adds a "macro" configuration for macro dependencies.
     ivyConfigurations.value += Macro,

--- a/sbt-app/src/sbt-test/compiler-project/no-bootclasspath/test
+++ b/sbt-app/src/sbt-test/compiler-project/no-bootclasspath/test
@@ -1,4 +1,4 @@
 > set scalaVersion := "2.13.12"
 > check213
-> set scalaVersion := "2.12.18"
+> set scalaVersion := "2.12.20"
 > check212

--- a/sbt-app/src/sbt-test/compiler-project/run-test/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/run-test/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 libraryDependencies ++= Seq(
 	"com.novocode" % "junit-interface" % "0.5" % Test,

--- a/sbt-app/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/separate-analysis-per-scala/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.19"
+lazy val scala212 = "2.12.20"
 lazy val scala213 = "2.13.12"
 ThisBuild / scalaVersion := scala212
 

--- a/sbt-app/src/sbt-test/console/project-compiler-bridge/project/build.sbt
+++ b/sbt-app/src/sbt-test/console/project-compiler-bridge/project/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"

--- a/sbt-app/src/sbt-test/dependency-graph/cachedResolution/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/cachedResolution/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.28"
 updateOptions := updateOptions.value.withCachedResolution(true)

--- a/sbt-app/src/sbt-test/dependency-graph/ignoreScalaLibrary/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/ignoreScalaLibrary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.2",

--- a/sbt-app/src/sbt-test/dependency-graph/toFileSubTask/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/toFileSubTask/build.sbt
@@ -1,5 +1,5 @@
 // ThisBuild / useCoursier := false
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / organization := "org.example"
 ThisBuild / version := "0.1"
 

--- a/sbt-app/src/sbt-test/dependency-management/artifact/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/artifact/build.sbt
@@ -6,7 +6,7 @@ lazy val check = taskKey[Unit]("")
 lazy val checkArtifact = taskKey[Unit]("")
 
 ThisBuild / useCoursier := false
-ThisBuild / scalaVersion     := "2.12.19"
+ThisBuild / scalaVersion     := "2.12.20"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"

--- a/sbt-app/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/cache-classifiers/multi.sbt
@@ -1,6 +1,6 @@
 import xsbti.AppConfiguration
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 // TTL of Coursier is 24h
 ThisBuild / useCoursier := false

--- a/sbt-app/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/cached-resolution-interproj/multi.sbt
@@ -3,7 +3,7 @@ lazy val check = taskKey[Unit]("Runs the check")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junit = "junit" % "junit" % "4.13.1"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def commonSettings: Seq[Def.Setting[_]] =

--- a/sbt-app/src/sbt-test/dependency-management/compiler-bridge-binary/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/compiler-bridge-binary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val check = taskKey[Unit]("")
 

--- a/sbt-app/src/sbt-test/dependency-management/conflict-coursier/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/conflict-coursier/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies ++= List(
   "org.webjars.npm" % "randomatic" % "1.1.7",
   "org.webjars.npm" % "is-odd"     % "2.0.0",

--- a/sbt-app/src/sbt-test/dependency-management/ext-pom-classifier/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ext-pom-classifier/build.sbt
@@ -2,6 +2,6 @@ ThisBuild / useCoursier := false
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.12.19",
+    scalaVersion := "2.12.20",
     externalPom()
   )

--- a/sbt-app/src/sbt-test/dependency-management/force-update-period/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/force-update-period/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / useCoursier := false
 
 name := "force-update-period"
-scalaVersion := "2.12.18"
+scalaVersion := "2.12.20"
 libraryDependencies += "log4j" % "log4j" % "1.2.16" % "compile"
 autoScalaLibrary := false
 

--- a/sbt-app/src/sbt-test/dependency-management/global-plugins/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/global-plugins/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"

--- a/sbt-app/src/sbt-test/dependency-management/snapshot-local/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/snapshot-local/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
 
 def customIvyPaths: Seq[Def.Setting[_]] = Seq(

--- a/sbt-app/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/snapshot-resolution/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 // TTL is 24h so we can't detect the change
 ThisBuild / useCoursier := false

--- a/sbt-app/src/sbt-test/java/cross/build.sbt
+++ b/sbt-app/src/sbt-test/java/cross/build.sbt
@@ -4,7 +4,7 @@ val check = inputKey[Unit]("Runs the check")
 
 lazy val root = (project in file("."))
   .settings(
-    ThisBuild / scalaVersion := "2.12.19",
+    ThisBuild / scalaVersion := "2.12.20",
     crossJavaVersions := List("1.8"),
 
     // read out.txt and see if it starts with the passed in number

--- a/sbt-app/src/sbt-test/java/cross/changes/build.sbt
+++ b/sbt-app/src/sbt-test/java/cross/changes/build.sbt
@@ -4,7 +4,7 @@ val check = inputKey[Unit]("Runs the check")
 
 lazy val root = (project in file("."))
   .settings(
-    ThisBuild / scalaVersion := "2.12.19",
+    ThisBuild / scalaVersion := "2.12.20",
     crossJavaVersions := List("1.8", "10"),
 
     // read out.txt and see if it starts with the passed in number

--- a/sbt-app/src/sbt-test/plugins/hydra/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/hydra/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val check = taskKey[Unit]("")
 

--- a/sbt-app/src/sbt-test/plugins/sbt-native-packager/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/sbt-native-packager/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 name := "hello"
 enablePlugins(JavaAppPackaging)

--- a/sbt-app/src/sbt-test/plugins/unidoc/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/unidoc/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"
 scalacOptions += "-Xfatal-warnings" // required for the test
 
 enablePlugins(ScalaUnidocPlugin)

--- a/sbt-app/src/sbt-test/project/aggregate/projA/build.sbt
+++ b/sbt-app/src/sbt-test/project/aggregate/projA/build.sbt
@@ -1,3 +1,3 @@
 name := "projA"
 
-scalaVersion := "2.12.19"
+scalaVersion := "2.12.20"

--- a/sbt-app/src/sbt-test/project/cross-plugins-defaults/build.sbt
+++ b/sbt-app/src/sbt-test/project/cross-plugins-defaults/build.sbt
@@ -1,7 +1,7 @@
 val baseSbt = "1."
 
-val buildCrossList = List("2.10.7", "2.11.12", "2.12.19")
-scalaVersion in ThisBuild := "2.12.19"
+val buildCrossList = List("2.10.7", "2.11.12", "2.12.20")
+scalaVersion in ThisBuild := "2.12.20"
 crossScalaVersions in ThisBuild := buildCrossList
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/sbt-app/src/sbt-test/project/flatten/build.sbt
+++ b/sbt-app/src/sbt-test/project/flatten/build.sbt
@@ -1,6 +1,6 @@
 val unpackage = TaskKey[Unit]("unpackage")
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/project/internal-tracking/build.sbt
+++ b/sbt-app/src/sbt-test/project/internal-tracking/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / trackInternalDependencies := TrackLevel.NoTracking
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/project/sbt-plugin/build.sbt
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = project.in(file("."))
   .enablePlugins(SbtPlugin)
   .settings(
-    scalaVersion := "2.12.19",
+    scalaVersion := "2.12.20",
     scalacOptions ++= Seq("-Xfatal-warnings", "-Xlint")
   )

--- a/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
+++ b/sbt-app/src/sbt-test/project/sbt-plugin/changes/oldSbtPlugin.sbt
@@ -1,6 +1,6 @@
 lazy val root = project.in(file("."))
   .settings(
-    scalaVersion := "2.12.19",
+    scalaVersion := "2.12.20",
     sbtPlugin := true,
     scalacOptions ++= Seq("-Xfatal-warnings", "-Xlint")
   )

--- a/sbt-app/src/sbt-test/project/semanticdb/build.sbt
+++ b/sbt-app/src/sbt-test/project/semanticdb/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbIncludeInJar := true
 

--- a/sbt-app/src/sbt-test/project/unified/build.sbt
+++ b/sbt-app/src/sbt-test/project/unified/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 import sbt.internal.CommandStrings.{ inspectBrief, inspectDetailed }
 import sbt.internal.Inspect

--- a/sbt-app/src/sbt-test/run/fork-loader/build.sbt
+++ b/sbt-app/src/sbt-test/run/fork-loader/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/source-dependencies/binary/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/binary/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val dep = project
 

--- a/sbt-app/src/sbt-test/source-dependencies/constants/test
+++ b/sbt-app/src/sbt-test/source-dependencies/constants/test
@@ -1,4 +1,4 @@
-> ++2.12.19!
+> ++2.12.20!
 
 $ copy-file changes/B.scala B.scala
 

--- a/sbt-app/src/sbt-test/source-dependencies/cross-source/test
+++ b/sbt-app/src/sbt-test/source-dependencies/cross-source/test
@@ -1,3 +1,3 @@
 # A.scala needs B.scala, it would be in source list
-> ++2.12.19!
+> ++2.12.20!
 > compile

--- a/sbt-app/src/sbt-test/source-dependencies/macro-annotation/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/macro-annotation/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val paradiseVersion = "2.1.1"
 val commonSettings = Seq(

--- a/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep-nested/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep-stackoverflow/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/macro-arg-dep/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt-app/src/sbt-test/source-dependencies/macro/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/macro/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val defaultSettings = Seq(
   libraryDependencies += scalaVersion("org.scala-lang" % "scala-reflect" % _ ).value

--- a/sbt-app/src/sbt-test/tests/arguments/build.sbt
+++ b/sbt-app/src/sbt-test/tests/arguments/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val foo = settingKey[Seq[String]]("foo")
 val checkFoo = inputKey[Unit]("check contents of foo")

--- a/sbt-app/src/sbt-test/tests/do-not-discover/build.sbt
+++ b/sbt-app/src/sbt-test/tests/do-not-discover/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/done/build.sbt
+++ b/sbt-app/src/sbt-test/tests/done/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/filter-runners/build.sbt
+++ b/sbt-app/src/sbt-test/tests/filter-runners/build.sbt
@@ -1,7 +1,7 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.2.2"
 val munit = "org.scalameta" %% "munit" % "0.7.22"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 libraryDependencies += scalatest % Test
 libraryDependencies += munit % Test

--- a/sbt-app/src/sbt-test/tests/fork-async/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-async/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
@@ -1,7 +1,7 @@
 import Tests._
 import Defaults._
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 val check = taskKey[Unit]("Check that tests are executed in parallel")
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/tests/fork-test-group-parallel-custom-tags/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-test-group-parallel-custom-tags/build.sbt
@@ -1,5 +1,5 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val TestATypeTag = Tags.Tag("TestA")
 val TestBTypeTag = Tags.Tag("TestB")

--- a/sbt-app/src/sbt-test/tests/fork-test-group-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-test-group-parallel/build.sbt
@@ -1,5 +1,5 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 Global / concurrentRestrictions := Seq(Tags.limitAll(4))
 libraryDependencies += specs % Test

--- a/sbt-app/src/sbt-test/tests/fork-uncaught2/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-uncaught2/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
 

--- a/sbt-app/src/sbt-test/tests/fork/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork/build.sbt
@@ -11,7 +11,7 @@ val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 def groupId(idx: Int) = "group_" + (idx + 1)
 def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / organization := "org.example"
 
 lazy val root = (project in file("."))

--- a/sbt-app/src/sbt-test/tests/fork2/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork2/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 fork := true
 libraryDependencies += scalatest % Test

--- a/sbt-app/src/sbt-test/tests/it/build.sbt
+++ b/sbt-app/src/sbt-test/tests/it/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
 

--- a/sbt-app/src/sbt-test/tests/junit-xml-report/build.sbt
+++ b/sbt-app/src/sbt-test/tests/junit-xml-report/build.sbt
@@ -14,7 +14,7 @@ val nestedSuitesReportFile = "target/test-reports/TEST-my.scalatest.MyNestedSuit
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt-app/src/sbt-test/tests/munit/build.sbt
+++ b/sbt-app/src/sbt-test/tests/munit/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val munit = "org.scalameta" %% "munit" % "0.7.22"
 

--- a/sbt-app/src/sbt-test/tests/nested-inproc-par/build.sbt
+++ b/sbt-app/src/sbt-test/tests/nested-inproc-par/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/nested-inproc-seq/build.sbt
+++ b/sbt-app/src/sbt-test/tests/nested-inproc-seq/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/nested-subproc/build.sbt
+++ b/sbt-app/src/sbt-test/tests/nested-subproc/build.sbt
@@ -1,7 +1,7 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/nested-tests/build.sbt
+++ b/sbt-app/src/sbt-test/tests/nested-tests/build.sbt
@@ -1,6 +1,6 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / version := "0.0.1" 
 ThisBuild / organization := "org.catastrophe"
 

--- a/sbt-app/src/sbt-test/tests/one-class-multi-framework/build.sbt
+++ b/sbt-app/src/sbt-test/tests/one-class-multi-framework/build.sbt
@@ -1,5 +1,5 @@
 val specsJunit = "org.specs2" %% "specs2-junit" % "4.3.4"
 val junitinterface = "com.novocode" % "junit-interface" % "0.11"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies += junitinterface % Test
 libraryDependencies += specsJunit % Test

--- a/sbt-app/src/sbt-test/tests/order/build.sbt
+++ b/sbt-app/src/sbt-test/tests/order/build.sbt
@@ -1,5 +1,5 @@
 val scalcheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 Test / parallelExecution := false
 libraryDependencies += scalcheck % Test

--- a/sbt-app/src/sbt-test/tests/resources/build.sbt
+++ b/sbt-app/src/sbt-test/tests/resources/build.sbt
@@ -1,3 +1,3 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies += specs % Test

--- a/sbt-app/src/sbt-test/tests/scala-instance-classloader/build.sbt
+++ b/sbt-app/src/sbt-test/tests/scala-instance-classloader/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.inc.ScalaInstance
 lazy val OtherScala = config("other-scala").hide
 lazy val junitinterface = "com.novocode" % "junit-interface" % "0.11"
 lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.5.17"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .configs(OtherScala)

--- a/sbt-app/src/sbt-test/tests/serial/build.sbt
+++ b/sbt-app/src/sbt-test/tests/serial/build.sbt
@@ -1,6 +1,6 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 ThisBuild / organization := "com.example"
 ThisBuild / version      := "0.0.1-SNAPSHOT"
 

--- a/sbt-app/src/sbt-test/tests/setup-cleanup/base.sbt
+++ b/sbt-app/src/sbt-test/tests/setup-cleanup/base.sbt
@@ -1,3 +1,3 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies += scalatest

--- a/sbt-app/src/sbt-test/tests/single-runner/build.sbt
+++ b/sbt-app/src/sbt-test/tests/single-runner/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt-app/src/sbt-test/tests/specs-run/build.sbt
+++ b/sbt-app/src/sbt-test/tests/specs-run/build.sbt
@@ -1,4 +1,4 @@
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 libraryDependencies += specs % Test

--- a/sbt-app/src/sbt-test/tests/t543/build.sbt
+++ b/sbt-app/src/sbt-test/tests/t543/build.sbt
@@ -7,7 +7,7 @@ val check = TaskKey[Unit]("check", "Check correct error has been returned.")
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val scalaxml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file(".")).
   settings(

--- a/sbt-app/src/sbt-test/tests/task/build.sbt
+++ b/sbt-app/src/sbt-test/tests/task/build.sbt
@@ -1,4 +1,4 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 libraryDependencies += scalatest
 Test / testOptions += Tests.Argument("-C", "custom.CustomReporter")

--- a/sbt-app/src/sbt-test/tests/test-exclude/build.sbt
+++ b/sbt-app/src/sbt-test/tests/test-exclude/build.sbt
@@ -1,5 +1,5 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/test-quick/build.sbt
+++ b/sbt-app/src/sbt-test/tests/test-quick/build.sbt
@@ -1,5 +1,5 @@
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/watch/commands/build.sbt
+++ b/sbt-app/src/sbt-test/watch/commands/build.sbt
@@ -53,4 +53,4 @@ expectFailure / watchOnFileInputEvent := { (_, e) =>
 }
 
 
-crossScalaVersions := Seq("2.11.12", "2.12.19")
+crossScalaVersions := Seq("2.11.12", "2.12.20")

--- a/server-test/src/server-test/response/build.sbt
+++ b/server-test/src/server-test/response/build.sbt
@@ -1,6 +1,6 @@
 import sbt.internal.server.{ ServerHandler, ServerIntent }
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := "2.12.20"
 
 Global / serverLog / logLevel := Level.Debug
 // custom handler


### PR DESCRIPTION
I'll un-draft after 2.12.20 has been announced

CI will fail for now because some dependencies haven't published yet (kind-projector, scalameta)