### PR TITLE
[2.x] Refactor `Settings` and optimize indexing of aggregate keys

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -9,19 +9,12 @@
 package sbt
 package internal
 
-import sbt.internal.util.{
-  AttributeEntry,
-  AttributeKey,
-  LineRange,
-  MessageOnlyException,
-  RangePosition,
-  Settings
-}
+import sbt.internal.util.{ AttributeKey, LineRange, MessageOnlyException, RangePosition }
 
 import java.io.File
 import java.nio.file.Path
 import sbt.internal.util.complete.DefaultParsers.validID
-import Def.{ ScopedKey, Setting }
+import Def.{ ScopedKey, Setting, Settings }
 import Scope.GlobalScope
 import sbt.SlashSyntax0.given
 import sbt.internal.parser.SbtParser
@@ -351,16 +344,10 @@ object BuildUtilLite:
 end BuildUtilLite
 
 object Index {
-  def taskToKeyMap(data: Settings[Scope]): Map[Task[?], ScopedKey[Task[?]]] = {
-
-    val pairs = data.scopes flatMap (scope =>
-      data.data(scope).entries collect { case AttributeEntry(key, value: Task[_]) =>
-        (value, ScopedKey(scope, key.asInstanceOf[AttributeKey[Task[?]]]))
-      }
-    )
-
-    pairs.toMap[Task[?], ScopedKey[Task[?]]]
-  }
+  def taskToKeyMap(data: Settings): Map[Task[?], ScopedKey[Task[?]]] =
+    data.data.collect { case (key, value: Task[?]) =>
+      (value, key.asInstanceOf[ScopedKey[Task[?]]])
+    }
 
   def allKeys(settings: Seq[Setting[?]]): Set[ScopedKey[?]] = {
     val result = new java.util.HashSet[ScopedKey[?]]
@@ -371,9 +358,6 @@ object Index {
     }
     result.asScala.toSet
   }
-
-  def attributeKeys(settings: Settings[Scope]): Set[AttributeKey[?]] =
-    settings.data.values.flatMap(_.keys).toSet[AttributeKey[?]]
 
   def stringToKeyMap(settings: Set[AttributeKey[?]]): Map[String, AttributeKey[?]] =
     stringToKeyMap0(settings)(_.label)
@@ -396,19 +380,17 @@ object Index {
 
   private type TriggerMap = collection.mutable.HashMap[TaskId[?], Seq[TaskId[?]]]
 
-  def triggers(ss: Settings[Scope]): Triggers = {
+  def triggers(ss: Settings): Triggers = {
     val runBefore = new TriggerMap
     val triggeredBy = new TriggerMap
-    for
-      a <- ss.data.values
-      case AttributeEntry(_, base: Task[?]) <- a.entries
-    do
+    ss.values.collect { case base: Task[?] =>
       def update(map: TriggerMap, key: AttributeKey[Seq[Task[?]]]): Unit =
         base.info.attributes.get(key).getOrElse(Seq.empty).foreach { task =>
           map(task) = base +: map.getOrElse(task, Nil)
         }
       update(runBefore, Def.runBefore)
       update(triggeredBy, Def.triggeredBy)
+    }
     val onComplete = (GlobalScope / Def.onComplete).get(ss).getOrElse(() => ())
     new Triggers(runBefore, triggeredBy, map => { onComplete(); map })
   }

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -54,7 +54,8 @@ trait BuildSyntax:
 end BuildSyntax
 
 /** A concrete settings system that uses `sbt.Scope` for the scope type. */
-object Def extends BuildSyntax with Init[Scope] with InitializeImplicits:
+object Def extends BuildSyntax with Init with InitializeImplicits:
+  type ScopeType = Scope
   type Classpath = Seq[Attributed[HashedVirtualFileRef]]
 
   def settings(ss: SettingsDefinition*): Seq[Setting[?]] = ss.flatMap(_.settings)

--- a/main-settings/src/main/scala/sbt/Project.scala
+++ b/main-settings/src/main/scala/sbt/Project.scala
@@ -334,7 +334,7 @@ object Project:
     ScopedKey(Scope.fillTaskAxis(scoped.scope, scoped.key), scoped.key)
 
   def mapScope(f: Scope => Scope): [a] => ScopedKey[a] => ScopedKey[a] =
-    [a] => (k: ScopedKey[a]) => ScopedKey(f(k.scope), k.key)
+    [a] => (k: ScopedKey[a]) => k.copy(scope = f(k.scope))
 
   def transform(g: Scope => Scope, ss: Seq[Def.Setting[?]]): Seq[Def.Setting[?]] =
     // We use caching to avoid creating new Scope instances too many times
@@ -361,7 +361,10 @@ object Project:
     Project.transform(Scope.replaceThis(scope), ss)
 
   private[sbt] def inScope[A](scope: Scope, i: Initialize[A]): Initialize[A] =
-    i.mapReferenced(Project.mapScope(Scope.replaceThis(scope)))
+    i.mapReferenced(replaceThis(scope))
+
+  private[sbt] def replaceThis(scope: Scope): Def.MapScoped =
+    mapScope(Scope.replaceThis(scope))
 
   /**
    * Normalize a String so that it is suitable for use as a dependency management module identifier.

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -11,7 +11,7 @@ package sbt
 import scala.annotation.targetName
 
 import sbt.internal.util.Types.*
-import sbt.internal.util.{ AttributeKey, KeyTag, Settings, SourcePosition }
+import sbt.internal.util.{ AttributeKey, KeyTag, SourcePosition }
 import sbt.internal.util.TupleMapExtension.*
 import sbt.util.OptJsonWriter
 import sbt.ConcurrentRestrictions.Tag
@@ -303,8 +303,7 @@ object Scoped:
       setting(scopedKey, app, source)
 
     /** From the given `Settings`, extract the value bound to this key. */
-    final def get(settings: Settings[Scope]): Option[A1] =
-      settings.get(scopedKey.scope, scopedKey.key)
+    final def get(settings: Def.Settings): Option[A1] = settings.get(scopedKey)
 
     /**
      * Creates an [[Def.Initialize]] with value `scala.None` if there was no previous definition of this key,
@@ -460,7 +459,7 @@ object Scoped:
 
     def toSettingKey: SettingKey[Task[A1]] = scopedSetting(scope, key)
 
-    def get(settings: Settings[Scope]): Option[Task[A1]] = settings.get(scope, key)
+    def get(settings: Def.Settings): Option[Task[A1]] = settings.get(scopedKey)
 
     /**
      * Creates an [[Def.Initialize]] with value `scala.None` if there was no previous definition of this key,

--- a/main-settings/src/main/scala/sbt/std/Instances.scala
+++ b/main-settings/src/main/scala/sbt/std/Instances.scala
@@ -47,7 +47,7 @@ end ParserInstance
 
 /** Composes the Task and Initialize Instances to provide an Instance for [A1] Initialize[Task[A1]]. */
 object FullInstance:
-  type SS = sbt.internal.util.Settings[Scope]
+  type SS = Def.Settings
   val settingsData = TaskKey[SS](
     "settings-data",
     "Provides access to the project data for the build.",

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -449,8 +449,8 @@ object EvaluateTask {
       ref: ProjectRef
   ): Option[(Task[T], NodeView)] = {
     val thisScope = Load.projectScope(ref)
-    val resolvedScope = Scope.replaceThis(thisScope)(taskKey.scope)
-    for (t <- structure.data.get(resolvedScope, taskKey.key))
+    val subScoped = Project.replaceThis(thisScope)(taskKey.scopedKey)
+    for (t <- structure.data.get(subScoped))
       yield (t, nodeView(state, streams, taskKey :: Nil))
   }
   def nodeView(

--- a/main/src/main/scala/sbt/ScopedKeyData.scala
+++ b/main/src/main/scala/sbt/ScopedKeyData.scala
@@ -11,16 +11,14 @@ package sbt
 import Def.ScopedKey
 import sbt.internal.util.KeyTag
 
-final case class ScopedKeyData[A](scoped: ScopedKey[A], value: Any) {
-  val key = scoped.key
-  val scope = scoped.scope
-  def typeName: String = key.tag.toString
+final case class ScopedKeyData[A](key: ScopedKey[A], definingKey: ScopedKey[A], value: Any) {
+  def typeName: String = key.key.tag.toString
   def settingValue: Option[Any] =
-    key.tag match
+    key.key.tag match
       case KeyTag.Setting(_) => Some(value)
       case _                 => None
   def description: String =
-    key.tag match
+    key.key.tag match
       case KeyTag.Task(typeArg)      => s"Task: $typeArg"
       case KeyTag.SeqTask(typeArg)   => s"Task: Seq[$typeArg]"
       case KeyTag.InputTask(typeArg) => s"Input task: $typeArg"

--- a/main/src/main/scala/sbt/SessionVar.scala
+++ b/main/src/main/scala/sbt/SessionVar.scala
@@ -58,11 +58,13 @@ object SessionVar {
       key: ScopedKey[Task[T]],
       context: Scope,
       state: State
-  ): ScopedKey[Task[T]] = {
-    val subScope = Scope.replaceThis(context)(key.scope)
-    val scope = Project.structure(state).data.definingScope(subScope, key.key) getOrElse subScope
-    ScopedKey(scope, key.key)
-  }
+  ): ScopedKey[Task[T]] =
+    val subScoped = Project.replaceThis(context)(key)
+    Project
+      .structure(state)
+      .data
+      .definingKey(subScoped)
+      .getOrElse(subScoped)
 
   def read[T](key: ScopedKey[Task[T]], state: State)(implicit f: JsonFormat[T]): Option[T] =
     Project.structure(state).streams(state).use(key) { s =>

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -266,29 +266,40 @@ object Aggregation {
       else extra.aggregates.forward(ref)
     }
 
+  /**
+   * Compute the reverse aggregate keys of all the `keys` at once.
+   * This is more performant than computing the revere aggregate keys of each key individually
+   * because of the duplicates. One aggregate key is the aggregation of many keys.
+   */
+  def reverseAggregate[Proj](
+      keys: Set[ScopedKey[?]],
+      extra: BuildUtil[Proj],
+  ): Iterable[ScopedKey[?]] =
+    val mask = ScopeMask()
+    def recur(keys: Set[ScopedKey[?]], acc: Set[ScopedKey[?]]): Set[ScopedKey[?]] =
+      if keys.isEmpty then acc
+      else
+        val aggKeys = for
+          key <- keys
+          ref <- projectAggregates(key.scope.project.toOption, extra, reverse = true)
+          toResolve = key.scope.copy(project = Select(ref))
+          resolved = Resolve(extra, Zero, key.key, mask)(toResolve)
+          scoped = ScopedKey(resolved, key.key)
+          if !acc.contains(scoped)
+        yield scoped
+        val filteredAggKeys = aggKeys.filter(aggregationEnabled(_, extra.data))
+        // recursive because an aggregate project can be aggregated in another aggregate project
+        recur(filteredAggKeys, acc ++ filteredAggKeys)
+    recur(keys, keys)
+
   def aggregate[A1, Proj](
       key: ScopedKey[A1],
       rawMask: ScopeMask,
-      extra: BuildUtil[Proj],
-      reverse: Boolean = false
+      extra: BuildUtil[Proj]
   ): Seq[ScopedKey[A1]] =
     val mask = rawMask.copy(project = true)
     Dag.topologicalSort(key): (k) =>
-      if reverse then reverseAggregatedKeys(k, extra, mask)
-      else if aggregationEnabled(k, extra.data) then aggregatedKeys(k, extra, mask)
-      else Nil
-
-  def reverseAggregatedKeys[T](
-      key: ScopedKey[T],
-      extra: BuildUtil[?],
-      mask: ScopeMask
-  ): Seq[ScopedKey[T]] =
-    projectAggregates(key.scope.project.toOption, extra, reverse = true) flatMap { ref =>
-      val toResolve = key.scope.copy(project = Select(ref))
-      val resolved = Resolve(extra, Zero, key.key, mask)(toResolve)
-      val skey = ScopedKey(resolved, key.key)
-      if (aggregationEnabled(skey, extra.data)) skey :: Nil else Nil
-    }
+      if aggregationEnabled(k, extra.data) then aggregatedKeys(k, extra, mask) else Nil
 
   def aggregatedKeys[T](
       key: ScopedKey[T],

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -11,7 +11,7 @@ package internal
 
 import java.text.DateFormat
 
-import sbt.Def.ScopedKey
+import sbt.Def.{ ScopedKey, Settings }
 import sbt.Keys.{ showSuccess, showTiming, timingFormat }
 import sbt.ProjectExtra.*
 import sbt.SlashSyntax0.given
@@ -157,7 +157,7 @@ object Aggregation {
   private def timingString(
       startTime: Long,
       endTime: Long,
-      data: Settings[Scope],
+      data: Settings,
       currentRef: ProjectRef,
   ): String = {
     val format = (currentRef / timingFormat).get(data) getOrElse defaultFormat
@@ -301,7 +301,7 @@ object Aggregation {
       ScopedKey(resolved, key.key)
     }
 
-  def aggregationEnabled(key: ScopedKey[?], data: Settings[Scope]): Boolean =
+  def aggregationEnabled(key: ScopedKey[?], data: Settings): Boolean =
     (Scope.fillTaskAxis(key.scope, key.key) / Keys.aggregate).get(data).getOrElse(true)
   private[sbt] val suppressShow =
     AttributeKey[Boolean]("suppress-aggregation-show", Int.MaxValue)

--- a/main/src/main/scala/sbt/internal/BuildUtil.scala
+++ b/main/src/main/scala/sbt/internal/BuildUtil.scala
@@ -9,13 +9,13 @@
 package sbt
 package internal
 
-import sbt.internal.util.{ Relation, Settings, Dag }
+import sbt.internal.util.{ Relation, Dag }
 
 import java.net.URI
 
 final class BuildUtil[Proj](
     val keyIndex: KeyIndex,
-    val data: Settings[Scope],
+    val data: Def.Settings,
     val root: URI,
     val rootProjectID: URI => String,
     val project: (URI, String) => Proj,
@@ -57,7 +57,7 @@ object BuildUtil {
       root: URI,
       units: Map[URI, LoadedBuildUnit],
       keyIndex: KeyIndex,
-      data: Settings[Scope]
+      data: Def.Settings
   ): BuildUtil[ResolvedProject] = {
     val getp = (build: URI, project: String) => Load.getProject(units, build, project)
     val configs = (_: ResolvedProject).configurations.map(c => ConfigKey(c.name))

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -15,7 +15,7 @@ import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.nio.file.{ Glob, RecursiveGlob }
 import sbt.Def.Initialize
-import sbt.internal.util.{ Attributed, Dag, Settings }
+import sbt.internal.util.{ Attributed, Dag }
 import sbt.librarymanagement.{ Configuration, TrackLevel }
 import sbt.librarymanagement.Configurations.names
 import sbt.std.TaskExtra._
@@ -180,7 +180,7 @@ private[sbt] object ClasspathImpl {
       projectRef: ProjectRef,
       conf: Configuration,
       self: Configuration,
-      data: Settings[Scope],
+      data: Def.Settings,
       deps: BuildDependencies,
       track: TrackLevel,
       log: Logger
@@ -198,7 +198,7 @@ private[sbt] object ClasspathImpl {
         projectRef: ProjectRef,
         conf: Configuration,
         self: Configuration,
-        data: Settings[Scope],
+        data: Def.Settings,
         deps: BuildDependencies,
         track: TrackLevel,
         log: Logger
@@ -244,7 +244,7 @@ private[sbt] object ClasspathImpl {
       projectRef: ProjectRef,
       conf: Configuration,
       self: Configuration,
-      data: Settings[Scope],
+      data: Def.Settings,
       deps: BuildDependencies,
       track: TrackLevel,
       log: Logger
@@ -282,7 +282,7 @@ private[sbt] object ClasspathImpl {
   def unmanagedDependencies0(
       projectRef: ProjectRef,
       conf: Configuration,
-      data: Settings[Scope],
+      data: Def.Settings,
       deps: BuildDependencies,
       log: Logger
   ): Initialize[Task[Classpath]] =
@@ -306,7 +306,7 @@ private[sbt] object ClasspathImpl {
   def unmanagedLibs(
       dep: ResolvedReference,
       conf: String,
-      data: Settings[Scope]
+      data: Def.Settings
   ): Task[Classpath] =
     getClasspath(unmanagedJars, dep, conf, data)
 
@@ -315,7 +315,7 @@ private[sbt] object ClasspathImpl {
       deps: BuildDependencies,
       conf: Configuration,
       self: Configuration,
-      data: Settings[Scope],
+      data: Def.Settings,
       track: TrackLevel,
       includeSelf: Boolean,
       log: Logger
@@ -346,7 +346,7 @@ private[sbt] object ClasspathImpl {
   def interSort(
       projectRef: ProjectRef,
       conf: Configuration,
-      data: Settings[Scope],
+      data: Def.Settings,
       deps: BuildDependencies
   ): Seq[(ProjectRef, String)] =
     val visited = (new LinkedHashSet[(ProjectRef, String)]).asScala
@@ -431,7 +431,7 @@ private[sbt] object ClasspathImpl {
   def allConfigs(conf: Configuration): Seq[Configuration] =
     Dag.topologicalSort(conf)(_.extendsConfigs)
 
-  def getConfigurations(p: ResolvedReference, data: Settings[Scope]): Seq[Configuration] =
+  def getConfigurations(p: ResolvedReference, data: Def.Settings): Seq[Configuration] =
     (p / ivyConfigurations).get(data).getOrElse(Nil)
 
   def confOpt(configurations: Seq[Configuration], conf: String): Option[Configuration] =
@@ -441,14 +441,14 @@ private[sbt] object ClasspathImpl {
       key: TaskKey[Seq[A]],
       dep: ResolvedReference,
       conf: Configuration,
-      data: Settings[Scope]
+      data: Def.Settings
   ): Task[Seq[A]] = getClasspath(key, dep, conf.name, data)
 
   def getClasspath[A](
       key: TaskKey[Seq[A]],
       dep: ResolvedReference,
       conf: String,
-      data: Settings[Scope]
+      data: Def.Settings
   ): Task[Seq[A]] =
     (dep / ConfigKey(conf) / key).get(data) match {
       case Some(x) => x

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -114,11 +114,9 @@ private[sbt] object Clean {
           // This is the special portion of the task where we clear out the relevant streams
           // and file outputs of a task.
           val streamsKey = scope.task.toOption.map(k => ScopedKey(scope.copy(task = Zero), k))
+          val stampKey = ScopedKey(scope, inputFileStamps.key)
           val stampsKey =
-            extracted.structure.data.getDirect(scope, inputFileStamps.key) match {
-              case Some(_) => ScopedKey(scope, inputFileStamps.key) :: Nil
-              case _       => Nil
-            }
+            if extracted.structure.data.contains(stampKey) then stampKey :: Nil else Nil
           val streamsGlobs =
             (streamsKey.toSeq ++ stampsKey)
               .map(k => manager(k).cacheDirectory.toPath.toGlob / **)

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -92,7 +92,7 @@ object GlobalPlugin {
         (prods ++ intcp).distinct
       )(updateReport.value)
     }
-    val resolvedTaskInit = taskInit.mapReferenced(Project.mapScope(Scope.replaceThis(p)))
+    val resolvedTaskInit = taskInit.mapReferenced(Project.replaceThis(p))
     val task = resolvedTaskInit.evaluate(data)
     val roots = resolvedTaskInit.dependencies
     evaluate(state, structure, task, roots)

--- a/main/src/main/scala/sbt/internal/Inspect.scala
+++ b/main/src/main/scala/sbt/internal/Inspect.scala
@@ -87,8 +87,7 @@ object Inspect {
     val extracted = Project.extract(s)
     import extracted._
     option match {
-      case Details(actual) =>
-        Project.details(extracted.structure, actual, sk.scope, sk.key)
+      case Details(actual) => Project.details(extracted.structure, actual, sk)
       case DependencyTreeMode =>
         val basedir = new File(Project.session(s).current.build)
         Project

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -376,7 +376,7 @@ private[sbt] object Load {
   ): StructureIndex = {
     val keys = Index.allKeys(settings)
     val attributeKeys = data.attributeKeys ++ keys.map(_.key)
-    val scopedKeys = (keys ++ data.keys).toVector
+    val scopedKeys = keys ++ data.keys
     val projectsMap = projects.view.mapValues(_.defined.keySet).toMap
     val configsMap: Map[String, Seq[Configuration]] =
       projects.values.flatMap(bu => bu.defined map { case (k, v) => (k, v.configurations) }).toMap

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -22,7 +22,7 @@ import java.io.PrintWriter
 
 sealed abstract class LogManager {
   def apply(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       writer: PrintWriter,
@@ -30,20 +30,20 @@ sealed abstract class LogManager {
   ): ManagedLogger
   @deprecated("Use alternate apply that provides a LoggerContext", "1.4.0")
   def apply(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       writer: PrintWriter
   ): ManagedLogger = apply(data, state, task, writer, LoggerContext.globalContext)
 
   def backgroundLog(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       context: LoggerContext
   ): ManagedLogger
   @deprecated("Use alternate background log that provides a LoggerContext", "1.4.0")
-  final def backgroundLog(data: Settings[Scope], state: State, task: ScopedKey[?]): ManagedLogger =
+  final def backgroundLog(data: Def.Settings, state: State, task: ScopedKey[?]): ManagedLogger =
     backgroundLog(data, state, task, LoggerContext.globalContext)
 }
 
@@ -62,7 +62,7 @@ object LogManager {
   // This is called by mkStreams
   //
   def construct(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State
   ): (ScopedKey[?], PrintWriter) => ManagedLogger =
     (task: ScopedKey[?], to: PrintWriter) => {
@@ -74,7 +74,7 @@ object LogManager {
 
   @deprecated("Use alternate constructBackgroundLog that provides a LoggerContext", "1.8.0")
   def constructBackgroundLog(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State
   ): ScopedKey[?] => ManagedLogger = {
     val context = state.get(Keys.loggerContext).getOrElse(LoggerContext.globalContext)
@@ -82,7 +82,7 @@ object LogManager {
   }
 
   def constructBackgroundLog(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       context: LoggerContext
   ): (ScopedKey[?]) => ManagedLogger =
@@ -119,7 +119,7 @@ object LogManager {
       extra: AppenderSupplier
   ) extends LogManager {
     def apply(
-        data: Settings[Scope],
+        data: Def.Settings,
         state: State,
         task: ScopedKey[?],
         to: PrintWriter,
@@ -137,7 +137,7 @@ object LogManager {
       )
 
     def backgroundLog(
-        data: Settings[Scope],
+        data: Def.Settings,
         state: State,
         task: ScopedKey[?],
         context: LoggerContext
@@ -150,16 +150,16 @@ object LogManager {
   // to change from global being the default to overriding, switch the order of state.get and data.get
   def getOr[T](
       key: AttributeKey[T],
-      data: Settings[Scope],
+      data: Def.Settings,
       scope: Scope,
       state: State,
       default: T
   ): T =
-    data.get(scope, key) orElse state.get(key) getOrElse default
+    data.get(ScopedKey(scope, key)).orElse(state.get(key)).getOrElse(default)
 
   @deprecated("Use defaultLogger that provides a LoggerContext", "1.4.0")
   def defaultLogger(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       console: Appender,
@@ -170,7 +170,7 @@ object LogManager {
     defaultLogger(data, state, task, console, backed, relay, extra, LoggerContext.globalContext)
   // This is the main function that is used to generate the logger for tasks.
   def defaultLogger(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       console: Appender,
@@ -242,7 +242,7 @@ object LogManager {
   }
 
   def backgroundLog(
-      data: Settings[Scope],
+      data: Def.Settings,
       state: State,
       task: ScopedKey[?],
       console: Appender,
@@ -271,7 +271,7 @@ object LogManager {
 
   // TODO: Fix this
   // if global logging levels are not explicitly set, set them from project settings
-  // private[sbt] def setGlobalLogLevels(s: State, data: Settings[Scope]): State =
+  // private[sbt] def setGlobalLogLevels(s: State, data: Def.Settings): State =
   //   if (hasExplicitGlobalLogLevels(s))
   //     s
   //   else {

--- a/main/src/main/scala/sbt/internal/ProjectQuery.scala
+++ b/main/src/main/scala/sbt/internal/ProjectQuery.scala
@@ -24,7 +24,8 @@ private[sbt] case class ProjectQuery(
       val scalaMatches =
         params.get(Keys.scalaBinaryVersion.key) match
           case Some(expected) =>
-            val actualSbv = structure.data.get(Scope.ThisScope.rescope(p), scalaBinaryVersion.key)
+            val actualSbv =
+              structure.data.get(Def.ScopedKey(Scope.ThisScope.rescope(p), scalaBinaryVersion.key))
             actualSbv match
               case Some(sbv) => sbv == expected
               case None      => true

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -9,7 +9,7 @@
 package sbt
 package internal
 
-import sbt.internal.util.{ AttributeKey, complete, Relation, Settings, Util }
+import sbt.internal.util.{ AttributeKey, complete, Relation, Util }
 import sbt.util.Show
 import sbt.librarymanagement.Configuration
 
@@ -138,7 +138,7 @@ private[sbt] object SettingCompletions {
    * The last part of the completion will generate a template for the value or function literal that will initialize the setting or task.
    */
   def settingParser(
-      settings: Settings[Scope],
+      settings: Def.Settings,
       rawKeyMap: Map[String, AttributeKey[?]],
       context: ResolvedProject,
   ): Parser[String] = {
@@ -156,7 +156,7 @@ private[sbt] object SettingCompletions {
   /** Parser for a Scope+AttributeKey (ScopedKey). */
   def scopedKeyParser(
       keyMap: Map[String, AttributeKey[?]],
-      settings: Settings[Scope],
+      settings: Def.Settings,
       context: ResolvedProject
   ): Parser[ScopedKey[?]] = {
     val cutoff = KeyRanks.MainCutoff
@@ -195,15 +195,11 @@ private[sbt] object SettingCompletions {
    */
   def scopeParser(
       key: AttributeKey[?],
-      settings: Settings[Scope],
+      settings: Def.Settings,
       context: ResolvedProject
   ): Parser[Scope] = {
-    val data = settings.data
-    val allScopes = data.keys.toSeq
-    val definedScopes = data.toSeq flatMap { case (scope, attrs) =>
-      if attrs.contains(key) then scope :: Nil else Nil
-    }
-    scope(allScopes, definedScopes, context)
+    val definedScopes = settings.keys.collect { case sk if sk.key == key => sk.scope }
+    scope(settings.scopes.toSeq, definedScopes.toSeq, context)
   }
 
   private def scope(

--- a/main/src/main/scala/sbt/internal/SettingGraph.scala
+++ b/main/src/main/scala/sbt/internal/SettingGraph.scala
@@ -25,11 +25,8 @@ object SettingGraph {
       compiled(structure.settings, false)(using structure.delegates, structure.scopeLocal, display)
     )
     def loop(scoped: ScopedKey[?], generation: Int): SettingGraph = {
-      val key = scoped.key
-      val scope = scoped.scope
-      val definedIn = structure.data.definingScope(scope, key) map { sc =>
-        display.show(ScopedKey(sc, key))
-      }
+      val data = Project.scopedKeyData(structure, scoped)
+      val definedIn = data.map(d => display.show(d.definingKey))
       val depends = cMap.get(scoped) match {
         case Some(c) => c.dependencies.toSet; case None => Set.empty
       }
@@ -39,8 +36,8 @@ object SettingGraph {
       SettingGraph(
         display.show(scoped),
         definedIn,
-        Project.scopedKeyData(structure, scope, key),
-        key.description,
+        data,
+        scoped.key.description,
         basedir,
         depends map { (x: ScopedKey[?]) =>
           loop(x, generation + 1)

--- a/main/src/main/scala/sbt/internal/server/SettingQuery.scala
+++ b/main/src/main/scala/sbt/internal/server/SettingQuery.scala
@@ -19,7 +19,7 @@ import sjsonnew._
 import sjsonnew.support.scalajson.unsafe._
 
 object SettingQuery {
-  import sbt.internal.util.{ AttributeKey, Settings }
+  import sbt.internal.util.AttributeKey
   import sbt.internal.util.complete.{ DefaultParsers, Parser }, DefaultParsers._
   import sbt.Def.{ showBuildRelativeKey2, ScopedKey }
 
@@ -70,7 +70,7 @@ object SettingQuery {
       currentBuild: URI,
       defaultConfigs: Option[ResolvedReference] => Seq[String],
       keyMap: Map[String, AttributeKey[?]],
-      data: Settings[Scope]
+      data: Def.Settings
   ): Parser[ParsedKey] =
     scopedKeyFull(index, currentBuild, defaultConfigs, keyMap) flatMap { choices =>
       Act.select(choices, data)(showBuildRelativeKey2(currentBuild))
@@ -81,7 +81,7 @@ object SettingQuery {
       currentBuild: URI,
       defaultConfigs: Option[ResolvedReference] => Seq[String],
       keyMap: Map[String, AttributeKey[?]],
-      data: Settings[Scope]
+      data: Def.Settings
   ): Parser[ScopedKey[?]] =
     scopedKeySelected(index, currentBuild, defaultConfigs, keyMap, data).map(_.key)
 
@@ -96,7 +96,7 @@ object SettingQuery {
 
   def getSettingValue[A](structure: BuildStructure, key: Def.ScopedKey[A]): Either[String, A] =
     structure.data
-      .get(key.scope, key.key)
+      .get(key)
       .toRight(s"Key ${Def.displayFull(key)} not found")
       .flatMap {
         case _: Task[_] => Left(s"Key ${Def.displayFull(key)} is a task, can only query settings")

--- a/main/src/test/scala/PluginCommandTest.scala
+++ b/main/src/test/scala/PluginCommandTest.scala
@@ -17,7 +17,6 @@ import sbt.internal.util.{
   ConsoleOut,
   GlobalLogging,
   MainAppender,
-  Settings,
   Terminal,
 }
 import sbt.internal.inc.PlainVirtualFileConverter
@@ -97,7 +96,7 @@ object FakeState {
     val delegates: (Scope) => Seq[Scope] = _ => Nil
     val scopeLocal: Def.ScopeLocal = _ => Nil
 
-    val (cMap, data: Settings[Scope]) =
+    val (cMap, data: Def.Settings) =
       Def.makeWithCompiledMap(settings)(using delegates, scopeLocal, Def.showFullKey)
     val extra: KeyIndex => BuildUtil[?] = (keyIndex) =>
       BuildUtil(base.toURI, Map.empty, keyIndex, data)

--- a/sbt-app/src/main/scala/sbt/Import.scala
+++ b/sbt-app/src/main/scala/sbt/Import.scala
@@ -9,6 +9,7 @@
 package sbt
 
 trait Import {
+  type Settings = Def.Settings
   type Setting[T] = Def.Setting[T]
   type ScopedKey[T] = Def.ScopedKey[T]
   type SettingsDefinition = Def.SettingsDefinition
@@ -146,7 +147,7 @@ trait Import {
   // type Dag[A <: Dag[A]] = sbt.internal.util.Dag[A]
   type DelegatingPMap[K[_], V[_]] = sbt.internal.util.DelegatingPMap[K, V]
   val ErrorHandling = sbt.internal.util.ErrorHandling
-  type EvaluateSettings[S] = sbt.internal.util.EvaluateSettings[S]
+  // type EvaluateSettings[I <: Init] = sbt.internal.util.EvaluateSettings[I]
   val EvaluationState = sbt.internal.util.EvaluationState
   val ExitHook = sbt.internal.util.ExitHook
   type ExitHook = sbt.internal.util.ExitHook
@@ -168,7 +169,7 @@ trait Import {
   type IDSet[T] = sbt.internal.util.IDSet[T]
   val IMap = sbt.internal.util.IMap
   type IMap[K[_], V[_]] = sbt.internal.util.IMap[K, V]
-  type Init[S] = sbt.internal.util.Init[S]
+  type Init = sbt.internal.util.Init
   type JLine = sbt.internal.util.JLine
   // val KCons = sbt.internal.util.KCons
   // type KCons[H, +T <: KList[M], +M[_]] = sbt.internal.util.KCons[H, T, M]
@@ -193,7 +194,6 @@ trait Import {
   val Relation = sbt.internal.util.Relation
   type Relation[A, B] = sbt.internal.util.Relation[A, B]
   val ScalaKeywords = sbt.internal.util.ScalaKeywords
-  type Settings[S] = sbt.internal.util.Settings[S]
   type SharedAttributeKey[T] = sbt.internal.util.SharedAttributeKey[T]
   val Signals = sbt.internal.util.Signals
   val SimpleReader = sbt.internal.util.SimpleReader

--- a/util-collection/src/test/scala-2/SettingsTest.scala
+++ b/util-collection/src/test/scala-2/SettingsTest.scala
@@ -191,7 +191,7 @@ object SettingsTest extends Properties("settings") {
     checkKey(chk, Some(expected), eval)
   }
 
-  def checkKey[T](key: ScopedKey[T], expected: Option[T], settings: Settings[Scope]) = {
+  def checkKey[T](key: ScopedKey[T], expected: Option[T], settings: Def.Settings) = {
     val value = settings.get(key.scope, key.key)
     ("Key: " + key) |:
       ("Value: " + value) |:
@@ -199,7 +199,7 @@ object SettingsTest extends Properties("settings") {
       (value == expected)
   }
 
-  def evaluate(settings: Seq[Setting[_]]): Settings[Scope] =
+  def evaluate(settings: Seq[Setting[_]]): Def.Settings =
     try {
       makeWithCompiledMap(settings)(delegates, scopeLocal, showFullKey)._2
     } catch {

--- a/util-collection/src/test/scala/SettingsExample.scala
+++ b/util-collection/src/test/scala/SettingsExample.scala
@@ -19,7 +19,8 @@ final case class Scope(nestIndex: Int, idAtIndex: Int = 0)
 //  Lots of type constructors would become binary, which as you may know requires lots of type lambdas
 //  when you want a type function with only one parameter.
 //  That would be a general pain.)
-case class SettingsExample() extends Init[Scope] {
+case class SettingsExample() extends Init {
+  type ScopeType = Scope
   // Provides a way of showing a Scope+AttributeKey[_]
   val showFullKey: Show[ScopedKey[?]] = Show[ScopedKey[?]]((key: ScopedKey[?]) => {
     s"${key.scope.nestIndex}(${key.scope.idAtIndex})/${key.key.label}"
@@ -64,7 +65,7 @@ case class SettingsUsage(val settingsExample: SettingsExample) {
   // "compiles" and applies the settings.
   //  This can be split into multiple steps to access intermediate results if desired.
   //  The 'inspect' command operates on the output of 'compile', for example.
-  val applied: Settings[Scope] =
+  val applied: Settings =
     makeWithCompiledMap(mySettings)(using delegates, scopeLocal, showFullKey)._2
 
   // Show results.


### PR DESCRIPTION
This PR contains a refactoring of  `Settings` and an optimization of the indexing of aggregate keys. Overall it speeds up the build even if doing less parallelism.

## Refactoring of Settings

`Settings0` used to be a `Map[Scope, AttributeMap`], and it is now a `Map[ScopedKey[x], x]`. This is better because we don't need to decompose all `ScopedKey[x]` into a `Scope` and an `AttributeKey[x]`, for recomposing it back later, which duplicates all `ScopedKey[x]`. It reduces the number of long-living `ScopedKey[x]` instances by 8%, and the total number of instances by 1.4%.

Also it improves the performance of `Settings0`, which was responsible of 2.95% of the total CPU time, and is now responsible of 0.41%.

## Optimization of indexing of aggregate keys

To build the index of all aggregate keys, we were computing the reverse aggregation of each key, before indexing them. And so each aggregate key was indexed many times, once for each aggregated project. It was parallelized to reduce the latency. In this PR, we compute the reverse aggregation of all the keys at once, removing all duplication. We cannot parallelize this process anymore but we don't need to, because it is a lot faster. It reduces the total CPU time by 12%. The impact for the user depends on its number of cores.

## Result

I am still loading `softwaremill/sttp` on my 12 core laptop.

To get the heap size and the number of instances I generate a heap dump after loading sbt once. To get the CPU time and the elapsed real time, I do `time sbt 'reload;reload;reload'`.

|         | Instances | Used heap size | CPU time   | Elapsed real time |
|---------|-----------|----------------|------------|-------------------|
| develop | 16,364 K  | 410 MB         | 158,972 ms | 35,485  ms          |
| This PR | 16,130 K  | 401 MB         | 139,792 ms | 34,347 ms           |
|         | 98.6 %    | 97.8 %         | 87.9%      | 96.7 %            |