### PR TITLE
[2.x] fix: Fix build.sbt position

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -97,8 +97,8 @@ class Eval(
           |  }
           |}
           |""".stripMargin
-        val startLine = header.linesIterator.toList.size
-        EvalSourceFile(srcName, startLine, contents)
+        val headerLine = header.linesIterator.toList.size
+        EvalSourceFile(srcName, headerLine, line - 1, contents)
 
       override def extract(run: Run, unit: CompilationUnit)(using ctx: Context): String =
         atPhase(Phases.typerPhase.next) {
@@ -159,8 +159,8 @@ class Eval(
           |${definitions.map(_._1).mkString("\n")}
           |}
           |""".stripMargin
-        val startLine = header.linesIterator.toList.size
-        EvalSourceFile(srcName, startLine, contents)
+        val headerLine = header.linesIterator.toList.size
+        EvalSourceFile(srcName, headerLine, 0, contents)
 
       override def extract(run: Run, unit: CompilationUnit)(using ctx: Context): Seq[String] =
         atPhase(Phases.typerPhase.next) {
@@ -319,13 +319,15 @@ object Eval:
   private[sbt] final val WrapValName = "$sbtdef"
 
   // used to map the position offset
-  class EvalSourceFile(name: String, startLine: Int, contents: String)
+  class EvalSourceFile(name: String, headerLine: Int, extraLine: Int, contents: String)
       extends SourceFile(
         new VirtualFile(name, contents.getBytes(StandardCharsets.UTF_8)),
         contents.toArray
       ):
-    override def lineToOffset(line: Int): Int = super.lineToOffset((line + startLine) max 0)
-    override def offsetToLine(offset: Int): Int = super.offsetToLine(offset) - startLine
+    override def lineToOffset(line: Int): Int =
+      super.lineToOffset((line + headerLine - extraLine) max 0)
+    override def offsetToLine(offset: Int): Int =
+      super.offsetToLine(offset) - headerLine + extraLine
   end EvalSourceFile
 
   trait EvalType[A]:


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7705

## Problem
Compiler warnings and errors is not correct for build.sbt.

## Solution
This adds line offset to the synthetic Scala file
so the original line position is displayed in the errors.

## Test

```scala
$ sbt
[info] welcome to sbt 2.0.0-SNAPSHOT (Azul Systems, Inc. Java 17.0.12)
[info] loading project definition from /private/tmp/foo/project
-- Deprecation Warning: /private/tmp/foo/build.sbt:2:2 -------------------------
2 |  Stream(1).sum
  |  ^^^^^^
  |value Stream in package scala is deprecated since 2.13.0: Use LazyList instead of Stream
-- Deprecation Warning: /private/tmp/foo/build.sbt:6:2 -------------------------
6 |  Stream(2).sum
  |  ^^^^^^
  |value Stream in package scala is deprecated since 2.13.0: Use LazyList instead of Stream
-- Deprecation Warning: /private/tmp/foo/build.sbt:10:2 ------------------------
10 |  Stream(3).sum
   |  ^^^^^^
   |value Stream in package scala is deprecated since 2.13.0: Use LazyList instead of Stream
```
