### PR TITLE
[2.x] Refactor slash syntax to mostly use methods

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
+++ b/buildfile/src/main/scala/sbt/internal/EvaluateConfigurations.scala
@@ -16,7 +16,6 @@ import java.nio.file.Path
 import sbt.internal.util.complete.DefaultParsers.validID
 import Def.{ ScopedKey, Setting, Settings }
 import Scope.GlobalScope
-import sbt.SlashSyntax0.given
 import sbt.internal.parser.SbtParser
 import sbt.io.IO
 import scala.jdk.CollectionConverters.*

--- a/main-settings/src/main/scala/sbt/DelegateIndex.scala
+++ b/main-settings/src/main/scala/sbt/DelegateIndex.scala
@@ -8,6 +8,8 @@
 
 package sbt
 
+import ScopeAxis.{ Select, zero }
+
 sealed trait DelegateIndex {
   def project(ref: ProjectRef): Seq[ScopeAxis[ResolvedReference]]
   def config(ref: ProjectRef, conf: ConfigKey): Seq[ScopeAxis[ConfigKey]]
@@ -23,9 +25,9 @@ private final class DelegateIndex0(refs: Map[ProjectRef, ProjectDelegates]) exte
       case Some(pd) =>
         pd.confs.get(conf) match {
           case Some(cs) => cs
-          case None => (Select(conf): ScopeAxis[ConfigKey]) :: (Zero: ScopeAxis[ConfigKey]) :: Nil
+          case None     => Select(conf) :: zero[ConfigKey] :: Nil
         }
-      case None => (Select(conf): ScopeAxis[ConfigKey]) :: (Zero: ScopeAxis[ConfigKey]) :: Nil
+      case None => Select(conf) :: zero[ConfigKey] :: Nil
     }
 }
 private final class ProjectDelegates(

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -11,6 +11,7 @@ package sbt
 import sbt.Def.{ Initialize, ScopedKey }
 import sbt.Previous._
 import sbt.Scope.Global
+import sbt.ScopeAxis.Select
 import sbt.SlashSyntax0.given
 import sbt.internal.util._
 import sbt.std.TaskExtra._

--- a/main-settings/src/main/scala/sbt/Previous.scala
+++ b/main-settings/src/main/scala/sbt/Previous.scala
@@ -12,7 +12,6 @@ import sbt.Def.{ Initialize, ScopedKey }
 import sbt.Previous._
 import sbt.Scope.Global
 import sbt.ScopeAxis.Select
-import sbt.SlashSyntax0.given
 import sbt.internal.util._
 import sbt.std.TaskExtra._
 import sbt.util.StampedFormat

--- a/main-settings/src/main/scala/sbt/Project.scala
+++ b/main-settings/src/main/scala/sbt/Project.scala
@@ -11,6 +11,7 @@ import java.io.File
 import java.util.Locale
 import sbt.librarymanagement.Configuration
 import sbt.Def.{ Initialize, ScopedKey, Setting }
+import sbt.ScopeAxis.Select
 import sbt.internal.util.Dag
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.DefaultParsers

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -33,7 +33,7 @@ sealed trait Reference:
   def /(configAxis: ScopeAxis[ConfigKey]): RefThenConfig =
     RefThenConfig(asScope.copy(config = configAxis))
 
-  final def /[K](key: Scoped.ScopingSetting[K]): K = key.rescope(asScope)
+  final def /[K](key: Scoped.ScopingSetting[K]): K = asScope.scope(key)
 
   final def /(key: AttributeKey[?]): Scope = asScope.rescope(key)
 end Reference

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -14,6 +14,7 @@ import java.net.URI
 import sbt.internal.util.AttributeKey
 import sbt.io.IO
 import sbt.librarymanagement.Configuration
+import sbt.ScopeAxis.{ Select, This }
 import sbt.SlashSyntax.RichConfiguration
 
 // in all of these, the URI must be resolved and normalized before it is definitive

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -14,8 +14,7 @@ import java.net.URI
 import sbt.internal.util.AttributeKey
 import sbt.io.IO
 import sbt.librarymanagement.Configuration
-import sbt.ScopeAxis.{ Select, This }
-import sbt.SlashSyntax.RichConfiguration
+import sbt.ScopeAxis.{ Select, This, RefThenConfig }
 
 // in all of these, the URI must be resolved and normalized before it is definitive
 
@@ -26,13 +25,13 @@ sealed trait Reference:
   private[sbt] def asScope: Scope =
     Scope(asScopeAxis, This, This, This)
 
-  def /(c: ConfigKey): RichConfiguration = RichConfiguration(asScope.rescope(c))
+  def /(c: ConfigKey): RefThenConfig = RefThenConfig(asScope.rescope(c))
 
-  def /(c: Configuration): RichConfiguration = RichConfiguration(asScope.rescope(c))
+  def /(c: Configuration): RefThenConfig = RefThenConfig(asScope.rescope(c))
 
   // This is for handling `Zero / Zero / name`.
-  def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
-    new RichConfiguration(asScope.copy(config = configAxis))
+  def /(configAxis: ScopeAxis[ConfigKey]): RefThenConfig =
+    RefThenConfig(asScope.copy(config = configAxis))
 
   final def /[K](key: Scoped.ScopingSetting[K]): K = key.rescope(asScope)
 

--- a/main-settings/src/main/scala/sbt/Reference.scala
+++ b/main-settings/src/main/scala/sbt/Reference.scala
@@ -14,7 +14,8 @@ import java.net.URI
 import sbt.internal.util.AttributeKey
 import sbt.io.IO
 import sbt.librarymanagement.Configuration
-import sbt.ScopeAxis.{ Select, This, RefThenConfig }
+import sbt.Scope.RefThenConfig
+import sbt.ScopeAxis.{ Select, This }
 
 // in all of these, the URI must be resolved and normalized before it is definitive
 
@@ -25,13 +26,13 @@ sealed trait Reference:
   private[sbt] def asScope: Scope =
     Scope(asScopeAxis, This, This, This)
 
-  def /(c: ConfigKey): RefThenConfig = RefThenConfig(asScope.rescope(c))
+  def /(c: ConfigKey): RefThenConfig = RefThenConfig(asScopeAxis, c)
 
-  def /(c: Configuration): RefThenConfig = RefThenConfig(asScope.rescope(c))
+  def /(c: Configuration): RefThenConfig = RefThenConfig(asScopeAxis, c: ConfigKey)
 
   // This is for handling `Zero / Zero / name`.
   def /(configAxis: ScopeAxis[ConfigKey]): RefThenConfig =
-    RefThenConfig(asScope.copy(config = configAxis))
+    RefThenConfig(asScopeAxis, configAxis)
 
   final def /[K](key: Scoped.ScopingSetting[K]): K = asScope.scope(key)
 

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -430,4 +430,23 @@ object Scope:
         t <- withZeroAxis(scope.task)
         e <- withZeroAxis(scope.extra)
       } yield Scope(Zero, c, t, e)
+
+  /**
+   * Temporary data structure to capture first two axis using slash syntax.
+   * In theory, we might be able to express this as type parameters of Scope,
+   * like Scope[Select[ThisBuild.type], Select[ConfigKey], This, This] but then
+   * scope becomes more complicated to deal with.
+   */
+  opaque type RefThenConfig = (ScopeAxis[Reference], ScopeAxis[ConfigKey])
+
+  object RefThenConfig:
+    def apply(project: ScopeAxis[Reference], config: ScopeAxis[ConfigKey]): RefThenConfig =
+      (project, config)
+    def apply(project: ScopeAxis[Reference], config: ConfigKey): RefThenConfig =
+      (project, Select(config))
+
+    extension (in: RefThenConfig)
+      def project: ScopeAxis[Reference] = in._1
+      def config: ScopeAxis[ConfigKey] = in._2
+  end RefThenConfig
 end Scope

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -32,6 +32,9 @@ final case class Scope private (
   def rescope(config: ConfigKey): Scope = copy(config = Select(config))
   def rescope(task: AttributeKey[?]): Scope = copy(task = Select(task))
 
+  final def /[K](key: Scoped.ScopingSetting[K]): K = scope(key)
+  def scope[K](key: Scoped.ScopingSetting[K]): K = key.rescope(this)
+
   def copy(
       project: ScopeAxis[Reference] = this.project,
       config: ScopeAxis[ConfigKey] = this.config,

--- a/main-settings/src/main/scala/sbt/Scope.scala
+++ b/main-settings/src/main/scala/sbt/Scope.scala
@@ -12,6 +12,7 @@ import java.net.URI
 
 import sbt.internal.util.{ AttributeKey, AttributeMap, Dag }
 import sbt.internal.util.Util._
+import sbt.ScopeAxis.{ Select, This, Zero }
 
 import sbt.io.IO
 import scala.collection.concurrent.TrieMap

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -8,46 +8,51 @@
 
 package sbt
 
-import sbt.internal.util.Util._
+import sbt.internal.util.Util.*
 
-sealed trait ScopeAxis[+S] {
-  def foldStrict[T](f: S => T, ifZero: T, ifThis: T): T = fold(f, ifZero, ifThis)
-  def fold[T](f: S => T, ifZero: => T, ifThis: => T): T = this match {
+enum ScopeAxis[+A1]:
+  /**
+   * Select is a type constructor that is used to wrap type `S`
+   * to make a scope component, equivalent of Some in Option.
+   */
+  case Select(axis: A1) extends ScopeAxis[A1]
+
+  /**
+   * This is a scope component that represents not being
+   * scoped by the user, which later could be further scoped automatically
+   * by sbt.
+   */
+  case This extends ScopeAxis[Nothing]
+
+  /**
+   * Zero is a scope component that represents not scoping.
+   * It is a universal fallback component that is strictly weaker
+   * than any other values on a scope axis.
+   */
+  case Zero extends ScopeAxis[Nothing]
+
+  def isSelect: Boolean = this match
+    case Select(_) => true
+    case _         => false
+
+  def foldStrict[A2](f: A1 => A2, ifZero: A2, ifThis: A2): A2 = fold(f, ifZero, ifThis)
+
+  def fold[A2](f: A1 => A2, ifZero: => A2, ifThis: => A2): A2 = this match
     case This      => ifThis
     case Zero      => ifZero
     case Select(s) => f(s)
-  }
-  def toOption: Option[S] = foldStrict(Option(_), none, none)
-  def map[T](f: S => T): ScopeAxis[T] =
-    foldStrict(s => Select(f(s)): ScopeAxis[T], Zero: ScopeAxis[T], This: ScopeAxis[T])
-  def isSelect: Boolean = false
-}
 
-/**
- * This is a scope component that represents not being
- * scoped by the user, which later could be further scoped automatically
- * by sbt.
- */
-case object This extends ScopeAxis[Nothing]
+  def toOption: Option[A1] = foldStrict(Option(_), none, none)
 
-/**
- * Zero is a scope component that represents not scoping.
- * It is a universal fallback component that is strictly weaker
- * than any other values on a scope axis.
- */
-case object Zero extends ScopeAxis[Nothing]
+  def map[A2](f: A1 => A2): ScopeAxis[A2] =
+    foldStrict(s => Select(f(s)): ScopeAxis[A2], Zero: ScopeAxis[A2], This: ScopeAxis[A2])
+end ScopeAxis
 
-/**
- * Select is a type constructor that is used to wrap type `S`
- * to make a scope component, equivalent of Some in Option.
- */
-final case class Select[S](s: S) extends ScopeAxis[S] {
-  override def isSelect = true
-}
+object ScopeAxis:
+  def `this`[A1]: ScopeAxis[A1] = ScopeAxis.This
+  def zero[A1]: ScopeAxis[A1] = ScopeAxis.Zero
 
-object ScopeAxis {
-  def fromOption[T](o: Option[T]): ScopeAxis[T] = o match {
-    case Some(v) => Select(v)
-    case None    => Zero
-  }
-}
+  def fromOption[A1](o: Option[A1]): ScopeAxis[A1] = o match
+    case Some(v) => ScopeAxis.Select(v)
+    case None    => ScopeAxis.Zero
+end ScopeAxis

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -76,11 +76,11 @@ object ScopeAxis:
   /** Temporary data structure to capture first two axis using slash syntax. */
   class RefThenConfig(val scope: Scope):
     override def toString(): String = scope.toString()
-    inline def /[K](key: Scoped.ScopingSetting[K]): K = scope / key
+    def /[K](key: Scoped.ScopingSetting[K]): K = scope / key
 
-    inline def /(task: AttributeKey[?]): Scope = scope.copy(task = Select(task))
+    def /(task: AttributeKey[?]): Scope = scope.copy(task = Select(task))
 
     /** This is for handling `Zero / Zero / Zero / name`. */
-    inline def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope = scope.copy(task = taskAxis)
+    def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope = scope.copy(task = taskAxis)
   end RefThenConfig
 end ScopeAxis

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -10,10 +10,9 @@ package sbt
 
 import sbt.internal.util.Util.*
 import sbt.librarymanagement.Configuration
-import sbt.internal.util.AttributeKey
 
 enum ScopeAxis[+A1]:
-  import ScopeAxis.RefThenConfig
+  import Scope.RefThenConfig
 
   /**
    * Select is a type constructor that is used to wrap type `S`
@@ -57,12 +56,12 @@ enum ScopeAxis[+A1]:
   inline def /[K](key: Scoped.ScopingSetting[K])(using A1 <:< Reference): K = key.rescope(asScope)
 
   inline def /(c: ConfigKey)(using A1 <:< Reference): RefThenConfig =
-    RefThenConfig(asScope.rescope(c))
+    RefThenConfig(this.asInstanceOf, c)
   inline def /(c: Configuration)(using A1 <:< Reference): RefThenConfig =
-    RefThenConfig(asScope.rescope(c))
+    RefThenConfig(this.asInstanceOf, c: ConfigKey)
   // This is for handling `Zero / Zero / name`.
   inline def /(configAxis: ScopeAxis[ConfigKey])(using A1 <:< Reference): RefThenConfig =
-    RefThenConfig(asScope.copy(config = configAxis))
+    RefThenConfig(this.asInstanceOf, configAxis)
 end ScopeAxis
 
 object ScopeAxis:
@@ -72,15 +71,4 @@ object ScopeAxis:
   def fromOption[A1](o: Option[A1]): ScopeAxis[A1] = o match
     case Some(v) => ScopeAxis.Select(v)
     case None    => ScopeAxis.Zero
-
-  /** Temporary data structure to capture first two axis using slash syntax. */
-  class RefThenConfig(val scope: Scope):
-    override def toString(): String = scope.toString()
-    def /[K](key: Scoped.ScopingSetting[K]): K = scope / key
-
-    def /(task: AttributeKey[?]): Scope = scope.copy(task = Select(task))
-
-    /** This is for handling `Zero / Zero / Zero / name`. */
-    def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope = scope.copy(task = taskAxis)
-  end RefThenConfig
 end ScopeAxis

--- a/main-settings/src/main/scala/sbt/ScopeAxis.scala
+++ b/main-settings/src/main/scala/sbt/ScopeAxis.scala
@@ -9,8 +9,12 @@
 package sbt
 
 import sbt.internal.util.Util.*
+import sbt.librarymanagement.Configuration
+import sbt.internal.util.AttributeKey
 
 enum ScopeAxis[+A1]:
+  import ScopeAxis.RefThenConfig
+
   /**
    * Select is a type constructor that is used to wrap type `S`
    * to make a scope component, equivalent of Some in Option.
@@ -46,6 +50,19 @@ enum ScopeAxis[+A1]:
 
   def map[A2](f: A1 => A2): ScopeAxis[A2] =
     foldStrict(s => Select(f(s)): ScopeAxis[A2], Zero: ScopeAxis[A2], This: ScopeAxis[A2])
+
+  def asScope(using A1 <:< Reference): Scope =
+    Scope(this.asInstanceOf[ScopeAxis[Reference]], This, This, This)
+
+  inline def /[K](key: Scoped.ScopingSetting[K])(using A1 <:< Reference): K = key.rescope(asScope)
+
+  inline def /(c: ConfigKey)(using A1 <:< Reference): RefThenConfig =
+    RefThenConfig(asScope.rescope(c))
+  inline def /(c: Configuration)(using A1 <:< Reference): RefThenConfig =
+    RefThenConfig(asScope.rescope(c))
+  // This is for handling `Zero / Zero / name`.
+  inline def /(configAxis: ScopeAxis[ConfigKey])(using A1 <:< Reference): RefThenConfig =
+    RefThenConfig(asScope.copy(config = configAxis))
 end ScopeAxis
 
 object ScopeAxis:
@@ -55,4 +72,15 @@ object ScopeAxis:
   def fromOption[A1](o: Option[A1]): ScopeAxis[A1] = o match
     case Some(v) => ScopeAxis.Select(v)
     case None    => ScopeAxis.Zero
+
+  /** Temporary data structure to capture first two axis using slash syntax. */
+  class RefThenConfig(val scope: Scope):
+    override def toString(): String = scope.toString()
+    inline def /[K](key: Scoped.ScopingSetting[K]): K = scope / key
+
+    inline def /(task: AttributeKey[?]): Scope = scope.copy(task = Select(task))
+
+    /** This is for handling `Zero / Zero / Zero / name`. */
+    inline def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope = scope.copy(task = taskAxis)
+  end RefThenConfig
 end ScopeAxis

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -13,88 +13,32 @@ import sbt.internal.util.AttributeKey
 import sbt.ScopeAxis.{ Select, This }
 
 /**
- * SlashSyntax implements the slash syntax to scope keys for build.sbt DSL.
- * The implicits are set up such that the order that the scope components
- * must appear in the order of the project axis, the configuration axis, and
- * the task axis. This ordering is the same as the shell syntax.
+ * SlashSyntax implements part of the slash syntax to scope keys for build.sbt DSL.
  *
  * @example
  *  {{{
- *  Global / cancelable := true
- *  ThisBuild / scalaVersion := "2.12.2"
  *  Test / test := ()
- *  console / scalacOptions += "-deprecation"
+ *  console.key / scalacOptions += "-deprecation"
  *  Compile / console / scalacOptions += "-Ywarn-numeric-widen"
- *  projA / Compile / console / scalacOptions += "-feature"
- *  Zero / Zero / name := "foo"
  *  }}}
  */
 trait SlashSyntax:
-  import SlashSyntax.*
-
-  given Conversion[ScopeAxis[Reference], RichReference] =
-    (a: ScopeAxis[Reference]) => RichReference(Scope(a, This, This, This))
-
-  given Conversion[ConfigKey, RichConfiguration] =
-    (c: ConfigKey) => RichConfiguration(Scope(This, Select(c), This, This))
-
-  given Conversion[Configuration, RichConfiguration] =
-    (c: Configuration) => (c: ConfigKey)
-
   /**
-   * This handles task scoping an existing scoped key (such as `Compile / test`)
-   * into a task scoping in `(Compile / test) / name`.
+   * Handles slash syntax for `key.key / key`.
    */
-  given Conversion[Scoped, Scope] =
-    (t: Scoped) => t.scope.copy(task = Select(t.key))
+  extension [A1](a: AttributeKey[A1])
+    def asScope: Scope = Scope(This, This, Select(a), This)
+    def /[K](key: Scoped.ScopingSetting[K]): K = a.asScope.scope(key)
 
-  given Conversion[Scoped, RichScope] =
-    (t: Scoped) => RichScope(t: Scope)
+  extension (c: ConfigKey)
+    def asScope: Scope = Scope(This, Select(c), This, This)
+    def /[K](key: Scoped.ScopingSetting[K]): K = c.asScope.scope(key)
+    def /(task: AttributeKey[?]): Scope = c.asScope.copy(task = Select(task))
 
-  given [A1]: Conversion[AttributeKey[A1], Scope] =
-    (a: AttributeKey[A1]) => Scope(This, This, Select(a), This)
-
-  given [A1]: Conversion[AttributeKey[A1], RichScope] =
-    (a: AttributeKey[A1]) => RichScope(a: Scope)
-
-  given Conversion[Scope, RichScope] =
-    (scope: Scope) => RichScope(scope)
-end SlashSyntax
-
-object SlashSyntax:
-
-  sealed trait HasSlashKey {
-    protected def scope: Scope
-    def /[K](key: Scoped.ScopingSetting[K]): K = key.rescope(scope)
-  }
-
-  sealed trait HasSlashKeyOrAttrKey extends HasSlashKey {
-    def /(key: AttributeKey[?]): Scope = scope.rescope(key)
-  }
-
-  /** RichReference wraps a reference to provide the `/` operator for scoping. */
-  final class RichReference(protected val scope: Scope) extends HasSlashKeyOrAttrKey {
-    def /(c: ConfigKey): RichConfiguration = new RichConfiguration(scope.rescope(c))
-
-    def /(c: Configuration): RichConfiguration = new RichConfiguration(scope.rescope(c))
-
-    // This is for handling `Zero / Zero / name`.
-    def /(configAxis: ScopeAxis[ConfigKey]): RichConfiguration =
-      new RichConfiguration(scope.copy(config = configAxis))
-  }
-
-  /** RichConfiguration wraps a configuration to provide the `/` operator for scoping. */
-  final class RichConfiguration(protected val scope: Scope) extends HasSlashKeyOrAttrKey {
-    // This is for handling `Zero / Zero / Zero / name`.
-    def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope =
-      scope.copy(task = taskAxis)
-  }
-
-  /**
-   * RichScope wraps a general scope to provide the `/` operator for scoping.
-   */
-  final class RichScope(protected val scope: Scope) extends HasSlashKeyOrAttrKey
-
+  extension (c: Configuration)
+    def asScope: Scope = (c: ConfigKey).asScope
+    def /[K](key: Scoped.ScopingSetting[K]): K = (c: ConfigKey) / key
+    def /(task: AttributeKey[?]): Scope = (c: ConfigKey) / task
 end SlashSyntax
 
 private[sbt] object SlashSyntax0 extends SlashSyntax

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -10,6 +10,7 @@ package sbt
 
 import sbt.librarymanagement.Configuration
 import sbt.internal.util.AttributeKey
+import sbt.ScopeAxis.{ Select, This }
 
 /**
  * SlashSyntax implements the slash syntax to scope keys for build.sbt DSL.

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -35,12 +35,6 @@ trait SlashSyntax:
   given Conversion[ScopeAxis[Reference], RichReference] =
     (a: ScopeAxis[Reference]) => RichReference(Scope(a, This, This, This))
 
-  given [A](using Conversion[A, Reference]): Conversion[A, RichReference] =
-    (a: A) => Select(a: Reference)
-
-  given Conversion[Reference, RichReference] =
-    (r: Reference) => Select(r)
-
   given Conversion[ConfigKey, RichConfiguration] =
     (c: ConfigKey) => RichConfiguration(Scope(This, Select(c), This, This))
 

--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -11,6 +11,8 @@ package sbt
 import sbt.librarymanagement.Configuration
 import sbt.internal.util.AttributeKey
 import sbt.ScopeAxis.{ Select, This }
+import sbt.Scope.RefThenConfig
+import sbt.Scope.RefThenConfig.{ project, config }
 
 /**
  * SlashSyntax implements part of the slash syntax to scope keys for build.sbt DSL.
@@ -39,6 +41,15 @@ trait SlashSyntax:
     def asScope: Scope = (c: ConfigKey).asScope
     def /[K](key: Scoped.ScopingSetting[K]): K = (c: ConfigKey) / key
     def /(task: AttributeKey[?]): Scope = (c: ConfigKey) / task
+
+  extension (in: RefThenConfig)
+    def asScope: Scope = in.project.asScope.copy(config = in.config)
+    def toString(): String = asScope.toString()
+    def /[K](key: Scoped.ScopingSetting[K]): K = asScope / key
+    def /(task: AttributeKey[?]): Scope = asScope.copy(task = Select(task))
+
+    /** This is for handling `Zero / Zero / Zero / name`. */
+    def /(taskAxis: ScopeAxis[AttributeKey[?]]): Scope = asScope.copy(task = taskAxis)
 end SlashSyntax
 
 private[sbt] object SlashSyntax0 extends SlashSyntax

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -33,6 +33,9 @@ sealed trait Scoped extends Equals:
     })
 
   override def hashCode(): Int = (scope, key).##
+
+  final def /[K](subkey: Scoped.ScopingSetting[K]): K =
+    scope.copy(task = Select(key)).scope(subkey)
 end Scoped
 
 /** A SettingKey, TaskKey or `Initialize[Task]` that can be converted into an `Initialize[Task]`. */
@@ -75,9 +78,6 @@ sealed abstract class SettingKey[A1]
 
   private[sbt] final inline def rescope(scope: Scope): SettingKey[A1] =
     Scoped.scopedSetting(Scope.replaceThis(this.scope)(scope), this.key)
-
-  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
-    subkey.rescope(scope.copy(task = Select(key)))
 
   /** Internal function for the setting macro. */
   inline def settingMacro[A](inline a: A): Initialize[A] =
@@ -156,9 +156,6 @@ sealed abstract class TaskKey[A1]
 
   private[sbt] final inline def rescope(scope: Scope): TaskKey[A1] =
     Scoped.scopedTask(Scope.replaceThis(this.scope)(scope), this.key)
-
-  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
-    subkey.rescope(scope.copy(task = Select(key)))
 
   inline def +=[A2](inline v: A2)(using Append.Value[A1, A2]): Setting[Task[A1]] =
     append1[A2](taskMacro(v))
@@ -239,9 +236,6 @@ sealed trait InputKey[A1]
 
   private[sbt] final inline def rescope(scope: Scope): InputKey[A1] =
     Scoped.scopedInput(Scope.replaceThis(this.scope)(scope), this.key)
-
-  final def /[A1](subkey: Scoped.ScopingSetting[A1]): A1 =
-    subkey.rescope(scope.copy(task = Select(key)))
 
   private inline def inputTaskMacro[A2](inline a: A2): Def.Initialize[InputTask[A2]] =
     ${ std.InputTaskMacro.inputTaskMacroImpl('a) }

--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -16,6 +16,7 @@ import sbt.internal.util.TupleMapExtension.*
 import sbt.util.OptJsonWriter
 import sbt.ConcurrentRestrictions.Tag
 import sbt.Def.{ Initialize, ScopedKey, Setting, setting }
+import sbt.ScopeAxis.Select
 import std.TaskMacro
 import std.TaskExtra.{ task => mktask, _ }
 import scala.reflect.ClassTag

--- a/main-settings/src/test/scala/sbt/AppendSpec.scala
+++ b/main-settings/src/test/scala/sbt/AppendSpec.scala
@@ -11,7 +11,6 @@ object AppendSpec {
   val onLoad = SettingKey[State => State]("onLoad")
 
   import Scope.Global
-  import SlashSyntax0.given
 
   def doSideEffect(): Unit = ()
 

--- a/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
+++ b/main-settings/src/test/scala/sbt/BuildSettingsInstances.scala
@@ -14,6 +14,7 @@ import hedgehog.*
 import scala.annotation.nowarn
 import scala.reflect.ClassTag
 import _root_.sbt.io.IO
+import _root_.sbt.ScopeAxis.{ Select, This, Zero }
 import _root_.sbt.Scoped.ScopingSetting
 import _root_.sbt.librarymanagement.syntax.*
 import _root_.sbt.internal.util.{ AttributeKey, AttributeMap }

--- a/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
@@ -12,6 +12,7 @@ package test
 import hedgehog.*
 import hedgehog.runner.*
 import Scope.{ Global, ThisScope }
+import ScopeAxis.{ Select, This, Zero }
 import SlashSyntax0.given
 import BuildSettingsInstances.given
 import _root_.sbt.internal.util.AttributeKey
@@ -19,6 +20,7 @@ import _root_.sbt.internal.util.AttributeKey
 object SlashSyntaxSpec extends Properties:
   override def tests: List[Test] = List(
     property("Global / key", propGlobalKey),
+    example("Zero / compile", zeroCompile),
     property("Reference / key", propReferenceKey),
     property("Reference / Config / key", propReferenceConfigKey),
     property("Reference / task.key / key", propReferenceAttrKeyKey),
@@ -42,6 +44,7 @@ object SlashSyntaxSpec extends Properties:
   )
 
   def gen[A1: Gen]: Gen[A1] = summon[Gen[A1]]
+  lazy val compile: TaskKey[Unit] = TaskKey[Unit]("compile", "compile")
 
   def propGlobalKey: Property =
     for
@@ -57,6 +60,10 @@ object SlashSyntaxSpec extends Properties:
         (if k.scope == ThisScope then actual.scope == Global
          else true)
     )
+
+  def zeroCompile: Result =
+    val actual = Zero / compile
+    Result.assert(actual.scope.project == Zero && actual.key == compile.key)
 
   def propReferenceKey: Property =
     for

--- a/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxSpec.scala
@@ -13,7 +13,7 @@ import hedgehog.*
 import hedgehog.runner.*
 import Scope.{ Global, ThisScope }
 import ScopeAxis.{ Select, This, Zero }
-import SlashSyntax0.given
+import SlashSyntax0.*
 import BuildSettingsInstances.given
 import _root_.sbt.internal.util.AttributeKey
 
@@ -23,6 +23,7 @@ object SlashSyntaxSpec extends Properties:
     example("Zero / compile", zeroCompile),
     property("Reference / key", propReferenceKey),
     property("Reference / Config / key", propReferenceConfigKey),
+    example("Zero / Zero / compile", zeroZeroCompile),
     property("Reference / task.key / key", propReferenceAttrKeyKey),
     property("Reference / task / key", propReferenceTaskKey),
     property("Reference / inputtask / key", propReferenceInputTaskKey),
@@ -37,6 +38,7 @@ object SlashSyntaxSpec extends Properties:
     property("task / key", propTaskKey),
     property("inputtask / key", propInputTaskKey),
     property("Scope / key", propScopeKey),
+    property("Reference / Config? / key", propReferenceConfigAxisKey),
     property("Reference? / key", propReferenceAxisKey),
     property("Reference? / Config? / key", propReferenceAxisConfigAxisKey),
     // property("Reference? / task.key? / key", propReferenceAxisAttrKeyAxisKey),
@@ -63,6 +65,10 @@ object SlashSyntaxSpec extends Properties:
 
   def zeroCompile: Result =
     val actual = Zero / compile
+    Result.assert(actual.scope.project == Zero && actual.key == compile.key)
+
+  def zeroZeroCompile: Result =
+    val actual = Zero / Zero / compile
     Result.assert(actual.scope.project == Zero && actual.key == compile.key)
 
   def propReferenceKey: Property =
@@ -327,6 +333,23 @@ object SlashSyntaxSpec extends Properties:
         // Only if the incoming scope is This/This/This,
         // Global scoping is effective.
         (if k.scope == ThisScope then actual.scope == scope
+         else true)
+    )
+
+  def propReferenceConfigAxisKey: Property =
+    for
+      ref <- gen[Reference].forAll
+      config <- gen[ScopeAxis[ConfigKey]].forAll
+      k <- genKey[Unit].forAll
+      actual = k match
+        case k: InputKey[?]   => ref / config / k
+        case k: TaskKey[?]    => ref / config / k
+        case k: SettingKey[?] => ref / config / k
+    yield Result.assert(
+      actual.key == k.key &&
+        (if k.scope.project == This then actual.scope.project == Select(ref)
+         else true) &&
+        (if k.scope.config == This then actual.scope.config == config
          else true)
     )
 

--- a/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
@@ -13,6 +13,7 @@ import sjsonnew._
 import sbt.Def.{ Setting, inputKey, settingKey, taskKey }
 import sbt.Scope.Global
 import sbt.ScopeAxis.Zero
+import sbt.SlashSyntax0.*
 import sbt.librarymanagement.ModuleID
 import sbt.librarymanagement.syntax._
 import sbt.{ LocalProject, ProjectReference, ThisBuild }

--- a/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
+++ b/main-settings/src/test/scala/sbt/SlashSyntaxTest.scala
@@ -12,9 +12,10 @@ import java.io.File
 import sjsonnew._
 import sbt.Def.{ Setting, inputKey, settingKey, taskKey }
 import sbt.Scope.Global
+import sbt.ScopeAxis.Zero
 import sbt.librarymanagement.ModuleID
 import sbt.librarymanagement.syntax._
-import sbt.{ LocalProject, ProjectReference, ThisBuild, Zero }
+import sbt.{ LocalProject, ProjectReference, ThisBuild }
 
 object SlashSyntaxTest extends sbt.SlashSyntax {
   final case class Proj(id: String)

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -12,6 +12,7 @@ import java.io.File
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.Keys._
 import sbt.ProjectExtra.extract
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.Act
 import sbt.internal.CommandStrings._

--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -13,7 +13,6 @@ import sbt.Def.{ ScopedKey, Setting }
 import sbt.Keys._
 import sbt.ProjectExtra.extract
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
 import sbt.internal.Act
 import sbt.internal.CommandStrings._
 import sbt.internal.inc.ScalaInstance

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -98,7 +98,7 @@ import scala.util.control.NonFatal
 import scala.xml.NodeSeq
 
 // incremental compiler
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 import sbt.internal.inc.{
   Analysis,
   AnalyzingCompiler,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -32,6 +32,7 @@ import sbt.Project.{
 }
 import sbt.ProjectExtra.*
 import sbt.Scope.{ GlobalScope, ThisBuildScope, ThisScope, fillTaskAxis }
+import sbt.ScopeAxis.{ Select, This, Zero }
 import sbt.State.StateOpsImpl
 import sbt.coursierint._
 import sbt.internal.CommandStrings.ExportStream

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -16,7 +16,6 @@ import sbt.Keys.{ TaskProgress => _, name => _, _ }
 import sbt.BuildExtra.*
 import sbt.ProjectExtra.*
 import sbt.Scope.Global
-import sbt.SlashSyntax0.given
 import sbt.internal.Aggregation.KeyValue
 import sbt.internal.TaskName._
 import sbt.internal._

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -17,7 +17,6 @@ import sbt.util.Show
 import std.Transform.DummyTaskMap
 import sbt.EvaluateTask.extractedTaskConfig
 import sbt.ProjectExtra.setProject
-import sbt.SlashSyntax0.given
 
 final case class Extracted(
     structure: BuildStructure,

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -10,6 +10,7 @@ package sbt
 
 import sbt.internal.{ Load, BuildStructure, Act, Aggregation, SessionSettings }
 import Scope.GlobalScope
+import sbt.ScopeAxis.This
 import Def.{ ScopedKey, Setting }
 import sbt.internal.util.complete.Parser
 import sbt.util.Show

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import sbt.Project.LoadAction
 import sbt.ProjectExtra.*
+import sbt.ScopeAxis.Select
 import sbt.internal.Aggregation.AnyKeys
 import sbt.internal._
 import sbt.internal.client.BspClient

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -14,7 +14,6 @@ import sbt.Keys._
 import Scope.GlobalScope
 import Def.ScopedKey
 import sbt.ScopeAxis.Select
-import sbt.SlashSyntax0.given
 import sbt.internal.Load
 import sbt.internal.CommandStrings._
 import Cross.{ spacedFirst, requireSession }

--- a/main/src/main/scala/sbt/PluginCross.scala
+++ b/main/src/main/scala/sbt/PluginCross.scala
@@ -13,6 +13,7 @@ import DefaultParsers._
 import sbt.Keys._
 import Scope.GlobalScope
 import Def.ScopedKey
+import sbt.ScopeAxis.Select
 import sbt.SlashSyntax0.given
 import sbt.internal.Load
 import sbt.internal.CommandStrings._

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -38,7 +38,6 @@ import Keys.{
 import Project.LoadAction
 import Scope.{ Global, ThisScope }
 import sbt.ScopeAxis.Select
-import sbt.SlashSyntax0.given
 import Def.{ Flattened, Initialize, ScopedKey, Setting }
 import sbt.internal.{
   Load,

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -37,6 +37,7 @@ import Keys.{
 }
 import Project.LoadAction
 import Scope.{ Global, ThisScope }
+import sbt.ScopeAxis.Select
 import sbt.SlashSyntax0.given
 import Def.{ Flattened, Initialize, ScopedKey, Setting }
 import sbt.internal.{

--- a/main/src/main/scala/sbt/RemoteCache.scala
+++ b/main/src/main/scala/sbt/RemoteCache.scala
@@ -21,6 +21,7 @@ import sbt.Keys._
 import sbt.Project.{ inConfig => _, * }
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
+import sbt.ScopeAxis.Select
 import sbt.SlashSyntax0.given
 import sbt.coursierint.LMCoursier
 import sbt.internal.inc.{ HashUtil, JarUtils }

--- a/main/src/main/scala/sbt/RemoteCache.scala
+++ b/main/src/main/scala/sbt/RemoteCache.scala
@@ -22,7 +22,7 @@ import sbt.Project.{ inConfig => _, * }
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
 import sbt.ScopeAxis.Select
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 import sbt.coursierint.LMCoursier
 import sbt.internal.inc.{ HashUtil, JarUtils }
 import sbt.internal.librarymanagement._

--- a/main/src/main/scala/sbt/ScopeFilter.scala
+++ b/main/src/main/scala/sbt/ScopeFilter.scala
@@ -13,6 +13,7 @@ import sbt.internal.util.{ AttributeKey, Dag }
 import sbt.librarymanagement.{ ConfigRef, Configuration }
 import sbt.internal.util.Types.const
 import Def.Initialize
+import sbt.ScopeAxis.{ Select, Zero }
 import java.net.URI
 
 sealed abstract class ScopeFilter { self =>

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -15,7 +15,7 @@ import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 import sbt.internal.inc.ModuleUtilities
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.librarymanagement.cross.CrossVersionUtil

--- a/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
@@ -19,6 +19,7 @@ import lmcoursier.definitions.{
 import sbt.librarymanagement._
 import sbt.Keys._
 import sbt.ProjectExtra.extract
+import sbt.SlashSyntax0.*
 
 object CoursierArtifactsTasks {
   def coursierPublicationsTask(

--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -15,6 +15,7 @@ import sbt.internal.util.complete.{ DefaultParsers, Parser }
 import Aggregation.{ KeyValue, Values }
 import DefaultParsers._
 import sbt.internal.util.Types.idFun
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.ProjectExtra.{ failure => _, * }
 import java.net.URI
 import sbt.internal.CommandStrings.{ MultiTaskCommand, ShowCommand, PrintCommand }

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -15,7 +15,6 @@ import sbt.Def.{ ScopedKey, Settings }
 import sbt.Keys.{ showSuccess, showTiming, timingFormat }
 import sbt.ProjectExtra.*
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }
 import sbt.internal.util._

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -14,6 +14,7 @@ import java.text.DateFormat
 import sbt.Def.{ ScopedKey, Settings }
 import sbt.Keys.{ showSuccess, showTiming, timingFormat }
 import sbt.ProjectExtra.*
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -16,6 +16,7 @@ import java.net.URI
 import Def.{ ScopeLocal, ScopedKey, Setting, displayFull }
 import BuildPaths.outputDirectory
 import Scope.GlobalScope
+import sbt.ScopeAxis.{ Select, This, Zero }
 import sbt.SlashSyntax0.given
 import BuildStreams.Streams
 import sbt.io.syntax._

--- a/main/src/main/scala/sbt/internal/BuildStructure.scala
+++ b/main/src/main/scala/sbt/internal/BuildStructure.scala
@@ -17,7 +17,6 @@ import Def.{ ScopeLocal, ScopedKey, Setting, displayFull }
 import BuildPaths.outputDirectory
 import Scope.GlobalScope
 import sbt.ScopeAxis.{ Select, This, Zero }
-import sbt.SlashSyntax0.given
 import BuildStreams.Streams
 import sbt.io.syntax._
 import sbt.internal.inc.MappedFileConverter

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -14,7 +14,6 @@ import java.net.URL
 import java.nio.file.Path
 import sbt.ClassLoaderLayeringStrategy._
 import sbt.Keys._
-import sbt.SlashSyntax0.given
 import sbt.internal.classpath.ClassLoaderCache
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.inc.classpath.ClasspathUtil

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -18,6 +18,7 @@ import sbt.Def.Initialize
 import sbt.internal.util.{ Attributed, Dag }
 import sbt.librarymanagement.{ Configuration, TrackLevel }
 import sbt.librarymanagement.Configurations.names
+import sbt.SlashSyntax0.*
 import sbt.std.TaskExtra._
 import sbt.util._
 import scala.jdk.CollectionConverters.*

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -16,6 +16,7 @@ import sbt.Def._
 import sbt.Keys._
 // import sbt.Project.richInitializeTask
 import sbt.ProjectExtra.*
+import sbt.ScopeAxis.Zero
 import sbt.SlashSyntax0.given
 import sbt.io.syntax._
 import sbt.nio.Keys._

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -17,7 +17,6 @@ import sbt.Keys._
 // import sbt.Project.richInitializeTask
 import sbt.ProjectExtra.*
 import sbt.ScopeAxis.Zero
-import sbt.SlashSyntax0.given
 import sbt.io.syntax._
 import sbt.nio.Keys._
 import sbt.nio.file._
@@ -162,7 +161,7 @@ private[sbt] object Clean {
   ): Def.Initialize[Task[Unit]] =
     (Def
       .task {
-        taskKey.scope / taskKey.key
+        taskKey.scope.rescope(taskKey.key)
       })
       .flatMapTask { case scope =>
         Def.task {

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -24,7 +24,6 @@ import sbt.BasicCommandStrings._
 import sbt.Def._
 import sbt.Keys._
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0.given
 import sbt.internal.Continuous.{ ContinuousState, FileStampRepository }
 import sbt.internal.LabeledFunctions._
 import sbt.internal.io.WatchState

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -18,6 +18,7 @@ import sbt.io.syntax._
 import sbt.Cross._
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.ProjectExtra.extract
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.DefaultParsers._
 import sbt.internal.util.AttributeKey

--- a/main/src/main/scala/sbt/internal/CrossJava.scala
+++ b/main/src/main/scala/sbt/internal/CrossJava.scala
@@ -19,7 +19,6 @@ import sbt.Cross._
 import sbt.Def.{ ScopedKey, Setting }
 import sbt.ProjectExtra.extract
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
 import sbt.internal.util.complete.DefaultParsers._
 import sbt.internal.util.AttributeKey
 import sbt.internal.util.complete.{ DefaultParsers, Parser }

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import sbt.Def.{ Classpath, ScopedKey, Setting }
 import sbt.ProjectExtra.extract
 import sbt.Scope.GlobalScope
-import sbt.SlashSyntax0.given
 import sbt.internal.inc.classpath.ClasspathFilter
 import sbt.internal.util.{ Attributed, ManagedLogger }
 import sbt.io.syntax._

--- a/main/src/main/scala/sbt/internal/FileChangesMacro.scala
+++ b/main/src/main/scala/sbt/internal/FileChangesMacro.scala
@@ -11,6 +11,7 @@ package internal
 
 import java.nio.file.{ Path => NioPath }
 
+import sbt.ScopeAxis.Select
 import sbt.nio.Keys._
 import sbt.nio.{ FileChanges, FileStamp }
 
@@ -100,6 +101,6 @@ object FileChangesMacro:
   private def getTaskScope[A: Type](in: Expr[TaskKey[A]])(using qctx: Quotes): Expr[sbt.Scope] =
     '{
       if $in.scope.task.toOption.isDefined then $in.scope
-      else $in.scope.copy(task = sbt.Select($in.key))
+      else $in.scope.copy(task = Select($in.key))
     }
 end FileChangesMacro

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -22,7 +22,7 @@ import Def.{ ScopedKey, Setting }
 import Keys._
 import Configurations.{ Compile, Runtime }
 import sbt.ProjectExtra.{ extract, runUnloadHooks, setProject }
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 import java.io.File
 import org.apache.ivy.core.module.{ descriptor, id }
 import descriptor.ModuleDescriptor, id.ModuleRevisionId

--- a/main/src/main/scala/sbt/internal/IvyConsole.scala
+++ b/main/src/main/scala/sbt/internal/IvyConsole.scala
@@ -26,7 +26,7 @@ import Def.Setting
 import Keys._
 import Scope.Global
 import sbt.ProjectExtra.{ extract, setProject }
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 
 import sbt.io.IO
 import xsbti.HashedVirtualFileRef

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -14,7 +14,6 @@ import sbt.internal.util.{ FilePosition, NoPosition, SourcePosition }
 import java.io.File
 import ProjectExtra.{ extract, scopedKeyData }
 import Scope.Global
-import sbt.SlashSyntax0.given
 import sbt.Def._
 
 object LintUnused {

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -15,6 +15,7 @@ import sbt.Keys._
 import sbt.Project.inScope
 import sbt.ProjectExtra.{ prefixConfigs, setProject, showLoadingKey, structure }
 import sbt.Scope.GlobalScope
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.BuildStreams._
 import sbt.internal.inc.classpath.ClasspathUtil

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -16,7 +16,7 @@ import sbt.Project.inScope
 import sbt.ProjectExtra.{ prefixConfigs, setProject, showLoadingKey, structure }
 import sbt.Scope.GlobalScope
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 import sbt.internal.BuildStreams._
 import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.inc.{ MappedFileConverter, ScalaInstance, ZincLmUtil, ZincUtil }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -13,6 +13,7 @@ import sbt.Def.ScopedKey
 import sbt.Keys._
 import sbt.ProjectExtra.showContextKey
 import sbt.Scope.Global
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.util.MainAppender._
 import sbt.internal.util.{ Terminal => ITerminal, _ }

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -14,7 +14,6 @@ import sbt.Keys._
 import sbt.ProjectExtra.showContextKey
 import sbt.Scope.Global
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
 import sbt.internal.util.MainAppender._
 import sbt.internal.util.{ Terminal => ITerminal, _ }
 import sbt.util.{ Level, Logger, LoggerContext }

--- a/main/src/main/scala/sbt/internal/Resolve.scala
+++ b/main/src/main/scala/sbt/internal/Resolve.scala
@@ -10,6 +10,7 @@ package sbt
 package internal
 
 import sbt.internal.util.AttributeKey
+import sbt.ScopeAxis.{ Select, This, Zero }
 
 object Resolve {
   def apply(

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -19,7 +19,7 @@ import EvaluateConfigurations.{ evaluateConfiguration => evaluate }
 import Configurations.Compile
 import Scope.Global
 import sbt.ProjectExtra.{ extract, setProject }
-import sbt.SlashSyntax0.given
+import sbt.SlashSyntax0.*
 
 import sbt.io.{ Hash, IO }
 

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -17,7 +17,6 @@ import ProjectExtra.{ relation }
 import Def.{ ScopedKey, Setting }
 import Scope.Global
 import sbt.ScopeAxis.{ Select, This, Zero }
-import sbt.SlashSyntax0.given
 import complete._
 import DefaultParsers._
 

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -16,6 +16,7 @@ import sbt.librarymanagement.Configuration
 import ProjectExtra.{ relation }
 import Def.{ ScopedKey, Setting }
 import Scope.Global
+import sbt.ScopeAxis.{ Select, This, Zero }
 import sbt.SlashSyntax0.given
 import complete._
 import DefaultParsers._

--- a/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
+++ b/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
@@ -14,7 +14,6 @@ import sbt.Keys._
 // import sbt.Project.richInitializeTask
 import sbt.ProjectExtra.*
 import sbt.ScopeAxis.Zero
-import sbt.SlashSyntax0.given
 import sbt.internal.io.Source
 import sbt.internal.nio.Globs
 import sbt.internal.util.complete.Parser

--- a/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
+++ b/main/src/main/scala/sbt/internal/WatchTransitiveDependencies.scala
@@ -13,6 +13,7 @@ import sbt.Def._
 import sbt.Keys._
 // import sbt.Project.richInitializeTask
 import sbt.ProjectExtra.*
+import sbt.ScopeAxis.Zero
 import sbt.SlashSyntax0.given
 import sbt.internal.io.Source
 import sbt.internal.nio.Globs

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -18,6 +18,7 @@ import sbt.Keys._
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
 import sbt.Scoped.richTaskSeq
+import sbt.SlashSyntax0.*
 import sbt.StandardMain.exchange
 import sbt.internal.bsp._
 import sbt.internal.langserver.ErrorCodes

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -18,7 +18,6 @@ import sbt.Keys._
 import sbt.ProjectExtra.*
 import sbt.ScopeFilter.Make._
 import sbt.Scoped.richTaskSeq
-import sbt.SlashSyntax0.given
 import sbt.StandardMain.exchange
 import sbt.internal.bsp._
 import sbt.internal.langserver.ErrorCodes

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import sbt.BasicCommandStrings.{ Shutdown, TerminateAction }
 import sbt.ProjectExtra.extract
-import sbt.SlashSyntax0.given
 import sbt.internal.langserver.{ CancelRequestParams, ErrorCodes, LogMessageParams, MessageType }
 import sbt.internal.protocol.{
   JsonRpcNotificationMessage,

--- a/main/src/main/scala/sbt/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/nio/CheckBuildSources.scala
@@ -15,7 +15,6 @@ import sbt.BasicCommandStrings.{ RebootCommand, Shutdown, TerminateAction }
 import sbt.Keys.{ baseDirectory, pollInterval, state }
 import sbt.ProjectExtra.extract
 import sbt.Scope.Global
-import sbt.SlashSyntax0.given
 import sbt.internal.CommandStrings.LoadProject
 import sbt.internal.SysProp
 import sbt.internal.util.{ AttributeKey, Terminal }

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import sbt.Keys._
 import sbt.ScopeAxis.{ Select, Zero }
-import sbt.SlashSyntax0.given
 import sbt.internal.Clean.ToSeqPath
 import sbt.internal.Continuous.FileStampRepository
 import sbt.internal.util.KeyTag

--- a/main/src/main/scala/sbt/nio/Settings.scala
+++ b/main/src/main/scala/sbt/nio/Settings.scala
@@ -13,6 +13,7 @@ import java.nio.file.{ Files, Path }
 import java.util.concurrent.ConcurrentHashMap
 
 import sbt.Keys._
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.SlashSyntax0.given
 import sbt.internal.Clean.ToSeqPath
 import sbt.internal.Continuous.FileStampRepository

--- a/main/src/test/scala/Delegates.scala
+++ b/main/src/test/scala/Delegates.scala
@@ -10,6 +10,7 @@ package sbt
 
 import sbt.internal.util.Types.idFun
 import sbt.internal.TestBuild._
+import sbt.ScopeAxis.{ Select, This, Zero }
 import hedgehog._
 import hedgehog.Result.{ all, assert, failure, success }
 import hedgehog.runner._

--- a/main/src/test/scala/ParseKeySpec.scala
+++ b/main/src/test/scala/ParseKeySpec.scala
@@ -12,6 +12,7 @@ import sbt.internal.TestBuild._
 import sbt.internal.util.complete.Parser
 import sbt.internal.{ Resolve, TestBuild }
 import sbt.ProjectExtra.equalKeys
+import sbt.ScopeAxis.{ Select, Zero }
 import hedgehog._
 import hedgehog.core.{ ShrinkLimit, SuccessCount }
 import hedgehog.runner._

--- a/main/src/test/scala/ParserSpec.scala
+++ b/main/src/test/scala/ParserSpec.scala
@@ -10,6 +10,7 @@ package sbt
 import java.net.URI
 
 import sbt.Def._
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.internal.TestBuild
 import sbt.internal.TestBuild._
 import sbt.internal.util.AttributeKey

--- a/main/src/test/scala/sbt/internal/TestBuild.scala
+++ b/main/src/test/scala/sbt/internal/TestBuild.scala
@@ -10,6 +10,7 @@ package sbt
 package internal
 
 import Def.{ ScopedKey, Setting }
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.internal.util.{ AttributeKey, Relation }
 import sbt.internal.util.Types.{ const, some }
 import sbt.internal.util.complete.Parser

--- a/main/src/test/scala/testpkg/CompletionSpec.scala
+++ b/main/src/test/scala/testpkg/CompletionSpec.scala
@@ -10,6 +10,7 @@ package testpkg
 import java.net.URI
 
 import sbt.{ Result => _, _ }
+import sbt.ScopeAxis.{ Select, Zero }
 import sbt.Def._
 import sbt.internal.TestBuild
 import sbt.internal.TestBuild._

--- a/sbt-app/src/main/scala/sbt/Import.scala
+++ b/sbt-app/src/main/scala/sbt/Import.scala
@@ -34,6 +34,9 @@ trait Import {
   type ClasspathDependency = ClasspathDep.ClasspathDependency
   val ResolvedClasspathDependency = ClasspathDep.ResolvedClasspathDependency
   type ResolvedClasspathDependency = ClasspathDep.ResolvedClasspathDependency
+  val Select = ScopeAxis.Select
+  val This = ScopeAxis.This
+  val Zero = ScopeAxis.Zero
   // sbt.testing
   type TestResult = sbt.protocol.testing.TestResult
   val TestResult = sbt.protocol.testing.TestResult


### PR DESCRIPTION
## Problem
Slash syntax is currently implemented via a series of implicit
converters (Conversion), which is not nice, partly because
the behavior is difficult to follow.

## Solution
This removes all the implicit converters and moves the slashes
into:
1. / methods under Reference for subproject scoping.
2. / methods under ScopeAxis with Reference type constraint
   for the initial Zero scoping.
3. Return RefThenConfig structure for intermediate config scoping.
4. / method under `Scoped`, which is base trait for the keys
   to implement task scoping e.g. `compile / scalacOptions`.
5. Extension methods for ConfigKey.
6. Extension methods for AttributeKey.