### PR TITLE
[1.x] Return exit code `1` when client crashes & add smoke test for client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
       run: |
         # test building sbtn on Linux
         sbt "-Dsbt.io.virtual=false" nativeImage
+        # smoke test native Image
+        ./client/target/bin/sbtn shutdown
         # test launcher script
         echo build using JDK 8 test using JDK 8 and JDK 11
         cd launcher-package

--- a/client/src/main/java/sbt/client/Client.java
+++ b/client/src/main/java/sbt/client/Client.java
@@ -9,19 +9,21 @@
 package sbt.client;
 
 import sbt.internal.client.NetworkClient;
-import java.nio.file.Paths;
 import org.fusesource.jansi.AnsiConsole;
 
 public class Client {
   public static void main(final String[] args) {
     boolean isWin = System.getProperty("os.name").toLowerCase().startsWith("win");
+    boolean hadError = false;
     try {
       if (isWin) AnsiConsole.systemInstall();
       NetworkClient.main(args);
     } catch (final Throwable t) {
       t.printStackTrace();
+      hadError = true;
     } finally {
       if (isWin) AnsiConsole.systemUninstall();
+      if (hadError) System.exit(1);
     }
   }
 }


### PR DESCRIPTION
Closes #7852
Closes #7853

With the change, CI Job 7 now [fails](https://github.com/sbt/sbt/actions/runs/11623624845/job/32370957314?pr=7854) when it produces a nonfunctional native image

```
[info] Welcome to the build for sbt.
java.lang.NoClassDefFoundError: Could not initialize class org.scalasbt.ipcsocket.JNIUnixDomainSocketLibraryProvider
	at org.scalasbt.ipcsocket.UnixDomainSocketLibraryProvider.get(UnixDomainSocketLibraryProvider.java:26)
	at org.scalasbt.ipcsocket.UnixDomainSocket.<init>(UnixDomainSocket.java:50)
	at sbt.protocol.ClientSocket$.localSocket(ClientSocket.scala:47)
	at sbt.protocol.ClientSocket$.socket(ClientSocket.scala:39)
	at sbt.internal.client.NetworkClient.mkSocket(NetworkClient.scala:147)
	at sbt.internal.client.NetworkClient.connect$1(NetworkClient.scala:196)
	at sbt.internal.client.NetworkClient.connectOrStartServerAndConnect(NetworkClient.scala:216)
	at sbt.internal.client.NetworkClient.init(NetworkClient.scala:226)
	at sbt.internal.client.NetworkClient.connect(NetworkClient.scala:764)
	at sbt.internal.client.NetworkClient$.clientImpl(NetworkClient.scala:1196)
	at sbt.internal.client.NetworkClient$.client(NetworkClient.scala:1187)
	at sbt.internal.client.NetworkClient$.$anonfun$main$4(NetworkClient.scala:1250)
	at scala.runtime.java8.JFunction0$mcI$sp.apply(JFunction0$mcI$sp.java:23)
	at sbt.internal.util.Terminal$.withStreams(Terminal.scala:431)
	at sbt.internal.client.NetworkClient$.main(NetworkClient.scala:1248)
	at sbt.internal.client.NetworkClient.main(NetworkClient.scala)
	at sbt.client.Client.main(Client.java:20)
	at java.base@23.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)

Error: Process completed with exit code 1.
```