### PR TITLE
[2.x] Remove Scala 2 cross build for `util` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,10 +141,6 @@ jobs:
           ./sbt -v --client "serverTestProj/test"
           # ./sbt -v --client doc
           ./sbt -v --client "all $UTIL_TESTS"
-          ./sbt -v --client ++2.13.x
-          ./sbt -v --client "all $UTIL_TESTS"
-          ./sbt -v --client ++2.12.x
-          ./sbt -v --client "all $UTIL_TESTS"
       - name: Build and test (2)
         if: ${{ matrix.jobtype == 2 }}
         shell: bash
@@ -171,8 +167,6 @@ jobs:
         shell: bash
         run: |
           ./sbt -v --client test
-          ./sbt -v --client "++2.13.x; all $UTIL_TESTS"
-          ./sbt -v --client "++2.12.x; all $UTIL_TESTS"
       # - name: Build and test (6)
       #  if: ${{ matrix.jobtype == 6 }}
       #  shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,6 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
 
 def utilCommonSettings: Seq[Setting[_]] = Def.settings(
   baseSettings,
-  crossScalaVersions := Seq(scala3),
 )
 
 def minimalSettings: Seq[Setting[_]] =

--- a/build.sbt
+++ b/build.sbt
@@ -104,12 +104,7 @@ def commonSettings: Seq[Setting[_]] = Def.settings(
 
 def utilCommonSettings: Seq[Setting[_]] = Def.settings(
   baseSettings,
-  crossScalaVersions := Seq(scala212, scala213, scala3),
-  libraryDependencies += Dependencies.scalaCollectionCompat,
-  libraryDependencies ++= {
-    if (scalaBinaryVersion.value == "3") Nil
-    else Seq(compilerPlugin(kindProjector))
-  }
+  crossScalaVersions := Seq(scala3),
 )
 
 def minimalSettings: Seq[Setting[_]] =
@@ -336,11 +331,6 @@ lazy val utilCore = project
   .settings(
     utilCommonSettings,
     name := "Util Core",
-    libraryDependencies ++= {
-      if (scalaBinaryVersion.value.startsWith("2")) {
-        Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
-      } else Seq.empty
-    },
     Utils.keywordsSettings,
     utilMimaSettings
   )
@@ -1337,7 +1327,6 @@ def customCommands: Seq[Setting[_]] = Seq(
     "clean" ::
       "+lowerUtils/compile" ::
       "+lowerUtils/publishSigned" ::
-      s"++$scala212" ::
       state
   },
   commands += Command.command("release") { state =>
@@ -1481,7 +1470,6 @@ lazy val lmCoursierDependencies = Def.settings(
   ),
   excludeDependencies ++= Seq(
     ExclusionRule("org.scala-lang.modules", "scala-xml_2.13"),
-    ExclusionRule("org.scala-lang.modules", "scala-collection-compat_2.13")
   ),
 )
 

--- a/internal/util-relation/src/main/scala/sbt/internal/util/Relation.scala
+++ b/internal/util-relation/src/main/scala/sbt/internal/util/Relation.scala
@@ -9,7 +9,6 @@
 package sbt.internal.util
 
 import Relation._
-import scala.collection.compat.*
 
 object Relation {
 


### PR DESCRIPTION
Only need to build `util` for Scala 3.

Fixes https://github.com/sbt/sbt/issues/7758

On my fork, dependency submission now [succeeds](https://github.com/Friendseeker/sbt/actions/runs/11299985849/job/31432037589)