### PR TITLE
[1.x] Refactor `dependencyTree` into an input task

### DIFF
--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -54,6 +54,7 @@ object PluginDiscovery {
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
       "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin,
       "sbt.plugins.MiniDependencyTreePlugin" -> sbt.plugins.MiniDependencyTreePlugin,
+      "sbt.plugins.DependencyReportPlugin" -> sbt.plugins.DependencyReportPlugin,
     )
     val detectedAutoPlugins = discover[AutoPlugin](AutoPlugins)
     val allAutoPlugins = (defaultAutoPlugins ++ detectedAutoPlugins.modules) map {

--- a/main/src/main/scala/sbt/internal/graph/rendering/DagreHTML.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/DagreHTML.scala
@@ -18,6 +18,11 @@ import sbt.io.IO
 
 object DagreHTML {
   def createLink(dotGraph: String, targetDirectory: File): URI = {
+    val graphHTML = createFile(dotGraph, targetDirectory)
+    new URI(graphHTML.toURI.toString)
+  }
+
+  def createFile(dotGraph: String, targetDirectory: File): File = {
     targetDirectory.mkdirs()
     val graphHTML = new File(targetDirectory, "graph.html")
     TreeView.saveResource("graph.html", graphHTML)
@@ -33,7 +38,6 @@ object DagreHTML {
       s"""data = "$graphString";""",
       IO.utf8
     )
-
-    new URI(graphHTML.toURI.toString)
+    graphHTML
   }
 }

--- a/main/src/main/scala/sbt/internal/graph/rendering/TreeView.scala
+++ b/main/src/main/scala/sbt/internal/graph/rendering/TreeView.scala
@@ -28,12 +28,17 @@ import scala.annotation.{ nowarn, tailrec }
   }
 
   def createLink(graphJson: String, targetDirectory: File): URI = {
+    val graphHTML = createFile(graphJson, targetDirectory)
+    new URI(graphHTML.toURI.toString)
+  }
+
+  def createFile(graphJson: String, targetDirectory: File): File = {
     targetDirectory.mkdirs()
     val graphHTML = new File(targetDirectory, "tree.html")
     saveResource("tree.html", graphHTML)
     IO.write(new File(targetDirectory, "tree.json"), graphJson, IO.utf8)
     IO.write(new File(targetDirectory, "tree.data.js"), s"tree_data = $graphJson;", IO.utf8)
-    new URI(graphHTML.toURI.toString)
+    graphHTML
   }
 
   private[rendering] def processSubtree(

--- a/main/src/main/scala/sbt/plugins/DependencyReportPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyReportPlugin.scala
@@ -1,0 +1,25 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+import sbt.PluginTrigger.AllRequirements
+import sbt.Project._
+import sbt.librarymanagement.Configurations.{ Compile, Test }
+
+object DependencyReportPlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = AllRequirements
+  override def requires = MiniDependencyTreePlugin
+
+  override def projectSettings: Seq[Def.Setting[?]] =
+    Seq(
+      inConfig(Compile)(DependencyTreeSettings.baseDependencyReportSettings),
+      inConfig(Test)(DependencyTreeSettings.baseDependencyReportSettings)
+    ).flatten
+}

--- a/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeKeys.scala
@@ -35,6 +35,12 @@ trait MiniDependencyTreeKeys {
 
 object MiniDependencyTreeKeys extends MiniDependencyTreeKeys
 
+trait DependencyReportKeys {
+  val dependencyReport = inputKey[Unit]("Generates a report of the project dependencies")
+}
+
+object DependencyReportKeys extends DependencyReportKeys
+
 abstract class DependencyTreeKeys {
   val dependencyGraphMLFile =
     settingKey[File]("The location the graphml file should be generated at")

--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -28,6 +28,7 @@ object DependencyTreeSettings {
   import sjsonnew.BasicJsonProtocol._
   import MiniDependencyTreeKeys._
   import DependencyTreeKeys._
+  import DependencyReportKeys._
 
   /**
    * Core settings needed for any graphing tasks.
@@ -89,6 +90,116 @@ object DependencyTreeSettings {
       }
     }
 
+  private val defaultDependencyDotHeader =
+    """|digraph "dependency-graph" {
+       |    graph[rankdir="LR"; splines=polyline]
+       |    edge [
+       |        arrowtail="none"
+       |    ]""".stripMargin
+
+  private val defaultDependencyDotNodeLabel =
+    (organization: String, name: String, version: String) =>
+      """%s<BR/><B>%s</B><BR/>%s""".format(organization, name, version)
+
+  /**
+   * Setting needed for dependency report
+   * an input task that offers most functionality of full dependency tree plugin
+   */
+  lazy val baseDependencyReportSettings: Seq[Setting[?]] = Seq(
+    dependencyReport := {
+      val defaultFormat = "text"
+
+      val args: Seq[String] = spaceDelimited().parsed
+
+      val (format, subformat) = args match {
+        case Seq()               => (defaultFormat, "")
+        case Seq(arg1)           => (arg1, "")
+        case Seq(arg1, arg2)     => (arg1, arg2)
+        case Seq(arg1, arg2, _*) => (arg1, arg2)
+      }
+
+      val graph = dependencyTreeModuleGraph0.value
+
+      val config = configuration.value.name
+
+      val targetDir =
+        if (subformat.isEmpty) target.value / config else target.value / config / subformat
+
+      def printAndPersistReport(report: String, fileExtension: String, targetDir: File): File = {
+        streams.value.log.info(report)
+        persistReport(report, fileExtension, targetDir)
+      }
+
+      val serializedReport = format match {
+        case "text" =>
+          val report = generateTextReport(graph, subformat, asciiGraphWidth.value)
+          printAndPersistReport(report, "txt", targetDir)
+        case "json" =>
+          val report = generateJsonReport(graph)
+          printAndPersistReport(report, "json", targetDir)
+        case "html"    => generateAndPersistHtmlReport(graph, subformat, targetDir)
+        case "graphml" => generateAndPersistGraphMLReport(graph, targetDir)
+        case _         => sys.error(s"Unsupported format: $format")
+      }
+
+      streams.value.log.info(s"Dependency report written to ${serializedReport.getAbsolutePath}")
+    },
+  )
+
+  private[sbt] def generateTextReport(
+      graph: ModuleGraph,
+      subformat: String,
+      graphWidth: Int
+  ): String = {
+    subformat match {
+      case "list"  => rendering.FlatList.render(_.id.idString)(graph)
+      case "stats" => rendering.Statistics.renderModuleStatsList(graph)
+      case "info"  => rendering.LicenseInfo.render(graph)
+      case _       => rendering.AsciiTree.asciiTree(graph, graphWidth)
+    }
+  }
+
+  private[sbt] def generateJsonReport(graph: ModuleGraph): String = {
+    TreeView.createJson(graph)
+  }
+
+  private[sbt] def createReportFile(targetDir: File, fileExtension: String): File = {
+    new File(targetDir, s"dependencies.$fileExtension")
+  }
+
+  private[sbt] def persistReport(report: String, fileExtension: String, targetDir: File): File = {
+    val target = createReportFile(targetDir, fileExtension)
+    IO.write(target, report, IO.utf8)
+    target
+  }
+
+  private[sbt] def generateAndPersistGraphMLReport(graph: ModuleGraph, targetDir: File): File = {
+    val target = createReportFile(targetDir, "xml")
+    rendering.GraphML.saveAsGraphML(graph, target.getAbsolutePath)
+    target
+  }
+
+  private[sbt] def generateAndPersistHtmlReport(
+      graph: ModuleGraph,
+      subformat: String,
+      targetDir: File
+  ): File = {
+    subformat match {
+      case "tree" =>
+        val renderedTree = TreeView.createJson(graph)
+        TreeView.createFile(renderedTree, targetDir)
+      case "graph" =>
+        val dotGraph = rendering.DOT.dotGraph(
+          graph,
+          defaultDependencyDotHeader,
+          defaultDependencyDotNodeLabel,
+          rendering.DOT.AngleBrackets,
+          colors = true,
+        )
+        DagreHTML.createFile(dotGraph, targetDir)
+    }
+  }
+
   /**
    * This is the maximum strength settings for DependencyTreePlugin.
    */
@@ -114,16 +225,9 @@ object DependencyTreeSettings {
         dependencyDotNodeColors.value
       ),
       dependencyDot := writeToFile(dependencyDot / asString, dependencyDotFile).value,
-      dependencyDotHeader :=
-        """|digraph "dependency-graph" {
-         |    graph[rankdir="LR"; splines=polyline]
-         |    edge [
-         |        arrowtail="none"
-         |    ]""".stripMargin,
+      dependencyDotHeader := defaultDependencyDotHeader,
       dependencyDotNodeColors := true,
-      dependencyDotNodeLabel := { (organization: String, name: String, version: String) =>
-        """%s<BR/><B>%s</B><BR/>%s""".format(organization, name, version)
-      },
+      dependencyDotNodeLabel := { defaultDependencyDotNodeLabel },
       // GraphML support
       dependencyGraphMLFile := {
         val config = configuration.value


### PR DESCRIPTION
Following Eugene's [comment](https://github.com/sbt/sbt/issues/7770#issuecomment-2417281267), this PR refactors `dependencyTree` into an input task, with the aim of

- Featuring minimal additional settings key (to avoid settings key explosion)
- Supporting all capabilities of `MiniDependencyTreePlugin`
- Supporting most capabilities of the full `DependencyTreePlugin`
- Supporting `json` output to both terminal & file
- Featuring a simple API

The refactored input task is called `dependencyReport`. Old `MiniDependencyTreePlugin` settings are still kept for compatibility purpose.

#### Syntax

`dependencyReport [format] [subformat]`

#### Parameters
- `format: text|json|html|graphml`: specifies the format of the output, defaults to `text`
- `subformat`: if applicable further specifies format of output
  - `text` format: `subformat` takes `list|stat|info`, corresponding to `dependencyList`, `dependencyStats`, `dependencyLicenseInfo`. Empty `subformat` corresponds to `dependencyTree`
  -  `html` format: `subformat` takes `tree|graph`, corresponding to `browseTreeHTMLTask, browseGraphHTMLTask`
  - `json/graphml` format: does not take `subformat`
  
#### Example

```
sbt:contraband> dependencyReport
[info] org.scala-sbt:contraband_2.12:0.5.3-SNAPSHOT [S]
[info]   +-com.eed3si9n:sjson-new-scalajson_2.12:0.10.0 [S]
[info]   | +-com.eed3si9n:shaded-jawn-parser_2.12:1.3.2 [S]
[info]   | +-com.eed3si9n:shaded-scalajson_2.12:1.0.0-M4 [S]
[info]   | +-com.eed3si9n:sjson-new-core_2.12:0.10.0 [S]
[info]   |
[info]   +-org.parboiled:parboiled_2.12:2.5.1 [S]
[info]
[info] Dependency report written to D:\Repos\contraband\library\target\compile\dependencies.txt

sbt:contraband> dependencyReport json
[info] [{"text":"org.scala-sbt:contraband_2.12:0.5.3-SNAPSHOT","children":[{"text":"com.eed3si9n:sjson-new-scalajson_2.12:0.10.0","children"
:[{"text":"com.eed3si9n:shaded-jawn-parser_2.12:1.3.2","children":[]},{"text":"com.eed3si9n:shaded-scalajson_2.12:1.0.0-M4","children":[]},{"text":"com.eed3si9n:sjson-new-core_2.12:0.10.0","children":[]}]},{"text":"org.parboiled:parboiled_2.12:2.5.1","children":[]}]}]
[info] Dependency report written to D:\Repos\contraband\library\target\compile\dependencies.json
[success] Total time: 0 s, completed Oct 30, 2024, 6:11:06 p.m.

sbt:contraband> Test / dependencyReport html graph
[info] Dependency report written to D:\Repos\contraband\library\target\test\graph\graph.html
```

Closes #7770