### PR TITLE
[1.x] Add instruction on how to stop a `run/runMain` task

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2040,6 +2040,13 @@ object Defaults extends BuildCommon {
     Def.inputTask {
       val handle = bgRunMain.evaluated
       val service = bgJobService.value
+      streams.value.log.info(
+        s"""
+           |Executing runMain in the background.
+           |To terminate the execution, run bgStop ${handle.id}.
+           |To execute runMain in the foreground, use fgRunMain instead.
+           |""".stripMargin
+      )
       service.waitForTry(handle).get
     }
 
@@ -2048,6 +2055,13 @@ object Defaults extends BuildCommon {
     Def.inputTask {
       val handle = bgRun.evaluated
       val service = bgJobService.value
+      streams.value.log.info(
+        s"""
+           |Executing run in the background.
+           |To terminate the execution, run bgStop ${handle.id}.
+           |To execute run in the foreground, use fgRun instead.
+           |""".stripMargin
+      )
       service.waitForTry(handle).get
     }
 


### PR DESCRIPTION
### Issue

`run, runMain` are background tasks, hence they cannot be stopped by `ctrl+c`, but rather needs to be stopped via `bgStop`.

Many `sbt` users are not aware of the fact and believes this is a bug, resulting in https://github.com/sbt/sbt/issues/6346, https://github.com/sbt/sbt/issues/6242, https://github.com/typelevel/cats-effect/issues/2251, https://github.com/typelevel/cats-effect/pull/3631, https://github.com/typelevel/cats-effect/pull/3774... (along with a long list of discussions on discord, omitted for brevity). 

In fact I also believed this is a bug 🤦‍♂️ and sunk quite some time trying to figure out what is going on... In fact, one may argue that this is indeed a bug, as `bgStop` takes an `id` as input, and the `id` associated with `run, runMain` are not currently surfaced...

### Solution

Whenever we invoke `run/runMain`, print a log informing about existence of `bgStop` and how to use that to stop `run/runMain` task. The log also includes Job ID for `run/runMain` for completeness.

Closes https://github.com/sbt/sbt/issues/6346
Closes https://github.com/sbt/sbt/issues/6242
Closes https://github.com/typelevel/cats-effect/issues/2251