### PR TITLE
[2.x] feat: Use _sbt2_3 suffix 

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.2


### PR DESCRIPTION
This is a forward port of https://github.com/sbt/sbt/pull/7671
Fixes https://github.com/sbt/sbt/issues/7655

## Problem
The extra attribute is a vestige from the days when sbt plugins were published on Ivy repos.

## Solution
This uses normal suffix system.