### PR TITLE
provide overloaded sbt.SettingKey.apply for label + rank, for better sbt plugins cross compilation between sbt 1.x and 2.x

### DIFF
--- a/main-settings/src/main/scala/sbt/Structure.scala
+++ b/main-settings/src/main/scala/sbt/Structure.scala
@@ -816,6 +816,16 @@ object SettingKey:
 
   def apply[A1: ClassTag: OptJsonWriter](
       label: String,
+      rank: Int,
+  ): SettingKey[A1] =
+    apply[A1](
+      label = label,
+      description = "",
+      rank = rank,
+    )
+
+  def apply[A1: ClassTag: OptJsonWriter](
+      label: String,
       description: String,
       rank: Int
   ): SettingKey[A1] =


### PR DESCRIPTION

Example: sbt-structure plugin.
It is currently cross-compiled for sbt 0.13, 1.2 and 1.3 but I am adding support for 2.0 for IntelliJ compat.
https://github.com/JetBrains/sbt-structure/blob/e65f4ecab65724b9f627dbadc4d6e16239358fd9/extractor/src/main/scala/org/jetbrains/sbt/StructureKeys.scala#L12
```scala
  val dependencyConfigurations: SettingKey[Seq[Configuration]] = SettingKey("ssDependencyConfigurations", rank = Invisible)
  val sourceConfigurations: SettingKey[Seq[Configuration]] = SettingKey("ssSourceConfigurations", rank = Invisible)
  val testConfigurations: SettingKey[Seq[Configuration]] = SettingKey("ssTestConfigurations", rank = Invisible)
  val acceptedProjects: TaskKey[Seq[ProjectRef]] = TaskKey("ssAcceptedProjects", rank = Invisible)
```

It would be nice to avoid specifying empty description `description = ""` everywhere just to make it compile in Scala 3.
An alternative solution would be to use `withRank`:
```scala
val dependencyConfigurations: SettingKey[Seq[Configuration]] = SettingKey[Seq[Configuration]]("ssDependencyConfigurations").withRank(Invisible)
```
But this solution requires duplication of the type argument (`[Seq[Configuration]]` in this case).
It would be nice to avoid code modifications completely, which should be solved by the new `sbt.SettingKey.apply` overload

