### PR TITLE
[2.x] refactor: Remove old sbt 0.13 shell syntax

### DIFF
--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -27,7 +27,7 @@ trait TestResultLogger {
    *
    * @param log The target logger to write output to.
    * @param results The test results about which to log.
-   * @param taskName The task about which we are logging. Eg. "my-module-b/test:test"
+   * @param taskName The task about which we are logging. Eg. "my-module-b/Test/test"
    */
   def run(log: Logger, results: Output, taskName: String): Unit
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -5049,7 +5049,7 @@ trait BuildExtra extends BuildCommon with DefExtra {
 
   /**
    * Disables post-compilation hook for determining tests for tab-completion (such as for 'test-only').
-   * This is useful for reducing test:compile time when not running test.
+   * This is useful for reducing Test/compile time when not running test.
    */
   def noTestCompletion(config: Configuration = Test): Setting[_] =
     inConfig(config)(Seq(definedTests := detectTests.value)).head

--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -36,7 +36,6 @@ final class ParsedKey(val key: ScopedKey[_], val mask: ScopeMask, val separaters
 end ParsedKey
 
 object Act {
-  val ZeroString = "*"
   private[sbt] val GlobalIdent = "Global"
   private[sbt] val ZeroIdent = "Zero"
   private[sbt] val ThisBuildIdent = "ThisBuild"
@@ -46,8 +45,6 @@ object Act {
     token(OptSpace ~> '/' <~ OptSpace).examples("/").map(_ => ())
 
   private[sbt] val slashSeq: Seq[String] = Seq("/")
-  private[sbt] val colonSeq: Seq[String] = Seq(":")
-  private[sbt] val colonColonSeq: Seq[String] = Seq("::")
 
   // this does not take aggregation into account
   def scopedKey(
@@ -242,26 +239,15 @@ object Act {
   def toAxis[T](opt: Option[T], ifNone: ScopeAxis[T]): ScopeAxis[T] =
     opt match { case Some(t) => Select(t); case None => ifNone }
 
-  def config(confs: Set[String]): Parser[ParsedAxis[String]] = {
-    val sep = ':' !!! "Expected ':' (if selecting a configuration)"
-    token(
-      (ZeroString ^^^ ParsedZero | value(examples(ID, confs, "configuration"))) <~ sep
-    ) ?? Omitted
-  }
-
   // New configuration parser that's able to parse configuration ident trailed by slash.
   private[sbt] def configIdent(
       confs: Set[String],
       idents: Set[String],
       fromIdent: String => String
   ): Parser[(ParsedAxis[String], Seq[String])] = {
-    val oldSep: Parser[Char] = ':'
     val sep: Parser[Unit] = spacedSlash !!! "Expected '/'"
     token(
-      ((ZeroString ^^^ (ParsedZero -> colonSeq)) <~ oldSep)
-        | ((ZeroString ^^^ (ParsedZero -> slashSeq)) <~ sep)
-        | ((ZeroIdent ^^^ (ParsedZero -> slashSeq)) <~ sep)
-        | (value(examples(ID, confs, "configuration")).map(_ -> colonSeq) <~ oldSep)
+      ((ZeroIdent ^^^ (ParsedZero -> slashSeq)) <~ sep)
         | (value(examples(CapitalizedID, idents, "configuration ident").map(fromIdent))
           .map(_ -> slashSeq) <~ sep)
     ) ?? (Omitted -> Nil)
@@ -358,16 +344,10 @@ object Act {
     val suggested = normKeys.map(_._1).toSet
     val keyP = filterStrings(examples(ID, suggested, "key"), valid.keySet, "key").map(valid)
 
-    ((token(
+    (token(
       value(keyP).map(_ -> slashSeq)
-        | ZeroString ^^^ (ParsedZero -> slashSeq)
         | ZeroIdent ^^^ (ParsedZero -> slashSeq)
-    ) <~ spacedSlash) |
-      (token(
-        value(keyP).map(_ -> colonColonSeq)
-          | ZeroString ^^^ (ParsedZero -> colonColonSeq)
-          | ZeroIdent ^^^ (ParsedZero -> colonColonSeq)
-      ) <~ token("::".id))) ?? (Omitted -> Nil)
+    ) <~ spacedSlash) ?? (Omitted -> Nil)
   }
 
   def resolveTask(task: ParsedAxis[AttributeKey[_]]): Option[AttributeKey[_]] =
@@ -411,11 +391,10 @@ object Act {
   }
 
   def projectRef(index: KeyIndex, currentBuild: URI): Parser[ParsedAxis[ResolvedReference]] = {
-    val global = token(ZeroString ~ spacedSlash) ^^^ ParsedZero
     val zeroIdent = token(ZeroIdent ~ spacedSlash) ^^^ ParsedZero
     val thisBuildIdent = value(token(ThisBuildIdent ~ spacedSlash) ^^^ BuildRef(currentBuild))
     val trailing = spacedSlash !!! "Expected '/' (if selecting a project)"
-    global | zeroIdent | thisBuildIdent |
+    zeroIdent | thisBuildIdent |
       value(resolvedReferenceIdent(index, currentBuild, trailing)) |
       value(resolvedReference(index, currentBuild, trailing))
   }
@@ -491,12 +470,6 @@ object Act {
     import Aggregation.evaluatingParser
     actionParser.flatMap { action =>
       val akp = aggregatedKeyParserSep(extracted)
-      def warnOldShellSyntax(seps: Seq[String], keyStrings: String): Unit =
-        if (seps.contains(":") || seps.contains("::")) {
-          state.log.warn(
-            s"sbt 0.13 shell syntax is deprecated; use slash syntax instead: $keyStrings"
-          )
-        } else ()
       def evaluate(pairs: Seq[(ScopedKey[_], Seq[String])]): Parser[() => State] = {
         val kvs = pairs.map(_._1)
         val seps = pairs.headOption.map(_._2).getOrElse(Nil)
@@ -510,7 +483,6 @@ object Act {
           {
             val keyStrings = preparedPairs.map(pp => showKey.show(pp.key)).mkString(", ")
             state.log.debug("Evaluating tasks: " + keyStrings)
-            warnOldShellSyntax(seps, keyStrings)
             evaluate()
           }
         }

--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -82,7 +82,7 @@ $PrintCommand <task>
 	Displays lines from the logging of previous commands that match `pattern`.
 
 $LastGrepCommand <pattern> [key]
-	Displays lines from logging associated with `key` that match `pattern`.  The key typically refers to a task (for example, test:compile).  The logging that is displayed is restricted to the logging for that particular task.
+	Displays lines from logging associated with `key` that match `pattern`.  The key typically refers to a task (for example, Test/compile).  The logging that is displayed is restricted to the logging for that particular task.
 
 	<pattern> is a regular expression interpreted by java.util.Pattern.  Matching text is highlighted (when highlighting is supported and enabled).
 	See also '$LastCommand'."""
@@ -94,7 +94,7 @@ $LastGrepCommand <pattern> [key]
 	Prints the logging for the previous command, typically at a more verbose level.
 
 $LastCommand <key>
-	Prints the logging associated with the provided key.  The key typically refers to a task (for example, test:compile).  The logging that is displayed is restricted to the logging for that particular task.
+	Prints the logging associated with the provided key.  The key typically refers to a task (for example, Test/compile).  The logging that is displayed is restricted to the logging for that particular task.
 
 	See also '$LastGrepCommand'."""
 

--- a/main/src/main/scala/sbt/internal/server/SettingQuery.scala
+++ b/main/src/main/scala/sbt/internal/server/SettingQuery.scala
@@ -36,7 +36,7 @@ object SettingQuery {
       index: KeyIndex,
       currentBuild: URI
   ): Parser[ParsedExplicitAxis[ResolvedReference]] = {
-    val global = token(Act.ZeroString ~ '/') ^^^ ParsedExplicitGlobal
+    val global = token(Act.GlobalIdent ~ '/') ^^^ ParsedExplicitGlobal
     val trailing = '/' !!! "Expected '/' (if selecting a project)"
     global | explicitValue(Act.resolvedReference(index, currentBuild, trailing))
   }
@@ -56,7 +56,12 @@ object SettingQuery {
     for {
       rawProject <- projectRef(index, currentBuild)
       proj = resolveProject(rawProject)
-      confAmb <- Act.config(index configs proj)
+      confPair <- Act.configIdent(
+        index.configs(proj),
+        index.configIdents(proj),
+        index.fromConfigIdent(proj)
+      )
+      (confAmb, seps) = confPair
       partialMask = ScopeMask(true, confAmb.isExplicit, false, false)
     } yield Act.taskKeyExtra(index, defaultConfigs, keyMap, proj, confAmb, partialMask, Nil)
   }

--- a/sbt-app/src/sbt-test/actions/previous/test
+++ b/sbt-app/src/sbt-test/actions/previous/test
@@ -6,5 +6,5 @@
 > checkNext 1 2
 
 > checkScopes 0 0
-> all x compile:y::x runtime:y::x y
+> all x Compile/y/x Runtime/y/x y
 > checkScopes 21 91

--- a/sbt-app/src/sbt-test/compiler-project/run-test/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/run-test/build.sbt
@@ -1,9 +1,7 @@
-ThisBuild / scalaVersion := "2.12.19"
-
+scalaVersion := "2.12.19"
 libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.5" % Test,
   "junit" % "junit" % "4.13.1" % Test,
   "commons-io" % "commons-io" % "2.5" % Runtime,
 )
-
 libraryDependencies += scalaVersion("org.scala-lang" % "scala-compiler" % _ ).value

--- a/sbt-app/src/sbt-test/compiler-project/run-test/src/test/scala/Basic.scala
+++ b/sbt-app/src/sbt-test/compiler-project/run-test/src/test/scala/Basic.scala
@@ -3,13 +3,11 @@ package foo.bar
 import org.junit._
 import org.junit.Assert._
 
-class Basic
-{
-	val foo = new Foo
-	@Test
-	def checkBind(): Unit =
-	{
-		try { assertTrue( foo.eval("3") == 3) }
-		catch { case e => e.printStackTrace; throw e}
-	}
+class Basic {
+  val foo = new Foo
+  @Test
+  def checkBind(): Unit = {
+    try { assertTrue( foo.eval("3") == 3) }
+    catch { case e => e.printStackTrace; throw e}
+  }
 }

--- a/sbt-app/src/sbt-test/compiler-project/run-test/test
+++ b/sbt-app/src/sbt-test/compiler-project/run-test/test
@@ -1,10 +1,10 @@
 > run 1
-> test:test
+> test
 > clean
 
 > run 2
-> test:test
+> test
 > clean
 
 > run -1
-> test:test
+> test

--- a/sbt-app/src/sbt-test/dependency-management/cache-classifiers/test
+++ b/sbt-app/src/sbt-test/dependency-management/cache-classifiers/test
@@ -1,7 +1,7 @@
 > a/publish
 
 $ copy-file changes/B.scala b/B.scala
--> b/test:compile
+-> b/Test/compile
 
 # Need to sleep 3s because the check depends on last modified time and typical resolution is 1s.
 $ sleep 3000
@@ -9,4 +9,4 @@ $ sleep 3000
 $ copy-file changes/A.scala a/src/test/scala/A.scala
 > a/publish
 
-> b/test:compile
+> b/Test/compile

--- a/sbt-app/src/sbt-test/dependency-management/ext-pom-classifier/test
+++ b/sbt-app/src/sbt-test/dependency-management/ext-pom-classifier/test
@@ -1,3 +1,3 @@
-> export compile:dependencyClasspath
-> export test:dependencyClasspath
-> test:compile
+> export Compile/dependencyClasspath
+> export Test/dependencyClasspath
+> Test/compile

--- a/sbt-app/src/sbt-test/dependency-management/ivy-settings-a/disabled
+++ b/sbt-app/src/sbt-test/dependency-management/ivy-settings-a/disabled
@@ -8,4 +8,4 @@ $ copy-file changes/scalacheck-ivy.xml ivy.xml
 
 $ copy-file changes/scala-tools-ivysettings.xml ivysettings.xml
 > check
-> test:compile
+> Test/compile

--- a/sbt-app/src/sbt-test/project1/cross-plugins-source/test
+++ b/sbt-app/src/sbt-test/project1/cross-plugins-source/test
@@ -1,3 +1,3 @@
 > show pluginCrossBuild::sbtDependency
 > compile
--> test:compile
+-> Test/compile

--- a/sbt-app/src/sbt-test/project1/flatten/test
+++ b/sbt-app/src/sbt-test/project1/flatten/test
@@ -3,20 +3,20 @@
 
 > compile
 > test
-> test:run
+> Test/run
 
 # This part verifies that the package-src action works properly under a flattened/merged source hierarchy
 
 > packageSrc
-> test:packageSrc
+> Test/packageSrc
 
 $ delete src
 $ delete test-src
 
--> test:run
+-> Test/run
 
 > unpackage
-> test:unpackage
+> Test/unpackage
 
-> test:test
-> test:run
+> Test/test
+> Test/run

--- a/sbt-app/src/sbt-test/project1/semanticdb/test
+++ b/sbt-app/src/sbt-test/project1/semanticdb/test
@@ -1,16 +1,16 @@
 > compile
 $ exists target/scala-2.12/classes/META-INF/semanticdb/src/main/scala/foo/Compile.scala.semanticdb
 
-> test:compile
+> Test/compile
 $ exists target/scala-2.12/test-classes/META-INF/semanticdb/src/test/scala/foo/Test.scala.semanticdb
 
-> it:compile
+> IntegrationTest/compile
 $ exists target/scala-2.12/it-classes/META-INF/semanticdb/src/it/scala/foo/IntegrationTest.scala.semanticdb
 
-> custom:compile
+> Custom/compile
 $ exists target/scala-2.12/custom-classes/META-INF/semanticdb/src/custom/scala/foo/Custom.scala.semanticdb
 
-> st:compile
+> SystemTest/compile
 $ exists target/scala-2.12/st-classes/META-INF/semanticdb/src/st/scala/foo/SystemTest.scala.semanticdb
 
 > check

--- a/sbt-app/src/sbt-test/tests/arguments/test
+++ b/sbt-app/src/sbt-test/tests/arguments/test
@@ -1,4 +1,4 @@
-# should fail because it should run all test:tests, some of which are expected to fail (1 and 4)
+# should fail because it should run all tests, some of which are expected to fail (1 and 4)
 -> testQuick
 
 $ touch success1

--- a/sbt-app/src/sbt-test/tests/it/test
+++ b/sbt-app/src/sbt-test/tests/it/test
@@ -1,28 +1,27 @@
 > clean
 $ delete src/
 $ copy-file changes/ClassFailModuleSuccess.scala src/it/scala/Test.scala
--> it:test
+-> IntegrationTest/test
 
 > clean
 $ delete src/
 $ copy-file changes/ClassFailModuleFail.scala src/it/scala/Test.scala
--> it:test
+-> IntegrationTest/test
 
 > clean
 $ delete src/
 $ copy-file changes/ClassSuccessModuleFail.scala src/it/scala/Test.scala
--> it:test
+-> IntegrationTest/test
 
 
 > clean
 $ delete src/
 $ copy-file changes/ClassSuccessModuleSuccess.scala src/it/scala/Test.scala
-> it:test
+> IntegrationTest/test
 
 # verify that a failing normal test fails when run directly
 $ copy-file changes/AlwaysFail.scala src/test/scala/AlwaysFail.scala
--> test:test
+-> Test/test
 
-# but that it does not affect the result of it:test (#539)
-> it:test
-
+# but that it does not affect the result of IntegrationTest/test (#539)
+> IntegrationTest/test

--- a/sbt-app/src/sbt-test/tests/resources/build.sbt
+++ b/sbt-app/src/sbt-test/tests/resources/build.sbt
@@ -1,3 +1,3 @@
+scalaVersion := "2.12.19"
 val specs = "org.specs2" %% "specs2-core" % "4.3.4"
-ThisBuild / scalaVersion := "2.12.19"
 libraryDependencies += specs % Test

--- a/sbt-app/src/sbt-test/tests/resources/test
+++ b/sbt-app/src/sbt-test/tests/resources/test
@@ -1,1 +1,1 @@
-> test:test
+> test

--- a/sbt-app/src/sbt-test/tests/test-quick/build.sbt
+++ b/sbt-app/src/sbt-test/tests/test-quick/build.sbt
@@ -1,7 +1,7 @@
 Global / cacheStores := Seq.empty
 
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
-ThisBuild / scalaVersion := "2.12.19"
+scalaVersion := "2.12.19"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-app/src/sbt-test/tests/test-quick/test
+++ b/sbt-app/src/sbt-test/tests/test-quick/test
@@ -27,7 +27,7 @@ $ sleep 2000
 # src/test compilation group change.
 
 $ copy-file changed/Base.scala src/test/scala/Base.scala
-> test:compile
+> Test/compile
 $ sleep 2000
 -> testQuick Create
 > testQuick Delete

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -112,7 +112,6 @@ class ClientTest extends AbstractServerTest {
   test("compi completions") {
     val expected = Vector(
       "compile",
-      "compile:",
       "compileAnalysisFile",
       "compileAnalysisFilename",
       "compileAnalysisTargetRoot",
@@ -135,7 +134,6 @@ class ClientTest extends AbstractServerTest {
     val testOnlyExpected = Vector(
       "testOnly",
       "testOnly/",
-      "testOnly::",
       "testOnly;",
     )
     assert(complete("testOnly") == testOnlyExpected)

--- a/tasks-standard/src/main/scala/sbt/std/Streams.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Streams.scala
@@ -22,8 +22,8 @@ import sbt.util._
 // no longer specific to Tasks, so 'TaskStreams' should be renamed
 /**
  * Represents a set of streams associated with a context. In sbt, this is a named set of streams for
- * a particular scoped key. For example, logging for test:compile is by default sent to the "out"
- * stream in the test:compile context.
+ * a particular scoped key. For example, logging for Test/compile is by default sent to the "out"
+ * stream in the Test/compile context.
  */
 sealed trait TaskStreams[Key] {
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7696

## Problem
sbt 1.x introduced the slash syntax midway, so it kept the old `a/test:console::scalacOptions` syntax, which hopefully aren't in any more. sbt 1.x has been displaying deprecation warning on this.

```scala
sbt:sbtRoot> mainProj/test:console::scalacOptions
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: mainProj / Test / console / scalacOption
```

## Solution

This removes the support from the shell parser.