### PR TITLE
Introducing sbt Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/sbt/sbt/actions/workflows/ci.yml/badge.svg)](https://github.com/sbt/sbt/actions/workflows/ci.yml)
 [![Latest version](https://img.shields.io/github/tag/sbt/sbt.svg)](https://index.scala-lang.org/sbt/sbt)
 [![Discord](https://img.shields.io/discord/632150470000902164?label=Discord%20%23sbt)](https://discord.com/channels/632150470000902164/922600050989875282)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20sbt%20Guru-006BFF)](https://gurubase.io/g/sbt)
 
   [sbt/sbt-zero-seven]: https://github.com/sbt/sbt-zero-seven
   [CONTRIBUTING]: CONTRIBUTING.md


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [sbt Guru](https://gurubase.io/g/sbt) to Gurubase. sbt Guru uses the data from this repo and data from the [docs](https://www.scala-sbt.org/1.x/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "sbt Guru", which highlights that sbt now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable sbt Guru in Gurubase, just let me know that's totally fine.
