### PR TITLE
[2.x] fix updateSbtClassifiers task

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -163,7 +163,7 @@ suite with `sbt testOnly`
 Scripted integration tests reside in `sbt-app/src/sbt-test` and are
 written using the same testing infrastructure sbt plugin authors can
 use to test their own plugins with sbt. You can read more about this
-style of tests [here](https://www.scala-sbt.org/1.0/docs/Testing-sbt-plugins).
+style of tests [here](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins).
 
 You can run the integration tests with the `sbt scripted` sbt
 command. To run a single test, such as the test in

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3714,17 +3714,21 @@ object Classpaths {
       val ref = thisProjectRef.value
       val unit = loadedBuild.value.units(ref.build).unit
       val converter = unit.converter
-      val pluginClasspath = unit.plugins.fullClasspath.toVector
+      val pluginClasspath = unit.plugins.pluginData.dependencyClasspath.toVector
+      // Exclude directories: an approximation to whether they've been published
+      // Note: it might be a redundant legacy from sbt 0.13/1.x times where the classpath contained directories
+      // but it's left jsut in case
       val pluginJars = pluginClasspath.filter: x =>
         !Files.isDirectory(converter.toPath(x.data))
-      // exclude directories: an approximation to whether they've been published
       val pluginIDs: Vector[ModuleID] = pluginJars.flatMap(_.get(moduleIDStr).map: str =>
         moduleIdJsonKeyFormat.read(str))
+
+      val dependencies = sbtDependency.value +: pluginIDs
       GetClassifiersModule(
         projectID.value,
         // TODO: Should it be sbt's scalaModuleInfo?
         scalaModuleInfo.value,
-        sbtDependency.value +: pluginIDs,
+        dependencies,
         // sbt is now on Maven Central, so this has changed from sbt 0.13.
         Vector(Configurations.Default) ++ Configurations.default,
         classifiers.toVector

--- a/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
@@ -1,5 +1,3 @@
-ThisBuild / scalaVersion := "2.11.12"
-
 ivyConfiguration := {
   throw new RuntimeException("updateSbtClassifiers should use updateSbtClassifiers / ivyConfiguration")
 }
@@ -8,5 +6,87 @@ dependencyResolution := {
   throw new RuntimeException("updateSbtClassifiers should use updateSbtClassifiers / dependencyResolution")
 }
 
-scalaOrganization := "doesnt.exist"
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.11.12",
+    scalaOrganization := "doesnt.exist",
+    name := "myProjectName",
 
+    TaskKey[Unit]("checkModuleIdsInUpdateSbtClassifiers") := {
+      val updateReport = updateSbtClassifiers.value
+      val moduleReports = updateReport.configurations.find(_.configuration.name == "default").get.modules
+
+      // Calling "distinct" as there are different entries for sources and javadoc classifiers with same module
+      val moduleIds = moduleReports.map(_.module).distinct
+      val moduleIdsShort = moduleIds.map(m => s"${m.organization}:${m.name}")
+
+      val expectedModuleIds = Seq(
+        "com.eed3si9n:gigahorse-apache-http_3",
+        "com.eed3si9n:gigahorse-core_3",
+        "com.eed3si9n:shaded-apache-httpasyncclient",
+        "com.eed3si9n:shaded-jawn-parser_3",
+        "com.eed3si9n:shaded-scalajson_3",
+        "com.eed3si9n:sjson-new-core_3",
+        "com.eed3si9n:sjson-new-murmurhash_3",
+        "com.eed3si9n:sjson-new-scalajson_3",
+        "com.github.ben-manes.caffeine:caffeine",
+        "com.github.mwiede:jsch",
+        "com.google.errorprone:error_prone_annotations",
+        "com.lmax:disruptor",
+        "com.swoval:file-tree-views",
+        "com.typesafe:config",
+        "com.typesafe:ssl-config-core_3",
+        "net.java.dev.jna:jna",
+        "net.java.dev.jna:jna-platform",
+        "net.openhft:zero-allocation-hashing",
+        "org.apache.logging.log4j:log4j-api",
+        "org.apache.logging.log4j:log4j-core",
+        "org.apache.logging.log4j:log4j-slf4j-impl",
+        "org.checkerframework:checker-qual",
+        "org.fusesource.jansi:jansi",
+        "org.jline:jline-builtins",
+        "org.jline:jline-native",
+        "org.jline:jline-reader",
+        "org.jline:jline-style",
+        "org.jline:jline-terminal",
+        "org.jline:jline-terminal-jni",
+        "org.reactivestreams:reactive-streams",
+        "org.scala-lang.modules:scala-asm",
+        "org.scala-lang.modules:scala-parallel-collections_3",
+        "org.scala-lang.modules:scala-parser-combinators_3",
+        "org.scala-lang.modules:scala-xml_3",
+        "org.scala-lang:scala-library",
+        "org.scala-lang:scala-reflect",
+        "org.scala-lang:scala3-compiler_3",
+        "org.scala-lang:scala3-interfaces",
+        "org.scala-lang:scala3-library_3",
+        "org.scala-lang:tasty-core_3",
+        "org.scala-sbt.ipcsocket:ipcsocket",
+        "org.scala-sbt.ivy:ivy",
+        "org.scala-sbt.jline:jline",
+        "org.scala-sbt:compiler-interface",
+        "org.scala-sbt:io_3",
+        "org.scala-sbt:launcher-interface",
+        "org.scala-sbt:sbinary_3",
+        "org.scala-sbt:template-resolver",
+        "org.scala-sbt:test-interface",
+        "org.scala-sbt:zinc-apiinfo_3",
+        "org.scala-sbt:zinc-classfile_3",
+        "org.scala-sbt:zinc-classpath_3",
+        "org.scala-sbt:zinc-compile-core_3",
+        "org.scala-sbt:zinc-core_3",
+        "org.scala-sbt:zinc-persist_3",
+        "org.scala-sbt:zinc_3",
+        "org.slf4j:slf4j-api",
+      )
+      def assertCollectionsEqual(message: String, expected: Seq[String], actual: Seq[String]): Unit =
+        // using the new line for a more readable comparison failure output
+        org.junit.Assert.assertEquals(message: String, expected.mkString("\n"), actual.mkString("\n"))
+
+      assertCollectionsEqual(
+        "Unexpected module ids in updateSbtClassifiers",
+        expectedModuleIds.sorted,
+        moduleIdsShort.sorted,
+      )
+    }
+  )

--- a/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/pending
+++ b/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/pending
@@ -1,1 +1,0 @@
-> updateSbtClassifiers

--- a/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/project/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/project/build.sbt
@@ -1,0 +1,4 @@
+// The library surves two purposes:
+// 1. add some non-standard library to the meta-build classpath to later check that it's included into updateSbtClassifiers
+// 2. use assertions from junit in custom assertion in `build.sbt` of current scripted test
+libraryDependencies += "junit" % "junit" % "4.13.2"

--- a/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/test
+++ b/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/test
@@ -1,0 +1,4 @@
+> updateSbtClassifiers
+
+# see assertion definition in build.sbt
+> checkModuleIdsInUpdateSbtClassifiers


### PR DESCRIPTION
Fixes #8022

(I copy the implementation notes from the original ticket description #8022)

I debugged `sbt.Classpaths.sbtClassifiersTasks` which led to `sbt.Classpaths.classifiersModuleTask`.
I noticed that when `GetClassifiersModule` is constructed, its dependencies contain some strange ModuleID (the second one)
```
org.scala-sbt:sbt:2.0.0-M3
default:testprojects_dirname-build:0.1.0-SNAPSHOT
```
Notice that the artifact name represents the directory name and none of the projects.
This gets to `sbt.librarymanagement.DependencyResolution#update` which tries to resolve it from the remote repositories and obviously fails.

The second dependency comes from `pluginIDs` which is constructed based on the meta-build full classpath.


This issue is similar to https://github.com/sbt/sbt/issues/798
The fix was 
```scala
val pluginJars = pluginClasspath.filter(_.data.isFile) // exclude directories: an approximation to whether they've been published
```
However in sbt 2.0 the `sbt.PluginData#definitionClasspath` points to a jar file, not to the directory with classes.

You can see that inspecting this part (I used a custom task to debug it)
```scala
val ref = thisProjectRef.value
val unit = loadedBuild.value.units(ref.build).unit
val converter = unit.converter
val pluginClasspath = unit.plugins.fullClasspath.toVector
```
The output will be like this:
```
Attributed(${OUT}/jvm/scala-3.6.2/testproject_dirname-build/testproject_dirname-build_sbt2.0.0-M3_3-0.1.0-SNAPSHOT.jar>sha256-a281266bb85297dff9648506156b379b01d51a25e9a5e47dffe372fd7b31bc83/1045)
Attributed(${SBT_BOOT}/scala-3.6.2/lib/scala-library.jar)
Attributed(${SBT_BOOT}/scala-3.6.2/lib/scala3-compiler_3-3.6.2.jar)
...
```

It seems like we should use `unit.plugins.pluginData.dependencyClasspath` instead of  `unit.plugins.fullClasspath` (we shouldn't include `sbt.PluginData#definitionClasspath`).
It fixes the issue locally.
