### PR TITLE
[2.x] Remove `enableConsistentCompileAnalysis`, `enableBinaryCompileAnalysis`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -867,14 +867,6 @@ object Defaults extends BuildCommon {
     }
   }
 
-  def defaultCompileSettings: Seq[Setting[?]] =
-    globalDefaults(
-      Seq(
-        enableBinaryCompileAnalysis :== true,
-        enableConsistentCompileAnalysis :== SysProp.analysis2024,
-      )
-    )
-
   lazy val configTasks: Seq[Setting[?]] = docTaskSettings(doc) ++
     inTask(compile)(compileInputsSettings) ++
     inTask(compileJava)(
@@ -893,7 +885,7 @@ object Defaults extends BuildCommon {
         }
       )
     ) ++
-    configGlobal ++ defaultCompileSettings ++ compileAnalysisSettings ++ Seq(
+    configGlobal ++ compileAnalysisSettings ++ Seq(
       compileOutputs := {
         import scala.jdk.CollectionConverters.*
         val c = fileConverter.value
@@ -2530,8 +2522,8 @@ object Defaults extends BuildCommon {
 
   private inline def analysisStore(inline analysisFile: TaskKey[File]): AnalysisStore =
     MixedAnalyzingCompiler.staticCachedStore(
-      analysisFile.value.toPath,
-      !enableBinaryCompileAnalysis.value
+      analysisFile = analysisFile.value.toPath,
+      useTextAnalysis = false,
     )
 
   def printWarningsTask: Initialize[Task[Unit]] =

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -237,8 +237,6 @@ object Keys {
   val scalaCompilerBridgeSource = settingKey[ModuleID]("Configures the module ID of the sources of the compiler bridge when scalaCompilerBridgeBinaryJar is None").withRank(CSetting)
   val scalaCompilerBridgeScope = taskKey[Unit]("The compiler bridge scope.").withRank(DTask)
   val scalaArtifacts = settingKey[Seq[String]]("Configures the list of artifacts which should match the Scala binary version").withRank(CSetting)
-  val enableBinaryCompileAnalysis = settingKey[Boolean]("Writes the analysis file in binary format").withRank(DSetting)
-  val enableConsistentCompileAnalysis = settingKey[Boolean]("Writes the analysis file in consistent binary format").withRank(DSetting)
   val crossJavaVersions = settingKey[Seq[String]]("The java versions used during JDK cross testing").withRank(BPlusSetting)
   val semanticdbEnabled = settingKey[Boolean]("Enables SemanticDB Scalac plugin").withRank(CSetting)
   val semanticdbCompilerPlugin = settingKey[ModuleID]("SemanticDB Scalac plugin").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/AnalysisUtil.scala
+++ b/main/src/main/scala/sbt/internal/AnalysisUtil.scala
@@ -31,7 +31,7 @@ private[sbt] object AnalysisUtil {
     MixedAnalyzingCompiler.staticCachedStore(
       analysisFile = analysisFile,
       useTextAnalysis = useTextAnalysis,
-      useConsistent = false,
+      useConsistent = useConsistent,
       mappers = ReadWriteMappers.getEmptyMappers(),
       sort = true,
       ec = ExecutionContext.global,

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -155,8 +155,6 @@ object SysProp {
   def useLog4J: Boolean = getOrFalse("sbt.log.uselog4j")
   def turbo: Boolean = getOrFalse("sbt.turbo")
   def pipelining: Boolean = getOrFalse("sbt.pipelining")
-  // opt-in or out of Zinc's consistent Analysis format.
-  def analysis2024: Boolean = getOrTrue("sbt.analysis2024")
 
   def taskTimings: Boolean = getOrFalse("sbt.task.timings")
   def taskTimingsOnShutdown: Boolean = getOrFalse("sbt.task.timings.on.shutdown")

--- a/main/src/main/scala/sbt/internal/server/Definition.scala
+++ b/main/src/main/scala/sbt/internal/server/Definition.scala
@@ -213,8 +213,8 @@ private[sbt] object Definition {
     s.log.debug(s"analysis location ${cacheFile}")
     updateCache(AnalysesAccess.cache)(
       cacheFile = cacheFile,
-      useBinary = enableBinaryCompileAnalysis.value,
-      useConsistent = enableConsistentCompileAnalysis.value,
+      useBinary = true,
+      useConsistent = true,
     )
   }
 


### PR DESCRIPTION
### Motivation

Consistent Analysis is the default 2.x analysis format, hence there's no need for two boolean settings key to configure analysis format.

### Changes

This PR removes settings key `enableConsistentCompileAnalysis`, `enableBinaryCompileAnalysis`.

Closes #7870