### PR TITLE
[1.x] feat: Support glob expressions in scripted

### DIFF
--- a/sbt-app/src/sbt-test/actions/clean-managed/test
+++ b/sbt-app/src/sbt-test/actions/clean-managed/test
@@ -1,6 +1,6 @@
 > compile
-$ exists target/scala-2.12/src_managed/foo.txt target/scala-2.12/src_managed/bar.txt
+$ exists target/**/src_managed/foo.txt target/**/src_managed/bar.txt
 
 > clean
-$ absent target/scala-2.12/src_managed/foo.txt
-$ exists target/scala-2.12/src_managed/bar.txt
+$ absent target/**/src_managed/foo.txt
+$ exists target/**/src_managed/bar.txt

--- a/sbt-app/src/sbt-test/actions/compile-clean/test
+++ b/sbt-app/src/sbt-test/actions/compile-clean/test
@@ -1,22 +1,22 @@
 $ touch target/cant-touch-this
 
 > Test/compile
-$ exists target/scala-2.12/classes/A.class
-$ exists target/scala-2.12/test-classes/B.class
+$ exists target/**/classes/A.class
+$ exists target/**/test-classes/B.class
 
 > Test/clean
 $ exists target/cant-touch-this
 # it should clean only compile classes
-$ exists target/scala-2.12/classes/A.class
-$ exists target/scala-2.12/classes/X.class
-$ absent target/scala-2.12/test-classes/B.class
+$ exists target/**/classes/A.class
+$ exists target/**/classes/X.class
+$ absent target/**/test-classes/B.class
 
 # compiling everything again, but now cleaning only compile classes
 > Test/compile
 > Compile/clean
 $ exists target/cant-touch-this
 # it should clean only compile classes
-$ absent target/scala-2.12/classes/A.class
-$ exists target/scala-2.12/test-classes/B.class
+$ absent target/**/classes/A.class
+$ exists target/**/test-classes/B.class
 # and X has to be kept, because of the cleanKeepFiles override
-$ exists target/scala-2.12/classes/X.class
+$ exists target/**/classes/X.class

--- a/sbt-app/src/sbt-test/actions/task-map/test
+++ b/sbt-app/src/sbt-test/actions/task-map/test
@@ -1,7 +1,7 @@
 > taskB
-$ exists target/b
-$ exists target/a
+$ exists target/**/b
+$ exists target/**/a
 
 > taskF
-$ exists target/e
-$ exists target/f
+$ exists target/**/e
+$ exists target/**/f


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/7932

## Problem
It's currently not easy to write a scripted test that works on both sbt 1.x and 2.x when you want to write exists test under target.

## Solution
Since we can only use the file system (and not evaluate Scala version etc)
1. this implements glob expression support in `exists`, `absent`, and `delete`.
2. this also introduces `||` operator that would mean a or b.