### PR TITLE
Fix thread name display in Trace-Viewer for chromium traces

### DIFF
--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -11,6 +11,7 @@ package internal
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.immutable.VectorBuilder
@@ -122,12 +123,13 @@ private[sbt] abstract class AbstractTaskExecuteProgress extends ExecuteProgress[
 object AbstractTaskExecuteProgress {
   private[sbt] class Timer() {
     val startNanos: Long = System.nanoTime()
+    @nowarn("cat=deprecation") val threadId: Long = Thread.currentThread().getId
     val threadName: String = Thread.currentThread().getName
     var endNanos: Long = 0L
     def stop(): Unit = {
       endNanos = System.nanoTime()
     }
-    def isActive = endNanos == 0L
+    def isActive: Boolean = endNanos == 0L
     def durationNanos: Long = endNanos - startNanos
     def startMicros: Long = (startNanos.toDouble / 1000).toLong
     def durationMicros: Long = (durationNanos.toDouble / 1000).toLong

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -11,6 +11,7 @@ package internal
 
 import java.io.File
 import java.nio.file.Files
+import scala.collection.mutable
 import sbt.internal.util.{ RMap, ConsoleOut }
 import sbt.io.IO
 import sbt.io.syntax._
@@ -56,17 +57,28 @@ private[sbt] final class TaskTraceEvent
     else ()
     val outFile = tracesDirectory / fileName
     val trace = Files.newBufferedWriter(outFile.toPath)
+    val threadNamesEmitted = mutable.Set.empty[Long]
     try {
       trace.append("""{"traceEvents": [""")
+      def threadNameEvent(tid: Long, name: String): String = {
+        s"""{"name": "thread_name", "ph": "M", "pid": 0, "tid": $tid, "args": {"name": "$name"}}"""
+      }
       def durationEvent(name: String, cat: String, t: Timer): String = {
         val sb = new java.lang.StringBuilder(name.length + 2)
         CompactPrinter.print(new JString(name), sb)
-        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tname": "${t.threadName}"}"""
+        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tid": ${t.threadId}}"""
       }
       val entryIterator = currentTimings
       while (entryIterator.hasNext) {
         val (key, value) = entryIterator.next()
         trace.append(durationEvent(taskName(key), "task", value))
+
+        if (!threadNamesEmitted.contains(value.threadId)) {
+          trace.append(",")
+          trace.append(threadNameEvent(value.threadId, value.threadName))
+          threadNamesEmitted += value.threadId
+        }
+
         if (entryIterator.hasNext) trace.append(",")
       }
       trace.append("]}")


### PR DESCRIPTION
Fix thread name display in Trace-Viewer for chromium traces.

Currently the wrong field name is set in the json (tname instead of tid).
This change makes sbt output tid with the thread id, and additionally adds thread_name metadata events to allow Trace-Viewer to translate thread ids into thread names.

https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#bookmark=id.iycbnb4z7i9g

FWIW, passing the thread name directly in the `tid` field also seems to work just as well currently, but given how easy it is to do this the right way, I didn't think of taking advantage of it...

<img width="2444" alt="Screenshot 2024-12-04 at 15 22 22" src="https://github.com/user-attachments/assets/85e4a75c-aa94-42d9-bde8-c9773de9bacb">
