### PR TITLE
[1.x] Reverts #7823 to restore Linux `sbtn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,6 @@ jobs:
         repository: sbt/zinc
         ref: 1.10.x
         path: zinc
-    - uses: graalvm/setup-graalvm@v1
-      if: ${{ matrix.jobtype >= 7 && matrix.jobtype <= 9 }}
-      with:
-        java-version: '23'
-        native-image-musl: 'true'
-        set-java-home: 'false'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:

--- a/build.sbt
+++ b/build.sbt
@@ -1176,13 +1176,8 @@ lazy val sbtClientProj = (project in file("client"))
     nativeImageReady := { () =>
       ()
     },
-    if (isArmArchitecture)
-      Seq(
-        nativeImageVersion := "23.0",
-        nativeImageJvm := "graalvm-java23",
-      )
-    else Nil,
-    nativeImageInstalled := !isArmArchitecture,
+    nativeImageVersion := "23.0",
+    nativeImageJvm := "graalvm-java23",
     nativeImageOutput := {
       val outputDir = (target.value / "bin").toPath
       if (!Files.exists(outputDir)) {
@@ -1204,7 +1199,7 @@ lazy val sbtClientProj = (project in file("client"))
       s"-H:Name=${target.value / "bin" / "sbtn"}",
     ) ++ (if (isLinux && isArmArchitecture)
             Seq("-H:PageSize=65536") // Make sure binary runs on kernels with page size set to 4k, 16 and 64k
-          else Nil) ++ (if (isLinux && !isArmArchitecture) Seq("--static", "--libc=musl") else Nil),
+          else Nil),
     buildThinClient := {
       val isFish = Def.spaceDelimited("").parsed.headOption.fold(false)(_ == "--fish")
       val ext = if (isWin) ".bat" else if (isFish) ".fish" else ".sh"


### PR DESCRIPTION
Reverts #7823 to unblock Linux sbt users from using `sbtn`, as static linked `sbtn` crashes in Linux. Crash was not caught by CI due to #7852

Closes #7851