### PR TITLE
[2.x] Submit dependency graph for security alert

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,7 +2,7 @@
 name: Submit Dependency Graph
 on:
   push:
-    branches: [1.9.x] # default branch of the project
+    branches: [1.10.x, develop]
 permissions: {}
 jobs:
   submit-graph:
@@ -13,4 +13,5 @@ jobs:
     runs-on: ubuntu-latest # or windows-latest, or macOS-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3


### PR DESCRIPTION
Forward ports #7746

Develop branch already has `- uses: sbt/setup-sbt@v1` in `ci.yml`, hence not including `ci.yml` in the changelist 