### PR TITLE
[2.x] Skip publishing local Zinc to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
           rm -rf "$HOME/.ivy2/local" || true
           rm -r $(find $HOME/.sbt/boot -name "*-SNAPSHOT") || true
       - name: Publish local Zinc
+        if: ${{ matrix.jobtype == 6 }}
         shell: bash
         run: |
           ./sbt -v lowerUtils/publishLocal


### PR DESCRIPTION
Publishing Zinc takes 3-4 min on each runner.