### PR TITLE
chore: update develop branch to set default CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
             distribution: temurin
             jobtype: 10
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     env:
       JAVA_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms800M -Xmx2G -Xss6M -XX:ReservedCodeCacheSize=128M -server -Dsbt.io.virtual=false -Dfile.encoding=UTF-8


### PR DESCRIPTION
### This is a 

chore update to `develop` branch, set a default timeout for the CI in `develop` branch as well

Follow-up on the discussion at https://github.com/sbt/sbt/pull/7766#issuecomment-2415502159