### PR TITLE
[2.x] fix: Remove -Wconf:cat=unused-nowarn:s

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -985,15 +985,6 @@ object Defaults extends BuildCommon {
           ) ++ old
         else old
       },
-      scalacOptions := {
-        val old = scalacOptions.value
-        if (
-          sbtPlugin.value && VersionNumber(scalaVersion.value)
-            .matchesSemVer(SemanticSelector("=2.12 >=2.12.13"))
-        )
-          old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
-        else old
-      },
       persistJarClasspath :== true,
       classpathEntryDefinesClassVF := {
         val cache =


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7723

## Problem
Currently the following warning shows up while compiling metabuild:

[warn] Failed to parse `-Wconf` configuration: cat=unused-nowarn:s
[warn] unknown category: unused-nowarn

-Wconf:cat=unused-nowarn in general was added as a Scala 2.12 of falsely warning about pure expression not doing anything in the macro.

## Solution
We should be able to remove the -Wconf flag in sbt 2.x.