### PR TITLE
[1.x] Remove deprecated `System.runFinalization`

### DIFF
--- a/main/src/main/scala/sbt/internal/GCUtil.scala
+++ b/main/src/main/scala/sbt/internal/GCUtil.scala
@@ -36,14 +36,6 @@ private[sbt] object GCUtil {
       log.debug(s"Forcing garbage collection...")
       // Force the detection of finalizers for scala.reflect weakhashsets
       System.gc()
-      // Force finalizers to run.
-      try {
-        System.runFinalization()
-      } catch {
-        case _: NoSuchMethodError =>
-      }
-      // Force actually cleaning the weak hash maps.
-      System.gc()
     } catch {
       case NonFatal(_) => // gotta catch em all
     }


### PR DESCRIPTION
### Issue

`runFinalization` is marked for removal in newer JDK version. This causes CI runs targeting Java 21 to fail.

```
[info] 	published ivy to C:\Users\runneradmin\.ivy2\local\org.scala-sbt\main-settings_2.12\1.10.2-SNAPSHOT\ivys\ivy.xml
[error] D:\a\sbt\sbt\main\src\main\scala\sbt\internal\AbstractTaskProgress.scala:125:49: method getId in class Thread is deprecated
[error]     val threadId: Long = Thread.currentThread().getId
[error]                                                 ^
[error] D:\a\sbt\sbt\main\src\main\scala\sbt\internal\GCUtil.scala:41:16: method runFinalization in class System is deprecated
[error]         System.runFinalization()
[error]                ^
[error] two errors found
[error] (mainProj / Compile / compileIncremental) Compilation failed
```

### Fix

Remove call to `runFinalization`.

### Impact

`runFinalization` is added to fix garbage collection issue in JDK 6, 7. Quoting https://github.com/sbt/sbt/issues/1223

> Java 8 replaces the PermGen with a "Meta" space, but it is still subject to leaks. However, it calls finalizers more promptly, which avoids this issue. Java 6 and Java 7 are both affected.

We no longer targets Java 6 & 7.