### PR TITLE
[1.x] Static link `musl` during x86 Linux Native Image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
         repository: sbt/zinc
         ref: 1.10.x
         path: zinc
+    - uses: graalvm/setup-graalvm@v1
+      with:
+        java-version: '23'
+        native-image-musl: 'true'
+        set-java-home: 'false'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         ref: 1.10.x
         path: zinc
     - uses: graalvm/setup-graalvm@v1
+      if: ${{ matrix.jobtype >= 7 && matrix.jobtype <= 9 }}
       with:
         java-version: '23'
         native-image-musl: 'true'

--- a/build.sbt
+++ b/build.sbt
@@ -1176,8 +1176,7 @@ lazy val sbtClientProj = (project in file("client"))
     nativeImageReady := { () =>
       ()
     },
-    nativeImageVersion := "23.0",
-    nativeImageJvm := "graalvm-java23",
+    nativeImageInstalled := true,
     nativeImageOutput := {
       val outputDir = (target.value / "bin").toPath
       if (!Files.exists(outputDir)) {
@@ -1199,7 +1198,7 @@ lazy val sbtClientProj = (project in file("client"))
       s"-H:Name=${target.value / "bin" / "sbtn"}",
     ) ++ (if (isLinux && isArmArchitecture)
             Seq("-H:PageSize=65536") // Make sure binary runs on kernels with page size set to 4k, 16 and 64k
-          else Nil),
+          else Nil) ++ (if (isLinux) Seq("--static", "--libc=musl") else Nil),
     buildThinClient := {
       val isFish = Def.spaceDelimited("").parsed.headOption.fold(false)(_ == "--fish")
       val ext = if (isWin) ".bat" else if (isFish) ".fish" else ".sh"

--- a/build.sbt
+++ b/build.sbt
@@ -1198,7 +1198,7 @@ lazy val sbtClientProj = (project in file("client"))
       s"-H:Name=${target.value / "bin" / "sbtn"}",
     ) ++ (if (isLinux && isArmArchitecture)
             Seq("-H:PageSize=65536") // Make sure binary runs on kernels with page size set to 4k, 16 and 64k
-          else Nil) ++ (if (isLinux) Seq("--static", "--libc=musl") else Nil),
+          else Nil) ++ (if (isLinux && !isArmArchitecture) Seq("--static", "--libc=musl") else Nil),
     buildThinClient := {
       val isFish = Def.spaceDelimited("").parsed.headOption.fold(false)(_ == "--fish")
       val ext = if (isWin) ".bat" else if (isFish) ".fish" else ".sh"


### PR DESCRIPTION
Partially fixes #7785

GraalVM does not support static link musl for arm64, we have to wait for upstream support. Hopefully not too many people use `abtn` on arm64 Linux distos without `GLIBC_2.32'  installed...