### PR TITLE
Fix ++ with a command argument

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -122,7 +122,10 @@ object Cross {
       .map { case uri ~ seg1 ~ cmd => (uri, seg1, cmd) }
     Parser.parse(command, parser) match {
       case Right((uri, seg1, cmd)) =>
-        structure.allProjectRefs.find(p => uri.contains(p.build.toString) && seg1 == p.project) match {
+        structure.allProjectRefs.find {
+          case p if uri.isDefined => seg1 == p.project && uri.contains(p.build.toString)
+          case p                  => seg1 == p.project
+        } match {
           case Some(proj) => (Seq(proj), cmd)
           case _          => (resolveAggregates(extracted), command)
         }

--- a/sbt-app/src/sbt-test/actions/cross-multiproject/test
+++ b/sbt-app/src/sbt-test/actions/cross-multiproject/test
@@ -21,6 +21,12 @@ $ exists sbt-foo/target/scala-2.12
 $ exists ref/target/scala-2.12
 -$ exists ref/target/scala-2.13
 
+# test safe switching
+> clean
+> ++ 2.12.20 -v libProj/compile
+$ exists lib/target/scala-2.12
+-$ exists lib/target/scala-2.13
+
 # Test legacy cross build with command support
 # > clean
 # > + build


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7861

## Problem
sbt 1.10.0 added support for ++ command with external reference, but broke ++ takes an aggregate command with slash.

## Solution
This fixes the parser