### PR TITLE
[2.x] refactor: Remove sbt 0.13 `in` methods

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -186,7 +186,7 @@ You'd need alternative DSL import since you can't rely on sbt package object.
 
 ```scala
 // for slash syntax
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 
 // for IO
 import sbt.io.syntax._

--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -23,7 +23,7 @@ import java.nio.file.Path
 import sbt.internal.util.complete.DefaultParsers.validID
 import Def.{ ScopedKey, Setting }
 import Scope.GlobalScope
-import sbt.SlashSyntax0.*
+import sbt.SlashSyntax0.given
 import sbt.internal.parser.SbtParser
 import sbt.io.IO
 import scala.jdk.CollectionConverters.*

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -11,7 +11,7 @@ package sbt
 import sbt.Def.{ Initialize, ScopedKey }
 import sbt.Previous._
 import sbt.Scope.Global
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.util._
 import sbt.std.TaskExtra._
 import sbt.util.StampedFormat

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -14,8 +14,7 @@ import java.net.URI
 import sbt.internal.util.AttributeKey
 import sbt.io.IO
 import sbt.librarymanagement.Configuration
-import sbt.SlashSyntax.{ RichConfiguration, RichScope }
-import scala.annotation.nowarn
+import sbt.SlashSyntax.RichConfiguration
 
 // in all of these, the URI must be resolved and normalized before it is definitive
 
@@ -26,20 +25,17 @@ sealed trait Reference:
   private[sbt] def asScope: Scope =
     Scope(asScopeAxis, This, This, This)
 
-  @nowarn
-  def /(c: ConfigKey): RichConfiguration = RichConfiguration(asScope in c)
+  def /(c: ConfigKey): RichConfiguration = RichConfiguration(asScope.rescope(c))
 
-  @nowarn
-  def /(c: Configuration): RichConfiguration = RichConfiguration(asScope in c)
+  def /(c: Configuration): RichConfiguration = RichConfiguration(asScope.rescope(c))
 
   // This is for handling `Zero / Zero / name`.
   def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
     new RichConfiguration(asScope.copy(config = configAxis))
 
-  final def /[K](key: Scoped.ScopingSetting[K]): K = key.in(asScope)
+  final def /[K](key: Scoped.ScopingSetting[K]): K = key.rescope(asScope)
 
-  @nowarn
-  final def /(key: AttributeKey[_]): RichScope = new RichScope(asScope in key)
+  final def /(key: AttributeKey[_]): Scope = asScope.rescope(key)
 end Reference
 
 /** A fully resolved, unique identifier for a project or build. */

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -20,39 +20,18 @@ final case class Scope(
     config: ScopeAxis[ConfigKey],
     task: ScopeAxis[AttributeKey[_]],
     extra: ScopeAxis[AttributeMap]
-) {
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(project: Reference, config: ConfigKey): Scope =
-    copy(project = Select(project), config = Select(config))
+):
+  def rescope(project: Reference): Scope = copy(project = Select(project))
+  def rescope(config: ConfigKey): Scope = copy(config = Select(config))
+  def rescope(task: AttributeKey[?]): Scope = copy(task = Select(task))
 
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(config: ConfigKey, task: AttributeKey[_]): Scope =
-    copy(config = Select(config), task = Select(task))
-
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(project: Reference, task: AttributeKey[_]): Scope =
-    copy(project = Select(project), task = Select(task))
-
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(project: Reference, config: ConfigKey, task: AttributeKey[_]): Scope =
-    copy(project = Select(project), config = Select(config), task = Select(task))
-
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(project: Reference): Scope = copy(project = Select(project))
-
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(config: ConfigKey): Scope = copy(config = Select(config))
-
-  @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(task: AttributeKey[_]): Scope = copy(task = Select(task))
-
-  override def toString: String = this match {
+  override def toString: String = this match
     case Scope(Zero, Zero, Zero, Zero) => "Global"
     case Scope(_, _, _, This)          => s"$project / $config / $task"
     case _                             => s"Scope($project, $config, $task, $extra)"
-  }
-}
-object Scope {
+end Scope
+
+object Scope:
   val ThisScope: Scope = Scope(This, This, This, This)
   val Global: Scope = Scope(Zero, Zero, Zero, Zero)
   val GlobalScope: Scope = Global
@@ -457,4 +436,4 @@ object Scope {
         t <- withZeroAxis(scope.task)
         e <- withZeroAxis(scope.extra)
       } yield Scope(Zero, c, t, e)
-}
+end Scope

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -72,9 +72,11 @@ sealed abstract class SettingKey[A1]
 
   final def scopedKey: ScopedKey[A1] = ScopedKey(scope, key)
 
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  final def in(scope: Scope): SettingKey[A1] =
+  private[sbt] final inline def rescope(scope: Scope): SettingKey[A1] =
     Scoped.scopedSetting(Scope.replaceThis(this.scope)(scope), this.key)
+
+  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
+    subkey.rescope(scope.copy(task = Select(key)))
 
   /** Internal function for the setting macro. */
   inline def settingMacro[A](inline a: A): Initialize[A] =
@@ -151,9 +153,11 @@ sealed abstract class TaskKey[A1]
 
   def scopedKey: ScopedKey[Task[A1]] = ScopedKey(scope, key)
 
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(scope: Scope): TaskKey[A1] =
+  private[sbt] final inline def rescope(scope: Scope): TaskKey[A1] =
     Scoped.scopedTask(Scope.replaceThis(this.scope)(scope), this.key)
+
+  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
+    subkey.rescope(scope.copy(task = Select(key)))
 
   inline def +=[A2](inline v: A2)(using Append.Value[A1, A2]): Setting[Task[A1]] =
     append1[A2](taskMacro(v))
@@ -232,9 +236,11 @@ sealed trait InputKey[A1]
 
   def scopedKey: ScopedKey[InputTask[A1]] = ScopedKey(scope, key)
 
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  def in(scope: Scope): InputKey[A1] =
+  private[sbt] final inline def rescope(scope: Scope): InputKey[A1] =
     Scoped.scopedInput(Scope.replaceThis(this.scope)(scope), this.key)
+
+  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
+    subkey.rescope(scope.copy(task = Select(key)))
 
   private inline def inputTaskMacro[A2](inline a: A2): Def.Initialize[InputTask[A2]] =
     ${ std.InputTaskMacro.inputTaskMacroImpl('a) }
@@ -261,52 +267,11 @@ object Scoped:
     ScopedKey(s.scope, s.key)
 
   /**
-   * Mixin trait for adding convenience vocabulary associated with specifying the [[Scope]] of a setting.
-   * Allows specification of the Scope or part of the [[Scope]] of a setting being referenced.
-   * @example
-   *  {{{
-   *  name in Global := "hello Global scope"
-   *
-   *  name in (Compile, packageBin) := "hello Compile scope packageBin"
-   *
-   *  name in Compile := "hello Compile scope"
-   *
-   *  name.in(Compile).:=("hello ugly syntax")
-   *  }}}
+   * A trait that provides rescope method.
    */
   sealed trait ScopingSetting[ResultType]:
-    private[sbt] def in(s: Scope): ResultType
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(s: Scope): ResultType
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(p: Reference): ResultType = in(Select(p), This, This)
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(t: Scoped): ResultType = in(This, This, Select(t.key))
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(c: ConfigKey): ResultType = in(This, Select(c), This)
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(c: ConfigKey, t: Scoped): ResultType = in(This, Select(c), Select(t.key))
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(p: Reference, c: ConfigKey): ResultType = in(Select(p), Select(c), This)
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(p: Reference, t: Scoped): ResultType = in(Select(p), This, Select(t.key))
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(p: Reference, c: ConfigKey, t: Scoped): ResultType =
-  //   in(Select(p), Select(c), Select(t.key))
-
-  // @deprecated(Scope.inIsDeprecated, "1.5.0")
-  // def in(
-  //     p: ScopeAxis[Reference],
-  //     c: ScopeAxis[ConfigKey],
-  //     t: ScopeAxis[AttributeKey[_]]
-  // ): ResultType = in(Scope(p, c, t, This))
+    // formerly known as "in"
+    private[sbt] def rescope(s: Scope): ResultType
   end ScopingSetting
 
   def scopedSetting[T](s: Scope, k: AttributeKey[T]): SettingKey[T] =

--- a/main-settings/src/test/scala/sbt/AppendSpec.scala
+++ b/main-settings/src/test/scala/sbt/AppendSpec.scala
@@ -12,7 +12,7 @@ object AppendSpec {
   val onLoad = SettingKey[State => State]("onLoad")
 
   import Scope.Global
-  import SlashSyntax0._
+  import SlashSyntax0.given
 
   def doSideEffect(): Unit = ()
 

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -12,7 +12,7 @@ import java.io.File
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.Keys._
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.Act
 import sbt.internal.CommandStrings._
 import sbt.internal.inc.ScalaInstance

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -97,7 +97,7 @@ import scala.util.control.NonFatal
 import scala.xml.NodeSeq
 
 // incremental compiler
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.inc.{
   Analysis,
   AnalyzingCompiler,
@@ -1508,7 +1508,7 @@ object Defaults extends BuildCommon {
 
   @nowarn
   def inputTests(key: InputKey[_]): Initialize[InputTask[Unit]] =
-    inputTests0.mapReferenced(Def.mapScope(_ in key.key))
+    inputTests0.mapReferenced(Def.mapScope((s) => s.rescope(key.key)))
 
   private[this] lazy val inputTests0: Initialize[InputTask[Unit]] = {
     val parser = loadForParser(definedTestNames)((s, i) => testOnlyParser(s, i getOrElse Nil))
@@ -5006,7 +5006,7 @@ trait BuildExtra extends BuildCommon with DefExtra {
         .flatMapTask { result =>
           initScoped(
             scoped.scopedKey,
-            ClassLoaders.runner mapReferenced Project.mapScope(s => s.in(config)),
+            ClassLoaders.runner mapReferenced Project.mapScope(_.rescope(config)),
           ).zipWith(Def.task {
             ((config / fullClasspath).value, streams.value, fileConverter.value, result)
           }) { (rTask, t) =>
@@ -5022,7 +5022,6 @@ trait BuildExtra extends BuildCommon with DefExtra {
 
   // public API
   /** Returns a vector of settings that create custom run task. */
-  @nowarn
   def fullRunTask(
       scoped: TaskKey[Unit],
       config: Configuration,
@@ -5032,7 +5031,7 @@ trait BuildExtra extends BuildCommon with DefExtra {
     Vector(
       scoped := initScoped(
         scoped.scopedKey,
-        ClassLoaders.runner mapReferenced Project.mapScope(s => s.in(config)),
+        ClassLoaders.runner mapReferenced Project.mapScope(_.rescope(config)),
       ).zipWith(Def.task { ((config / fullClasspath).value, streams.value, fileConverter.value) }) {
         case (rTask, t) =>
           (t, rTask).mapN { case ((cp, s, converter), r) =>

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -16,7 +16,7 @@ import sbt.Keys.{ TaskProgress => _, name => _, _ }
 import sbt.BuildExtra.*
 import sbt.ProjectExtra.*
 import sbt.Scope.Global
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.Aggregation.KeyValue
 import sbt.internal.TaskName._
 import sbt.internal._

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -17,7 +17,7 @@ import sbt.util.Show
 import std.Transform.DummyTaskMap
 import sbt.EvaluateTask.extractedTaskConfig
 import sbt.ProjectExtra.setProject
-import scala.annotation.nowarn
+import sbt.SlashSyntax0.given
 
 final case class Extracted(
     structure: BuildStructure,
@@ -46,9 +46,9 @@ final case class Extracted(
   def getOpt[T](key: TaskKey[T]): Option[Task[T]] =
     structure.data.get(inCurrent(key.scope), key.key)
 
-  @nowarn
   private[this] def inCurrent(scope: Scope): Scope =
-    if (scope.project == This) scope in currentRef else scope
+    if scope.project == This then scope.rescope(currentRef)
+    else scope
 
   /**
    * Runs the task specified by `key` and returns the transformed State and the resulting value of the task.
@@ -114,7 +114,7 @@ final case class Extracted(
     )
 
   private[this] def resolve[K <: Scoped.ScopingSetting[K] with Scoped](key: K): K =
-    key in Scope.resolveScope(GlobalScope, currentRef.build, rootProject)(key.scope)
+    Scope.resolveScope(GlobalScope, currentRef.build, rootProject)(key.scope) / key
 
   private def getOrError[T](scope: Scope, key: AttributeKey[_], value: Option[T])(implicit
       display: Show[ScopedKey[_]]

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -13,7 +13,7 @@ import DefaultParsers._
 import sbt.Keys._
 import Scope.GlobalScope
 import Def.ScopedKey
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.Load
 import sbt.internal.CommandStrings._
 import Cross.{ spacedFirst, requireSession }

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -37,7 +37,7 @@ import Keys.{
 }
 import Project.LoadAction
 import Scope.{ Global, ThisScope }
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import Def.{ Flattened, Initialize, ScopedKey, Setting }
 import sbt.internal.{
   Load,

--- a/main/src/main/scala/sbt/RemoteCache.scala
+++ b/main/src/main/scala/sbt/RemoteCache.scala
@@ -21,7 +21,7 @@ import sbt.Keys._
 import sbt.Project.{ inConfig => _, * }
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.coursierint.LMCoursier
 import sbt.internal.inc.{ HashUtil, JarUtils }
 import sbt.internal.librarymanagement._
@@ -206,9 +206,9 @@ object RemoteCache {
   ): Seq[Def.Setting[_]] =
     inTask(packageCache)(
       Seq(
-        packageCache.in(Defaults.TaskZero) := {
+        (Defaults.TaskZero / packageCache) := {
           val converter = fileConverter.value
-          val original = packageBin.in(Defaults.TaskZero).value
+          val original = (Defaults.TaskZero / packageBin).value
           val originalFile = converter.toPath(original)
           val artp = artifactPath.value
           val artpFile = converter.toPath(artp)
@@ -243,7 +243,7 @@ object RemoteCache {
           ModuleDescriptorConfiguration(remoteCacheProjectId.value, projectInfo.value)
             .withScalaModuleInfo(smi)
         },
-        pushRemoteCache.in(Defaults.TaskZero) := (Def.task {
+        (Defaults.TaskZero / pushRemoteCache) := (Def.task {
           val s = streams.value
           val config = pushRemoteCacheConfiguration.value
           val is = (pushRemoteCache / ivySbt).value

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -15,7 +15,7 @@ import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.inc.ModuleUtilities
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.librarymanagement.cross.CrossVersionUtil

--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -12,7 +12,6 @@ import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 import java.io.File
 
-import sbt.SlashSyntax0._
 import sbt.io._, syntax._
 import sbt.util._
 import sbt.internal.util.{ ConsoleAppender, Terminal => ITerminal }

--- a/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
@@ -19,7 +19,6 @@ import lmcoursier.definitions.{
 import sbt.librarymanagement._
 import sbt.Keys._
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0._
 
 object CoursierArtifactsTasks {
   def coursierPublicationsTask(

--- a/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierRepositoriesTasks.scala
@@ -13,7 +13,6 @@ import sbt.librarymanagement._
 import sbt.Keys._
 import sbt.ProjectExtra.transitiveInterDependencies
 import sbt.ScopeFilter.Make._
-import sbt.SlashSyntax0._
 
 object CoursierRepositoriesTasks {
   private object CResolvers {

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -14,6 +14,7 @@ import java.text.DateFormat
 import sbt.Def.ScopedKey
 import sbt.Keys.{ showSuccess, showTiming, timingFormat }
 import sbt.ProjectExtra.*
+import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }
 import sbt.internal.util._
@@ -294,7 +295,7 @@ object Aggregation {
     }
 
   def aggregationEnabled(key: ScopedKey[_], data: Settings[Scope]): Boolean =
-    Keys.aggregate in Scope.fillTaskAxis(key.scope, key.key) get data getOrElse true
+    (Scope.fillTaskAxis(key.scope, key.key) / Keys.aggregate).get(data).getOrElse(true)
   private[sbt] val suppressShow =
     AttributeKey[Boolean]("suppress-aggregation-show", Int.MaxValue)
 }

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -16,6 +16,7 @@ import java.net.URI
 import Def.{ ScopeLocal, ScopedKey, Setting, displayFull }
 import BuildPaths.outputDirectory
 import Scope.GlobalScope
+import sbt.SlashSyntax0.given
 import BuildStreams.Streams
 import sbt.io.syntax._
 import sbt.internal.inc.MappedFileConverter
@@ -400,5 +401,5 @@ object BuildStreams {
     refTarget(GlobalScope.copy(project = Select(ref)), fallbackBase, data)
 
   def refTarget(scope: Scope, fallbackBase: File, data: Settings[Scope]): File =
-    (Keys.target in scope get data getOrElse outputDirectory(fallbackBase)) / StreamsDirectory
+    ((scope / Keys.target).get(data) getOrElse outputDirectory(fallbackBase)) / StreamsDirectory
 }

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -14,7 +14,7 @@ import java.net.URL
 import java.nio.file.Path
 import sbt.ClassLoaderLayeringStrategy._
 import sbt.Keys._
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.classpath.ClassLoaderCache
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.inc.classpath.ClasspathUtil

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -11,7 +11,6 @@ package internal
 
 import java.io.File
 import java.util.LinkedHashSet
-import sbt.SlashSyntax0._
 import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.nio.file.{ Glob, RecursiveGlob }

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -16,7 +16,7 @@ import sbt.Def._
 import sbt.Keys._
 // import sbt.Project.richInitializeTask
 import sbt.ProjectExtra.*
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.io.syntax._
 import sbt.nio.Keys._
 import sbt.nio.file._
@@ -163,7 +163,7 @@ private[sbt] object Clean {
   ): Def.Initialize[Task[Unit]] =
     (Def
       .task {
-        taskKey.scope in taskKey.key
+        taskKey.scope / taskKey.key
       })
       .flatMapTask { case scope =>
         Def.task {

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -10,7 +10,6 @@ package sbt
 package internal
 
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0._
 import sbt.internal.classpath.AlternativeZincUtil
 import sbt.internal.inc.{ ScalaInstance, ZincLmUtil }
 import sbt.internal.util.Terminal

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -24,7 +24,7 @@ import sbt.BasicCommandStrings._
 import sbt.Def._
 import sbt.Keys._
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.Continuous.{ ContinuousState, FileStampRepository }
 import sbt.internal.LabeledFunctions._
 import sbt.internal.io.WatchState

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -18,7 +18,7 @@ import sbt.io.syntax._
 import sbt.Cross._
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.DefaultParsers._
 import sbt.internal.util.AttributeKey
 import sbt.internal.util.complete.{ DefaultParsers, Parser }

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import sbt.Def.{ Classpath, ScopedKey, Setting }
 import sbt.ProjectExtra.extract
 import sbt.Scope.GlobalScope
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.inc.classpath.ClasspathFilter
 import sbt.internal.util.{ Attributed, ManagedLogger }
 import sbt.io.syntax._

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -22,7 +22,7 @@ import Def.{ ScopedKey, Setting }
 import Keys._
 import Configurations.{ Compile, Runtime }
 import sbt.ProjectExtra.{ extract, runUnloadHooks, setProject }
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import java.io.File
 import org.apache.ivy.core.module.{ descriptor, id }
 import descriptor.ModuleDescriptor, id.ModuleRevisionId
@@ -74,7 +74,7 @@ object GlobalPlugin {
   @nowarn
   def extract(state: State, structure: BuildStructure): (State, GlobalPluginData) = {
     import structure.{ data, root, rootProject }
-    val p: Scope = Scope.GlobalScope in ProjectRef(root, rootProject(root))
+    val p: Scope = Scope.GlobalScope.rescope(ProjectRef(root, rootProject(root)))
 
     // If we reference it directly (if it's an executionRoot) then it forces an update, which is not what we want.
     val updateReport = (Def.task { () }).flatMapTask { case _ => Def.task { update.value } }
@@ -113,7 +113,7 @@ object GlobalPlugin {
   }
 
   @nowarn
-  val globalPluginSettings = Project.inScope(Scope.GlobalScope in LocalRootProject)(
+  val globalPluginSettings = Project.inScope(Scope.GlobalScope.rescope(LocalRootProject))(
     Seq(
       organization := SbtArtifacts.Organization,
       onLoadMessage := Keys.baseDirectory("loading global plugins from " + _).value,

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -27,7 +27,7 @@ import Def.Setting
 import Keys._
 import Scope.Global
 import sbt.ProjectExtra.{ extract, setProject }
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 
 import sbt.io.IO
 

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -13,7 +13,6 @@ import java.io.File
 import java.util.concurrent.Callable
 
 import sbt.Def.ScopedKey
-import sbt.SlashSyntax0._
 import sbt.internal.librarymanagement._
 import sbt.librarymanagement._
 import sbt.librarymanagement.syntax._

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -15,7 +15,7 @@ import sbt.internal.util.{ FilePosition, NoPosition, SourcePosition }
 import java.io.File
 import ProjectExtra.{ extract, scopedKeyData }
 import Scope.Global
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.Def._
 
 object LintUnused {

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -15,7 +15,7 @@ import sbt.Keys._
 import sbt.Project.inScope
 import sbt.ProjectExtra.{ prefixConfigs, setProject, showLoadingKey, structure }
 import sbt.Scope.GlobalScope
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.BuildStreams._
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.inc.{ MappedFileConverter, ScalaInstance, ZincLmUtil, ZincUtil }
@@ -33,7 +33,7 @@ import xsbti.compile.{ ClasspathOptionsUtil, Compilers }
 import java.io.File
 import java.net.URI
 import java.nio.file.{ Path, Paths }
-import scala.annotation.{ nowarn, tailrec }
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 private[sbt] object Load {
@@ -1318,8 +1318,7 @@ private[sbt] object Load {
       case None     => Nil
 
   /** These are the settings defined when loading a project "meta" build. */
-  @nowarn
-  val autoPluginSettings: Seq[Setting[_]] = inScope(GlobalScope in LocalRootProject)(
+  val autoPluginSettings: Seq[Setting[_]] = inScope(GlobalScope.rescope(LocalRootProject))(
     Seq(
       sbtPlugin :== true,
       isMetaBuild :== true,

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -13,7 +13,7 @@ import sbt.Def.ScopedKey
 import sbt.Keys._
 import sbt.ProjectExtra.showContextKey
 import sbt.Scope.Global
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.util.MainAppender._
 import sbt.internal.util.{ Terminal => ITerminal, _ }
 import sbt.util.{ Level, Logger, LoggerContext }
@@ -68,7 +68,7 @@ object LogManager {
     (task: ScopedKey[_], to: PrintWriter) => {
       val context = state.get(Keys.loggerContext).getOrElse(LoggerContext.globalContext)
       val manager: LogManager =
-        (logManager in task.scope).get(data) getOrElse defaultManager(state.globalLogging.console)
+        (task.scope / logManager).get(data) getOrElse defaultManager(state.globalLogging.console)
       manager(data, state, task, to, context)
     }
 
@@ -88,7 +88,7 @@ object LogManager {
   ): (ScopedKey[_]) => ManagedLogger =
     (task: ScopedKey[_]) => {
       val manager: LogManager =
-        (logManager in task.scope).get(data) getOrElse defaultManager(state.globalLogging.console)
+        (task.scope / logManager).get(data) getOrElse defaultManager(state.globalLogging.console)
       manager.backgroundLog(data, state, task, context)
     }
 

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -19,7 +19,7 @@ import EvaluateConfigurations.{ evaluateConfiguration => evaluate }
 import Configurations.Compile
 import Scope.Global
 import sbt.ProjectExtra.{ extract, setProject }
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 
 import sbt.io.{ Hash, IO }
 

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -16,6 +16,7 @@ import sbt.librarymanagement.Configuration
 import ProjectExtra.{ relation }
 import Def.{ ScopedKey, Setting }
 import Scope.Global
+import sbt.SlashSyntax0.given
 import complete._
 import DefaultParsers._
 
@@ -59,10 +60,8 @@ private[sbt] object SettingCompletions {
       val global = ScopedKey(Global, akey)
       val globalSetting = resolve(Def.setting(global, setting.init, setting.pos))
       globalSetting ++ allDefs.flatMap { d =>
-        if (d.key == akey)
-          Seq(SettingKey(akey) in d.scope := { global.value })
-        else
-          Nil
+        if d.key == akey then Seq((d.scope / SettingKey(akey)) := global.value)
+        else Nil
       }
     }
     val redefined = settings.flatMap(x => rescope(x))

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -19,7 +19,7 @@ import sbt.Project._
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
 import sbt.Scoped.richTaskSeq
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.StandardMain.exchange
 import sbt.internal.bsp._
 import sbt.internal.langserver.ErrorCodes
@@ -583,7 +583,7 @@ object BuildServerProtocol {
         (ref, project) <- loadedBuild.allProjectRefs
         setting <- project.settings
         if setting.key.key.label == Keys.bspTargetIdentifier.key.label
-      } yield Scope.replaceThis(Scope.Global.in(ref))(setting.key.scope)
+      } yield Scope.replaceThis(Scope.Global.rescope(ref))(setting.key.scope)
 
       import sbt.TupleSyntax.*
       t2ToApp2(
@@ -1010,7 +1010,7 @@ object BuildServerProtocol {
           .flatMap(_.split(","))
           .map(name => ConfigKey(name.trim))
           .filter { config =>
-            val scope = Scope.Global.in(project, config)
+            val scope = Scope.Global.rescope(project).rescope(config)
             allScopes.contains(scope)
           }
         (project, configs)

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import sbt.BasicCommandStrings.{ Shutdown, TerminateAction }
 import sbt.ProjectExtra.extract
+import sbt.SlashSyntax0.given
 import sbt.internal.langserver.{ CancelRequestParams, ErrorCodes, LogMessageParams, MessageType }
 import sbt.internal.protocol.{
   JsonRpcNotificationMessage,
@@ -446,7 +447,11 @@ final class NetworkChannel(
                   keys.filter(k => k.key.label == "testOnly" || k.key.label == "testQuick")
                 val (testState, cachedTestNames) = testKeys.foldLeft((sstate, true)) {
                   case ((st, allCached), k) =>
-                    SessionVar.loadAndSet(sbt.Keys.definedTestNames in k.scope, st, true) match {
+                    SessionVar.loadAndSet(
+                      (k.scope / Keys.definedTestNames).scopedKey,
+                      st,
+                      true
+                    ) match {
                       case (nst, d) => (nst, allCached && d.isDefined)
                     }
                 }
@@ -454,7 +459,7 @@ final class NetworkChannel(
                 val (runState, cachedMainClassNames) = runKeys.foldLeft((testState, true)) {
                   case ((st, allCached), k) =>
                     SessionVar.loadAndSet(
-                      sbt.Keys.discoveredMainClasses in k.scope,
+                      (k.scope / Keys.discoveredMainClasses).scopedKey,
                       st,
                       true
                     ) match {

--- a/main/src/main/scala/sbt/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/nio/CheckBuildSources.scala
@@ -15,7 +15,7 @@ import sbt.BasicCommandStrings.{ RebootCommand, Shutdown, TerminateAction }
 import sbt.Keys.{ baseDirectory, pollInterval, state }
 import sbt.ProjectExtra.extract
 import sbt.Scope.Global
-import sbt.SlashSyntax0._
+import sbt.SlashSyntax0.given
 import sbt.internal.CommandStrings.LoadProject
 import sbt.internal.SysProp
 import sbt.internal.util.{ AttributeKey, Terminal }

--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -13,7 +13,6 @@ import java.io.File
 
 import sbt.Def._
 import sbt.Keys._
-import sbt.SlashSyntax0._
 import sbt.Project._
 import sbt.ProjectExtra.*
 import sbt.internal.graph._
@@ -173,7 +172,7 @@ object DependencyTreeSettings {
         val str = (key / asString).value
         s.log.info(str)
       },
-      key / toFile := {
+      (key / toFile) := {
         val (targetFile, force) = targetFileAndForceParser.parsed
         writeToFile(key.key.label, (key / asString).value, targetFile, force, streams.value)
       },

--- a/main/src/main/scala/sbt/plugins/SbtPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SbtPlugin.scala
@@ -11,7 +11,6 @@ package plugins
 
 import sbt.Def.Setting
 import sbt.Keys.*
-import sbt.SlashSyntax0.*
 
 object SbtPlugin extends AutoPlugin:
   override def requires = ScriptedPlugin

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -5,6 +5,7 @@ import java.lang.reflect.InvocationTargetException
 import sbt._
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.inc.classpath.{ ClasspathUtilities, FilteredLoader }
+import scala.annotation.nowarn
 
 object LocalScriptedPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
@@ -89,6 +90,7 @@ object Scripted {
     (token(Space) ~> (PagedIds | testIdAsGroup)).* map (_.flatten)
   }
 
+  @nowarn
   def doScripted(
       scriptedSbtInstance: ScalaInstance,
       sourcePath: File,

--- a/sbt-app/src/sbt-test/tests/serial/test
+++ b/sbt-app/src/sbt-test/tests/serial/test
@@ -3,9 +3,9 @@
 # if the tests are actually executed concurrently.  The default concurrent
 # restrictions limit the number of concurrent tasks to the number of processors,
 # so we set it to 2.
-> set concurrentRestrictions in Global := Seq(Tags.limitAll(2))
+> set Global / concurrentRestrictions := Seq(Tags.limitAll(2))
 -> test
 
 # this should prevent concurrent execution of tests
-> set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
+> set Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
 > test


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7702

## Problem
See https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+to+slash+syntax

We should remove `scalacOptions in (Compile, console)` notation. This was deprecated in https://eed3si9n.com/sbt-1.5.0.

## Solution
This renames `in` to `rescope` for internal usage, and ports the usages to slash.