### PR TITLE
[1.x] Bump Jansi to 3.27.1

### DIFF
--- a/client/src/main/java/sbt/client/Client.java
+++ b/client/src/main/java/sbt/client/Client.java
@@ -9,7 +9,7 @@
 package sbt.client;
 
 import sbt.internal.client.NetworkClient;
-import org.fusesource.jansi.AnsiConsole;
+import org.jline.jansi.AnsiConsole;
 
 public class Client {
   public static void main(final String[] args) {

--- a/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
@@ -11,7 +11,7 @@ package sbt.internal.util
 import java.io.InputStream
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import org.fusesource.jansi.internal.Kernel32
+import org.jline.nativ.Kernel32
 import org.jline.utils.InfoCmp.Capability
 import scala.annotation.tailrec
 import Terminal.SimpleInputStream

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,7 +93,7 @@ object Dependencies {
   val jline3Native = "org.jline" % "jline-native" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val jansi = "org.fusesource.jansi" % "jansi" % "2.4.1"
+  val jansi = "org.jline" % "jansi-core" % jline3Version
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   val junit = "junit" % "junit" % "4.13.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,7 +93,7 @@ object Dependencies {
   val jline3Native = "org.jline" % "jline-native" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val jansi = "org.jline" % "jansi-core" % jline3Version
+  val jansi = "org.jline" % "jansi" % jline3Version
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.10"
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.4"
   val junit = "junit" % "junit" % "4.13.1"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7865

Changes compared to Jansi 2.4.1 (summarized from https://github.com/jline/jline3/commits/master/jansi-core)
- https://github.com/jline/jline3/commit/f79eeb290af809d29955caee54c17d08d34466f5 (Add tripleto hexadecimal color support)

Tested locally on Windows via running `sbt` on a small test project. Tab completion & history are working.