### PR TITLE
[2.x] refactor: Remove unused tasks

### DIFF
--- a/main/src/main/scala/sbt/RemoteCache.scala
+++ b/main/src/main/scala/sbt/RemoteCache.scala
@@ -142,9 +142,7 @@ object RemoteCache {
     },
     pushRemoteCacheConfiguration / publishMavenStyle := true,
     Compile / packageCache / pushRemoteCacheArtifact := true,
-    Test / packageCache / pushRemoteCacheArtifact := true,
     Compile / packageCache / artifact := Artifact(moduleName.value, cachedCompileClassifier),
-    Test / packageCache / artifact := Artifact(moduleName.value, cachedTestClassifier),
     remoteCachePom / pushRemoteCacheArtifact := true,
     remoteCachePom := {
       val s = streams.value


### PR DESCRIPTION
**Problem/Solution**
Unused setting ends up showing warnings on startup. This removes the unused settings from sbt 1.x remote cache.