### PR TITLE
[1.x] fix: --allow-empty fixes

### DIFF
--- a/launcher-package/src/universal/conf/sbtopts
+++ b/launcher-package/src/universal/conf/sbtopts
@@ -9,7 +9,7 @@
 
 # Starts sbt even if the current directory contains no sbt project.
 #
--sbt-create
+#--allow-empty
 
 # Path to global settings/plugins directory (default: ~/.sbt)
 #
@@ -31,11 +31,11 @@
 #
 #-no-share
 
-# Put SBT in offline mode.
+# Put sbt in offline mode.
 #
 #-offline
 
-# Sets the SBT version to use.
+# Sets the sbt version to use.
 #-sbt-version  0.11.3
 
 # Scala version (default: latest release)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7942
Fixes https://github.com/sbt/sbt/issues/2123

## Problem
1. Currently users are automatically opted into `-create-sbt`, somewhat implicitly.
2. When somehow they are not, the check mechanism currently blocks for input.
3. The working directory check is invoked even for `sbt --script-version`

## Solution
1. Support a new location for `sbtopts` file under `$XDG_CONFIG_HOME/sbt`
2. Rename `-create-sbt` to `--allow-empty`, and don't opt everyone in
3. Run the working directory check only when sbt is about to start a session
4. Exit 1 instead of blocking for input