### PR TITLE
[1.x] Bump minimum Java version in launcher script to `8`

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -910,7 +910,7 @@ if !sbtBinaryV_1! geq 2 (
 exit /B 0
 
 :checkjava
-set /a required_version=6
+set /a required_version=8
 if /I !JAVA_VERSION! GEQ !required_version! (
   exit /B 0
 )

--- a/sbt
+++ b/sbt
@@ -493,7 +493,7 @@ run() {
   }
 
   # TODO - java check should be configurable...
-  checkJava "6"
+  checkJava "8"
 
   # Java 9 support
   copyRt


### PR DESCRIPTION
### Issue

sbt official supports Java 8 as minimum supported Java version, yet launcher script assumes the minimum supported Java version is Java 6

### Solution

Bump minimum Java version in launcher script to `8`