### PR TITLE
[1.x] Stop background jobs when pressing `ctrl-c`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1071,6 +1071,7 @@ lazy val mainProj = (project in file("main"))
       exclude[MissingClassProblem]("sbt.internal.server.BuildServerReporter$"),
       exclude[IncompatibleTemplateDefProblem]("sbt.internal.server.BuildServerReporter"),
       exclude[MissingClassProblem]("sbt.internal.CustomHttp*"),
+      exclude[ReversedMissingMethodProblem]("sbt.JobHandle.isAutoCancel"),
     )
   )
   .configure(

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -100,4 +100,5 @@ abstract class JobHandle {
   def id: Long
   def humanReadableName: String
   def spawningTask: ScopedKey[_]
+  def isAutoCancel: Boolean
 }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2039,6 +2039,11 @@ object Defaults extends BuildCommon {
   def foregroundRunMainTask: Initialize[InputTask[Unit]] =
     Def.inputTask {
       val handle = bgRunMain.evaluated
+      handle match {
+        case threadJobHandle: AbstractBackgroundJobService#ThreadJobHandle =>
+          threadJobHandle.isAutoCancel = true
+        case _ =>
+      }
       val service = bgJobService.value
       service.waitForTry(handle).get
     }
@@ -2047,6 +2052,11 @@ object Defaults extends BuildCommon {
   def foregroundRunTask: Initialize[InputTask[Unit]] =
     Def.inputTask {
       val handle = bgRun.evaluated
+      handle match {
+        case threadJobHandle: AbstractBackgroundJobService#ThreadJobHandle =>
+          threadJobHandle.isAutoCancel = true
+        case _ =>
+      }
       val service = bgJobService.value
       service.waitForTry(handle).get
     }

--- a/main/src/main/scala/sbt/EvaluateTask.scala
+++ b/main/src/main/scala/sbt/EvaluateTask.scala
@@ -531,6 +531,7 @@ object EvaluateTask {
         log.warn("Canceling execution...")
         RunningProcesses.killAll()
         ConcurrentRestrictions.cancelAll()
+        DefaultBackgroundJobService.stop()
         shutdownImpl(true)
       }
     }

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -508,6 +508,15 @@ private[sbt] object DefaultBackgroundJobService {
     backgroundJobServices.values.forEach(_.shutdown())
     backgroundJobServices.clear()
   }
+
+  private[sbt] def stop(): Unit = {
+    backgroundJobServices
+      .values()
+      .forEach(jobService => {
+        jobService.jobs.foreach(jobService.stop)
+      })
+  }
+
   private[sbt] lazy val backgroundJobServiceSetting: Setting[_] =
     (GlobalScope / Keys.bgJobService) := {
       val path = (GlobalScope / sbt.Keys.bgJobServiceDirectory).value


### PR DESCRIPTION
Implements https://github.com/sbt/sbt/pull/7914#discussion_r1859286435

> In case of `run` we should forward cancellation to cancelling the `bgRun` job.

Tested via a local `sbt` build, using reproduction from https://github.com/sbt/sbt/issues/6346.

Supersedes #7914

Closes https://github.com/sbt/sbt/issues/6346
Closes https://github.com/sbt/sbt/issues/6242
Closes https://github.com/typelevel/cats-effect/issues/2251