### PR TITLE
[1.x] Remove direct dependency on `org.fusesource.jansi`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1170,7 +1170,6 @@ lazy val sbtClientProj = (project in file("client"))
     mimaPreviousArtifacts := Set.empty,
     crossPaths := false,
     exportJars := true,
-    libraryDependencies += jansi,
     libraryDependencies += scalatest % Test,
     Compile / mainClass := Some("sbt.client.Client"),
     nativeImageReady := { () =>

--- a/client/src/main/java/sbt/client/Client.java
+++ b/client/src/main/java/sbt/client/Client.java
@@ -9,20 +9,16 @@
 package sbt.client;
 
 import sbt.internal.client.NetworkClient;
-import org.fusesource.jansi.AnsiConsole;
 
 public class Client {
   public static void main(final String[] args) {
-    boolean isWin = System.getProperty("os.name").toLowerCase().startsWith("win");
     boolean hadError = false;
     try {
-      if (isWin) AnsiConsole.systemInstall();
       NetworkClient.main(args);
     } catch (final Throwable t) {
       t.printStackTrace();
       hadError = true;
     } finally {
-      if (isWin) AnsiConsole.systemUninstall();
       if (hadError) System.exit(1);
     }
   }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/WindowsInputStream.scala
@@ -11,7 +11,7 @@ package sbt.internal.util
 import java.io.InputStream
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import org.fusesource.jansi.internal.Kernel32
+import org.jline.nativ.Kernel32
 import org.jline.utils.InfoCmp.Capability
 import scala.annotation.tailrec
 import Terminal.SimpleInputStream


### PR DESCRIPTION
### Motivation

- Jansi development is inactive, with its last [update](https://github.com/fusesource/jansi/releases/tag/jansi-2.4.1) all the way back in Oct 12, 2023
- Jansi contains native code
- `sbt` does not use Jansi all that much

Also recent Jansi-related tickets such as https://github.com/sbt/sbt/issues/7865 would not exist if we do not depend on `org.fusesource.jansi`.

### Changes

- Remove the usage of `org.fusesource.jansi.AnsiConsole` in sbt thin client
  - Since Windows 10 introduced ANSI support, `org.fusesource.jansi.AnsiConsole` is no longer necessary on Windows.
- Remove the usage of Jansi's JNI methods, replacing them with equivalent methods from JLine3.

### Addressing diamond dependency & sbtn build concern

Eugene [pointed out](https://github.com/sbt/sbt/pull/7872#discussion_r1831528366) that changing a dependency containing native code may cause breakage if
- downstream of sbt uses the same dependency
  - historically diamond `JLine` dependency had broken `sbt console`
- sbtn build may fail & become nonfunctional

This PR addresses the concern by testing `sbtn console` on a sample Scala 2.12.20, Scala 2.13.15 and Scala 3.3.4 project, against a `sbtn` executable built against the PR branch. No regression is identified.

#### Windows

![image](https://github.com/user-attachments/assets/6ca1de07-e541-4adb-a440-49346e17c002)

#### Mac

Terminal used: IntelliJ IDE Terminal

3.3.4
<img width="544" alt="image" src="https://github.com/user-attachments/assets/8e224a46-743d-4611-9ebf-ec2b2977b946">

2.13.15
<img width="744" alt="image" src="https://github.com/user-attachments/assets/1a92ab2b-694c-4903-a864-cdf113a6693a">

2.12.20
<img width="548" alt="image" src="https://github.com/user-attachments/assets/fdd02b6c-e882-4c14-b0f3-5e53b007dcb7">

Supersedes #7872