### PR TITLE
[1.x] Synchronize `java.awt.Desktop.browse()`

### DIFF
--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -245,7 +245,10 @@ object DependencyTreeSettings {
     Def.task {
       val uri = uriKey.value
       streams.value.log.info(s"Opening ${uri} in browser...")
-      java.awt.Desktop.getDesktop.browse(uri)
+      val desktop = java.awt.Desktop.getDesktop
+      desktop.synchronized {
+        desktop.browse(uri)
+      }
       uri
     }
 


### PR DESCRIPTION
### Issue

`java.awt.Desktop.browse()` is not thread safe. (At least on Windows).

### Fix

Add `synchronized`

Fixes #7828. Confirmed the fix via publishing sbt locally & running `dependencyBrowseTree` against that sbt build.
