### PR TITLE
[1.x] Let Consistent Analysis to be opt-in by default

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -140,7 +140,7 @@ object SysProp {
   def turbo: Boolean = getOrFalse("sbt.turbo")
   def pipelining: Boolean = getOrFalse("sbt.pipelining")
   // opt-in or out of Zinc's consistent Analysis format.
-  def analysis2024: Boolean = getOrTrue("sbt.analysis2024")
+  def analysis2024: Boolean = getOrFalse("sbt.analysis2024")
 
   def taskTimings: Boolean = getOrFalse("sbt.task.timings")
   def taskTimingsOnShutdown: Boolean = getOrFalse("sbt.task.timings.on.shutdown")


### PR DESCRIPTION
Consistent Analysis, while having better performance on very large codebases, results in less accurate invalidation due to omission of timestamp information. For small codebases the performance improvement is negligible (<200ms per incremental compile), yet the drawback of less accurate invalidation remains.

As per [discussion](https://github.com/sbt/sbt/issues/7790#issuecomment-2425284663) with Eugene, we shall make it opt-in by default instead of opt-out.

(As reference consistent analysis saves ~500ms of incremental compilation time for `scala2` according to Stefan's [benchmark data](https://github.com/sbt/zinc/pull/1326#issue-2067847403) collected on a M2 Pro MacBook)