### PR TITLE
[1.x] Clear Zinc Analysis Cache during `Compile / clean`, `Test / clean`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -928,7 +928,20 @@ object Defaults extends BuildCommon {
         tastyFiles.map(_.getAbsoluteFile)
       } else Nil
     }.value,
-    clean := (compileOutputs / clean).value,
+    clean := {
+      val _ = (compileOutputs / clean).value
+      val setup = compileIncSetup.value
+      try {
+        val store = AnalysisUtil.staticCachedStore(
+          analysisFile = setup.cacheFile.toPath,
+          useTextAnalysis = !enableBinaryCompileAnalysis.value,
+          useConsistent = enableConsistentCompileAnalysis.value,
+        )
+        store.clearCache()
+      } catch {
+        case NonFatal(_) => ()
+      }
+    },
     earlyOutputPing := Def.promise[Boolean],
     compileProgress := {
       val s = streams.value

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -930,10 +930,10 @@ object Defaults extends BuildCommon {
     }.value,
     clean := {
       val _ = (compileOutputs / clean).value
-      val setup = compileIncSetup.value
+      val analysisFile = compileAnalysisFile.value
       try {
         val store = AnalysisUtil.staticCachedStore(
-          analysisFile = setup.cacheFile.toPath,
+          analysisFile = analysisFile.toPath,
           useTextAnalysis = !enableBinaryCompileAnalysis.value,
           useConsistent = enableConsistentCompileAnalysis.value,
         )


### PR DESCRIPTION
### Issue

While `compile` clears `previousCompile`, `Compile / clean` does not clear `Compile / previousCompile` (and vice versa for `Test / clean`)

```
sbt:sbt insanity>  Compile / compile
[info] compiling 1 Scala source to /Users/jiahuitan/sbt insanity/target/scala-3.3.4/classes ...
[success] Total time: 0 s, completed Dec 22, 2024, 1:19:40 a.m.
sbt:sbt insanity>  Compile / clean
[success] Total time: 0 s, completed Dec 22, 2024, 1:19:45 a.m.
sbt:sbt insanity>  show Compile / previousCompile
[info] PreviousResult(analysis: Optional[Analysis: 2 Scala sources, 3 classes, 2 binary dependencies], setup: Optional[MiniSetup(output: SingleOutput(/Users/jiahuitan/sbt insanity/target/scala-3.3.4/classes), options: MiniOptions(classpathHash: [Lxsbti.compile.FileHash;@3697cfee, scalacOptions: [Ljava.lang.String;@22a05923, javacOptions: [Ljava.lang.String;@22a05923), compilerVersion: 3.3.4, order: Mixed, storeApis: true, extra: [Lxsbti.T2;@3a7f9efc)])
[success] Total time: 0 s, completed Dec 22, 2024, 1:19:51 a.m.
``` 

### Fix

`Compile / clean`, `Test / clean` uses the below implementation in `Defaults.scala`

https://github.com/sbt/sbt/blob/bb796dc0e4475a156d6b81bae8052ef04c420bf6/main/src/main/scala/sbt/Defaults.scala#L930

Suffices to add logic to clean Zinc cache above, similar to

https://github.com/sbt/sbt/blob/bb796dc0e4475a156d6b81bae8052ef04c420bf6/main/src/main/scala/sbt/Defaults.scala#L713-L726

### Validating the fix

Tested locally on a locally built `sbt`.

```
sbt:test-1-10-7> compile
[success] Total time: 0 s, completed Dec 22, 2024, 1:09:41 a.m.
sbt:test-1-10-7> show previousCompile
[info] PreviousResult(analysis: Optional[Analysis: 2 Scala sources, 3 classes, 2 binary dependencies], setup: Optional[MiniSetup(output: SingleOutput(/Users/jiahuitan/test-1-10-7/target/scala-3.3.4/classes), options: MiniOptions(classpathHash: [Lxsbti.compile.FileHash;@1df8c7f4, scalacOptions: [Ljava.lang.String;@75a6cdb, javacOptions: [Ljava.lang.String;@75a6cdb), compilerVersion: 3.3.4, order: Mixed, storeApis: true, extra: [Lxsbti.T2;@1ce07709)])
[success] Total time: 0 s, completed Dec 22, 2024, 1:09:50 a.m.
sbt:test-1-10-7> clean
[success] Total time: 0 s, completed Dec 22, 2024, 1:09:51 a.m.
sbt:test-1-10-7> show previousCompile
[info] PreviousResult(analysis: Optional.empty, setup: Optional.empty)
[success] Total time: 0 s, completed Dec 22, 2024, 1:09:58 a.m.
sbt:test-1-10-7> Compile / compile
[info] compiling 1 Scala source to /Users/jiahuitan/test-1-10-7/target/scala-3.3.4/classes ...
[success] Total time: 1 s, completed Dec 22, 2024, 1:10:07 a.m.
sbt:test-1-10-7> clean
[success] Total time: 0 s, completed Dec 22, 2024, 1:10:14 a.m.
sbt:test-1-10-7> show previousCompile
[info] PreviousResult(analysis: Optional.empty, setup: Optional.empty)
[success] Total time: 0 s, completed Dec 22, 2024, 1:10:17 a.m.
sbt:test-1-10-7> show Compile / previousCompile
[info] PreviousResult(analysis: Optional.empty, setup: Optional.empty)
[success] Total time: 0 s, completed Dec 22, 2024, 1:10:25 a.m.
sbt:test-1-10-7> show Test / previousCompile
[info] compiling 1 Scala source to /Users/jiahuitan/test-1-10-7/target/scala-3.3.4/classes ...
[info] PreviousResult(analysis: Optional.empty, setup: Optional.empty)
[success] Total time: 0 s, completed Dec 22, 2024, 1:10:40 a.m.
sbt:test-1-10-7> Test / compile
[info] compiling 1 Scala source to /Users/jiahuitan/test-1-10-7/target/scala-3.3.4/test-classes ...
[success] Total time: 0 s, completed Dec 22, 2024, 1:10:56 a.m.
sbt:test-1-10-7> show Test / previousCompile
[info] PreviousResult(analysis: Optional[Analysis: 1 Scala source, 1 class, 1 binary dependency], setup: Optional[MiniSetup(output: SingleOutput(/Users/jiahuitan/test-1-10-7/target/scala-3.3.4/test-classes), options: MiniOptions(classpathHash: [Lxsbti.compile.FileHash;@14e8304b, scalacOptions: [Ljava.lang.String;@75a6cdb, javacOptions: [Ljava.lang.String;@75a6cdb), compilerVersion: 3.3.4, order: Mixed, storeApis: true, extra: [Lxsbti.T2;@7b0d88e0)])
[success] Total time: 0 s, completed Dec 22, 2024, 1:11:01 a.m.
sbt:test-1-10-7> Test / clean
[success] Total time: 0 s, completed Dec 22, 2024, 1:11:05 a.m.
sbt:test-1-10-7> show Test / previousCompile
[info] PreviousResult(analysis: Optional.empty, setup: Optional.empty)
[success] Total time: 0 s, completed Dec 22, 2024, 1:11:16 a.m.

```