### PR TITLE
[1.x] Replace `NNBSP` with standard space

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1011,7 +1011,7 @@ class NetworkClient(
   private def timing(startTime: Long, endTime: Long): String = {
     import java.text.DateFormat
     val format = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
-    val nowString = format.format(new java.util.Date(endTime))
+    val nowString = format.format(new java.util.Date(endTime)).replace("\u202F", "\u0020")
     val total = math.max(0, (endTime - startTime + 500) / 1000)
     val totalString = s"$total s" +
       (if (total <= 60) ""

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -152,7 +152,7 @@ object Aggregation {
   }
 
   def timing(format: java.text.DateFormat, startTime: Long, endTime: Long): String = {
-    val nowString = format.format(new java.util.Date(endTime))
+    val nowString = format.format(new java.util.Date(endTime)).replace("\u202F", "\u0020")
     val total = (endTime - startTime + 500) / 1000
     val totalString = s"$total s" +
       (if (total <= 60) ""

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -17,6 +17,7 @@ import sbt.SlashSyntax0._
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }
 import sbt.internal.util._
+import sbt.internal.client.NetworkClient
 import sbt.std.Transform.DummyTaskMap
 import sbt.util.{ Logger, Show }
 import scala.annotation.nowarn
@@ -152,20 +153,7 @@ object Aggregation {
   }
 
   def timing(format: java.text.DateFormat, startTime: Long, endTime: Long): String = {
-    val nowString = format.format(new java.util.Date(endTime)).replace("\u202F", "\u0020")
-    val total = (endTime - startTime + 500) / 1000
-    val totalString = s"$total s" +
-      (if (total <= 60) ""
-       else {
-         val maybeHours = total / 3600 match {
-           case 0 => ""
-           case h => f"$h%02d:"
-         }
-         val mins = f"${total % 3600 / 60}%02d"
-         val secs = f"${total % 60}%02d"
-         s" ($maybeHours$mins:$secs)"
-       })
-    s"Total time: $totalString, completed $nowString"
+    NetworkClient.timing(format, startTime, endTime)
   }
 
   def defaultFormat: DateFormat = {

--- a/main/src/test/scala/sbt/internal/AggregationSpec.scala
+++ b/main/src/test/scala/sbt/internal/AggregationSpec.scala
@@ -22,4 +22,8 @@ object AggregationSpec extends verify.BasicTestSuite {
     assert(timing(6003099).startsWith("Total time: 6003 s (01:40:03),"))
     assert(timing(96003099).startsWith("Total time: 96003 s (26:40:03),"))
   }
+
+  test("timing should not emit special space characters") {
+    assert(!timing(96003099).contains("\u202F"))
+  }
 }


### PR DESCRIPTION
### Issue

Java 20 started to use `NNBSP` as space when formatting date. Probably due to some unknown JDK bug, `NNBSP` becomes garbled once outputted to terminal under certain conditions.

> [success] Total time: 57 s, completed Oct 29, 2024, 5:38:13ΓÇ»p.m.

### Solution

Replace `NNBSP` with standard space.

(Adapted from https://github.com/nodejs/node/commit/492fc95bdf)

Closes https://github.com/sbt/sbt/issues/7558