### PR TITLE
[2.x] Remove instances of `Info` and `BasicAttributeMap`

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -404,7 +404,7 @@ object Index {
       case AttributeEntry(_, base: Task[?]) <- a.entries
     do
       def update(map: TriggerMap, key: AttributeKey[Seq[Task[?]]]): Unit =
-        base.info.attributes.get(key).getOrElse(Seq.empty).foreach { task =>
+        base.getOrElse(key, Seq.empty).foreach { task =>
           map(task) = base +: map.getOrElse(task, Nil)
         }
       update(runBefore, Def.runBefore)

--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -351,17 +351,6 @@ object BuildUtilLite:
 end BuildUtilLite
 
 object Index {
-  def taskToKeyMap(data: Settings[Scope]): Map[Task[?], ScopedKey[Task[?]]] = {
-
-    val pairs = data.scopes flatMap (scope =>
-      data.data(scope).entries collect { case AttributeEntry(key, value: Task[_]) =>
-        (value, ScopedKey(scope, key.asInstanceOf[AttributeKey[Task[?]]]))
-      }
-    )
-
-    pairs.toMap[Task[?], ScopedKey[Task[?]]]
-  }
-
   def allKeys(settings: Seq[Setting[?]]): Set[ScopedKey[?]] = {
     val result = new java.util.HashSet[ScopedKey[?]]
     settings.foreach { s =>

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -463,10 +463,7 @@ object Tests {
       fun: TestFunction,
       tags: Seq[(Tag, Int)]
   ): Task[Map[String, SuiteResult]] = {
-    val base = Task[(String, (SuiteResult, Seq[TestTask]))](
-      Info[(String, (SuiteResult, Seq[TestTask]))]().setName(name),
-      Action.Pure(() => (name, fun.apply()), `inline` = false)
-    )
+    val base = Task(Action.Pure(() => (name, fun.apply()), `inline` = false)).setName(name)
     val taggedBase = base.tagw(tags*).tag(fun.tags.map(ConcurrentRestrictions.Tag(_))*)
     taggedBase flatMap { case (name, (result, nested)) =>
       val nestedRunnables = createNestedRunnables(loader, fun, nested)

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -457,11 +457,11 @@ object Def extends BuildSyntax with Init[Scope] with InitializeImplicits:
         sys.error(s"Dummy task '$name' did not get converted to a full task.")
       )
       .named(name)
-    base.copy(info = base.info.set(isDummyTask, true))
+    base.set(isDummyTask, true)
   }
 
   private[sbt] def isDummy(t: Task[?]): Boolean =
-    t.info.attributes.get(isDummyTask) getOrElse false
+    t.get(isDummyTask).getOrElse(false)
 end Def
 
 sealed trait InitializeImplicits { self: Def.type =>

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -127,7 +127,7 @@ object Previous {
     val successfulTaskResults = (
       for
         case results.TPair(task: Task[?], Result.Value(v)) <- results.toTypedSeq
-        key <- task.info.attributes.get(Def.taskDefinitionKey).asInstanceOf[Option[AnyTaskKey]]
+        key <- task.get(Def.taskDefinitionKey).asInstanceOf[Option[AnyTaskKey]]
       yield key -> v
     ).toMap
     // We then traverse the successful results and look up all of the referenced values for

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -385,7 +385,7 @@ object Scoped:
       ): Initialize[Task[A1]] =
         Initialize
           .joinAny[Task](coerceToAnyTaskSeq(tasks))
-          .zipWith(init)((ts, i) => i.copy(info = i.info.set(key, ts)))
+          .zipWith(init)((ts, i) => i.set(key, ts))
 
     extension [A1](init: Initialize[InputTask[A1]])
       @targetName("onTaskInitializeInputTask")

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -582,8 +582,8 @@ object EvaluateTask {
     Function.chain(
       results.toTypedSeq flatMap {
         case results.TPair(_, Result.Value(KeyValue(_, st: StateTransform))) => Some(st.transform)
-        case results.TPair(Task(info, _), Result.Value(v)) => info.post(v).get(transformState)
-        case _                                             => Nil
+        case results.TPair(Task(_, post, _), Result.Value(v)) => post(v).get(transformState)
+        case _                                                => Nil
       }
     )
 

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -582,8 +582,8 @@ object EvaluateTask {
     Function.chain(
       results.toTypedSeq flatMap {
         case results.TPair(_, Result.Value(KeyValue(_, st: StateTransform))) => Some(st.transform)
-        case results.TPair(Task(_, post, _), Result.Value(v)) => post(v).get(transformState)
-        case _                                                => Nil
+        case results.TPair(task: Task[?], Result.Value(v)) => task.post(v).get(transformState)
+        case _                                             => Nil
       }
     )
 

--- a/main/src/main/scala/sbt/SessionVar.scala
+++ b/main/src/main/scala/sbt/SessionVar.scala
@@ -49,10 +49,9 @@ object SessionVar {
 
   def orEmpty(opt: Option[Map]) = opt.getOrElse(emptyMap)
 
-  def transform[S](task: Task[S], f: (State, S) => State): Task[S] = {
+  def transform[S](task: Task[S], f: (State, S) => State): Task[S] =
     val g = (s: S, map: AttributeMap) => map.put(Keys.transformState, (state: State) => f(state, s))
-    task.copy(info = task.info.postTransform(g))
-  }
+    task.postTransform(g)
 
   def resolveContext[T](
       key: ScopedKey[Task[T]],

--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -112,7 +112,7 @@ private[sbt] abstract class AbstractTaskExecuteProgress extends ExecuteProgress 
   }
   private def taskName0(t: TaskId[?]): String = {
     def definedName(node: Task[?]): Option[String] =
-      node.info.name.orElse(TaskName.transformNode(node).map(showScopedKey.show))
+      node.name.orElse(TaskName.transformNode(node).map(showScopedKey.show))
     def inferredName(t: Task[?]): Option[String] = nameDelegate(t) map taskName
     def nameDelegate(t: Task[?]): Option[TaskId[?]] =
       Option(anonOwners.get(t)).orElse(Option(calledBy.get(t)))

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -71,7 +71,6 @@ final class BuildStructure(
 // information that is not original, but can be reconstructed from the rest of BuildStructure
 final class StructureIndex(
     val keyMap: Map[String, AttributeKey[?]],
-    val taskToKey: Map[Task[?], ScopedKey[Task[?]]],
     val triggers: Triggers,
     val keyIndex: KeyIndex,
     val aggregateKeyIndex: KeyIndex,

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -384,7 +384,6 @@ private[sbt] object Load {
     val aggIndex = KeyIndex.aggregate(scopedKeys.toVector, extra(keyIndex), projectsMap, configsMap)
     new StructureIndex(
       Index.stringToKeyMap(attributeKeys),
-      Index.taskToKeyMap(data),
       Index.triggers(data),
       keyIndex,
       aggIndex

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -366,7 +366,7 @@ private[sbt] object Load {
   }
 
   def setDefinitionKey[T](tk: Task[T], key: ScopedKey[?]): Task[T] =
-    if (isDummy(tk)) tk else Task(tk.info.set(Keys.taskDefinitionKey, key), tk.work)
+    if (isDummy(tk)) tk else tk.set(Keys.taskDefinitionKey, key)
 
   def structureIndex(
       data: Settings[Scope],

--- a/main/src/main/scala/sbt/internal/TaskName.scala
+++ b/main/src/main/scala/sbt/internal/TaskName.scala
@@ -15,9 +15,9 @@ import Keys.taskDefinitionKey
 private[sbt] object TaskName {
   def name(node: Task[?]): String = definedName(node).getOrElse(anonymousName(node))
   def definedName(node: Task[?]): Option[String] =
-    node.info.name.orElse(transformNode(node).map(displayFull))
+    node.name.orElse(transformNode(node).map(displayFull))
   def anonymousName(node: TaskId[?]): String =
     "<anon-" + System.identityHashCode(node).toHexString + ">"
   def transformNode(node: Task[?]): Option[ScopedKey[?]] =
-    node.info.attributes.get(taskDefinitionKey)
+    node.get(taskDefinitionKey)
 }

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -145,7 +145,7 @@ private[sbt] object Settings {
    * @return the setting with the task definition
    */
   private def addTaskDefinition[T](setting: Def.Setting[Task[T]]): Def.Setting[Task[T]] =
-    setting.mapInit((sk, task) => Task(task.info.set(taskDefinitionKey, sk), task.work))
+    setting.mapInit((sk, task) => task.set(taskDefinitionKey, sk))
 
   /**
    * Returns all of the paths described by a glob along with their basic file attributes.

--- a/tasks-standard/src/main/scala/sbt/Task.scala
+++ b/tasks-standard/src/main/scala/sbt/Task.scala
@@ -14,31 +14,44 @@ import ConcurrentRestrictions.{ Tag, TagMap, tagsKey }
 import sbt.util.Monad
 
 /**
- * Combines metadata `info` and a computation `work` to define a task.
+ * Combines metadata `attributes` and a computation `work` to define a task.
  */
-final case class Task[A](info: Info[A], work: Action[A]) extends TaskId[A]:
-  override def toString = info.name getOrElse ("Task(" + info + ")")
-  override def hashCode = info.hashCode
+final case class Task[A](attributes: AttributeMap, post: A => AttributeMap, work: Action[A])
+    extends TaskId[A]:
+  override def toString = name.getOrElse(s"Task($attributes)")
+  override def hashCode = (attributes, post).hashCode
+
+  def name = attributes.get(Task.Name)
+  def description = attributes.get(Task.Description)
+  def get[B](key: AttributeKey[B]): Option[B] = attributes.get(key)
+  def getOrElse[B](key: AttributeKey[B], default: => B): B = attributes.getOrElse(key, default)
+
+  def setName(name: String): Task[A] = set(Task.Name, name)
+  def setDescription(description: String): Task[A] = set(Task.Description, description)
+  def set[A](key: AttributeKey[A], value: A) = copy(attributes = this.attributes.put(key, value))
+
+  def postTransform(f: (A, AttributeMap) => AttributeMap): Task[A] = copy(post = a => f(a, post(a)))
 
   def tag(tags: Tag*): Task[A] = tagw(tags.map(t => (t, 1))*)
-  def tagw(tags: (Tag, Int)*): Task[A] = {
-    val tgs: TagMap = info.get(tagsKey).getOrElse(TagMap.empty)
+  def tagw(tags: (Tag, Int)*): Task[A] =
+    val tgs: TagMap = get(tagsKey).getOrElse(TagMap.empty)
     val value = tags.foldLeft(tgs)((acc, tag) => acc + tag)
-    val nextInfo = info.set(tagsKey, value)
-    withInfo(info = nextInfo)
-  }
-
-  def tags: TagMap = info.get(tagsKey).getOrElse(TagMap.empty)
-  def name: Option[String] = info.name
-
-  def attributes: AttributeMap = info.attributes
-
-  private[sbt] def withInfo(info: Info[A]): Task[A] =
-    Task(info = info, work = this.work)
+    set(tagsKey, value)
+  def tags: TagMap = get(tagsKey).getOrElse(TagMap.empty)
 end Task
 
 object Task:
   import sbt.std.TaskExtra.*
+
+  def apply[A](work: Action[A]): Task[A] =
+    new Task[A](AttributeMap.empty, defaultAttributeMap, work)
+
+  def apply[A](attributes: AttributeMap, work: Action[A]): Task[A] =
+    new Task[A](attributes, defaultAttributeMap, work)
+
+  val Name = AttributeKey[String]("name")
+  val Description = AttributeKey[String]("description")
+  val defaultAttributeMap = const(AttributeMap.empty)
 
   given taskMonad: Monad[Task] with
     type F[a] = Task[a]
@@ -54,34 +67,3 @@ object Task:
     override def flatMap[A1, A2](in: F[A1])(f: A1 => F[A2]): F[A2] = in.flatMap(f)
     override def flatten[A1](in: Task[Task[A1]]): Task[A1] = in.flatMap(identity)
 end Task
-
-/**
- * Used to provide information about a task, such as the name, description, and tags for controlling
- * concurrent execution.
- * @param attributes
- *   Arbitrary user-defined key/value pairs describing this task
- * @param post
- *   a transformation that takes the result of evaluating this task and produces user-defined
- *   key/value pairs.
- */
-final case class Info[T](
-    attributes: AttributeMap = AttributeMap.empty,
-    post: T => AttributeMap = Info.defaultAttributeMap
-) {
-  import Info._
-  def name = attributes.get(Name)
-  def description = attributes.get(Description)
-  def setName(n: String) = set(Name, n)
-  def setDescription(d: String) = set(Description, d)
-  def set[A](key: AttributeKey[A], value: A) = copy(attributes = this.attributes.put(key, value))
-  def get[A](key: AttributeKey[A]): Option[A] = attributes.get(key)
-  def postTransform(f: (T, AttributeMap) => AttributeMap) = copy(post = (t: T) => f(t, post(t)))
-
-  override def toString = if (attributes.isEmpty) "_" else attributes.toString
-}
-
-object Info:
-  val Name = AttributeKey[String]("name")
-  val Description = AttributeKey[String]("description")
-  val defaultAttributeMap = const(AttributeMap.empty)
-end Info

--- a/tasks-standard/src/main/scala/sbt/std/Transform.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Transform.scala
@@ -17,7 +17,7 @@ import sbt.internal.util.Types.*
 
 object Transform:
   def fromDummy[A](original: Task[A])(action: => A): Task[A] =
-    original.copy(work = Action.Pure(() => action, false))
+    new Task(original.attributes, original.post, work = Action.Pure(() => action, false))
 
   def fromDummyStrict[T](original: Task[T], value: T): Task[T] = fromDummy(original)(value)
 
@@ -57,8 +57,8 @@ object Transform:
         case Join(in, f)         => uniform(in)(f)
 
       def inline1[T](t: TaskId[T]): Option[() => T] = t match
-        case Task(_, _, Action.Pure(eval, true)) => Some(eval)
-        case _                                   => None
+        case Task(Action.Pure(eval, true)) => Some(eval)
+        case _                             => None
 
   def uniform[A1, D](tasks: Seq[Task[D]])(
       f: Seq[Result[D]] => Either[Task[A1], A1]

--- a/tasks-standard/src/main/scala/sbt/std/Transform.scala
+++ b/tasks-standard/src/main/scala/sbt/std/Transform.scala
@@ -17,7 +17,7 @@ import sbt.internal.util.Types.*
 
 object Transform:
   def fromDummy[A](original: Task[A])(action: => A): Task[A] =
-    Task(original.info, Action.Pure(() => action, false))
+    original.copy(work = Action.Pure(() => action, false))
 
   def fromDummyStrict[T](original: Task[T], value: T): Task[T] = fromDummy(original)(value)
 
@@ -57,8 +57,8 @@ object Transform:
         case Join(in, f)         => uniform(in)(f)
 
       def inline1[T](t: TaskId[T]): Option[() => T] = t match
-        case Task(_, Action.Pure(eval, true)) => Some(eval)
-        case _                                => None
+        case Task(_, _, Action.Pure(eval, true)) => Some(eval)
+        case _                                   => None
 
   def uniform[A1, D](tasks: Seq[Task[D]])(
       f: Seq[Result[D]] => Either[Task[A1], A1]

--- a/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/Attributes.scala
@@ -173,6 +173,12 @@ trait AttributeMap {
   def get[T](k: AttributeKey[T]): Option[T]
 
   /**
+   * Gets the value of type `T` associated with the key `k` or `default` if no value is associated. If
+   * a key with the same label but a different type is defined, this method will return `default`.
+   */
+  def getOrElse[T](k: AttributeKey[T], default: => T): T
+
+  /**
    * Returns this map without the mapping for `k`. This method will not remove a mapping for a key
    * with the same label but a different type.
    */
@@ -245,6 +251,8 @@ private class BasicAttributeMap(private val backing: Map[AttributeKey[?], Any])
   def isEmpty: Boolean = backing.isEmpty
   def apply[T](k: AttributeKey[T]) = backing(k).asInstanceOf[T]
   def get[T](k: AttributeKey[T]) = backing.get(k).asInstanceOf[Option[T]]
+  def getOrElse[T](k: AttributeKey[T], default: => T): T =
+    backing.getOrElse(k, default).asInstanceOf[T]
   def remove[T](k: AttributeKey[T]): AttributeMap = new BasicAttributeMap(backing - k)
   def contains[T](k: AttributeKey[T]) = backing.contains(k)
 


### PR DESCRIPTION
`Task`, `Info` and `BasicAttributeMap` corresponds to 11% of all the living instances in the heap after loading.

The main idea of this PR is to remove the instances of `Info`, by merging `Info` in `Task`, and the instances of `BasicAttributeMap` by making it an opaque type. Additionally I explicited that `Task` uses reference equality (its not a case class anymore) and I removed `Structure.taskKey` which is not used anywhere, neither internally nor in any sbt 1.x plugin.

Result:

|         | Instances | Used heap size | Elapsed real time |
|---------|-----------|----------------|-------------------|
| develop (as of yesterday) | 16,364 K  | 410 MB         | 35,668 ms         |
| This PR | 15,012 K  | 380 MB         | 33,892 ms         |
|         | 91.7 %    | 92.7 %         | 95.0 %            |