### PR TITLE
[2.x] fix: fallback to file copy

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -288,6 +288,7 @@ class DiskActionCacheStore(base: Path) extends AbstractActionCacheStore:
                 scala.Console.err.println(
                   "[info] failed to a create symbolic link. consider enabling Developer Mode"
                 )
+              symlinkSupported.set(false)
               copyFile(outPath)
         else copyFile(outPath)
       afterFileWrite(ref, result, outputDirectory)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7656

## Problem
Disk cache currently uses symbolic links, which won't work on Windows without the Administrator privileges or Developer Mode.

## Solution
This falls back to using file copy.