### PR TITLE
[1.x] Pass `useConsistent` to `staticCachedStore`

### DIFF
--- a/main/src/main/scala/sbt/internal/AnalysisUtil.scala
+++ b/main/src/main/scala/sbt/internal/AnalysisUtil.scala
@@ -30,7 +30,7 @@ private[sbt] object AnalysisUtil {
     MixedAnalyzingCompiler.staticCachedStore(
       analysisFile = analysisFile,
       useTextAnalysis = useTextAnalysis,
-      useConsistent = false,
+      useConsistent = useConsistent,
       mappers = ReadWriteMappers.getEmptyMappers(),
       sort = true,
       parallelism = parallelism,


### PR DESCRIPTION
Not sure if there's a specific reason to drop `useConsistent` in `AnalysisUtil.staticCachedStore`, but if we don't have a specific reason we should pass it along. If we do have a specific reason I feel we should add a comment here to explain the rationale.