### PR TITLE
fix: [1.x] Fixes BSP

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1127,7 +1127,6 @@ object NetworkClient {
         sbtArguments += s"-Dsbt.script=$sbtScript"
       }
     }
-    if (!sbtArguments.contains("--server")) sbtArguments += "--server"
     new Arguments(
       base,
       sbtArguments.toSeq,


### PR DESCRIPTION
Fixes #7792

## Problem
Calling -bsp with --sbt-launch-jar causes "Unrecognized option: --server". This is because --server is passed in twice since #7775

## Solution
Since the server invocation by BSP client already passes in --server, we can remove the extra --server append.