### PR TITLE
[1.x] Avoid upstream compilation when calling `previousCompile`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2580,6 +2580,7 @@ object Defaults extends BuildCommon {
   private[sbt] def jnone[A]: Optional[A] = none[A].toOptional
   def compileAnalysisSettings: Seq[Setting[_]] = Seq(
     previousCompile := {
+      // Avoid compileIncSetup since it would trigger upstream compilation
       val analysisFile = compileAnalysisFile.value
       val store = AnalysisUtil.staticCachedStore(
         analysisFile = analysisFile.toPath,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2580,9 +2580,9 @@ object Defaults extends BuildCommon {
   private[sbt] def jnone[A]: Optional[A] = none[A].toOptional
   def compileAnalysisSettings: Seq[Setting[_]] = Seq(
     previousCompile := {
-      val setup = compileIncSetup.value
+      val analysisFile = compileAnalysisFile.value
       val store = AnalysisUtil.staticCachedStore(
-        analysisFile = setup.cacheFile.toPath,
+        analysisFile = analysisFile.toPath,
         useTextAnalysis = !enableBinaryCompileAnalysis.value,
         useConsistent = enableConsistentCompileAnalysis.value,
       )


### PR DESCRIPTION
### Issue

`previousCompile` triggers upstream project compilation. So when user do `show B / previousCompile`, without the user knowing, upstream projects of `B` are compiled.

c.c. #7982

### Fix

Avoid usage of `compileIncSetup` in `previousCompile`. `compileIncSetup` task triggers upstream compilation to gather upstream analysis.


Fix #7982