### PR TITLE
[1.x] fix: Fixes glob in scripted

### DIFF
--- a/sbt-app/src/sbt-test/actions/add-alias/test
+++ b/sbt-app/src/sbt-test/actions/add-alias/test
@@ -2,3 +2,5 @@
 -> demo-failure
 > +z
 > z
+
+$ absent /tmp/non-existent


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7958

## Problem
Absolute path handling regressed.

## Solution
Create an absolute glob for expression starting with `/`.
