### PR TITLE
[1.x] fix: serverIdleTimeOut -> serverIdleTimeout

### DIFF
--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -93,7 +93,7 @@ object BasicKeys {
 
   val serverIdleTimeout =
     AttributeKey[Option[FiniteDuration]](
-      "serverIdleTimeOut",
+      "serverIdleTimeout",
       "If set to a defined value, sbt server will exit if it goes at least the specified duration without receiving any commands.",
       10000
     )


### PR DESCRIPTION
This is a 1.x backport of https://github.com/sbt/sbt/pull/7651 by @lervag

Use consistent name for the option. The variable is named `serverIdleTimeout` and this also seems the proper camelcasing of the words.