### PR TITLE
[2.x] fix: Resurrect `or` for tasks

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1111,8 +1111,8 @@ object Defaults extends BuildCommon {
       val interval = pollInterval.value
       val _antiEntropy = watchAntiEntropy.value
       val base = thisProjectRef.value
-      val msg = watchingMessage.?.value.getOrElse(Watched.defaultWatchingMessage)
-      val trigMsg = triggeredMessage.?.value.getOrElse(Watched.defaultTriggeredMessage)
+      val msg = watchingMessage.getOrElse(Watched.defaultWatchingMessage).value
+      val trigMsg = triggeredMessage.getOrElse(Watched.defaultTriggeredMessage).value
       new Watched {
         val scoped = (base / watchTransitiveSources)
         val key = scoped.scopedKey

--- a/sbt-app/src/sbt-test/project/task/build.sbt
+++ b/sbt-app/src/sbt-test/project/task/build.sbt
@@ -1,0 +1,24 @@
+lazy val undefinedIntTask = taskKey[Int]("")
+lazy val intTask1 = taskKey[Int]("")
+lazy val orResultTask = taskKey[Int]("")
+lazy val checkOption = taskKey[Unit]("")
+lazy val checkGetOrElse = taskKey[Unit]("")
+lazy val checkOr = taskKey[Unit]("")
+
+intTask1 := 1
+
+checkOption := {
+  val x = undefinedIntTask.option.value
+  assert(x == None)
+}
+
+checkGetOrElse := {
+  val x = undefinedIntTask.getOrElse(10).value
+  assert(x == 10)
+}
+
+orResultTask := (undefinedIntTask or intTask1).value
+checkOr := {
+  val x = orResultTask.value
+  assert(x == 1)
+}

--- a/sbt-app/src/sbt-test/project/task/test
+++ b/sbt-app/src/sbt-test/project/task/test
@@ -1,0 +1,5 @@
+> checkOption
+
+> checkGetOrElse
+
+> checkOr


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7748

## Problem
1. `or` is missing
2. `?` should have English method name

## Solution
1. This resurrects `or`
2. Name `??` as `option`, since `get` is taken