### PR TITLE
[1.x] Bump JLine 3 to `3.28.0`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
   val sjsonNewMurmurhash = sjsonNew("sjson-new-murmurhash")
 
   val jline = "org.scala-sbt.jline" % "jline" % "2.14.7-sbt-9a88bc413e2b34a4580c001c654d1a7f4f65bf18"
-  val jline3Version = "3.27.1"
+  val jline3Version = "3.28.0"
   val jline3Terminal = "org.jline" % "jline-terminal" % jline3Version
   val jline3JNI = "org.jline" % "jline-terminal-jni" % jline3Version
   val jline3Native = "org.jline" % "jline-native" % jline3Version


### PR DESCRIPTION
https://github.com/jline/jline3/releases/tag/jline-3.28.0

7 feature PRs, 4 bugfix PRs, 2 maintenance PRs.

Other than https://github.com/jline/jline3/pull/1129, only `.java` files are changed. There's no change around native code & JNI layer.

1 regression (https://github.com/jline/jline3/issues/1139) with `ScriptFile` execution, but it doesn't look like `sbt` is using `ScriptFile` functionalities.

Tested locally on Windows & M1 MacBook against locally published sbt release and tab completion, history, console are working.