### PR TITLE
[2.x] Implement worker + forked console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -531,6 +531,34 @@ lazy val testAgentProj = (project in file("testing") / "agent")
     mimaSettings,
   )
 
+lazy val workerProj = (project in file("worker"))
+  .dependsOn(exampleWorkProj % Test)
+  .settings(
+    name := "worker",
+    testedBaseSettings,
+    Compile / doc / javacOptions := Nil,
+    autoScalaLibrary := false,
+    libraryDependencies ++=
+      Seq(
+        jline,
+        jline3Terminal,
+        jline3JNI,
+        jline3Native,
+        jline3Reader,
+      ),
+    libraryDependencies += "org.scala-lang" %% "scala3-library" % scalaVersion.value % Test,
+    // run / fork := false,
+    Test / fork := true,
+  )
+  .configure(addSbtIOForTest)
+
+lazy val exampleWorkProj = (project in file("internal") / "example-work")
+  .settings(
+    minimalSettings,
+    name := "example work",
+    publish / skip := true,
+  )
+
 // Basic task engine
 lazy val taskProj = (project in file("tasks"))
   .dependsOn(collectionProj, utilControl)
@@ -656,24 +684,17 @@ lazy val actionsProj = (project in file("main-actions"))
     utilLogging,
     utilRelation,
     utilTracking,
+    workerProj,
+    protocolProj,
   )
   .settings(
     testedBaseSettings,
     name := "Actions",
     libraryDependencies += sjsonNewScalaJson.value,
     libraryDependencies += jline3Terminal,
+    // Test / fork := true,
+    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     mimaSettings,
-    mimaBinaryIssueFilters ++= Seq(
-      // Removed unused private[sbt] nested class
-      exclude[MissingClassProblem]("sbt.Doc$Scaladoc"),
-      // Removed no longer used private[sbt] method
-      exclude[DirectMissingMethodProblem]("sbt.Doc.generate"),
-      exclude[DirectMissingMethodProblem]("sbt.compiler.Eval.filesModifiedBytes"),
-      exclude[DirectMissingMethodProblem]("sbt.compiler.Eval.fileModifiedBytes"),
-      exclude[DirectMissingMethodProblem]("sbt.Doc.$init$"),
-      // Added field in nested private[this] class
-      exclude[ReversedMissingMethodProblem]("sbt.compiler.Eval#EvalType.sourceName"),
-    ),
   )
   .dependsOn(lmCore)
   .configure(
@@ -1227,6 +1248,7 @@ def allProjects =
     lmCoursier,
     lmCoursierShaded,
     lmCoursierShadedPublishing,
+    workerProj,
   ) ++ lowerUtilProjects
 
 // These need to be cross published to 2.12 and 2.13 for Zinc

--- a/internal/example-work/src/main/scala/Hello.scala
+++ b/internal/example-work/src/main/scala/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+class Hello
+
+object Hello:
+  def main(args: Array[String]): Unit =
+    if args.toList == List("boom") then sys.error("boom")
+    else println(s"${args.mkString}")
+end Hello

--- a/main-actions/src/main/scala/sbt/internal/ConsoleMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/ConsoleMain.scala
@@ -1,0 +1,102 @@
+package sbt
+package internal
+
+import java.io.File
+import java.nio.file.Paths
+// import org.jline.terminal.{ Terminal as JTerminal }
+import sbt.internal.inc.{ AnalyzingCompiler, ScalaInstance, ZincUtil }
+import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.internal.worker.ConsoleConfig
+import sbt.io.IO
+import sbt.util.{ LogExchange, Logger }
+import sjsonnew.support.scalajson.unsafe.{ Parser, Converter }
+import xsbti.compile.ClasspathOptionsUtil
+// import sbt.internal.util.{ DeprecatedJLine } // Terminal as ITerminal
+
+class ConsoleMain:
+  def run(config: ConsoleConfig): Unit =
+    val si = scalaInstance(config)
+    val compiler = analyzingCompiler(config, si)
+    val console = new Console(compiler)
+    given log: Logger = LogExchange.logger("console")
+    val externalCp = config.externalDependencyJars.map(Paths.get(_))
+    IO.withTemporaryDirectory: tempDir =>
+      val loader = ClasspathUtil.makeLoader(externalCp, si, tempDir.toPath())
+      // DeprecatedJLine.setTerminalOverride(jline3)
+      console(
+        classpath = externalCp.map(_.toFile),
+        options = Nil,
+        loader = loader,
+        initialCommands = "",
+        cleanupCommands = "",
+      )()
+
+  // def jline3: JTerminal =
+  //   val term =
+  //     org.jline.terminal.TerminalBuilder
+  //       .builder()
+  //       .system(false)
+  //       // .paused(true)
+  //       .build()
+  //   term
+
+  def analyzingCompiler(config: ConsoleConfig, si: ScalaInstance): AnalyzingCompiler =
+    val bridgeProvider = ZincUtil.constantBridgeProvider(si, new File(config.bridgeJar))
+    val classpathOptions = ClasspathOptionsUtil.auto()
+    AnalyzingCompiler(
+      si,
+      bridgeProvider,
+      classpathOptions,
+      _ => (),
+      None
+    )
+
+  def scalaInstance(config: ConsoleConfig): ScalaInstance =
+    val siConfig = config.scalaInstanceConfig
+    val libraryJars = siConfig.libraryJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val allCompilerJars =
+      siConfig.allCompilerJars
+        .map(Paths.get(_))
+        .sortBy(_.getFileName.toString())
+    val jlineJars = allCompilerJars.filter(_.getFileName.toString().contains("jline"))
+    val compilerJars =
+      allCompilerJars.filterNot(x => libraryJars.contains(x) || jlineJars.contains(x)).distinct
+    val allDocJars = siConfig.allDocJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val docJars = allDocJars
+      .filterNot(jar => libraryJars.contains(jar) || compilerJars.contains(jar))
+      .distinct
+    val allJars = libraryJars ++ compilerJars ++ docJars
+    // val jlineLoader = ClasspathUtil.toLoader(jlineJars)
+    val jlineLoader = classOf[org.jline.terminal.Terminal].getClassLoader()
+    val currentLoader = classOf[ConsoleMain].getClassLoader()
+    val libraryLoader = ClasspathUtil.toLoader(libraryJars, jlineLoader)
+    val compilerLoader = ClasspathUtil.toLoader(compilerJars, libraryLoader)
+    val fullLoader =
+      if docJars.isEmpty then compilerLoader
+      else ClasspathUtil.toLoader(docJars, compilerLoader)
+    new ScalaInstance(
+      version = siConfig.scalaVersion,
+      loader = fullLoader,
+      loaderCompilerOnly = compilerLoader,
+      loaderLibraryOnly = libraryLoader,
+      libraryJars = libraryJars.map(_.toFile).toArray,
+      compilerJars = compilerJars.map(_.toFile).toArray,
+      allJars = allJars.map(_.toFile).toArray,
+      explicitActual = Some(siConfig.scalaVersion)
+    )
+end ConsoleMain
+
+object ConsoleMain:
+  def main(args: Array[String]): Unit =
+    args.toList match
+      case Nil => println("ConsoleMain")
+      case arg :: Nil if arg.startsWith("@") =>
+        import sbt.internal.worker.codec.JsonProtocol.given
+        val arg1 = arg.drop(1)
+        val s = IO.read(File(arg1))
+        val json = Parser.parseFromString(s).get
+        val config = Converter.fromJson[ConsoleConfig](json).get
+        val main = ConsoleMain()
+        main.run(config)
+      case _ => sys.exit(1)
+end ConsoleMain

--- a/main-actions/src/main/scala/sbt/internal/ForkWorker.scala
+++ b/main-actions/src/main/scala/sbt/internal/ForkWorker.scala
@@ -1,0 +1,97 @@
+package sbt
+package internal
+
+import java.net.URLClassLoader
+import java.nio.file.{ Files, Path, Paths }
+import java.io.File
+import java.util.Properties
+import sbt.internal.worker.{ ConsoleConfig, WorkerMain }
+import sbt.io.IO
+import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter }
+import sbt.internal.util.{ Terminal as ITerminal }
+
+// Used for currentClasspath
+private[sbt] class ForkWorker
+
+private[sbt] object ForkWorker:
+  def console(config: ConsoleConfig): Int =
+    IO.withTemporaryDirectory: tempDir =>
+      import sbt.internal.worker.codec.JsonProtocol.given
+      val json = Converter.toJson[ConsoleConfig](config).get
+      // change to the following to debug params.json
+      // val params = Paths.get("/tmp/params.json")
+      val params = tempDir.toPath().resolve("params.json")
+      IO.write(params.toFile(), CompactPrinter(json))
+      runWithCurrentClasspath(
+        mainClass = classOf[ConsoleMain].getCanonicalName,
+        args = List(s"@$params"),
+      )
+
+  def runWithCurrentClasspath(mainClass: String, args: List[String]): Int =
+    run(
+      mainClass = mainClass,
+      classpath = currentClasspath,
+      args = args,
+    )
+
+  /**
+   * Runs arbitrary mainClass with arbitrary classpath using a worker.
+   */
+  def run(mainClass: String, classpath: List[Path], args: List[String]): Int =
+    IO.withTemporaryDirectory: tempDir =>
+      val props = Properties()
+      props.setProperty("mainClass", mainClass)
+      classpath.zipWithIndex.foreach { case (item, idx) =>
+        props.setProperty(f"classpath$idx%04d", item.toString())
+      }
+      args.zipWithIndex.foreach { case (item, idx) =>
+        props.setProperty(f"args$idx%04d", item.toString())
+      }
+      // change to the following to debug 0.params
+      // val propPath = Paths.get("/tmp/0.param")
+      val propPath = tempDir.toPath().resolve("0.params")
+      val out = Files.newOutputStream(propPath)
+      try {
+        props.store(out, "")
+      } finally out.close()
+      val fullCp = Seq(
+        IO.classLocationPath(classOf[WorkerMain]),
+        IO.classLocationPath(classOf[jline.Terminal]),
+        IO.classLocationPath(classOf[org.jline.terminal.impl.jni.JniNativePty]),
+        IO.classLocationPath(classOf[org.jline.terminal.Terminal]),
+        IO.classLocationPath(classOf[org.jline.reader.History]),
+        IO.classLocationPath(classOf[org.jline.nativ.JLineLibrary]),
+        IO.classLocationPath(classOf[org.jline.builtins.Source]),
+        IO.classLocationPath(classOf[org.jline.utils.InfoCmp]),
+        IO.classLocationPath(classOf[org.jline.style.StyleFactory]),
+        IO.classLocationPath(classOf[org.jline.keymap.KeyMap[?]]),
+      )
+      val javaArgs = Seq(
+        "-classpath",
+        fullCp.mkString(File.pathSeparator),
+        classOf[WorkerMain].getCanonicalName,
+        "run",
+        propPath.toString()
+      )
+      val forkOptions = ForkOptions()
+        .withEnvVars(sys.env)
+        .withConnectInput(true)
+        .withRunJVMOptions(Vector("-Dsbt.io.virtual=false"))
+      val terminal = ITerminal.console
+      terminal.restore()
+      val exitCode = Fork.java(
+        config = forkOptions,
+        arguments = javaArgs,
+      )
+      terminal.restore()
+      exitCode
+
+  def currentClasspath: List[Path] =
+    val cl = classOf[ForkWorker].getClassLoader() match
+      case cl: URLClassLoader => cl
+    val urls = cl.getURLs().toList
+    urls.map((u) => Paths.get(u.toURI())) ++ Vector(
+      IO.classLocationPath(classOf[xsbti.compile.ScalaInstance]),
+      IO.classLocationPath(classOf[xsbti.Logger]),
+    )
+end ForkWorker

--- a/main-actions/src/test/scala/sbt/internal/ForkWorkerTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/ForkWorkerTest.scala
@@ -1,0 +1,12 @@
+package sbt.internal
+
+object ForkWorkerTest extends verify.BasicTestSuite:
+  test("test") {
+    assert(
+      ForkWorker.runWithCurrentClasspath(
+        mainClass = classOf[ConsoleMain].getCanonicalName,
+        args = List(),
+      ) == 0
+    )
+  }
+end ForkWorkerTest

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -58,6 +58,7 @@ import sbt.internal.server.{
   VirtualTerminal
 }
 import sbt.internal.testing.TestLogger
+import sbt.internal.worker.ConsoleConfig
 import sbt.internal.util.Attributed.data
 import sbt.internal.util.Types.*
 import sbt.internal.util.{ Terminal as ITerminal, * }
@@ -743,6 +744,12 @@ object Defaults extends BuildCommon {
         Some(jar)
       else None
     },
+    scalaCompilerBridgeJar := (Def.taskDyn {
+      val s = streams.value
+      val b = scalaCompilerBridgeBinaryJar.value
+      if b.isDefined then Def.task { b.get }
+      else scalaCompilerBridgeJarTask(scalaCompilerBridgeSource, s.log)
+    }).value,
     scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),
     auxiliaryClassFiles ++= {
       if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
@@ -752,6 +759,12 @@ object Defaults extends BuildCommon {
     consoleProject / scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(
       appConfiguration.value.provider.scalaProvider.version
     ),
+    consoleProject / scalaCompilerBridgeJar := (Def.taskDyn {
+      val s = streams.value
+      val b = scalaCompilerBridgeBinaryJar.value
+      if (consoleProject / scalaCompilerBridgeBinaryJar).value.isDefined then Def.task { b.get }
+      else scalaCompilerBridgeJarTask(consoleProject / scalaCompilerBridgeSource, s.log)
+    }).value,
     classpathOptions := ClasspathOptionsUtil.noboot(scalaVersion.value),
     console / classpathOptions := ClasspathOptionsUtil.replNoboot(scalaVersion.value),
   )
@@ -768,6 +781,25 @@ object Defaults extends BuildCommon {
       derive(scalaBinaryVersion := binaryScalaVersion(scalaVersion.value))
     )
   )
+
+  def scalaCompilerBridgeJarTask(sourceKey: Def.Initialize[ModuleID], log: Logger) = Def.task {
+    val st = state.value
+    val g = BuildPaths.getGlobalBase(st)
+    val zincDir = BuildPaths.getZincDirectory(st, g)
+    val app = appConfiguration.value
+    val launcher = app.provider.scalaProvider.launcher
+    val dr = scalaCompilerBridgeDependencyResolution.value
+    ZincLmUtil.scalaCompilerBridge(
+      scalaInstance = scalaInstance.value,
+      globalLock = launcher.globalLock,
+      componentProvider = app.provider.components,
+      secondaryCacheDir = Option(zincDir),
+      dependencyResolution = dr,
+      compilerBridgeSource = scalaCompilerBridgeSource.value,
+      scalaJarsTarget = zincDir,
+      log = log
+    )
+  }
 
   def makeCrossSources(
       scalaSrcDir: File,
@@ -838,29 +870,12 @@ object Defaults extends BuildCommon {
       val app = appConfiguration.value
       val launcher = app.provider.scalaProvider.launcher
       val dr = scalaCompilerBridgeDependencyResolution.value
-      val scalac =
-        scalaCompilerBridgeBinaryJar.value match {
-          case Some(jar) =>
-            AlternativeZincUtil.scalaCompiler(
-              scalaInstance = scalaInstance.value,
-              classpathOptions = classpathOptions.value,
-              compilerBridgeJar = jar,
-              classLoaderCache = st.get(BasicKeys.classLoaderCache)
-            )
-          case _ =>
-            ZincLmUtil.scalaCompiler(
-              scalaInstance = scalaInstance.value,
-              classpathOptions = classpathOptions.value,
-              globalLock = launcher.globalLock,
-              componentProvider = app.provider.components,
-              secondaryCacheDir = Option(zincDir),
-              dependencyResolution = dr,
-              compilerBridgeSource = scalaCompilerBridgeSource.value,
-              scalaJarsTarget = zincDir,
-              classLoaderCache = st.get(BasicKeys.classLoaderCache),
-              log = streams.value.log
-            )
-        }
+      val scalac = AlternativeZincUtil.scalaCompiler(
+        scalaInstance = scalaInstance.value,
+        classpathOptions = classpathOptions.value,
+        compilerBridgeJar = scalaCompilerBridgeJar.value,
+        classLoaderCache = st.get(BasicKeys.classLoaderCache)
+      )
       val compilers = ZincUtil.compilers(
         instance = scalaInstance.value,
         classpathOptions = classpathOptions.value,
@@ -901,6 +916,7 @@ object Defaults extends BuildCommon {
     configGlobal ++ compileAnalysisSettings ++ Seq(
       compileOutputs := {
         import scala.jdk.CollectionConverters.*
+        val s = streams.value
         val c = fileConverter.value
         val (_, vfDir, packedDir) = compileIncremental.value
         val classFiles = compile.value.readStamps.getAllProductStamps.keySet.asScala
@@ -1005,7 +1021,10 @@ object Defaults extends BuildCommon {
         cache.get
       },
       compileIncSetup := compileIncSetupTask.value,
-      console := consoleTask.value,
+      console := {
+        if (console / fork).value then forkedConsoleTask.value
+        else consoleTask.value
+      },
       collectAnalyses := Definition.collectAnalysesTask.map(_ => ()).value,
       consoleQuick := consoleQuickTask.value,
       discoveredMainClasses := compile
@@ -2216,6 +2235,22 @@ object Defaults extends BuildCommon {
       val cc = (task / cleanupCommands).value
       (new Console(compiler))(cpFiles, sc, loader, ic, cc)()(using s.log).get
       println()
+    }
+
+  private def forkedConsoleTask: Initialize[Task[Unit]] =
+    Def.task {
+      val sic = Compiler.scalaInstanceConfigTask.value
+      val bridge = scalaCompilerBridgeJar.value
+      val conv = fileConverter.value
+      val depsJars = externalDependencyClasspath.value.toVector
+        .map(_.data)
+        .map(conv.toPath)
+      val config = ConsoleConfig(
+        scalaInstanceConfig = sic,
+        bridgeJar = bridge.toString(),
+        externalDependencyJars = depsJars.map(_.toString()),
+      )
+      ForkWorker.console(config)
     }
 
   private def exported(w: PrintWriter, command: String): Seq[String] => Unit =
@@ -4170,6 +4205,7 @@ object Classpaths {
     }
 
   def makeProducts: Initialize[Task[Seq[File]]] = Def.task {
+    val s = streams.value
     val c = fileConverter.value
     val resources = copyResources.value.map(_._2).toSet
     val classDir = classDirectory.value

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -236,6 +236,7 @@ object Keys {
   val scalaCompilerBridgeBinaryJar = taskKey[Option[File]]("Optionally, the jar of the compiler bridge. When not None, this takes precedence over scalaCompilerBridgeSource").withRank(CSetting)
   val scalaCompilerBridgeSource = settingKey[ModuleID]("Configures the module ID of the sources of the compiler bridge when scalaCompilerBridgeBinaryJar is None").withRank(CSetting)
   val scalaCompilerBridgeScope = taskKey[Unit]("The compiler bridge scope.").withRank(DTask)
+  val scalaCompilerBridgeJar = taskKey[File]("The compiler bridge JAR.").withRank(CSetting)
   val scalaArtifacts = settingKey[Seq[String]]("Configures the list of artifacts which should match the Scala binary version").withRank(CSetting)
   val crossJavaVersions = settingKey[Seq[String]]("The java versions used during JDK cross testing").withRank(BPlusSetting)
   val semanticdbEnabled = settingKey[Boolean]("Enables SemanticDB Scalac plugin").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -3,6 +3,7 @@ package internal
 
 import java.io.File
 import sbt.internal.inc.ScalaInstance
+import sbt.internal.worker.ScalaInstanceConfig
 import sbt.librarymanagement.{
   Artifact,
   Configurations,
@@ -15,15 +16,28 @@ import xsbti.ScalaProvider
 
 object Compiler:
   def scalaInstanceTask: Def.Initialize[Task[ScalaInstance]] =
+    Def.task {
+      val config = scalaInstanceConfigTask.value
+      makeScalaInstance(
+        config.scalaVersion,
+        config.libraryJars.map(File(_)).toArray,
+        config.allCompilerJars.map(File(_)),
+        config.allDocJars.map(File(_)),
+        Keys.state.value,
+        Keys.scalaInstanceTopLoader.value,
+      )
+    }
+
+  def scalaInstanceConfigTask: Def.Initialize[Task[ScalaInstanceConfig]] =
     Def.taskDyn {
       val sh = Keys.scalaHome.value
       val app = Keys.appConfiguration.value
       val sv = Keys.scalaVersion.value
       sh match
-        case Some(h) => scalaInstanceFromHome(h)
+        case Some(h) => scalaInstanceConfigFromHome(h)
         case _ =>
           val scalaProvider = app.provider.scalaProvider
-          scalaInstanceFromUpdate
+          scalaInstanceConfigFromUpdate
     }
 
   // use the same class loader as the Scala classes used by sbt
@@ -51,23 +65,21 @@ object Compiler:
       case _ => ScalaInstance(sv, scalaProvider)
   }
 
-  def scalaInstanceFromHome(dir: File): Def.Initialize[Task[ScalaInstance]] = Def.task {
+  def scalaInstanceConfigFromHome(dir: File): Def.Initialize[Task[ScalaInstanceConfig]] = Def.task {
     val dummy = ScalaInstance(dir)(Keys.state.value.classLoaderCache.apply)
     Seq(dummy.loader, dummy.loaderLibraryOnly).foreach {
       case a: AutoCloseable => a.close()
       case _                =>
     }
-    makeScalaInstance(
+    ScalaInstanceConfig(
       dummy.version,
-      dummy.libraryJars,
-      dummy.compilerJars.toSeq,
-      dummy.allJars.toSeq,
-      Keys.state.value,
-      Keys.scalaInstanceTopLoader.value,
+      dummy.libraryJars.toVector.map(_.toString()),
+      dummy.compilerJars.toVector.map(_.toString()),
+      dummy.allJars.toVector.map(_.toString()),
     )
   }
 
-  def scalaInstanceFromUpdate: Def.Initialize[Task[ScalaInstance]] = Def.task {
+  def scalaInstanceConfigFromUpdate: Def.Initialize[Task[ScalaInstanceConfig]] = Def.task {
     val sv = Keys.scalaVersion.value
     val fullReport = Keys.update.value
 
@@ -135,13 +147,13 @@ object Compiler:
         .flatMap(_.artifacts.map(_._2))
     val libraryJars = ScalaArtifacts.libraryIds(sv).map(file)
 
-    makeScalaInstance(
+    ScalaInstanceConfig(
       sv,
-      libraryJars,
-      allCompilerJars,
-      allDocJars,
-      Keys.state.value,
-      Keys.scalaInstanceTopLoader.value,
+      libraryJars.toVector.map(_.toString),
+      allCompilerJars.toVector.map(_.toString),
+      allDocJars.toVector.map(_.toString),
+      // Keys.state.value,
+      // Keys.scalaInstanceTopLoader.value,
     )
   }
 

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -49,6 +49,7 @@ object LintUnused {
       shellPrompt,
       sLog,
       traceLevel,
+      scalaCompilerBridgeSource,
     ),
     includeLintKeys := Set(
       scalacOptions,

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -304,7 +304,11 @@ object BuildServerProtocol {
       OutputPathsItem(id, Vector(OutputPathItem(target.value.toURI, OutputPathItemKind.Directory)))
     },
     bspBuildTargetCompileItem := bspCompileTask.value,
-    bspBuildTargetRun := bspRunTask.evaluated,
+    bspBuildTargetRun := {
+      // declared defensively to prevent References to undefined settings at runtime
+      val s = streams.value
+      bspRunTask.evaluated
+    },
     bspBuildTargetScalacOptionsItem := {
       val target = Keys.bspTargetIdentifier.value
       val scalacOptions = Keys.scalacOptions.value.toVector

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,6 +58,7 @@ object Dependencies {
   }
 
   def addSbtIO = addSbtModule(sbtIoPath, "io", sbtIO)
+  def addSbtIOForTest = addSbtModule(sbtIoPath, "io", sbtIO, Some(Test))
 
   def addSbtCompilerInterface = addSbtModule(sbtZincPath, "compilerInterface", compilerInterface)
   def addSbtCompilerClasspath = addSbtModule(sbtZincPath, "zincClasspath", compilerClasspath)

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/ConsoleConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/ConsoleConfig.scala
@@ -1,0 +1,40 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class ConsoleConfig private (
+  val scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig,
+  val bridgeJar: String,
+  val externalDependencyJars: Vector[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: ConsoleConfig => (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJar == x.bridgeJar) && (this.externalDependencyJars == x.externalDependencyJars)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.ConsoleConfig".##) + scalaInstanceConfig.##) + bridgeJar.##) + externalDependencyJars.##)
+  }
+  override def toString: String = {
+    "ConsoleConfig(" + scalaInstanceConfig + ", " + bridgeJar + ", " + externalDependencyJars + ")"
+  }
+  private def copy(scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJar: String = bridgeJar, externalDependencyJars: Vector[String] = externalDependencyJars): ConsoleConfig = {
+    new ConsoleConfig(scalaInstanceConfig, bridgeJar, externalDependencyJars)
+  }
+  def withScalaInstanceConfig(scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig): ConsoleConfig = {
+    copy(scalaInstanceConfig = scalaInstanceConfig)
+  }
+  def withBridgeJar(bridgeJar: String): ConsoleConfig = {
+    copy(bridgeJar = bridgeJar)
+  }
+  def withExternalDependencyJars(externalDependencyJars: Vector[String]): ConsoleConfig = {
+    copy(externalDependencyJars = externalDependencyJars)
+  }
+}
+object ConsoleConfig {
+  
+  def apply(scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJar: String, externalDependencyJars: Vector[String]): ConsoleConfig = new ConsoleConfig(scalaInstanceConfig, bridgeJar, externalDependencyJars)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/ScalaInstanceConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/ScalaInstanceConfig.scala
@@ -1,0 +1,44 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class ScalaInstanceConfig private (
+  val scalaVersion: String,
+  val libraryJars: Vector[String],
+  val allCompilerJars: Vector[String],
+  val allDocJars: Vector[String]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: ScalaInstanceConfig => (this.scalaVersion == x.scalaVersion) && (this.libraryJars == x.libraryJars) && (this.allCompilerJars == x.allCompilerJars) && (this.allDocJars == x.allDocJars)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.ScalaInstanceConfig".##) + scalaVersion.##) + libraryJars.##) + allCompilerJars.##) + allDocJars.##)
+  }
+  override def toString: String = {
+    "ScalaInstanceConfig(" + scalaVersion + ", " + libraryJars + ", " + allCompilerJars + ", " + allDocJars + ")"
+  }
+  private def copy(scalaVersion: String = scalaVersion, libraryJars: Vector[String] = libraryJars, allCompilerJars: Vector[String] = allCompilerJars, allDocJars: Vector[String] = allDocJars): ScalaInstanceConfig = {
+    new ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, allDocJars)
+  }
+  def withScalaVersion(scalaVersion: String): ScalaInstanceConfig = {
+    copy(scalaVersion = scalaVersion)
+  }
+  def withLibraryJars(libraryJars: Vector[String]): ScalaInstanceConfig = {
+    copy(libraryJars = libraryJars)
+  }
+  def withAllCompilerJars(allCompilerJars: Vector[String]): ScalaInstanceConfig = {
+    copy(allCompilerJars = allCompilerJars)
+  }
+  def withAllDocJars(allDocJars: Vector[String]): ScalaInstanceConfig = {
+    copy(allDocJars = allDocJars)
+  }
+}
+object ScalaInstanceConfig {
+  
+  def apply(scalaVersion: String, libraryJars: Vector[String], allCompilerJars: Vector[String], allDocJars: Vector[String]): ScalaInstanceConfig = new ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, allDocJars)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ConsoleConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ConsoleConfigFormats.scala
@@ -1,0 +1,31 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ConsoleConfigFormats { self: sbt.internal.worker.codec.ScalaInstanceConfigFormats & sjsonnew.BasicJsonProtocol =>
+implicit lazy val ConsoleConfigFormat: JsonFormat[sbt.internal.worker.ConsoleConfig] = new JsonFormat[sbt.internal.worker.ConsoleConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.ConsoleConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val scalaInstanceConfig = unbuilder.readField[sbt.internal.worker.ScalaInstanceConfig]("scalaInstanceConfig")
+      val bridgeJar = unbuilder.readField[String]("bridgeJar")
+      val externalDependencyJars = unbuilder.readField[Vector[String]]("externalDependencyJars")
+      unbuilder.endObject()
+      sbt.internal.worker.ConsoleConfig(scalaInstanceConfig, bridgeJar, externalDependencyJars)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.ConsoleConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("scalaInstanceConfig", obj.scalaInstanceConfig)
+    builder.addField("bridgeJar", obj.bridgeJar)
+    builder.addField("externalDependencyJars", obj.externalDependencyJars)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
@@ -1,0 +1,10 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+trait JsonProtocol extends sjsonnew.BasicJsonProtocol
+  with sbt.internal.worker.codec.ScalaInstanceConfigFormats
+  with sbt.internal.worker.codec.ConsoleConfigFormats
+object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ScalaInstanceConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ScalaInstanceConfigFormats.scala
@@ -1,0 +1,33 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaInstanceConfigFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val ScalaInstanceConfigFormat: JsonFormat[sbt.internal.worker.ScalaInstanceConfig] = new JsonFormat[sbt.internal.worker.ScalaInstanceConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.ScalaInstanceConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val scalaVersion = unbuilder.readField[String]("scalaVersion")
+      val libraryJars = unbuilder.readField[Vector[String]]("libraryJars")
+      val allCompilerJars = unbuilder.readField[Vector[String]]("allCompilerJars")
+      val allDocJars = unbuilder.readField[Vector[String]]("allDocJars")
+      unbuilder.endObject()
+      sbt.internal.worker.ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, allDocJars)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.ScalaInstanceConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("scalaVersion", obj.scalaVersion)
+    builder.addField("libraryJars", obj.libraryJars)
+    builder.addField("allCompilerJars", obj.allCompilerJars)
+    builder.addField("allDocJars", obj.allDocJars)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -1,0 +1,17 @@
+package sbt.internal.worker
+@target(Scala)
+@codecPackage("sbt.internal.worker.codec")
+@fullCodec("JsonProtocol")
+
+type ScalaInstanceConfig {
+  scalaVersion: String!
+  libraryJars: [String],
+  allCompilerJars: [String],
+  allDocJars: [String],
+}
+
+type ConsoleConfig {
+  scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig!
+  bridgeJar: String!
+  externalDependencyJars: [String]
+}

--- a/protocol/src/main/scala/sbt/protocol/Serialization.scala
+++ b/protocol/src/main/scala/sbt/protocol/Serialization.scala
@@ -109,6 +109,11 @@ object Serialization {
   }
 
   /** This formats the message according to JSON-RPC. https://www.jsonrpc.org/specification */
+  private[sbt] def serializeResponseMessageBody(message: JsonRpcResponseMessage): String =
+    import sbt.internal.protocol.codec.JsonRPCProtocol.given
+    serializeResponseBody(message)
+
+  /** This formats the message according to JSON-RPC. https://www.jsonrpc.org/specification */
   private[sbt] def serializeRequestMessage(message: JsonRpcRequestMessage): Array[Byte] = {
     import sbt.internal.protocol.codec.JsonRPCProtocol.given
     serializeResponse(message)
@@ -122,9 +127,18 @@ object Serialization {
     serializeResponse(message)
   }
 
-  private[sbt] def serializeResponse[A: JsonWriter](message: A): Array[Byte] = {
+  private[sbt] def serializeNotificationMessageBody(
+      message: JsonRpcNotificationMessage,
+  ): String =
+    import sbt.internal.protocol.codec.JsonRPCProtocol.given
+    serializeResponseBody(message)
+
+  private[sbt] def serializeResponseBody[A: JsonWriter](message: A): String =
     val json: JValue = Converter.toJson[A](message).get
-    val body = CompactPrinter(json)
+    CompactPrinter(json)
+
+  private[sbt] def serializeResponse[A: JsonWriter](message: A): Array[Byte] = {
+    val body = serializeResponseBody(message)
     val bodyLength = body.getBytes("UTF-8").length
 
     Iterator(

--- a/worker/src/main/java/sbt/internal/worker/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker/WorkerMain.java
@@ -1,0 +1,104 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.worker;
+
+import java.io.InputStream;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+public final class WorkerMain {
+  public static void main(final String[] args) throws Exception {
+    try {
+      if (args.length != 2) {
+        System.err.println("missing args");
+        System.exit(1);
+      }
+      if (args[0].equals("run")) {
+        WorkerMain app = new WorkerMain();
+        app.run(Paths.get(args[1]));
+        System.exit(0);
+      } else {
+        System.exit(1);
+      }
+    } catch (Throwable e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  void run(String mainClassName, List<Path> classpath, List<String> args) throws Exception {
+    URL[] urls =
+        classpath
+            .stream()
+            .map(
+                path -> {
+                  try {
+                    return path.toUri().toURL();
+                  } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .toArray(URL[]::new);
+    URLClassLoader cl = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
+    try {
+      Class<?> mainClass = cl.loadClass(mainClassName);
+      Method mainMethod = mainClass.getMethod("main", String[].class);
+      String[] mainArgs = args.stream().toArray(String[]::new);
+      mainMethod.invoke(null, (Object) mainArgs);
+    } finally {
+      cl.close();
+    }
+  }
+
+  void run(Properties props) throws Exception {
+    String mainClass = props.getProperty("mainClass");
+    Enumeration<?> names0 = props.propertyNames();
+    LinkedList<String> names = new LinkedList<>();
+    LinkedList<String> args = new LinkedList<>();
+    LinkedList<Path> classpath = new LinkedList<>();
+    while (names0.hasMoreElements()) {
+      String name = names0.nextElement().toString();
+      names.add(name);
+    }
+    Collections.sort(names);
+    for (String name : names) {
+      String v = props.getProperty(name);
+      if (name.startsWith("classpath")) {
+        classpath.add(Paths.get(v));
+      } else if (name.startsWith("args")) {
+        args.add(v);
+      }
+    }
+    run(mainClass, classpath, args);
+  }
+
+  void run(Path propPath) throws Exception {
+    Properties props = new Properties();
+    InputStream inputStream = Files.newInputStream(propPath);
+    try {
+      props.load(inputStream);
+      run(props);
+    } finally {
+      inputStream.close();
+    }
+  }
+}

--- a/worker/src/test/scala/sbt/internal/worker/WorkerTest.scala
+++ b/worker/src/test/scala/sbt/internal/worker/WorkerTest.scala
@@ -1,0 +1,19 @@
+package sbt.internal.worker
+
+import java.util.Properties
+import sbt.io.IO
+
+object WorkerTest extends verify.BasicTestSuite:
+  val main = WorkerMain()
+
+  test("run props") {
+    val prop = Properties()
+    prop.setProperty("mainClass", "example.Hello")
+    prop.setProperty("classpath0000", IO.classLocationPath(classOf[example.Hello]).toString)
+    prop.setProperty("classpath0001", IO.classLocationPath(classOf[scala.quoted.Quotes]).toString)
+    prop.setProperty("classpath0002", IO.classLocationPath(classOf[scala.AnyVal]).toString)
+    prop.setProperty("args0000", "hi")
+    main.run(prop)
+    System.out.flush()
+  }
+end WorkerTest

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -65,6 +65,24 @@ object ZincLmUtil {
     )
   }
 
+  def scalaCompilerBridge(
+      scalaInstance: XScalaInstance,
+      globalLock: GlobalLock,
+      componentProvider: ComponentProvider,
+      secondaryCacheDir: Option[File],
+      dependencyResolution: DependencyResolution,
+      compilerBridgeSource: ModuleID,
+      scalaJarsTarget: File,
+      log: Logger
+  ): File =
+    val compilerBridgeProvider = ZincComponentCompiler.interfaceProvider(
+      compilerBridgeSource,
+      new ZincComponentManager(globalLock, componentProvider, secondaryCacheDir, log),
+      dependencyResolution,
+      scalaJarsTarget,
+    )
+    compilerBridgeProvider.fetchCompiledBridge(scalaInstance, log)
+
   def fetchDefaultBridgeModule(
       scalaVersion: String,
       dependencyResolution: DependencyResolution,


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/1918

## Problem
1. See https://eed3si9n.com/rfc-4-persistent-worker/ for the general motivation. We want to move long-running tasks out of the command loop, and potentially from the sbt process entirely.
2. `console / fork` issue was created a long time ago since it's closely related to running and testing, which already can fork.

## Solution
1. This implements a pure Java app called worker, which can run arbitrary application. For now I'm using property files to communicate. I'll likely switch to using JSON. The worker currently implements `run` command, which can run a program specified in the properties file.
2. This also implements `ConsoleMain`, which is a command line program that wraps Zinc's `console` function.

## Caveat
One major limitation of the `Compile / console / fork := true` implementation at this time is that I wasn't able to configure JLine terminal to xterm-256color, which uses a sequence of characters to send up and down keys. So while the color works, up and down keys do not, which is inconvenient for Scala repl. Nonetheless, this is still a useful demonstration of the forked task running in a worker process that's able to accept ordinary key inputs.