### PR TITLE
Fix race condition in NetworkChannel

### DIFF
--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -241,7 +241,6 @@ final class NetworkChannel(
       }
     }
   }
-  thread.start()
 
   private[sbt] def isLanguageServerProtocol: Boolean = true
 
@@ -365,7 +364,6 @@ final class NetworkChannel(
     impl()
   }, s"sbt-$name-write-thread")
   writeThread.setDaemon(true)
-  writeThread.start()
 
   def publishBytes(event: Array[Byte], delimit: Boolean): Unit =
     try pendingWrites.put(event -> delimit)
@@ -914,6 +912,9 @@ final class NetworkChannel(
     }
   }
   private[sbt] def isAttached: Boolean = attached.get
+
+  thread.start()
+  writeThread.start()
 }
 
 object NetworkChannel {

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -163,7 +163,7 @@ final class NetworkChannel(
       }
   }
 
-  val thread = new Thread(s"sbt-networkchannel-${connection.getPort}") {
+  private[this] val thread = new Thread(s"sbt-networkchannel-${connection.getPort}") {
     private val ct = "Content-Type: "
     private val x1 = "application/sbt-x1"
     override def run(): Unit = {


### PR DESCRIPTION
Fixes #6864

`NetworkChannel` starts two threads which may reference `outputBuffer` before the field is initialized, resulting in a NPE:
```
Exception in thread "sbt-networkchannel-0" java.lang.NullPointerException: Cannot enter synchronized block because "this.sbt$internal$server$NetworkChannel$$outputBuffer" is null
        at sbt.internal.server.NetworkChannel.sbt$internal$server$NetworkChannel$$doFlush(NetworkChannel.scala:672)
        at sbt.internal.server.NetworkChannel.shutdown(NetworkChannel.scala:568)
        at sbt.internal.server.NetworkChannel.shutdown(NetworkChannel.scala:554)
        at sbt.internal.server.NetworkChannel$$anon$3.run(NetworkChannel.scala:190)
```

It's easier to see in the disassembly:
```java
public NetworkChannel(...) {
    ...
    this.thread = new Thread(...); // calls shutdown
    this.thread().start();
    this.writeThread = new Thread(...); // also calls shutdown
    this.writeThread.setDaemon(true);
    this.writeThread.start();
    this.sbt$internal$server$NetworkChannel$$outputBuffer = new LinkedBlockingQueue();
    this.sbt$internal$server$NetworkChannel$$flushExecutor = Executors.newSingleThreadScheduledExecutor(...);
}
```

This PR moves the thread start to the end of the constructor.
