### PR TITLE
[1.x] fix: Allow scripted to go through

### DIFF
--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -71,13 +71,11 @@ object ScriptedPlugin extends AutoPlugin {
           "org.scala-sbt" % "scripted-sbt" % scriptedSbt.value % ScriptedConf,
           "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % ScriptedLaunchConf
         )
-      case Some((1, _)) =>
+      case _ =>
         Seq(
           "org.scala-sbt" %% "scripted-sbt" % scriptedSbt.value % ScriptedConf,
           "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % ScriptedLaunchConf
         )
-      case Some((x, y)) => sys error s"Unknown sbt version ${scriptedSbt.value} ($x.$y)"
-      case None         => sys error s"Unknown sbt version ${scriptedSbt.value}"
     }),
     scriptedClasspath := getJars(ScriptedConf).value,
     scriptedTests := scriptedTestsTask.value,


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7669

## Problem

Currently scripted does version checking to block sbt 2.x plugins to be cross published from sbt 1.x.

## Solution
Remove the sbt version matching so scripted would work on both sbt 1.x and 2.x here.
