### PR TITLE
fix: serverIdleTimeOut -> serverIdleTimeout

### DIFF
--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -94,7 +94,7 @@ object BasicKeys {
 
   val serverIdleTimeout =
     AttributeKey[Option[FiniteDuration]](
-      "serverIdleTimeOut",
+      "serverIdleTimeout",
       "If set to a defined value, sbt server will exit if it goes at least the specified duration without receiving any commands.",
       10000
     )


### PR DESCRIPTION
Use consistent name for the option. The variable is named `serverIdleTimeout` and this also seems the proper camelcasing of the words.

This addresses #7631.