### PR TITLE
[2.x] Implement client-side run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -728,7 +728,7 @@ lazy val protocolProj = (project in file("protocol"))
 // General command support and core commands not specific to a build system
 lazy val commandProj = (project in file("main-command"))
   .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
-  .dependsOn(protocolProj, completeProj, utilLogging, utilCache)
+  .dependsOn(protocolProj, completeProj, utilLogging, runProj, utilCache)
   .settings(
     testedBaseSettings,
     name := "Command",

--- a/main-command/src/main/scala/sbt/internal/CommandChannel.scala
+++ b/main-command/src/main/scala/sbt/internal/CommandChannel.scala
@@ -63,6 +63,8 @@ abstract class CommandChannel {
       }
     }
   }
+  protected def appendExec(commandLine: String, execId: Option[String]): Boolean =
+    append(Exec(commandLine, execId.orElse(Some(Exec.newExecId)), Some(CommandSource(name))))
   def poll: Option[Exec] = Option(commandQueue.poll)
 
   def prompt(e: ConsolePromptEvent): Unit = userThread.onConsolePromptEvent(e)
@@ -81,20 +83,20 @@ abstract class CommandChannel {
   private[sbt] final def logLevel: Level.Value = level.get
   private def setLevel(value: Level.Value, cmd: String): Boolean = {
     level.set(value)
-    append(Exec(cmd, Some(Exec.newExecId), Some(CommandSource(name))))
+    appendExec(cmd, None)
   }
-  private[sbt] def onCommand: String => Boolean = {
-    case "error" => setLevel(Level.Error, "error")
-    case "debug" => setLevel(Level.Debug, "debug")
-    case "info"  => setLevel(Level.Info, "info")
-    case "warn"  => setLevel(Level.Warn, "warn")
-    case cmd =>
-      if (cmd.nonEmpty) append(Exec(cmd, Some(Exec.newExecId), Some(CommandSource(name))))
-      else false
-  }
-  private[sbt] def onFastTrackTask: String => Boolean = { (s: String) =>
+  private[sbt] def onCommandLine(cmd: String): Boolean =
+    cmd match
+      case "error" => setLevel(Level.Error, "error")
+      case "debug" => setLevel(Level.Debug, "debug")
+      case "info"  => setLevel(Level.Info, "info")
+      case "warn"  => setLevel(Level.Warn, "warn")
+      case cmd =>
+        if cmd.nonEmpty then appendExec(cmd, None)
+        else false
+  private[sbt] def onFastTrackTask(cmd: String): Boolean = {
     fastTrack.synchronized(fastTrack.forEach { q =>
-      q.add(new FastTrackTask(this, s))
+      q.add(new FastTrackTask(this, cmd))
       ()
     })
     true

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -13,7 +13,7 @@ package client
 import java.io.{ File, IOException, InputStream, PrintStream }
 import java.lang.ProcessBuilder.Redirect
 import java.net.{ Socket, SocketException }
-import java.nio.file.Files
+import java.nio.file.{ Files, Paths }
 import java.util.UUID
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import java.util.concurrent.{ ConcurrentHashMap, LinkedBlockingQueue, TimeUnit }
@@ -21,8 +21,16 @@ import java.text.DateFormat
 
 import sbt.BasicCommandStrings.{ DashDashDetachStdio, DashDashServer, Shutdown, TerminateAction }
 import sbt.internal.langserver.{ LogMessageParams, MessageType, PublishDiagnosticsParams }
+import sbt.internal.worker.{ GeneralParams, RunInfo }
 import sbt.internal.protocol.*
-import sbt.internal.util.{ ConsoleAppender, ConsoleOut, Signals, Terminal, Util }
+import sbt.internal.util.{
+  ConsoleAppender,
+  ConsoleOut,
+  MessageOnlyException,
+  Signals,
+  Terminal,
+  Util
+}
 import sbt.io.IO
 import sbt.io.syntax.*
 import sbt.protocol.*
@@ -41,6 +49,7 @@ import Serialization.{
   attach,
   cancelReadSystemIn,
   cancelRequest,
+  general,
   promptChannel,
   readSystemIn,
   systemIn,
@@ -61,6 +70,7 @@ import Serialization.{
 }
 import NetworkClient.Arguments
 import java.util.concurrent.TimeoutException
+import sbt.util.Logger
 
 trait ConsoleInterface {
   def appendLog(level: Level.Value, message: => String): Unit
@@ -163,6 +173,11 @@ class NetworkClient(
   private def startInputThread(): Unit = inputThread.get match {
     case null => inputThread.set(new RawInputThread)
     case _    =>
+  }
+  private lazy val log: Logger = new Logger {
+    def trace(t: => Throwable): Unit = ()
+    def success(message: => String): Unit = ()
+    def log(level: Level.Value, message: => String): Unit = console.appendLog(level, message)
   }
 
   private[sbt] def connectOrStartServerAndConnect(
@@ -641,6 +656,12 @@ class NetworkClient(
             case Success(params) => splitDiagnostics(params); Vector()
             case Failure(_)      => Vector()
           }
+        case (`general`, Some(json)) =>
+          import sbt.internal.worker.codec.JsonProtocol.*
+          Converter.fromJson[GeneralParams](json) match {
+            case Success(params) => generalRun(params).get; Vector.empty
+            case Failure(_)      => Vector.empty
+          }
         case (`Shutdown`, Some(_))                => Vector.empty
         case (msg, _) if msg.startsWith("build/") => Vector.empty
         case _ =>
@@ -685,6 +706,50 @@ class NetworkClient(
       val msg = s"$f:$line:$offset: ${d.message}"
       (level, msg)
     }
+  }
+
+  private def generalRun(params: GeneralParams): Try[Unit] =
+    params.runInfo match {
+      case Some(info) => generalRun(info)
+      case _          => Failure(new MessageOnlyException(s"runInfo is not specified in $params"))
+    }
+
+  private def generalRun(runInfo: RunInfo): Try[Unit] = {
+    val option = ForkOptions(
+      javaHome = runInfo.javaHome.map(new File(_)),
+      outputStrategy = None, // TODO: Handle buffered output etc
+      bootJars = Vector.empty,
+      workingDirectory = runInfo.workingDirectory.map(new File(_)),
+      runJVMOptions = runInfo.jvmOptions,
+      connectInput = runInfo.connectInput,
+      envVars = runInfo.environmentVariables,
+    )
+    def jvmRun(): Try[Unit] = {
+      // ForkRun handles exit code handling and cancellation
+      val runner = new ForkRun(option)
+      runner
+        .run(
+          mainClass = runInfo.mainClass.getOrElse(sys.error("no main class")),
+          classpath = runInfo.classpath.map(_.path).map(Paths.get),
+          options = runInfo.args,
+          log = log
+        )
+    }
+    def nativeRun(): Try[Unit] = {
+      import java.lang.{ ProcessBuilder as JProcessBuilder }
+      val command = runInfo.cmd.toList ++ runInfo.args.toList
+      val jpb = new JProcessBuilder(command*)
+      val exitCode =
+        try Fork.blockForExitCode(Fork.forkInternal(option, Nil, jpb))
+        catch {
+          case _: InterruptedException =>
+            log.warn("run canceled")
+            1
+        }
+      Run.processExitCode(exitCode, "runner")
+    }
+    if (runInfo.jvm) jvmRun()
+    else nativeRun()
   }
 
   def onRequest(msg: JsonRpcRequestMessage): Unit = {

--- a/main-command/src/main/scala/sbt/internal/ui/UITask.scala
+++ b/main-command/src/main/scala/sbt/internal/ui/UITask.scala
@@ -28,7 +28,7 @@ private[sbt] trait UITask extends Runnable with AutoCloseable {
   private[sbt] def reader: UITask.Reader
   private final def handleInput(s: Either[String, String]): Boolean = s match {
     case Left(m)    => channel.onFastTrackTask(m)
-    case Right(cmd) => channel.onCommand(cmd)
+    case Right(cmd) => channel.onCommandLine(cmd)
   }
   private val isStopped = new AtomicBoolean(false)
   override def run(): Unit = {
@@ -56,6 +56,20 @@ private[sbt] object UITask {
   object Reader {
     // Avoid filling the stack trace since it isn't helpful here
     object interrupted extends InterruptedException
+
+    /**
+     * Return Left for fast track commands, otherwise return Right(...).
+     */
+    def splitCommand(cmd: String): Either[String, String] =
+      // We need to put the empty string on the fast track queue so that we can
+      // reprompt the user if another command is running on the server.
+      if (cmd.isEmpty()) Left("")
+      else
+        cmd match {
+          case Shutdown | TerminateAction | Cancel => Left(cmd)
+          case cmd                                 => Right(cmd)
+        }
+
     def terminalReader(parser: Parser[?])(
         terminal: Terminal,
         state: State
@@ -77,16 +91,9 @@ private[sbt] object UITask {
                 this.synchronized(this.wait())
                 Right("") // should be unreachable
               // JLine returns null on ctrl+d when there is no other input. This interprets
-              // ctrl+d with no input as an exit
-              case None => Left(TerminateAction)
-              case Some(s: String) =>
-                s.trim() match {
-                  // We need to put the empty string on the fast track queue so that we can
-                  // reprompt the user if another command is running on the server.
-                  case ""                                                => Left("")
-                  case cmd @ (`Shutdown` | `TerminateAction` | `Cancel`) => Left(cmd)
-                  case cmd                                               => Right(cmd)
-                }
+              // ctrl+d with no imput as an exit
+              case None            => Left(TerminateAction)
+              case Some(s: String) => splitCommand(s.trim())
             }
           }
           terminal.setPrompt(Prompt.Pending)

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -71,6 +71,8 @@ abstract class BackgroundJobService extends Closeable {
 
   def waitFor(job: JobHandle): Unit
 
+  private[sbt] def createWorkingDirectory: File
+
   /** Copies classpath to temporary directories. */
   def copyClasspath(
       products: Classpath,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -27,8 +27,8 @@ import sbt.internal.librarymanagement.{ CompatibilityWarningOptions, IvySbt }
 import sbt.internal.remotecache.RemoteCacheArtifact
 import sbt.internal.server.BuildServerProtocol.BspFullWorkspace
 import sbt.internal.server.{ BspCompileTask, BuildServerReporter, ServerHandler }
-import sbt.internal.util.{ AttributeKey, ProgressState, SourcePosition }
-import sbt.internal.util.StringAttributeKey
+import sbt.internal.util.{ AttributeKey, ProgressState, StringAttributeKey, SourcePosition }
+import sbt.internal.worker.GeneralParams
 import sbt.io.*
 import sbt.librarymanagement.Configurations.CompilerPlugin
 import sbt.librarymanagement.LibraryManagementCodec.*
@@ -483,6 +483,8 @@ object Keys {
 
   @cacheLevel(include = Array.empty)
   val bspReporter = taskKey[BuildServerReporter]("").withRank(DTask)
+  val bspGeneral0 = inputKey[GeneralParams]("Implementation of sbt/general command").withRank(DTask)
+  val bspGeneralRunInfo = inputKey[GeneralParams]("Implementation of general run info").withRank(DTask)
 
   val csrCacheDirectory = settingKey[File]("Coursier cache directory. Uses -Dsbt.coursier.home or Coursier's default.").withRank(CSetting)
   val csrMavenProfiles = settingKey[Set[String]]("").withRank(CSetting)

--- a/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
+++ b/main/src/main/scala/sbt/internal/DefaultBackgroundJobService.scala
@@ -146,6 +146,16 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
     override val isAutoCancel = false
   }
 
+  private[sbt] def createWorkingDirectory: File = {
+    val id = nextId.getAndIncrement()
+    createWorkingDirectory(id)
+  }
+  private[sbt] def createWorkingDirectory(id: Long): File = {
+    val workingDir = serviceTempDir / s"job-$id"
+    IO.createDirectory(workingDir)
+    workingDir
+  }
+
   def doRunInBackground(
       spawningTask: ScopedKey[?],
       state: State,
@@ -155,8 +165,7 @@ private[sbt] abstract class AbstractBackgroundJobService extends BackgroundJobSe
     val extracted = Project.extract(state)
     val logger =
       LogManager.constructBackgroundLog(extracted.structure.data, state, context)(spawningTask)
-    val workingDir = serviceTempDir / s"job-$id"
-    IO.createDirectory(workingDir)
+    val workingDir = createWorkingDirectory(id)
     val job =
       try {
         new ThreadJobHandle(id, spawningTask, logger, workingDir, start(logger, workingDir))

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -23,10 +23,13 @@ import sbt.StandardMain.exchange
 import sbt.internal.bsp.*
 import sbt.internal.langserver.ErrorCodes
 import sbt.internal.protocol.JsonRpcRequestMessage
+import sbt.internal.worker.{ FilePath, GeneralParams, RunInfo }
 import sbt.internal.util.{ Attributed, ErrorHandling }
 import sbt.internal.util.complete.{ Parser, Parsers }
+import sbt.io.IO
 import sbt.librarymanagement.CrossVersion.binaryScalaVersion
 import sbt.librarymanagement.{ Configuration, ScalaArtifacts }
+import sbt.protocol.Serialization
 import sbt.std.TaskExtra
 import sbt.util.Logger
 import sjsonnew.shaded.scalajson.ast.unsafe.{ JNull, JValue }
@@ -264,7 +267,9 @@ object BuildServerProtocol {
       val result = ScalaMainClassesResult(successfulItems.toVector, None)
       state.value.respondEvent(result)
     }.evaluated,
-    bspScalaMainClasses / aggregate := false
+    bspScalaMainClasses / aggregate := false,
+    bspGeneral0 := bspGeneral0Task.evaluated,
+    bspGeneral0 / aggregate := false,
   )
 
   // This will be scoped to Compile, Test, IntegrationTest etc
@@ -357,7 +362,8 @@ object BuildServerProtocol {
       } else {
         new BuildServerForwarder(meta, logger, underlying)
       }
-    }
+    },
+    bspGeneralRunInfo := bspGeneralRunInfoTask.evaluated,
   )
   private[sbt] object Method {
     final val Initialize = "build/initialize"
@@ -875,13 +881,68 @@ object BuildServerProtocol {
   private val jsonParser: Parser[Try[JValue]] = Parsers.any.*.map(_.mkString)
     .map(JsonParser.parseFromString)
 
+  private def bspGeneral0Task: Def.Initialize[InputTask[GeneralParams]] = Def.inputTaskDyn {
+    val tokens = spaceDelimited().parsed
+    val state = Keys.state.value
+    val p = Act.aggregatedKeyParser(state)
+    if (tokens.isEmpty) {
+      sys.error("usage: bspGeneral0 run")
+    }
+    val scopedKey = Parser.parse(tokens.head, p) match {
+      case Right(x :: Nil) => x
+      case Right(xs)       => sys.error("too many keys")
+      case Left(err)       => sys.error(err)
+    }
+    bspGeneralRunInfo.rescope(scopedKey.scope).toTask(" " + tokens.tail.mkString(" "))
+  }
+
+  private def bspGeneralRunInfoTask: Def.Initialize[InputTask[GeneralParams]] = Def.inputTask {
+    val state = Keys.state.value
+    val args = spaceDelimited().parsed
+    val mainClass = (Keys.run / Keys.mainClass).value
+    val service = bgJobService.value
+    val fo = (Keys.run / Keys.forkOptions).value
+    val workingDir = service.createWorkingDirectory
+    val conv = Keys.fileConverter.value
+    val cp = service.copyClasspath(
+      exportedProductJars.value,
+      fullClasspathAsJars.value,
+      workingDir,
+      hashContents = true,
+      conv,
+    )
+    val cpPaths = cp.toVector.map: x =>
+      FilePath(conv.toPath(x.data).toUri(), x.data.contentHashStr)
+    val strategy = fo.outputStrategy.map(_.getClass().getSimpleName().filter(_ != '$'))
+    // sbtn doesn't set java.home, so we need to do the fallback here
+    val javaHome =
+      fo.javaHome.map(IO.toURI).orElse(sys.props.get("java.home").map(x => IO.toURI(new File(x))))
+    val info = RunInfo(
+      jvm = true,
+      args = args.toVector,
+      classpath = cpPaths,
+      mainClass = mainClass,
+      connectInput = fo.connectInput,
+      javaHome = javaHome,
+      outputStrategy = strategy,
+      workingDirectory = fo.workingDirectory.map(IO.toURI),
+      jvmOptions = fo.runJVMOptions,
+      environmentVariables = fo.envVars.toMap,
+    )
+    val result = GeneralParams(
+      runInfo = info
+    )
+    import sbt.internal.worker.codec.JsonProtocol.*
+    state.notifyEvent(Serialization.general, result)
+    result
+  }
+
   private def bspRunTask: Def.Initialize[InputTask[Unit]] =
     Def.inputTaskDyn {
       val json = jsonParser.parsed
       val runParams = json.flatMap(Converter.fromJson[RunParams]).get
       val defaultClass = Keys.mainClass.value
       val defaultJvmOptions = Keys.javaOptions.value
-
       val mainClass = runParams.dataKind match {
         case Some("scala-main-class") =>
           val data = runParams.data.getOrElse(JNull)

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -126,7 +126,7 @@ final class NetworkChannel(
       self.jsonRpcNotify(method, params)
 
     def appendExec(commandLine: String, execId: Option[String]): Boolean =
-      self.append(Exec(commandLine, execId, Some(CommandSource(name))))
+      self.appendExec(commandLine, execId)
 
     def appendExec(exec: Exec): Boolean = self.append(exec)
 
@@ -142,6 +142,20 @@ final class NetworkChannel(
     private[sbt] def onCancellationRequest(execId: Option[String], crp: CancelRequestParams): Unit =
       self.onCancellationRequest(execId, crp)
   }
+
+  // Take over commandline for network channel
+  private val networkCommand: PartialFunction[String, String] = {
+    case cmd if cmd.split(" ").head.split("/").last == "run" =>
+      s"bspGeneral0 $cmd"
+  }
+  override protected def appendExec(commandLine: String, execId: Option[String]): Boolean =
+    if (networkCommand.isDefinedAt(commandLine))
+      super.appendExec(networkCommand(commandLine), execId)
+    else super.appendExec(commandLine, execId)
+  override private[sbt] def onCommandLine(cmd: String): Boolean =
+    if (networkCommand.isDefinedAt(cmd))
+      appendExec(networkCommand(cmd), None)
+    else super.onCommandLine(cmd)
 
   protected def authenticate(token: String): Boolean = instance.authenticate(token)
 
@@ -373,40 +387,6 @@ final class NetworkChannel(
   def publishBytes(event: Array[Byte], delimit: Boolean): Unit =
     try pendingWrites.put(event -> delimit)
     catch { case _: InterruptedException => }
-
-  def onCommand(command: CommandMessage): Unit = command match {
-    case x: InitCommand  => onInitCommand(x)
-    case x: ExecCommand  => onExecCommand(x)
-    case x: SettingQuery => onSettingQuery(None, x)
-  }
-
-  private def onInitCommand(cmd: InitCommand): Unit = {
-    if (auth(ServerAuthentication.Token)) {
-      cmd.token match {
-        case Some(x) =>
-          authenticate(x) match {
-            case true =>
-              initialized = true
-              notifyEvent(ChannelAcceptedEvent(name))
-            case _ => sys.error("invalid token")
-          }
-        case None => sys.error("init command but without token.")
-      }
-    } else {
-      initialized = true
-    }
-  }
-
-  private def onExecCommand(cmd: ExecCommand) = {
-    if (initialized) {
-      append(
-        Exec(cmd.commandLine, cmd.execId orElse Some(Exec.newExecId), Some(CommandSource(name)))
-      )
-      ()
-    } else {
-      log.warn(s"ignoring command $cmd before initialization")
-    }
-  }
 
   protected def onSettingQuery(execId: Option[String], req: SettingQuery) = {
     if (initialized) {

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/FilePath.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/FilePath.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class FilePath private (
+  val path: java.net.URI,
+  val digest: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: FilePath => (this.path == x.path) && (this.digest == x.digest)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.worker.FilePath".##) + path.##) + digest.##)
+  }
+  override def toString: String = {
+    "FilePath(" + path + ", " + digest + ")"
+  }
+  private def copy(path: java.net.URI = path, digest: String = digest): FilePath = {
+    new FilePath(path, digest)
+  }
+  def withPath(path: java.net.URI): FilePath = {
+    copy(path = path)
+  }
+  def withDigest(digest: String): FilePath = {
+    copy(digest = digest)
+  }
+}
+object FilePath {
+  
+  def apply(path: java.net.URI, digest: String): FilePath = new FilePath(path, digest)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/GeneralParams.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/GeneralParams.scala
@@ -1,0 +1,40 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+/**
+ * Parameter for the sbt/general command, which is a generic command to
+ * run a program.
+ */
+final class GeneralParams private (
+  val runInfo: Option[sbt.internal.worker.RunInfo]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: GeneralParams => (this.runInfo == x.runInfo)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.worker.GeneralParams".##) + runInfo.##)
+  }
+  override def toString: String = {
+    "GeneralParams(" + runInfo + ")"
+  }
+  private def copy(runInfo: Option[sbt.internal.worker.RunInfo] = runInfo): GeneralParams = {
+    new GeneralParams(runInfo)
+  }
+  def withRunInfo(runInfo: Option[sbt.internal.worker.RunInfo]): GeneralParams = {
+    copy(runInfo = runInfo)
+  }
+  def withRunInfo(runInfo: sbt.internal.worker.RunInfo): GeneralParams = {
+    copy(runInfo = Option(runInfo))
+  }
+}
+object GeneralParams {
+  
+  def apply(runInfo: Option[sbt.internal.worker.RunInfo]): GeneralParams = new GeneralParams(runInfo)
+  def apply(runInfo: sbt.internal.worker.RunInfo): GeneralParams = new GeneralParams(Option(runInfo))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/RunInfo.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/RunInfo.scala
@@ -1,0 +1,98 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class RunInfo private (
+  val jvm: Boolean,
+  val args: Vector[String],
+  val classpath: Vector[sbt.internal.worker.FilePath],
+  val mainClass: Option[String],
+  val connectInput: Boolean,
+  val javaHome: Option[java.net.URI],
+  val outputStrategy: Option[String],
+  val workingDirectory: Option[java.net.URI],
+  val jvmOptions: Vector[String],
+  val environmentVariables: scala.collection.immutable.Map[String, String],
+  val inputs: Vector[sbt.internal.worker.FilePath],
+  val outputs: Vector[sbt.internal.worker.FilePath],
+  val cmd: Option[String]) extends Serializable {
+  
+  private def this(jvm: Boolean, args: Vector[String], classpath: Vector[sbt.internal.worker.FilePath], mainClass: Option[String], connectInput: Boolean, javaHome: Option[java.net.URI], outputStrategy: Option[String], workingDirectory: Option[java.net.URI], jvmOptions: Vector[String], environmentVariables: scala.collection.immutable.Map[String, String]) = this(jvm, args, classpath, mainClass, connectInput, javaHome, outputStrategy, workingDirectory, jvmOptions, environmentVariables, Vector(), Vector(), None)
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: RunInfo => (this.jvm == x.jvm) && (this.args == x.args) && (this.classpath == x.classpath) && (this.mainClass == x.mainClass) && (this.connectInput == x.connectInput) && (this.javaHome == x.javaHome) && (this.outputStrategy == x.outputStrategy) && (this.workingDirectory == x.workingDirectory) && (this.jvmOptions == x.jvmOptions) && (this.environmentVariables == x.environmentVariables) && (this.inputs == x.inputs) && (this.outputs == x.outputs) && (this.cmd == x.cmd)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.RunInfo".##) + jvm.##) + args.##) + classpath.##) + mainClass.##) + connectInput.##) + javaHome.##) + outputStrategy.##) + workingDirectory.##) + jvmOptions.##) + environmentVariables.##) + inputs.##) + outputs.##) + cmd.##)
+  }
+  override def toString: String = {
+    "RunInfo(" + jvm + ", " + args + ", " + classpath + ", " + mainClass + ", " + connectInput + ", " + javaHome + ", " + outputStrategy + ", " + workingDirectory + ", " + jvmOptions + ", " + environmentVariables + ", " + inputs + ", " + outputs + ", " + cmd + ")"
+  }
+  private def copy(jvm: Boolean = jvm, args: Vector[String] = args, classpath: Vector[sbt.internal.worker.FilePath] = classpath, mainClass: Option[String] = mainClass, connectInput: Boolean = connectInput, javaHome: Option[java.net.URI] = javaHome, outputStrategy: Option[String] = outputStrategy, workingDirectory: Option[java.net.URI] = workingDirectory, jvmOptions: Vector[String] = jvmOptions, environmentVariables: scala.collection.immutable.Map[String, String] = environmentVariables, inputs: Vector[sbt.internal.worker.FilePath] = inputs, outputs: Vector[sbt.internal.worker.FilePath] = outputs, cmd: Option[String] = cmd): RunInfo = {
+    new RunInfo(jvm, args, classpath, mainClass, connectInput, javaHome, outputStrategy, workingDirectory, jvmOptions, environmentVariables, inputs, outputs, cmd)
+  }
+  def withJvm(jvm: Boolean): RunInfo = {
+    copy(jvm = jvm)
+  }
+  def withArgs(args: Vector[String]): RunInfo = {
+    copy(args = args)
+  }
+  def withClasspath(classpath: Vector[sbt.internal.worker.FilePath]): RunInfo = {
+    copy(classpath = classpath)
+  }
+  def withMainClass(mainClass: Option[String]): RunInfo = {
+    copy(mainClass = mainClass)
+  }
+  def withMainClass(mainClass: String): RunInfo = {
+    copy(mainClass = Option(mainClass))
+  }
+  def withConnectInput(connectInput: Boolean): RunInfo = {
+    copy(connectInput = connectInput)
+  }
+  def withJavaHome(javaHome: Option[java.net.URI]): RunInfo = {
+    copy(javaHome = javaHome)
+  }
+  def withJavaHome(javaHome: java.net.URI): RunInfo = {
+    copy(javaHome = Option(javaHome))
+  }
+  def withOutputStrategy(outputStrategy: Option[String]): RunInfo = {
+    copy(outputStrategy = outputStrategy)
+  }
+  def withOutputStrategy(outputStrategy: String): RunInfo = {
+    copy(outputStrategy = Option(outputStrategy))
+  }
+  def withWorkingDirectory(workingDirectory: Option[java.net.URI]): RunInfo = {
+    copy(workingDirectory = workingDirectory)
+  }
+  def withWorkingDirectory(workingDirectory: java.net.URI): RunInfo = {
+    copy(workingDirectory = Option(workingDirectory))
+  }
+  def withJvmOptions(jvmOptions: Vector[String]): RunInfo = {
+    copy(jvmOptions = jvmOptions)
+  }
+  def withEnvironmentVariables(environmentVariables: scala.collection.immutable.Map[String, String]): RunInfo = {
+    copy(environmentVariables = environmentVariables)
+  }
+  def withInputs(inputs: Vector[sbt.internal.worker.FilePath]): RunInfo = {
+    copy(inputs = inputs)
+  }
+  def withOutputs(outputs: Vector[sbt.internal.worker.FilePath]): RunInfo = {
+    copy(outputs = outputs)
+  }
+  def withCmd(cmd: Option[String]): RunInfo = {
+    copy(cmd = cmd)
+  }
+  def withCmd(cmd: String): RunInfo = {
+    copy(cmd = Option(cmd))
+  }
+}
+object RunInfo {
+  
+  def apply(jvm: Boolean, args: Vector[String], classpath: Vector[sbt.internal.worker.FilePath], mainClass: Option[String], connectInput: Boolean, javaHome: Option[java.net.URI], outputStrategy: Option[String], workingDirectory: Option[java.net.URI], jvmOptions: Vector[String], environmentVariables: scala.collection.immutable.Map[String, String]): RunInfo = new RunInfo(jvm, args, classpath, mainClass, connectInput, javaHome, outputStrategy, workingDirectory, jvmOptions, environmentVariables)
+  def apply(jvm: Boolean, args: Vector[String], classpath: Vector[sbt.internal.worker.FilePath], mainClass: String, connectInput: Boolean, javaHome: java.net.URI, outputStrategy: String, workingDirectory: java.net.URI, jvmOptions: Vector[String], environmentVariables: scala.collection.immutable.Map[String, String]): RunInfo = new RunInfo(jvm, args, classpath, Option(mainClass), connectInput, Option(javaHome), Option(outputStrategy), Option(workingDirectory), jvmOptions, environmentVariables)
+  def apply(jvm: Boolean, args: Vector[String], classpath: Vector[sbt.internal.worker.FilePath], mainClass: Option[String], connectInput: Boolean, javaHome: Option[java.net.URI], outputStrategy: Option[String], workingDirectory: Option[java.net.URI], jvmOptions: Vector[String], environmentVariables: scala.collection.immutable.Map[String, String], inputs: Vector[sbt.internal.worker.FilePath], outputs: Vector[sbt.internal.worker.FilePath], cmd: Option[String]): RunInfo = new RunInfo(jvm, args, classpath, mainClass, connectInput, javaHome, outputStrategy, workingDirectory, jvmOptions, environmentVariables, inputs, outputs, cmd)
+  def apply(jvm: Boolean, args: Vector[String], classpath: Vector[sbt.internal.worker.FilePath], mainClass: String, connectInput: Boolean, javaHome: java.net.URI, outputStrategy: String, workingDirectory: java.net.URI, jvmOptions: Vector[String], environmentVariables: scala.collection.immutable.Map[String, String], inputs: Vector[sbt.internal.worker.FilePath], outputs: Vector[sbt.internal.worker.FilePath], cmd: String): RunInfo = new RunInfo(jvm, args, classpath, Option(mainClass), connectInput, Option(javaHome), Option(outputStrategy), Option(workingDirectory), jvmOptions, environmentVariables, inputs, outputs, Option(cmd))
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FilePathFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FilePathFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait FilePathFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val FilePathFormat: JsonFormat[sbt.internal.worker.FilePath] = new JsonFormat[sbt.internal.worker.FilePath] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.FilePath = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val path = unbuilder.readField[java.net.URI]("path")
+      val digest = unbuilder.readField[String]("digest")
+      unbuilder.endObject()
+      sbt.internal.worker.FilePath(path, digest)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.FilePath, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("path", obj.path)
+    builder.addField("digest", obj.digest)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/GeneralParamsFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/GeneralParamsFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait GeneralParamsFormats { self: sbt.internal.worker.codec.RunInfoFormats & sbt.internal.worker.codec.FilePathFormats & sjsonnew.BasicJsonProtocol =>
+implicit lazy val GeneralParamsFormat: JsonFormat[sbt.internal.worker.GeneralParams] = new JsonFormat[sbt.internal.worker.GeneralParams] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.GeneralParams = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val runInfo = unbuilder.readField[Option[sbt.internal.worker.RunInfo]]("runInfo")
+      unbuilder.endObject()
+      sbt.internal.worker.GeneralParams(runInfo)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.GeneralParams, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("runInfo", obj.runInfo)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
@@ -1,0 +1,11 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+trait JsonProtocol extends sjsonnew.BasicJsonProtocol
+  with sbt.internal.worker.codec.FilePathFormats
+  with sbt.internal.worker.codec.RunInfoFormats
+  with sbt.internal.worker.codec.GeneralParamsFormats
+object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/RunInfoFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/RunInfoFormats.scala
@@ -1,0 +1,51 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait RunInfoFormats { self: sbt.internal.worker.codec.FilePathFormats & sjsonnew.BasicJsonProtocol =>
+implicit lazy val RunInfoFormat: JsonFormat[sbt.internal.worker.RunInfo] = new JsonFormat[sbt.internal.worker.RunInfo] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.RunInfo = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val jvm = unbuilder.readField[Boolean]("jvm")
+      val args = unbuilder.readField[Vector[String]]("args")
+      val classpath = unbuilder.readField[Vector[sbt.internal.worker.FilePath]]("classpath")
+      val mainClass = unbuilder.readField[Option[String]]("mainClass")
+      val connectInput = unbuilder.readField[Boolean]("connectInput")
+      val javaHome = unbuilder.readField[Option[java.net.URI]]("javaHome")
+      val outputStrategy = unbuilder.readField[Option[String]]("outputStrategy")
+      val workingDirectory = unbuilder.readField[Option[java.net.URI]]("workingDirectory")
+      val jvmOptions = unbuilder.readField[Vector[String]]("jvmOptions")
+      val environmentVariables = unbuilder.readField[scala.collection.immutable.Map[String, String]]("environmentVariables")
+      val inputs = unbuilder.readField[Vector[sbt.internal.worker.FilePath]]("inputs")
+      val outputs = unbuilder.readField[Vector[sbt.internal.worker.FilePath]]("outputs")
+      val cmd = unbuilder.readField[Option[String]]("cmd")
+      unbuilder.endObject()
+      sbt.internal.worker.RunInfo(jvm, args, classpath, mainClass, connectInput, javaHome, outputStrategy, workingDirectory, jvmOptions, environmentVariables, inputs, outputs, cmd)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.RunInfo, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("jvm", obj.jvm)
+    builder.addField("args", obj.args)
+    builder.addField("classpath", obj.classpath)
+    builder.addField("mainClass", obj.mainClass)
+    builder.addField("connectInput", obj.connectInput)
+    builder.addField("javaHome", obj.javaHome)
+    builder.addField("outputStrategy", obj.outputStrategy)
+    builder.addField("workingDirectory", obj.workingDirectory)
+    builder.addField("jvmOptions", obj.jvmOptions)
+    builder.addField("environmentVariables", obj.environmentVariables)
+    builder.addField("inputs", obj.inputs)
+    builder.addField("outputs", obj.outputs)
+    builder.addField("cmd", obj.cmd)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -1,0 +1,31 @@
+package sbt.internal.worker
+@target(Scala)
+@codecPackage("sbt.internal.worker.codec")
+@fullCodec("JsonProtocol")
+
+type FilePath {
+  path: java.net.URI!
+  digest: String!
+}
+
+type RunInfo {
+  jvm: Boolean!
+  args: [String],
+  classpath: [sbt.internal.worker.FilePath],
+  mainClass: String
+  connectInput: Boolean!
+  javaHome: java.net.URI
+  outputStrategy: String
+  workingDirectory: java.net.URI
+  jvmOptions: [String]
+  environmentVariables: StringStringMap!
+  inputs: [sbt.internal.worker.FilePath] @since("0.1.0"),
+  outputs: [sbt.internal.worker.FilePath] @since("0.1.0"),
+  cmd: String @since("0.1.0"),
+}
+
+## Parameter for the sbt/general command, which is a generic command to
+## run a program.
+type GeneralParams {
+  runInfo: sbt.internal.worker.RunInfo
+}

--- a/protocol/src/main/scala/sbt/protocol/Serialization.scala
+++ b/protocol/src/main/scala/sbt/protocol/Serialization.scala
@@ -27,6 +27,7 @@ object Serialization {
   private[sbt] val VsCode = "application/vscode-jsonrpc; charset=utf-8"
   val readSystemIn = "sbt/readSystemIn"
   val cancelReadSystemIn = "sbt/cancelReadSystemIn"
+  val general = "sbt/general"
   val systemIn = "sbt/systemIn"
   val systemOut = "sbt/systemOut"
   val systemErr = "sbt/systemErr"

--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -35,15 +35,8 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
    * `config`. If `runnerClass` is defined for this Fork instance, it is prepended to `arguments` to
    * define the arguments passed to the forked command.
    */
-  def apply(config: ForkOptions, arguments: Seq[String]): Int = {
-    val p = fork(config, arguments)
-    RunningProcesses.add(p)
-    try p.exitValue()
-    finally {
-      if (p.isAlive()) p.destroy()
-      RunningProcesses.remove(p)
-    }
-  }
+  def apply(config: ForkOptions, arguments: Seq[String]): Int =
+    Fork.blockForExitCode(fork(config, arguments))
 
   /**
    * Forks the configured process and returns a `Process` that can be used to wait for completion or
@@ -58,30 +51,17 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
     val preOptions = makeOptions(runJVMOptions, bootJars, arguments)
     val (classpathEnv, options) = Fork.fitClasspath(preOptions)
     val command = executable +: options
-
-    val environment: List[(String, String)] = envVars.toList ++
-      classpathEnv.map(value => Fork.ClasspathEnvKey -> value)
     val jpb =
       if (Fork.shouldUseArgumentsFile(options))
         new JProcessBuilder(executable, Fork.createArgumentsFile(options))
       else
         new JProcessBuilder(command*)
-    workingDirectory.foreach(jpb.directory(_))
-    environment.foreach { case (k, v) => jpb.environment.put(k, v) }
-    if (connectInput) {
-      jpb.redirectInput(Redirect.INHERIT)
-      ()
+    val extraEnv = classpathEnv.toList.map { value =>
+      Fork.ClasspathEnvKey -> value
     }
-    val process = Process(jpb)
-
-    outputStrategy.getOrElse(StdoutOutput: OutputStrategy) match {
-      case StdoutOutput => process.run(connectInput = false)
-      case out: BufferedOutput =>
-        out.logger.buffer { process.run(out.logger, connectInput = false) }
-      case out: LoggedOutput => process.run(out.logger, connectInput = false)
-      case out: CustomOutput => (process #> out.output).run(connectInput = false)
-    }
+    Fork.forkInternal(config, extraEnv, jpb)
   }
+
   private def makeOptions(
       jvmOptions: Seq[String],
       bootJars: Iterable[File],
@@ -189,5 +169,37 @@ object Fork {
     pw.flush()
     pw.close()
     s"@${file.getAbsolutePath}"
+  }
+
+  private[sbt] def forkInternal(
+      config: ForkOptions,
+      extraEnv: List[(String, String)],
+      jpb: JProcessBuilder
+  ): Process = {
+    import config.{ envVars as env, * }
+    val environment: List[(String, String)] = env.toList ++ extraEnv
+    workingDirectory.foreach(jpb.directory(_))
+    environment.foreach { case (k, v) => jpb.environment.put(k, v) }
+    if (connectInput) {
+      jpb.redirectInput(Redirect.INHERIT)
+      ()
+    }
+    val process = Process(jpb)
+    outputStrategy.getOrElse(StdoutOutput: OutputStrategy) match {
+      case StdoutOutput => process.run(connectInput = false)
+      case out: BufferedOutput =>
+        out.logger.buffer { process.run(out.logger, connectInput = false) }
+      case out: LoggedOutput => process.run(out.logger, connectInput = false)
+      case out: CustomOutput => (process #> out.output).run(connectInput = false)
+    }
+  }
+
+  private[sbt] def blockForExitCode(p: Process): Int = {
+    RunningProcesses.add(p)
+    try p.exitValue()
+    finally {
+      if (p.isAlive()) p.destroy()
+      RunningProcesses.remove(p)
+    }
   }
 }

--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -32,15 +32,6 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
       options: Seq[String],
       log: Logger
   ): Try[Unit] = {
-    def processExitCode(exitCode: Int, label: String): Try[Unit] =
-      if (exitCode == 0) Success(())
-      else
-        Failure(
-          new MessageOnlyException(
-            s"""Nonzero exit code returned from $label: $exitCode""".stripMargin
-          )
-        )
-
     log.info(s"running (fork) $mainClass ${Run.runOptionsStr(options)}")
     val c = configLogged(log)
     val scalaOpts = scalaOptions(mainClass, classpath, options)
@@ -48,10 +39,10 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
       try Fork.java(c, scalaOpts)
       catch {
         case _: InterruptedException =>
-          log.warn("Run canceled.")
+          log.warn("run canceled")
           1
       }
-    processExitCode(exitCode, "runner")
+    Run.processExitCode(exitCode, "runner")
   }
 
   def fork(
@@ -211,4 +202,13 @@ object Run:
       case str if str.contains(" ") => "\"" + str + "\""
       case str                      => str
     }).mkString(" ")
+
+  private[sbt] def processExitCode(exitCode: Int, label: String): Try[Unit] =
+    if (exitCode == 0) Success(())
+    else
+      Failure(
+        new MessageOnlyException(
+          s"""nonzero exit code returned from $label: $exitCode""".stripMargin
+        )
+      )
 end Run

--- a/server-test/src/server-test/client/build.sbt
+++ b/server-test/src/server-test/client/build.sbt
@@ -1,8 +1,9 @@
+scalaVersion := "3.6.3"
+
 TaskKey[Unit]("willSucceed") := println("success")
 
 TaskKey[Unit]("willFail") := { throw new Exception("failed") }
 
-scalaVersion := "2.12.20"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 
 TaskKey[Unit]("fooBar") := { () }

--- a/server-test/src/server-test/client/src/main/scala/A.scala
+++ b/server-test/src/server-test/client/src/main/scala/A.scala
@@ -1,1 +1,3 @@
-object A
+class A
+
+@main def hello() = println("Hello, World!")

--- a/server-test/src/server-test/client/src/test/scala/FooSpec.scala
+++ b/server-test/src/server-test/client/src/test/scala/FooSpec.scala
@@ -1,3 +1,3 @@
 package test.pkg
 
-class FooSpec extends org.scalatest.FlatSpec
+class FooSpec extends munit.FunSuite

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -59,7 +59,7 @@ class ClientTest extends AbstractServerTest {
       case r => r
     }
   }
-  private def client(args: String*): Int = {
+  private def client(args: String*): Int =
     background(
       NetworkClient.client(
         testPath.toFile,
@@ -70,6 +70,19 @@ class ClientTest extends AbstractServerTest {
         false
       )
     )
+  private def clientWithStdoutLines(args: String*): (Int, Seq[String]) = {
+    val out = new CachingPrintStream
+    val exitCode = background(
+      NetworkClient.client(
+        testPath.toFile,
+        args.toArray,
+        NullInputStream,
+        out,
+        NullPrintStream,
+        false
+      )
+    )
+    (exitCode, out.lines)
   }
   // This ensures that the completion command will send a tab that triggers
   // sbt to call definedTestNames or discoveredMainClasses if there hasn't
@@ -108,6 +121,11 @@ class ClientTest extends AbstractServerTest {
   }
   test("three commands with middle failure") {
     assert(client("compile;willFail;willSucceed") == 1)
+  }
+  test("run") {
+    val (exitCode, lines) = clientWithStdoutLines("run")
+    assert(exitCode == 0)
+    assert(lines.toList.exists(_.endsWith("Hello, World!")))
   }
   test("compi completions") {
     val expected = Vector(


### PR DESCRIPTION
Related blog post [sudori part 7: client-side run with sbt](https://eed3si9n.com/sudori-part7-client-side-run-with-sbt/)
This is a forward port of https://github.com/sbt/sbt/pull/8040

## Problem
`run` task blocks the server, but during the run the server is just waiting for the built program to finish.

## Solution
This implements client-side run where the server creates a sandbox environment, and sends the information to the client, and the client forks a new JVM to perform the run.
