### PR TITLE
[1.x] Migrate all usages of `System.console == null`

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -130,7 +130,7 @@ object LineReader {
           Option(mask.map(reader.readLine(prompt, _)).getOrElse(reader.readLine(prompt)))
         } catch {
           case e: EndOfFileException =>
-            if (terminal == Terminal.console && System.console == null) None
+            if (terminal == Terminal.console && !Terminal.hasConsole) None
             else Some("exit")
           case _: IOError | _: ClosedException => Some("exit")
           case _: UserInterruptException | _: ClosedByInterruptException |

--- a/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/JLine3.scala
@@ -20,6 +20,7 @@ import org.jline.terminal.Attributes.{ InputFlag, LocalFlag }
 import org.jline.terminal.Terminal.SignalHandler
 import org.jline.terminal.impl.{ AbstractTerminal, DumbTerminal }
 import org.jline.terminal.spi.{ SystemStream, TerminalProvider }
+import sbt.internal.util.Terminal.hasConsole
 import scala.collection.JavaConverters._
 import scala.util.Try
 import java.util.concurrent.LinkedBlockingQueue
@@ -31,7 +32,7 @@ private[sbt] object JLine3 {
     val term =
       org.jline.terminal.TerminalBuilder
         .builder()
-        .system(System.console != null)
+        .system(hasConsole)
         .paused(true)
         .build()
     initialAttributes.get match {

--- a/main-command/src/main/scala/sbt/internal/ui/UITask.scala
+++ b/main-command/src/main/scala/sbt/internal/ui/UITask.scala
@@ -17,6 +17,7 @@ import sbt.BasicKeys.{ historyPath, colorShellPrompt }
 import sbt.State
 import sbt.internal.CommandChannel
 import sbt.internal.util.ConsoleAppender.{ ClearPromptLine, ClearScreenAfterCursor, DeleteLine }
+import sbt.internal.util.Terminal.hasConsole
 import sbt.internal.util._
 import sbt.internal.util.complete.{ Parser }
 
@@ -70,7 +71,7 @@ private[sbt] object UITask {
             if (thread.isInterrupted || closed.get) throw interrupted
             (try reader.readLine(clear + terminal.prompt.mkPrompt())
             finally reader.close) match {
-              case None if terminal == Terminal.console && System.console == null =>
+              case None if terminal == Terminal.console && !hasConsole =>
                 // No stdin is attached to the process so just ignore the result and
                 // block until the thread is interrupted.
                 this.synchronized(this.wait())

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -27,6 +27,7 @@ import sbt.internal.inc.ScalaInstance
 import sbt.internal.io.Retry
 import sbt.internal.nio.{ CheckBuildSources, FileTreeRepository }
 import sbt.internal.server.{ BuildServerProtocol, NetworkChannel }
+import sbt.internal.util.Terminal.hasConsole
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util.complete.{ Parser, SizeParser }
 import sbt.internal.util.{ Terminal => ITerminal, _ }
@@ -151,8 +152,7 @@ private[sbt] object xMain {
 
     try Some(new BootServerSocket(configuration)) -> None
     catch {
-      case e: ServerAlreadyBootingException
-          if System.console != null && !ITerminal.startedByRemoteClient =>
+      case e: ServerAlreadyBootingException if hasConsole && !ITerminal.startedByRemoteClient =>
         printThrowable(e)
         println("Create a new server? y/n (default y)")
         val exit =

--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -22,6 +22,7 @@ import sbt.librarymanagement._
 import sbt.librarymanagement.ivy.{ IvyConfiguration, IvyDependencyResolution }
 import sbt.internal.inc.classpath.ClasspathUtil
 import BasicCommandStrings._, BasicKeys._
+import sbt.internal.util.Terminal.hasConsole
 
 private[sbt] object TemplateCommandUtil {
   def templateCommand: Command = templateCommand0(TemplateCommand)
@@ -185,7 +186,7 @@ private[sbt] object TemplateCommandUtil {
     "disneystreaming/smithy4s.g8" -> "A Smithy4s project",
   )
   private def fortifyArgs(templates: List[(String, String)]): List[String] =
-    if (System.console eq null) Nil
+    if (!hasConsole) Nil
     else
       ITerminal.withStreams(true, false) {
         assert(templates.size <= 20, "template list cannot have more than 20 items")

--- a/main/src/main/scala/sbt/internal/InstallSbtn.scala
+++ b/main/src/main/scala/sbt/internal/InstallSbtn.scala
@@ -11,6 +11,7 @@ package internal
 
 import Def._
 import Keys.{ sbtVersion, state, terminal }
+import sbt.internal.util.Terminal.hasConsole
 
 import java.io.{ File, FileInputStream, FileOutputStream, InputStream, IOException }
 import java.net.URI
@@ -37,7 +38,7 @@ private[sbt] object InstallSbtn {
       Files.deleteIfExists(tmp)
       ()
     }
-    val shell = if (System.console != null) getShell(term) else "none"
+    val shell = if (hasConsole) getShell(term) else "none"
     shell match {
       case "none" =>
       case s =>


### PR DESCRIPTION
### Issue

[nartamonov](https://github.com/nartamonov) pointed out that JDK 22 changed the behavior of `System.console` in #7580.

> In JDK 22, System.console() has been changed to return a Console with enhanced editing features that improve the experience of programs that use the Console API. In addition, System.console() now returns a Console object when the standard streams are redirected or connected to a virtual terminal. Prior to JDK 22, System.console() instead returned null for these cases. This change may impact code that checks the return from System.console() to test if the JVM is connected to a terminal. If required, the -Djdk.console=java.base flag will restore the old behavior where the console is only returned when it is connected to a terminal. Starting JDK 22, one could also use the new Console.isTerminal() method to test if the console is connected to a terminal.

`sbt` assumes the old behavior of `System.console` and use `System.console == null` to check if connection to terminal exists, causing issue like #7580 and #7841

### Solution

We reflectively call `Console.isTerminal()` if it exists, otherwise fall back to JDK 8 `System.console == null` comparison.

Closes #7841
Closes #7842