### PR TITLE
[1.x] fix: Fix Chrome tracing file

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Util.scala
@@ -12,6 +12,8 @@ import java.util.Locale
 
 import scala.reflect.macros.blackbox
 import scala.language.experimental.macros
+import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
 
 object Util {
   def makeList[T](size: Int, value: T): List[T] = List.fill(size)(value)
@@ -77,4 +79,39 @@ object Util {
   class Macro(val c: blackbox.Context) {
     def ignore(f: c.Tree): c.Expr[Unit] = c.universe.reify({ c.Expr[Any](f).splice; () })
   }
+
+  lazy val majorJavaVersion: Int =
+    try {
+      val javaVersion = sys.props.get("java.version").getOrElse("1.0")
+      if (javaVersion.startsWith("1.")) {
+        javaVersion.split("\\.")(1).toInt
+      } else {
+        javaVersion.split("\\.")(0).toInt
+      }
+    } catch {
+      case NonFatal(_) => 0
+    }
+
+  private type GetId = {
+    def getId: Long
+  }
+  private type ThreadId = {
+    def threadId: Long
+  }
+
+  /**
+   * Returns current thread id.
+   * Thread.threadId was added in JDK 19, and deprecated Thread#getId
+   * https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#threadId()
+   */
+  def threadId: Long =
+    if (majorJavaVersion < 19) {
+      (Thread.currentThread(): AnyRef) match {
+        case g: GetId @unchecked => g.getId
+      }
+    } else {
+      (Thread.currentThread(): AnyRef) match {
+        case g: ThreadId @unchecked => g.threadId
+      }
+    }
 }

--- a/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/AbstractTaskProgress.scala
@@ -9,6 +9,7 @@
 package sbt
 package internal
 
+import sbt.internal.util.Util
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.JavaConverters._
@@ -123,6 +124,7 @@ object AbstractTaskExecuteProgress {
   private[sbt] class Timer() {
     val startNanos: Long = System.nanoTime()
     val threadName: String = Thread.currentThread().getName
+    val threadId: Long = Util.threadId
     var endNanos: Long = 0L
     def stop(): Unit = {
       endNanos = System.nanoTime()

--- a/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
+++ b/main/src/main/scala/sbt/internal/TaskTraceEvent.scala
@@ -61,7 +61,7 @@ private[sbt] final class TaskTraceEvent
       def durationEvent(name: String, cat: String, t: Timer): String = {
         val sb = new java.lang.StringBuilder(name.length + 2)
         CompactPrinter.print(new JString(name), sb)
-        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tname": "${t.threadName}"}"""
+        s"""{"name": ${sb.toString}, "cat": "$cat", "ph": "X", "ts": ${(t.startMicros)}, "dur": ${(t.durationMicros)}, "pid": 0, "tid": "${t.threadId}"}"""
       }
       val entryIterator = currentTimings
       while (entryIterator.hasNext) {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8017

## Problem
We changed the content of Chrome tracing file incorrectly and renamed tid to tname.

## Solution
1. This renames tname back to to tid.
2. To retain the fix to avoid Thread#getId, this calls either the JDK 8 way or the JDK 19 way reflectively.