### PR TITLE
[2.x] Optimize evaluation of `.all` on tasks and settings

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -327,6 +327,7 @@ object Defaults extends BuildCommon {
       outputStrategy :== None, // TODO - This might belong elsewhere.
       buildStructure := Project.structure(state.value),
       settingsData := buildStructure.value.data,
+      allScopes := ScopeFilter.allScopes.value,
       checkBuildSources / aggregate :== false,
       checkBuildSources / changedInputFiles / aggregate := false,
       checkBuildSources / Continuous.dynamicInputs := None,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -632,6 +632,7 @@ object Keys {
   val forcegc = settingKey[Boolean]("Enables (true) or disables (false) forcing garbage collection after task run when needed.").withRank(BMinusSetting)
   val minForcegcInterval = settingKey[Duration]("Minimal interval to check for forcing garbage collection.")
   val settingsData = std.FullInstance.settingsData
+  private[sbt] val allScopes = settingKey[ScopeFilter.AllScopes]("Internal use: a view of all scopes for filtering")
   @cacheLevel(include = Array.empty)
   val streams = taskKey[TaskStreams]("Provides streams for logging and persisting data.").withRank(DTask)
   val taskDefinitionKey = Def.taskDefinitionKey

--- a/sbt-app/src/sbt-test/actions/multi-scope/build.sbt
+++ b/sbt-app/src/sbt-test/actions/multi-scope/build.sbt
@@ -1,7 +1,7 @@
 lazy val taskX = taskKey[Set[Int]]("numbers")
 lazy val filterX = ScopeFilter( inDependencies(ThisProject, transitive=false, includeRoot=false) )
 
-lazy val filterA: ScopeFilter.ScopeFilter = ScopeFilter(
+lazy val filterA: ScopeFilter = ScopeFilter(
 	inAggregates( LocalProject(e.id) ),
 	inConfigurations(Compile,Test) || inZeroConfiguration,
 	inTasks(console) || inZeroTask


### PR DESCRIPTION
In anticipation of #7641, I am trying to optimize the loading time of big project matrices, such as https://github.com/softwaremill/sttp, which contains 218 projects and more than 200,000 keys.

## Before

The CPU profiling shows that the evaluation of `.all` is far more expensive than it should be. This is because we call `ScopeFilter.apply` on each and every scope.
![taskKeyAll-before](https://github.com/user-attachments/assets/e4eaca9a-73a3-4439-ba03-6fcd2cf3519a)

## After

The optimization consists of grouping all scopes by project, config and task to speed up the filtering.

![taskKeyAll-after](https://github.com/user-attachments/assets/615b32c9-1d67-4eaa-979a-a3abf00af83a)

## Backporting to sbt 1.x?

I've done the profiling on sbt 1.x but the changes are not strictly binary compatible. Probably it is possible to backport the optimization in a binary compatible way but the code is going to be much more ugly.