### PR TITLE
[2.x] Reduce number of long-living instances to speed up loading

### DIFF
--- a/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
@@ -10,6 +10,8 @@ package sbt.internal.util
 
 import java.util.Locale
 
+import scala.collection.concurrent.TrieMap
+
 object Util {
   def makeList[T](size: Int, value: T): List[T] = List.fill(size)(value)
 
@@ -70,5 +72,10 @@ object Util {
 
   extension [A](value: A) {
     def some: Option[A] = (Some(value): Option[A])
+  }
+
+  private[sbt] def withCaching[A1, A2](f: A1 => A2): A1 => A2 = {
+    val cache = TrieMap.empty[A1, A2]
+    x => cache.getOrElseUpdate(x, f(x))
   }
 }

--- a/main-settings/src/main/scala/sbt/Project.scala
+++ b/main-settings/src/main/scala/sbt/Project.scala
@@ -15,6 +15,7 @@ import sbt.internal.util.Dag
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.DefaultParsers
 import Scope.ThisScope
+import sbt.Scope.ThisBuildScope
 
 sealed trait ProjectDefinition[PR <: ProjectReference] {
 
@@ -345,10 +346,10 @@ object Project:
     ss.map(_.mapReferenced(f))
 
   def inThisBuild(ss: Seq[Setting[?]]): Seq[Setting[?]] =
-    inScope(ThisScope.copy(project = Select(ThisBuild)))(ss)
+    inScope(ThisBuildScope)(ss)
 
   private[sbt] def inThisBuild[T](i: Initialize[T]): Initialize[T] =
-    inScope(ThisScope.copy(project = Select(ThisBuild)), i)
+    inScope(ThisBuildScope, i)
 
   private[sbt] def inConfig[T](conf: Configuration, i: Initialize[T]): Initialize[T] =
     inScope(ThisScope.copy(config = Select(conf)), i)

--- a/main-settings/src/main/scala/sbt/Project.scala
+++ b/main-settings/src/main/scala/sbt/Project.scala
@@ -16,6 +16,7 @@ import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.DefaultParsers
 import Scope.ThisScope
 import sbt.Scope.ThisBuildScope
+import sbt.internal.util.Util
 
 sealed trait ProjectDefinition[PR <: ProjectReference] {
 
@@ -336,14 +337,8 @@ object Project:
     [a] => (k: ScopedKey[a]) => ScopedKey(f(k.scope), k.key)
 
   def transform(g: Scope => Scope, ss: Seq[Def.Setting[?]]): Seq[Def.Setting[?]] =
-    val f = mapScope(g)
-    ss.map { setting =>
-      setting.mapKey(f).mapReferenced(f)
-    }
-
-  def transformRef(g: Scope => Scope, ss: Seq[Def.Setting[?]]): Seq[Def.Setting[?]] =
-    val f = mapScope(g)
-    ss.map(_.mapReferenced(f))
+    val f = mapScope(Util.withCaching(g))
+    ss.map(_.mapKey(f).mapReferenced(f))
 
   def inThisBuild(ss: Seq[Setting[?]]): Seq[Setting[?]] =
     inScope(ThisBuildScope)(ss)

--- a/main-settings/src/main/scala/sbt/Project.scala
+++ b/main-settings/src/main/scala/sbt/Project.scala
@@ -337,6 +337,8 @@ object Project:
     [a] => (k: ScopedKey[a]) => ScopedKey(f(k.scope), k.key)
 
   def transform(g: Scope => Scope, ss: Seq[Def.Setting[?]]): Seq[Def.Setting[?]] =
+    // We use caching to avoid creating new Scope instances too many times
+    // Creating a new Scope is CPU expensive because of the uniqueness cache
     val f = mapScope(Util.withCaching(g))
     ss.map(_.mapKey(f).mapReferenced(f))
 

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -15,6 +15,7 @@ import sbt.internal.util.Util._
 
 import sbt.io.IO
 import scala.collection.concurrent.TrieMap
+import scala.runtime.ScalaRunTime
 
 final case class Scope private (
     project: ScopeAxis[Reference],
@@ -22,6 +23,8 @@ final case class Scope private (
     task: ScopeAxis[AttributeKey[?]],
     extra: ScopeAxis[AttributeMap]
 ):
+  override val hashCode = ScalaRunTime._hashCode(this)
+
   def rescope(project: Reference): Scope = copy(project = Select(project))
   def rescope(config: ConfigKey): Scope = copy(config = Select(config))
   def rescope(task: AttributeKey[?]): Scope = copy(task = Select(task))

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -23,6 +23,8 @@ final case class Scope private (
     task: ScopeAxis[AttributeKey[?]],
     extra: ScopeAxis[AttributeMap]
 ):
+  // Since we use a uniqueness cache we can pre-compute the hashCode for free
+  // It is always going to be used at least once
   override val hashCode = ScalaRunTime._hashCode(this)
 
   def rescope(project: Reference): Scope = copy(project = Select(project))
@@ -43,6 +45,9 @@ final case class Scope private (
 end Scope
 
 object Scope:
+  // We use a global uniqueness cache to avoid duplicating Scope.
+  // At the time of writing, it divides the number of long-living instances by 15
+  // reducing the pressure on the heap, and speed up the loading.
   private val uniquenessCache = TrieMap.empty[Scope, Scope]
 
   def apply(

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -56,6 +56,7 @@ object Scope:
 
   val ThisScope: Scope = new Scope(This, This, This, This)
   val Global: Scope = new Scope(Zero, Zero, Zero, Zero)
+  val ThisBuildScope: Scope = Scope(Select(ThisBuild), This, This, This)
   val GlobalScope: Scope = Global
 
   private[sbt] final val inIsDeprecated =

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -274,6 +274,8 @@ private[sbt] object Load {
       finalTransforms(settings0)
     }
     val delegates = timed("Load.apply: config.delegates", log) {
+      // We use caching to avoid creating new Scope instances too many times
+      // Creating a new Scope is CPU expensive because of the uniqueness cache
       Util.withCaching(config.delegates(loaded))
     }
     val (cMap, data) = timed("Load.apply: Def.make(settings)...", log) {

--- a/sbt-app/src/main/scala/package.scala
+++ b/sbt-app/src/main/scala/package.scala
@@ -33,7 +33,6 @@ package object sbt
     fillTaskAxis,
     mapScope,
     transform,
-    transformRef,
     inThisBuild,
     inScope,
     normalizeModuleID

--- a/util-collection/src/main/scala/sbt/internal/util/INode.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/INode.scala
@@ -40,7 +40,10 @@ abstract class EvaluateSettings[ScopeType]:
   private val transform: [A] => Initialize[A] => INode[A] = [A] =>
     (fa: Initialize[A]) =>
       fa match
-        case k: Keyed[s, A]   => single(getStatic(k.scopedKey), k.transform)
+        case g: GetValue[s, A]     => single(getStatic(g.scopedKey), g.transform)
+        case k: KeyedInitialize[A] =>
+          // TODO create a Single node with no transform?
+          single(getStatic(k.scopedKey), identity)
         case u: Uniform[s, A] => UniformNode(u.inputs.map(transform[s]), u.f)
         case a: Apply[k, A] =>
           MixedNode[k, A](TupleMapExtension.transform(a.inputs)(transform), a.f)


### PR DESCRIPTION
After loading, instances of `ScopedKey`, `Scope`, `Select` or `ProjectRef` represent 25.6% of the total number of instances, and 27.3% of the heap size. The main idea of this PR is to reduce the number of duplicated instances using uniqueness caches.

## Uniqueness cache on `Scope`

It reduces the number of `Scope` instances by 94%. On its own, it slows down the loading, because `Scope.apply` becomes more expensive and it is called too many times. This can be compensated by using temporary caches in `Project.transform` and `delegates: Scope => Seq[Scope]`, to avoid calling `Scope.apply` to create too many short-lived instances.

It also reduces the number of `Select` by 92% and `ProjectRef` by 99.8%, which make them totally negligible.

Since we use a uniqueness cache we might as well pre-compute the hash code of each scope, which reduce the CPU time.

## Uniqueness cache on `ScopedKey` (uncommited)

I think it is also worth mentioning that I tried a uniqueness cache on `ScopedKey` but it was not really better. Indeed, on one hand it reduced the number of `ScopedKey` by 59.6%, but on the other hand it was counterbalanced by the number of nodes in the cache itself.

## Other changes

The first commit reduces the number of `Init.GetValue` by 48% for free.

## Result

I am still using sttp to collect those metrics, on my 12 CPUs laptop, and JDK temurin 17 (G1GC).

**It shows up a 20% speedup of the loading time compared to sbt 2.0.0-M2, and a 41% speedup compared to sbt 1.10.2. Those are rough estimations.**

### Compared to 2.0.0-M2

|          | Settings | Instances | Used Heap size | Load time |
|----------|----------|-----------|----------------|-----------|
| 2.0.0-M2 | 212961   | 20,920 K  | 532 MB         | 7949 ms   |
| This PR  | 212961   | 16,365 K  | 410 MB         | 6328 ms   |
|          | 100 %    | 78 %      | 77 %           | 80 %      |

### Compare to 1.10.2

|         | Settings | Instances | Used Heap size | Load time |
|---------|----------|-----------|----------------|-----------|
| 1.10.2  | 197031   | 23,524 K  | 675 MB         | 10629 ms  |
| This PR | 212961   | 16,365 K  | 410 MB         | 6328 ms   |
|         | 108 %    | 70 %      | 61 %           | 59 %      |
