### PR TITLE
[1.x] Use generic early output file name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,8 @@ def mimaSettingsSince(versions: Seq[String]): Seq[Def.Setting[_]] = Def settings
     exclude[DirectMissingMethodProblem]("sbt.PluginData.this"),
     exclude[IncompatibleResultTypeProblem]("sbt.EvaluateTask.executeProgress"),
     exclude[DirectMissingMethodProblem]("sbt.Keys.currentTaskProgress"),
-    exclude[IncompatibleResultTypeProblem]("sbt.PluginData.copy$default$10")
+    exclude[IncompatibleResultTypeProblem]("sbt.PluginData.copy$default$10"),
+    exclude[DirectMissingMethodProblem]("sbt.Defaults.configArtifactPathSetting"),
   ),
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -178,8 +178,7 @@ def mimaSettingsSince(versions: Seq[String]): Seq[Def.Setting[_]] = Def settings
     exclude[DirectMissingMethodProblem]("sbt.PluginData.this"),
     exclude[IncompatibleResultTypeProblem]("sbt.EvaluateTask.executeProgress"),
     exclude[DirectMissingMethodProblem]("sbt.Keys.currentTaskProgress"),
-    exclude[IncompatibleResultTypeProblem]("sbt.PluginData.copy$default$10"),
-    exclude[DirectMissingMethodProblem]("sbt.Defaults.configArtifactPathSetting"),
+    exclude[IncompatibleResultTypeProblem]("sbt.PluginData.copy$default$10")
   ),
 )
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -647,7 +647,8 @@ object Defaults extends BuildCommon {
       val dir = classDirectory.value
       converter.toVirtualFile(dir.toPath)
     },
-    earlyOutput / artifactPath := configArtifactPathSetting(artifact, "early").value,
+    earlyOutput / artifactPath := crossTarget.value /
+      (prefix(configuration.value.name) + "early") / "early.jar",
     earlyOutput := {
       val converter = fileConverter.value
       val jar = (earlyOutput / artifactPath).value
@@ -1812,23 +1813,6 @@ object Defaults extends BuildCommon {
       filter: ScopedTaskable[FileFilter],
       excludes: ScopedTaskable[FileFilter]
   ): Initialize[Task[Seq[File]]] = collectFiles(dirs: Taskable[Seq[File]], filter, excludes)
-
-  private[sbt] def configArtifactPathSetting(
-      art: SettingKey[Artifact],
-      extraPrefix: String
-  ): Initialize[File] =
-    Def.setting {
-      val f = artifactName.value
-      crossTarget.value /
-        (prefix(configuration.value.name) + extraPrefix) / f(
-        ScalaVersion(
-          (artifactName / scalaVersion).value,
-          (artifactName / scalaBinaryVersion).value
-        ),
-        projectID.value,
-        art.value
-      )
-    }
 
   private[sbt] def prefixArtifactPathSetting(
       art: SettingKey[Artifact],

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -647,8 +647,7 @@ object Defaults extends BuildCommon {
       val dir = classDirectory.value
       converter.toVirtualFile(dir.toPath)
     },
-    earlyOutput / artifactPath := crossTarget.value /
-      (prefix(configuration.value.name) + "early") / "early.jar",
+    earlyOutput / artifactPath := configArtifactPathSetting(artifact, "early").value,
     earlyOutput := {
       val converter = fileConverter.value
       val jar = (earlyOutput / artifactPath).value
@@ -1813,6 +1812,15 @@ object Defaults extends BuildCommon {
       filter: ScopedTaskable[FileFilter],
       excludes: ScopedTaskable[FileFilter]
   ): Initialize[Task[Seq[File]]] = collectFiles(dirs: Taskable[Seq[File]], filter, excludes)
+
+  private[sbt] def configArtifactPathSetting(
+      art: SettingKey[Artifact],
+      extraPrefix: String
+  ): Initialize[File] =
+    Def.setting {
+      crossTarget.value /
+        (prefix(configuration.value.name) + "early") / "early.jar"
+    }
 
   private[sbt] def prefixArtifactPathSetting(
       art: SettingKey[Artifact],

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining/build.sbt
@@ -17,6 +17,6 @@ lazy val use = project
       val x = (dep / Compile / compile).value
       val picklePath = (Compile / internalDependencyPicklePath).value
       assert(picklePath.size == 1 &&
-        picklePath.head.data.name == "dep_2.13-0.1.0-SNAPSHOT.jar", s"picklePath = ${picklePath}")
+        picklePath.head.data.name == "early.jar", s"picklePath = ${picklePath}")
     },
   )


### PR DESCRIPTION
### Issue

While analysis is stored as `inc_compile.zip`, early output has elaborate file name such as `project_3-0.1.0-SNAPSHOT.jar`. Since the file name contains version, as a result for user with `GitVersioning` plugin, the version changes every commit therefore due to file name mismatch Zinc forces full recompilation.

### Solution

Use a generic filename. Since `inc_compile.zip` did not seem to have caused any problem, this PR changes early output file name to `early.jar`.

Closes https://github.com/sbt/sbt/issues/7767