### PR TITLE
[1.x] feat: Use _sbt2_3 suffix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import scala.util.Try
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 ThisBuild / version := {
-  val v = "1.10.0-SNAPSHOT"
+  val v = "1.10.2-SNAPSHOT"
   nightlyVersion.getOrElse(v)
 }
 ThisBuild / version2_13 := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/7655

## Problem
The extra attribute is a vestige from the days when sbt plugins were published on Ivy repos. On sbt 2.x, we want to switch to using `_sbt2_3` suffix system.

## Solution
1. This uses normal suffix system.
2. This drops the POM-consistent workaround POM and JAR publishing when sbt version is >1.

## Note

To be clear during the milestones etc it would look more like:

```
[info]  published sbt-vimquit_sbt2.0.0-M1_3 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_sbt2.0.0-M1_3/0.1.1-SNAPSHOT/sbt-vimquit_sbt2.0.0-M1_3-0.1.1-SNAPSHOT.jar
```

not `_sbt2_3` literally.

```
sbt:sbt-vimquit> publishM2
[info] 	published sbt-vimquit_2.12_1.0 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit_2.12_1.0-0.1.1-SNAPSHOT-javadoc.jar
[info] 	published sbt-vimquit          to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit-0.1.1-SNAPSHOT-sources.jar
[info] 	published sbt-vimquit_2.12_1.0 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit_2.12_1.0-0.1.1-SNAPSHOT.jar
[info] 	published sbt-vimquit          to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit-0.1.1-SNAPSHOT-javadoc.jar
[info] 	published sbt-vimquit          to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit-0.1.1-SNAPSHOT.jar
[info] 	published sbt-vimquit_2.12_1.0 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit_2.12_1.0-0.1.1-SNAPSHOT-sources.jar
[info] 	published sbt-vimquit_2.12_1.0 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit_2.12_1.0-0.1.1-SNAPSHOT.pom
[info] 	published sbt-vimquit          to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_2.12_1.0/0.1.1-SNAPSHOT/sbt-vimquit-0.1.1-SNAPSHOT.pom

sbt:sbt-vimquit> ++3.3.3!
sbt:sbt-vimquit> publishM2
[info] 	published sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3/0.1.1-SNAPSHOT/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3-0.1.1-SNAPSHOT.pom
[info] 	published sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3/0.1.1-SNAPSHOT/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3-0.1.1-SNAPSHOT.jar
[info] 	published sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3/0.1.1-SNAPSHOT/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3-0.1.1-SNAPSHOT-sources.jar
[info] 	published sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3 to file:/Users/xxx/.m2/repository/com/eed3si9n/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3/0.1.1-SNAPSHOT/sbt-vimquit_sbt2.0.0-alpha11-SNAPSHOT_3-0.1.1-SNAPSHOT-javadoc.jar
```