### PR TITLE
[1.x] Use `jline-terminal-jni` to replace deprecated Jansi & JNA Provider

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -378,8 +378,8 @@ lazy val utilLogging = (project in file("internal") / "util-logging")
       Seq(
         jline,
         jline3Terminal,
-        jline3JNA,
-        jline3Jansi,
+        jline3JNI,
+        jline3Native,
         log4jApi,
         log4jCore,
         disruptor,

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1237,7 +1237,6 @@ object NetworkClient {
         System.out.flush()
       })
       Runtime.getRuntime.addShutdownHook(hook)
-      if (Util.isNonCygwinWindows) sbt.internal.util.JLine3.forceWindowsJansi()
       val parsed = parseArgs(restOfArgs)
       System.exit(Terminal.withStreams(isServer = false, isSubProcess = false) {
         val term = Terminal.console

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,8 +89,8 @@ object Dependencies {
   val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-9c3b6aca11c57e339441442bbf58e550cdfecb79"
   val jline3Version = "3.27.0"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
-  val jline3Jansi = "org.jline" % "jline-terminal-jansi" % jline3Version
-  val jline3JNA = "org.jline" % "jline-terminal-jna" % jline3Version
+  val jline3JNI = "org.jline" % "jline-terminal-jni" % jline3Version
+  val jline3Native = "org.jline" % "jline-native" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
   val jansi = "org.fusesource.jansi" % "jansi" % "2.4.1"


### PR DESCRIPTION
### Issue

JLine 3 deprecated Jansi & JNA terminal provider in 3.26.0.

### Solution

Use JNI terminal provider, which is the recommended default by JLine 3.

> Since JLine 3.24.0, JLine provides its own JNI based provider and native libraries. This is the best default choice, with no additional dependency.

(c.c. https://github.com/jline/jline3)

### Testing

I tested manually on Windows that `sbtn, sbt` (via Powershell & cmd) and IntelliJ SBT shell works the same way as before (with smart tab completion / history working). Will do more testing on a Apple Silicon Macbook once I get access to it later today.

More testing from PR reviewers are welcomed, as I am not a heavy sbt shell user therefore I am probably not testing all workflows. Suffices to checkout the PR branch, run `sbt publishLocalBin`, wipe out `~\.sbt\boot\scala-2.12.20\org.scala-sbt\sbt\1.10.4-SNAPSHOT`if exists then start a new sbt project with `build.properties` set to `sbt.version = 1.10.4-SNAPSHOT`.

Would also appreciate comments on what type of workflows should be tested & how to test them.

Closes https://github.com/sbt/sbt/issues/7793