### PR TITLE
[1.x] Remove deprecated `Thread.getId`

### DIFF
--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -122,7 +122,7 @@ private[sbt] abstract class AbstractTaskExecuteProgress extends ExecuteProgress[
 object AbstractTaskExecuteProgress {
   private[sbt] class Timer() {
     val startNanos: Long = System.nanoTime()
-    val threadId: Long = Thread.currentThread().getId
+    val threadName: String = Thread.currentThread().getName
     var endNanos: Long = 0L
     def stop(): Unit = {
       endNanos = System.nanoTime()

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -61,7 +61,7 @@ private[sbt] final class TaskTraceEvent
       def durationEvent(name: String, cat: String, t: Timer): String = {
         val sb = new java.lang.StringBuilder(name.length + 2)
         CompactPrinter.print(new JString(name), sb)
-        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tid": ${t.threadId}}"""
+        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tname": ${t.threadName}}"""
       }
       val entryIterator = currentTimings
       while (entryIterator.hasNext) {


### PR DESCRIPTION
### Issue

`Thread.getId` is deprecated since Java 19

### Fix

Replace with `Thread.getName`