### PR TITLE
Add setting to allow demoting the SIP-51 build failure

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -571,6 +571,7 @@ object Keys {
   val conflictManager = settingKey[ConflictManager]("Selects the conflict manager to use for dependency management.").withRank(CSetting)
   val autoScalaLibrary = settingKey[Boolean]("Adds a dependency on scala-library if true.").withRank(ASetting)
   val managedScalaInstance = settingKey[Boolean]("Automatically obtains Scala tools as managed dependencies if true.").withRank(BSetting)
+  val allowUnsafeScalaLibUpgrade = settingKey[Boolean]("Allow the Scala library on the compilation classpath to be newer than the scalaVersion (see Scala SIP-51).").withRank(CSetting)
   val sbtResolver = settingKey[Resolver]("Provides a resolver for obtaining sbt as a dependency.").withRank(BMinusSetting)
   val sbtResolvers = settingKey[Seq[Resolver]]("The external resolvers for sbt and plugin dependencies.").withRank(BMinusSetting)
   val sbtDependency = settingKey[ModuleID]("Provides a definition for declaring the current version of sbt.").withRank(BMinusSetting)

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -34,6 +34,7 @@ object LintUnused {
       commands,
       crossScalaVersions,
       crossSbtVersions,
+      allowUnsafeScalaLibUpgrade,
       initialize,
       lintUnusedKeysOnLoad,
       onLoad,

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/a/A.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/a/A.scala
@@ -1,0 +1,27 @@
+import scala.language.reflectiveCalls
+
+
+package scala.collection.immutable {
+  object Exp {
+    // Access RedBlackTree.validate added in Scala 2.13.13
+    def v = RedBlackTree.validate(null)(null)
+  }
+}
+
+
+object A extends App {
+  println(scala.util.Properties.versionString)
+}
+
+object AMacro {
+  import scala.language.experimental.macros
+  import scala.reflect.macros.blackbox.Context
+
+  def m(x: Int): Int = macro impl
+
+  def impl(c: Context)(x: c.Expr[Int]): c.Expr[Int] = {
+    import c.universe._
+    println(scala.collection.immutable.Exp.v)
+    c.Expr(q"2 + $x")
+  }
+}

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/b/B.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/b/B.scala
@@ -1,0 +1,7 @@
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+
+object B extends App {
+  println(AMacro.m(33)) // fails
+  Files.write(Paths.get(s"s${scala.util.Properties.versionNumberString}.txt"), "nix".getBytes)
+}

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/build.sbt
@@ -1,0 +1,39 @@
+import sbt.librarymanagement.InclExclRule
+
+lazy val a = project.settings(
+  scalaVersion := "2.13.13",
+  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.13", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
+)
+
+lazy val b = project.dependsOn(a).settings(
+  allowUnsafeScalaLibUpgrade := true,
+  scalaVersion := "2.13.12",
+
+  // dependencies are upgraded to 2.13.13
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.13", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
+
+  // check the compiler uses the 2.13.12 library on its runtime classpath
+  TaskKey[Unit]("checkScala") := {
+    val i = scalaInstance.value
+    i.libraryJars.filter(_.toString.contains("scala-library")).toList match {
+      case List(l) => assert(l.toString.contains("2.13.12"), i.toString)
+    }
+    assert(i.compilerJars.filter(_.toString.contains("scala-library")).isEmpty, i.toString)
+    assert(i.otherJars.filter(_.toString.contains("scala-library")).isEmpty, i.toString)
+  },
+)
+
+lazy val c = project.dependsOn(a).settings(
+  allowUnsafeScalaLibUpgrade := true,
+  scalaVersion := "2.13.12",
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.13", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
+)
+
+def checkLibs(v: String, cp: Classpath, filter: String): Unit = {
+  for (p <- cp)
+    if (p.toString.matches(filter)) {
+      println(s"$p -- $v")
+      assert(p.toString.contains(v), p)
+    }
+}

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/c/C.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/c/C.scala
@@ -1,0 +1,7 @@
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+
+object C extends App {
+  assert(scala.collection.immutable.Exp.v == null)
+  Files.write(Paths.get(s"s${scala.util.Properties.versionNumberString}.txt"), "nix".getBytes)
+}

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-warn/test
@@ -1,0 +1,11 @@
+> a/checkLibs
+> b/checkLibs
+> b/checkScala
+> c/checkLibs
+
+# macro expansion fails
+-> b/compile
+
+> c/run
+$ exists s2.13.13.txt
+$ delete s2.13.13.txt


### PR DESCRIPTION
Add a `allowUnsafeScalaLibUpgrade` setting (default is `false`) to demote the SIP-51 build failure to a warning.

Follow-up for https://github.com/sbt/sbt/pull/7480.

If the scalaVersion is 2.13.12 but some dependency pulls in scala-library 2.13.13, the compiler will stay at 2.13.12, but the dependency classpath will contain scala-library 2.13.13.

This usually works, the compiler can run fine with a newer scala-library on its dependency classpath.
Macro expansion may fail, if the macro uses some library class / method that doesn't exist in the old version. The macro itself is loaded from the dependency classpath into the class loader running the compiler, where the older Scala library is on the runtime classpath.
Using the Scala REPL in sbt may also fail in a similar fashion.

Example how the warning looks:

```
[warn] Expected `b/scalaVersion` to be 2.13.13 or later, but found 2.13.12.
[warn] To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
[warn] should not be older than scala-library on the dependency classpath.
[warn]
[warn] Note that the dependency classpath and the runtime classpath of your project
[warn] contain the newer scala-library 2.13.13, even if the scalaVersion is 2.13.12.
[warn] Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.
[warn]
[warn] See `b/evicted` to know why scala-library 2.13.13 is getting pulled in.
```