### PR TITLE
[1.x] Submit dependency graph for security alert & Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       with:
         distribution: "${{ matrix.distribution }}"
         java-version: "${{ matrix.java }}"
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,4 +13,5 @@ jobs:
     runs-on: ubuntu-latest # or windows-latest, or macOS-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,7 +2,7 @@
 name: Submit Dependency Graph
 on:
   push:
-    branches: [1.9.x] # default branch of the project
+    branches: [1.10.x, develop]
 permissions: {}
 jobs:
   submit-graph:


### PR DESCRIPTION
We have the dependency submission mechanism, but the branch name used is wrong, hence dependency graph on 1.10.x branch is never submitted.

This PR fixes the branch name

Also fixes CI failures due to sbt command not found