### PR TITLE
[2.x] deps: Update to Scala 3.5.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
   val scala212 = "2.12.20"
   val scala213 = "2.13.15"
-  val scala3 = "3.3.4"
+  val scala3 = "3.5.2"
   val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala3
   def nightlyVersion: Option[String] =


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7831

## Problem
There are some Scala 3 language changes that's getting stricter etc, such that sbt doesn't compile on 3.5.x series.

## Solution
This fixes some of the issues, like adding `using` and fixing https://github.com/sbt/sbt/issues/7831.
