### PR TITLE
[2.x] Try fix flaky CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
             distribution: zulu
             jobtype: 9
           - os: ubuntu-latest
-            java: 8
+            java: 11
             distribution: temurin
             jobtype: 10
           - os: windows-latest
-            java: 8
+            java: 11
             distribution: temurin
             jobtype: 10
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fix #7754 

`scripted lm-coursier/*` runs on Java 8 and is flaky. Other scripted tests run on Java 11 and are not flaky.

Running `scripted lm-coursier/*` on Java 11 should fix the flakiness.