### PR TITLE
[1.x] Improve message format for `loading settings for project`

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1054,7 +1054,7 @@ private[sbt] object Load {
         def settings(files: Seq[File]): Seq[Setting[_]] = {
           if (files.nonEmpty)
             log.info(
-              s"${files.map(_.getName).mkString(s"loading settings for project ${p.id} from ", ",", " ...")}"
+              s"${files.map(_.getName).mkString(s"loading settings for project ${p.id} from ", ", ", "...")}"
             )
           for {
             file <- files


### PR DESCRIPTION
Before

```
[info] loading settings for project test-multiple-plugins-build from plugins.sbt,plugins2.sbt ...
```

After

```
[info] loading settings for project test-multiple-plugins-build from plugins.sbt, plugins2.sbt...
```