### PR TITLE
[1.x] Make timing outputs consistently show hours and hint at time format

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1130,13 +1130,13 @@ object NetworkClient {
     val totalString = s"$total s" +
       (if (total <= 60) ""
        else {
-         val maybeHours = total / 3600 match {
-           case 0 => ""
-           case h => f"$h%02d:"
+         val hours = total / 3600 match {
+           case 0 => "0"
+           case h => f"$h%02d"
          }
          val mins = f"${total % 3600 / 60}%02d"
          val secs = f"${total % 60}%02d"
-         s" ($maybeHours$mins:$secs)"
+         s" ($hours:$mins:$secs.0)"
        })
     s"Total time: $totalString, completed $nowString"
   }

--- a/main/src/test/scala/sbt/internal/AggregationSpec.scala
+++ b/main/src/test/scala/sbt/internal/AggregationSpec.scala
@@ -12,15 +12,15 @@ object AggregationSpec extends verify.BasicTestSuite {
   val timing = Aggregation.timing(Aggregation.defaultFormat, 0, _: Long)
 
   test("timing should format total time properly") {
-    assert(timing(101).startsWith("Total time: 0 s,"))
-    assert(timing(1000).startsWith("Total time: 1 s,"))
-    assert(timing(3000).startsWith("Total time: 3 s,"))
-    assert(timing(30399).startsWith("Total time: 30 s,"))
-    assert(timing(60399).startsWith("Total time: 60 s,"))
-    assert(timing(60699).startsWith("Total time: 61 s (01:01),"))
-    assert(timing(303099).startsWith("Total time: 303 s (05:03),"))
-    assert(timing(6003099).startsWith("Total time: 6003 s (01:40:03),"))
-    assert(timing(96003099).startsWith("Total time: 96003 s (26:40:03),"))
+    assert(timing(101).startsWith("Total time: 0 s"))
+    assert(timing(1000).startsWith("Total time: 1 s"))
+    assert(timing(3000).startsWith("Total time: 3 s"))
+    assert(timing(30399).startsWith("Total time: 30 s"))
+    assert(timing(60399).startsWith("Total time: 60 s"))
+    assert(timing(60699).startsWith("Total time: 61 s (0:01:01.0)"))
+    assert(timing(303099).startsWith("Total time: 303 s (0:05:03.0)"))
+    assert(timing(6003099).startsWith("Total time: 6003 s (01:40:03.0)"))
+    assert(timing(96003099).startsWith("Total time: 96003 s (26:40:03.0)"))
   }
 
   test("timing should not emit special space characters") {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8003
This backports https://github.com/sbt/sbt/pull/8019 to 1.x