### PR TITLE
[1.x] Throw exception when `sbt new` fails to find template

### DIFF
--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -84,7 +84,9 @@ private[sbt] object TemplateCommandUtil {
       hit
     } match {
       case Some(_) => // do nothing
-      case None    => System.err.println("Template not found for: " + arguments.mkString(" "))
+      case None =>
+        val error = "Template not found for: " + arguments.mkString(" ")
+        throw new IllegalArgumentException(error)
     }
 
   private def tryTemplate(
@@ -276,7 +278,8 @@ private[sbt] object TemplateCommandUtil {
       case TypelevelToolkitSlug :: Nil => typelevelToolkitTemplate()
       case SbtCrossPlatformSlug :: Nil => sbtCrossPlatformTemplate()
       case _ =>
-        System.err.println("Local template not found for: " + arguments.mkString(" "))
+        val error = "Local template not found for: " + arguments.mkString(" ")
+        throw new IllegalArgumentException(error)
     }
 
   private final val defaultScalaV = "3.3.4"


### PR DESCRIPTION
### Issue

`sbt new` return `0` when it fails to find template, as when it fails to find template, it merely prints the error therefore `sbt` thinks the command succeeded.

### Fix

Throw exception when `sbt new` fails to find template.

#### Before

```
~/test
❯ sbt new file://NON_EXISTENT_PATH
Template not found for: file://NON_EXISTENT_PATH

~/test
❯ echo $?                         
0
```

#### After

```
~/test/project
❯ cd .. 

~/test
❯ sbt new file://NON_EXISTENT_PATH
[info] [launcher] getting org.scala-sbt sbt 1.10.4-SNAPSHOT  (this may take some time)...
java.lang.IllegalArgumentException: Template not found for: file://NON_EXISTENT_PATH
	at sbt.TemplateCommandUtil$.run(TemplateCommandUtil.scala:89)
	at sbt.TemplateCommandUtil$.runTemplate(TemplateCommandUtil.scala:54)
	at sbt.TemplateCommandUtil$.$anonfun$templateCommand0$2(TemplateCommandUtil.scala:31)
```

Fixes #7020