### PR TITLE
[2.x] fix: Fix Scala 3.x - 2.12 sandwich for matrix

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4116,35 +4116,34 @@ object Classpaths {
 
   private[sbt] def isScala213(sv: String) = sv.startsWith("2.13.")
 
-  private[sbt] def isScala2Scala3Sandwich(sbv1: String, sbv2: String): Boolean = {
-    def compare(a: String, b: String): Boolean =
-      a == "2.13" && (b.startsWith("0.") || b.startsWith("3"))
-    compare(sbv1, sbv2) || compare(sbv2, sbv1)
-  }
-
   def projectDependenciesTask: Initialize[Task[Seq[ModuleID]]] =
     Def.task {
       val sbv = scalaBinaryVersion.value
       val ref = thisProjectRef.value
       val data = settingsData.value
       val deps = buildDependencies.value
-      deps.classpath(ref) flatMap { dep =>
-        for {
-          depProjId <- (dep.project / projectID).get(data)
-          depSBV <- (dep.project / scalaBinaryVersion).get(data)
-          depCross <- (dep.project / crossVersion).get(data)
-        } yield {
-          depCross match {
-            case b: CrossVersion.Binary if isScala2Scala3Sandwich(sbv, depSBV) =>
+      deps
+        .classpath(ref)
+        .flatMap: dep =>
+          for
+            depProjId <- (dep.project / projectID).get(data)
+            depSBV <- (dep.project / scalaBinaryVersion).get(data)
+            depCross <- (dep.project / crossVersion).get(data)
+            depAuto <- (dep.project / autoScalaLibrary).get(data)
+          yield depCross match
+            case b: CrossVersion.Binary
+                if depAuto && VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) =>
               depProjId
                 .withCrossVersion(CrossVersion.constant(b.prefix + depSBV))
                 .withConfigurations(dep.configuration)
                 .withExplicitArtifacts(Vector.empty)
+            case _ if depAuto && VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) =>
+              depProjId
+                .withCrossVersion(CrossVersion.constant(depSBV))
+                .withConfigurations(dep.configuration)
+                .withExplicitArtifacts(Vector.empty)
             case _ =>
               depProjId.withConfigurations(dep.configuration).withExplicitArtifacts(Vector.empty)
-          }
-        }
-      }
     }
 
   private[sbt] def depMap: Initialize[Task[Map[ModuleRevisionId, ModuleDescriptor]]] =

--- a/main/src/main/scala/sbt/ProjectMatrix.scala
+++ b/main/src/main/scala/sbt/ProjectMatrix.scala
@@ -333,7 +333,6 @@ object ProjectMatrix {
       name := self.id,
       sourceDirectory := base.getAbsoluteFile / "src",
       unmanagedBase := base.getAbsoluteFile / "lib",
-      projectDependencies := projectDependenciesTask.value,
       projectMatrixBaseDirectory := base,
     )
 

--- a/main/src/main/scala/sbt/VirtualAxis.scala
+++ b/main/src/main/scala/sbt/VirtualAxis.scala
@@ -66,11 +66,10 @@ object VirtualAxis {
     isScala2Scala3Sandwich(str(sbv1), str(sbv2))
   }
 
-  private[sbt] def isScala2Scala3Sandwich(sbv1: String, sbv2: String): Boolean = {
+  private[sbt] def isScala2Scala3Sandwich(sbv1: String, sbv2: String): Boolean =
     def compare(a: String, b: String): Boolean =
-      a == "2.13" && (b.startsWith("0.") || b.startsWith("3."))
+      a == "2.13" && (b == "3" || b.startsWith("3."))
     compare(sbv1, sbv2) || compare(sbv2, sbv1)
-  }
 
   // This admits partial Scala version
   private[sbt] def isPartialVersionEquals(ax1: VirtualAxis, ax2: VirtualAxis): Boolean = {

--- a/sbt-app/src/sbt-test/project-matrix/jvm-sandwich/build.sbt
+++ b/sbt-app/src/sbt-test/project-matrix/jvm-sandwich/build.sbt
@@ -1,14 +1,20 @@
 lazy val check = taskKey[Unit]("")
-lazy val scala3M1 = "3.0.0-M1"
+lazy val scala3 = "3.5.2"
 lazy val scala3M2 = "3.0.0-M2"
-lazy val scala213 = "2.13.4"
+lazy val scala213 = "2.13.14"
 
 lazy val fooApp = (projectMatrix in file("foo-app"))
   .dependsOn(fooCore)
   .settings(
     name := "foo app",
+    TaskKey[Unit]("check") := {
+      val deps = (Compile / projectDependencies).value
+      deps.foreach { dep =>
+        println(s"$dep - ${dep.crossVersion}")
+      }
+    },
   )
-  .jvmPlatform(scalaVersions = Seq(scala3M1, scala3M2))
+  .jvmPlatform(scalaVersions = Seq(scala3, scala3M2))
 
 lazy val fooCore = (projectMatrix in file("foo-core"))
   .settings(
@@ -27,7 +33,7 @@ lazy val barCore = (projectMatrix in file("bar-core"))
   .settings(
     name := "bar core",
   )
-  .jvmPlatform(scalaVersions = Seq(scala3M1))
+  .jvmPlatform(scalaVersions = Seq(scala3))
 
 // choose 2.13 when bazCore offers both 2.13 and Dotty
 lazy val bazApp = (projectMatrix in file("baz-app"))
@@ -48,4 +54,4 @@ lazy val bazCore = (projectMatrix in file("baz-core"))
     name := "baz core",
     exportJars := true,
   )
-  .jvmPlatform(scalaVersions = Seq(scala213, scala3M1, scala3M2))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3, scala3M2))

--- a/sbt-app/src/sbt-test/project-matrix/jvm-sandwich/test
+++ b/sbt-app/src/sbt-test/project-matrix/jvm-sandwich/test
@@ -1,6 +1,8 @@
 > projects
 
-> fooApp3_0_0_M1/compile
+> fooApp/check
+
+> fooApp/compile
 
 > barApp2_13/compile
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7405

## Problem
Currently Scala 3.x - 2.13 sandwich doesn't seem to work for projectMatrix. This is due to isScala2Scala3Sandwich checking for `"3."` while projectMatrix uses scalaBinaryVersion, which is 3.

## Solution
This consolidates the implementation of isScala2Scala3Sandwich with the one in Defaults module, and check for both `"3"` and `"3."`