### PR TITLE
[2.x] feat: Non-blocking run

### DIFF
--- a/main-command/src/main/scala/sbt/internal/CommandChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/CommandChannel.scala
@@ -101,6 +101,10 @@ abstract class CommandChannel {
   }
 
   private[sbt] def terminal: Terminal
+  private[sbt] var _active: Boolean = true
+  private[sbt] def pause(): Unit = _active = false
+  private[sbt] def isPaused: Boolean = !_active
+  private[sbt] def resume(): Unit = _active = true
 }
 
 // case class Exec(commandLine: String, source: Option[CommandSource])

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -110,3 +110,5 @@ abstract class JobHandle {
   def humanReadableName: String
   def spawningTask: ScopedKey[_]
 }
+
+case class RunInfo(handle: JobHandle)

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -111,4 +111,9 @@ abstract class JobHandle {
   def spawningTask: ScopedKey[_]
 }
 
-case class RunInfo(handle: JobHandle)
+/**
+ * This datatype is used signal the task engine or the commands
+ * that the background job is emulated to be a foreground job on
+ * the originating channel.
+ */
+case class EmulateForeground(handle: JobHandle)

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -86,6 +86,8 @@ abstract class BackgroundJobService extends Closeable {
       hashContents: Boolean,
       converter: FileConverter,
   ): Classpath = copyClasspath(products, full, workingDirectory, converter)
+
+  private[sbt] def pauseChannelDuringJob(state: State, handle: JobHandle): Unit
 }
 
 object BackgroundJobService {

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2152,27 +2152,17 @@ object Defaults extends BuildCommon {
     }
 
   // `runMain` calls bgRunMain in the background and pauses the current channel
-  def foregroundRunMainTask: Initialize[InputTask[RunInfo]] =
+  def foregroundRunMainTask: Initialize[InputTask[EmulateForeground]] =
     Def.inputTask {
       val handle = bgRunMain.evaluated
-      val service = bgJobService.value
-      val st = state.value
-      st.remainingCommands match
-        case Nil => service.waitForTry(handle).get
-        case _   => service.pauseChannelDuringJob(st, handle)
-      RunInfo(handle)
+      EmulateForeground(handle)
     }
 
   // `run` task calls bgRun in the background and pauses the current channel
-  def foregroundRunTask: Initialize[InputTask[RunInfo]] =
+  def foregroundRunTask: Initialize[InputTask[EmulateForeground]] =
     Def.inputTask {
       val handle = bgRun.evaluated
-      val service = bgJobService.value
-      val st = state.value
-      st.remainingCommands match
-        case Nil => service.waitForTry(handle).get
-        case _   => service.pauseChannelDuringJob(st, handle)
-      RunInfo(handle)
+      EmulateForeground(handle)
     }
 
   def runMainTask(

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -319,9 +319,9 @@ object Keys {
   // Run Keys
   val selectMainClass = taskKey[Option[String]]("Selects the main class to run.").withRank(BMinusTask)
   val mainClass = taskKey[Option[String]]("Defines the main class for packaging or running.").withRank(BPlusTask)
-  val run = inputKey[RunInfo]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
-  val runBlock = inputKey[RunInfo]("Runs a main class, and blocks until it's done.").withRank(DTask)
-  val runMain = inputKey[RunInfo]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
+  val run = inputKey[EmulateForeground]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
+  val runBlock = inputKey[EmulateForeground]("Runs a main class, and blocks until it's done.").withRank(DTask)
+  val runMain = inputKey[EmulateForeground]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
   val discoveredMainClasses = taskKey[Seq[String]]("Auto-detects main classes.").withRank(BMinusTask)
   val runner = taskKey[ScalaRun]("Implementation used to run a main class.").withRank(DTask)
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -319,8 +319,8 @@ object Keys {
   // Run Keys
   val selectMainClass = taskKey[Option[String]]("Selects the main class to run.").withRank(BMinusTask)
   val mainClass = taskKey[Option[String]]("Defines the main class for packaging or running.").withRank(BPlusTask)
-  val run = inputKey[Unit]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
-  val runMain = inputKey[Unit]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
+  val run = inputKey[RunVoid]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
+  val runMain = inputKey[RunVoid]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
   val discoveredMainClasses = taskKey[Seq[String]]("Auto-detects main classes.").withRank(BMinusTask)
   val runner = taskKey[ScalaRun]("Implementation used to run a main class.").withRank(DTask)
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -319,8 +319,9 @@ object Keys {
   // Run Keys
   val selectMainClass = taskKey[Option[String]]("Selects the main class to run.").withRank(BMinusTask)
   val mainClass = taskKey[Option[String]]("Defines the main class for packaging or running.").withRank(BPlusTask)
-  val run = inputKey[RunVoid]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
-  val runMain = inputKey[RunVoid]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
+  val run = inputKey[RunInfo]("Runs a main class, passing along arguments provided on the command line.").withRank(APlusTask)
+  val runBlock = inputKey[RunInfo]("Runs a main class, and blocks until it's done.").withRank(DTask)
+  val runMain = inputKey[RunInfo]("Runs the main class selected by the first argument, passing the remaining arguments to the main method.").withRank(ATask)
   val discoveredMainClasses = taskKey[Seq[String]]("Auto-detects main classes.").withRank(BMinusTask)
   val runner = taskKey[ScalaRun]("Implementation used to run a main class.").withRank(DTask)
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -80,13 +80,13 @@ object Aggregation {
       case Result.Value(_) => true
       case Result.Inc(_)   => false
     // run task ends earlier than the program run
-    val isRunVoid = results match
-      case Result.Value(Seq(KeyValue(_, RunVoid))) => true
-      case _                                       => false
+    val isRunInfo = results match
+      case Result.Value(Seq(KeyValue(_, RunInfo(_)))) => true
+      case _                                          => false
     results.toEither.foreach { r =>
       if show.taskValues then printSettings(r, show.print) else ()
     }
-    if show.success && !isRunVoid && !state.get(suppressShow).getOrElse(false) then
+    if show.success && !isRunInfo && !state.get(suppressShow).getOrElse(false) then
       printSuccess(start, stop, extracted, success, cacheSummary, log)
     else ()
 

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -79,16 +79,24 @@ object Aggregation {
     val success = results match
       case Result.Value(_) => true
       case Result.Inc(_)   => false
-    // run task ends earlier than the program run
-    val isRunInfo = results match
-      case Result.Value(Seq(KeyValue(_, RunInfo(_)))) => true
-      case _                                          => false
+    val isPaused = currentChannel(state) match
+      case Some(channel) => channel.isPaused
+      case None          => false
     results.toEither.foreach { r =>
       if show.taskValues then printSettings(r, show.print) else ()
     }
-    if show.success && !isRunInfo && !state.get(suppressShow).getOrElse(false) then
+    if !isPaused && show.success && !state.get(suppressShow).getOrElse(false) then
       printSuccess(start, stop, extracted, success, cacheSummary, log)
     else ()
+
+  private def currentChannel(state: State): Option[CommandChannel] =
+    state.currentCommand match
+      case Some(exec) =>
+        exec.source match
+          case Some(source) =>
+            StandardMain.exchange.channels.find(_.name == source.channelName)
+          case _ => None
+      case _ => None
 
   def timedRun[A](
       s: State,

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -79,10 +79,14 @@ object Aggregation {
     val success = results match
       case Result.Value(_) => true
       case Result.Inc(_)   => false
+    // run task ends earlier than the program run
+    val isRunVoid = results match
+      case Result.Value(Seq(KeyValue(_, RunVoid))) => true
+      case _                                       => false
     results.toEither.foreach { r =>
       if show.taskValues then printSettings(r, show.print) else ()
     }
-    if show.success && !state.get(suppressShow).getOrElse(false) then
+    if show.success && !isRunVoid && !state.get(suppressShow).getOrElse(false) then
       printSuccess(start, stop, extracted, success, cacheSummary, log)
     else ()
 

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -146,10 +146,11 @@ private[sbt] final class CommandExchange {
   }
 
   private def addConsoleChannel(): Unit =
-    if (!Terminal.startedByRemoteClient) {
+    if Terminal.startedByRemoteClient then ()
+    else
       val name = ConsoleChannel.defaultName
       subscribe(new ConsoleChannel(name, mkAskUser(name)))
-    }
+
   def run(s: State): State = run(s, s.get(autoStartServer).getOrElse(true))
   def run(s: State, autoStart: Boolean): State = {
     if (autoStartServerSysProp && autoStart) runServer(s)
@@ -376,13 +377,14 @@ private[sbt] final class CommandExchange {
 
   private[sbt] def setExec(exec: Option[Exec]): Unit = currentExecRef.set(exec.orNull)
 
-  def prompt(event: ConsolePromptEvent): Unit = {
+  def prompt(event: ConsolePromptEvent): Unit =
     currentExecRef.set(null)
     channels.foreach {
       case c if ContinuousCommands.isInWatch(lastState.get, c) =>
-      case c                                                   => c.prompt(event)
+      case c =>
+        if c.isPaused then ()
+        else c.prompt(event)
     }
-  }
   def unprompt(event: ConsoleUnpromptEvent): Unit = channels.foreach(_.unprompt(event))
 
   def logMessage(event: LogEvent): Unit = {

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -309,11 +309,11 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
   private[sbt] def pauseChannelDuringJob(state: State, handle: JobHandle): Unit =
     currentChannel(state) match
       case Some(channel) =>
-        val level = channel.logLevel
-        channel.setLevel(Level.Error)
-        channel.pause()
         handle match
           case t: ThreadJobHandle =>
+            val level = channel.logLevel
+            channel.setLevel(Level.Error)
+            channel.pause()
             t.job.onStop: () =>
               channel.setLevel(level)
               channel.resume()

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -212,3 +212,14 @@ object Run:
       case str                      => str
     }).mkString(" ")
 end Run
+
+/**
+ * RunVoid is a special `Unit` type used to indicate that it's a `run` task.
+ * When a task returns RunVoid, [success] log is omitted.
+ */
+sealed trait RunVoid
+
+/**
+ * The only resident of RunVoid type.
+ */
+case object RunVoid extends RunVoid

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -212,14 +212,3 @@ object Run:
       case str                      => str
     }).mkString(" ")
 end Run
-
-/**
- * RunVoid is a special `Unit` type used to indicate that it's a `run` task.
- * When a task returns RunVoid, [success] log is omitted.
- */
-sealed trait RunVoid
-
-/**
- * The only resident of RunVoid type.
- */
-case object RunVoid extends RunVoid

--- a/sbt-app/src/sbt-test/actions/add-alias/build.sbt
+++ b/sbt-app/src/sbt-test/actions/add-alias/build.sbt
@@ -1,3 +1,3 @@
-addCommandAlias("demo-success", "run true")
-addCommandAlias("demo-failure", "run false")
+addCommandAlias("demo-success", "runBlock true")
+addCommandAlias("demo-failure", "runBlock false")
 addCommandAlias("z", "scalaVersion")

--- a/sbt-app/src/sbt-test/classloader-cache/jni/build.sbt
+++ b/sbt-app/src/sbt-test/classloader-cache/jni/build.sbt
@@ -7,7 +7,7 @@ val dropLibraryPath = taskKey[Unit]("Drop the last path from the java.library.pa
 val wrappedRun = taskKey[Unit]("Run with modified java.library.path")
 val wrappedTest = taskKey[Unit]("Test with modified java.library.path")
 
-def wrap(task: InputKey[Unit]): Def.Initialize[Task[Unit]] =
+def wrap[A1](task: InputKey[A1]): Def.Initialize[Task[Unit]] =
   Def.sequential(appendToLibraryPath, task.toTask(""), dropLibraryPath)
 
 // ThisBuild / turbo := true
@@ -35,6 +35,6 @@ val root = (project in file(".")).settings(
     val cp = System.getProperty("java.library.path", "").split(":").dropRight(1)
     System.setProperty("java.library.path", cp.mkString(":"))
   },
-  wrappedRun := wrap(Runtime / run).value,
+  wrappedRun := wrap(Runtime / runBlock).value,
   wrappedTest := wrap(Test / testOnly).value
 )

--- a/sbt-app/src/sbt-test/dependency-management/aar-packaging/test
+++ b/sbt-app/src/sbt-test/dependency-management/aar-packaging/test
@@ -1,3 +1,3 @@
 $ delete output
-> run
+> runBlock
 $ exists output

--- a/sbt-app/src/sbt-test/dependency-management/exclude-dependencies2/test
+++ b/sbt-app/src/sbt-test/dependency-management/exclude-dependencies2/test
@@ -1,3 +1,3 @@
 $ delete output
-> run
+> runBlock
 $ exists output

--- a/sbt-app/src/sbt-test/dependency-management/profiles/test
+++ b/sbt-app/src/sbt-test/dependency-management/profiles/test
@@ -1,3 +1,3 @@
 $ delete output
-> run
+> runBlock
 $ exists output

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
@@ -1,12 +1,12 @@
 > a/checkLibs
 > b/checkLibs
 
-> b/run
+> b/runBlock
 $ exists s2.13.8.txt
 $ delete s2.13.8.txt
 
 # don't crash when expanding the macro
-> b3/run
+> b3/runBlock
 $ exists s2.13.10.txt
 $ delete s2.13.10.txt
 

--- a/sbt-app/src/sbt-test/dependency-management/url-no-head/test
+++ b/sbt-app/src/sbt-test/dependency-management/url-no-head/test
@@ -1,3 +1,3 @@
 $ delete output
-> run
+> runBlock
 $ exists output

--- a/sbt-app/src/sbt-test/package/resources/test
+++ b/sbt-app/src/sbt-test/package/resources/test
@@ -4,7 +4,7 @@
 
 # This should fail because the Main object is in package jartest and the resource is directly
 # in src/main/resources
--> run
+-> runBlock
 
 > package
 
@@ -18,7 +18,7 @@ $ copy-file src/main/resources/main_resource_test src/main/resources/jartest/mai
 $ delete src/main/resources/main_resource_test
 
 # This should succeed because sbt should put the resource on the runClasspath
-> run
+> runBlock
 
 # This is necessary because package bases whether or not to run on last modified times, which don't have
 # high enough resolution to notice the above move of main_resource_test

--- a/sbt-app/src/sbt-test/source-dependencies/constants/test
+++ b/sbt-app/src/sbt-test/source-dependencies/constants/test
@@ -3,14 +3,14 @@
 $ copy-file changes/B.scala B.scala
 
 $ copy-file changes/A1.scala A.scala
-> run 1
+> runBlock 1
 $ copy-file changes/A2.scala A.scala
-> run 2
+> runBlock 2
 
 > clean
 > ++2.13.12!
 
 $ copy-file changes/A1.scala A.scala
-> run 1
+> runBlock 1
 $ copy-file changes/A2.scala A.scala
-> run 2
+> runBlock 2

--- a/sbt-app/src/sbt-test/source-dependencies/implicit-search/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/implicit-search/build.sbt
@@ -1,2 +1,1 @@
-ThisBuild / scalaVersion := "2.12.17"
-
+scalaVersion := "2.12.19"

--- a/sbt-app/src/sbt-test/source-dependencies/implicit-search/test
+++ b/sbt-app/src/sbt-test/source-dependencies/implicit-search/test
@@ -2,10 +2,10 @@ $ copy-file changes/A1.scala A.scala
 $ copy-file changes/B.scala B.scala
 $ copy-file changes/C.scala C.scala
 > compile
--> run
+-> runBlock
 
 $ copy-file changes/A2.scala A.scala
 $ sleep 1000
 
 > compile
-> run
+> runBlock

--- a/sbt-app/src/sbt-test/source-dependencies/java-basic/test
+++ b/sbt-app/src/sbt-test/source-dependencies/java-basic/test
@@ -36,10 +36,10 @@ $ delete src/main/java/a/A.java
 # It shouldn't run though, because it doesn't have a main method
 $ copy-file changes/B1.java src/main/java/a/b/B.java
 > compile
--> run
+-> runBlock
 
 
 # Replace B with a new B that has a main method and should therefore run
 # if the main method was properly detected
 $ copy-file changes/B3.java src/main/java/a/b/B.java
-> run
+> runBlock

--- a/sbt-app/src/sbt-test/source-dependencies/linearization/test
+++ b/sbt-app/src/sbt-test/source-dependencies/linearization/test
@@ -1,7 +1,7 @@
 > compile
 
 # the value of F.x should be 16
-> run 16
+> runBlock 16
 
 # modify D.scala so that the linearization changes
 $ copy-file changes/D.scala D.scala
@@ -12,4 +12,4 @@ $ sleep 1000
 
 # if F is recompiled, the value of x should be 11, otherwise it will still be 16
 # and this will fail
-> run 11
+> runBlock 11

--- a/sbt-app/src/sbt-test/source-dependencies/named/test
+++ b/sbt-app/src/sbt-test/source-dependencies/named/test
@@ -4,7 +4,7 @@
 > compile
 
 # result should be 1
-> run 1
+> runBlock 1
 
 # change order of arguments in A.x
 $ copy-file changes/A.scala A.scala
@@ -13,4 +13,4 @@ $ copy-file changes/A.scala A.scala
 > compile
 
 # Should still get 1 and not -1
-> run 1
+> runBlock 1

--- a/sbt-app/src/sbt-test/source-dependencies/specialized/test
+++ b/sbt-app/src/sbt-test/source-dependencies/specialized/test
@@ -2,7 +2,7 @@
 > compile
 
 # verify that erased A.x can be called normally and reflectively
-> run false
+> runBlock false
 
 # make A.x specialized
 $ copy-file changes/A.scala A.scala
@@ -12,4 +12,4 @@ $ copy-file changes/A.scala A.scala
 
 # verify that specialized A.x can be called normally and reflectively
 # NOTE: this test doesn't actually work correctly: have to check the output to see that B.scala was recompiled
-> run true
+> runBlock true


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/6178
Ref https://github.com/sbt/sbt/issues/7687

## Problem
`run` currently blocks all other commands, such as BSP commands.

## Solution
`run` no longer blocks the command execution loop. Instead it pauses the prompt on the current command channel.
