### PR TITLE
[2.x] fix: Remove build.properties from a scripted

### DIFF
--- a/sbt-app/src/sbt-test/project-matrix/jvm/project/build.properties
+++ b/sbt-app/src/sbt-test/project-matrix/jvm/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=2.0.0-alpha12-SNAPSHOT


### PR DESCRIPTION
## Problem
build.properties hardcodes sbt version.

## Solution
This can be removed.