### PR TITLE
add lmCoursierShadedPublishing to allProjects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1216,6 +1216,7 @@ def allProjects =
     lmCoursierDefinitions,
     lmCoursier,
     lmCoursierShaded,
+    lmCoursierShadedPublishing,
   ) ++ lowerUtilProjects
 
 // These need to be cross published to 2.12 and 2.13 for Zinc


### PR DESCRIPTION
I tried to use a locally published version of sbt, but one the dependencies was missing. 

I think this was happening because `lmCoursierShadedPublishing` is not being aggregated in the root and is not being published locally when I run `publishLocal`