### PR TITLE
chore: set a default timeout for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             distribution: adopt
             jobtype: 9
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     env:
       JAVA_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8


### PR DESCRIPTION
### This is a

Chore update to close https://github.com/sbt/sbt/issues/7747

### Background 

Some job runs forever, set a default 25 mins to kill them

### Solution

Reference: https://stackoverflow.com/questions/59073731/set-default-timeout-on-github-action-pipeline