### PR TITLE
[1.x] Fix stdout freshness issue

### DIFF
--- a/run/src/main/scala/sbt/Run.scala
+++ b/run/src/main/scala/sbt/Run.scala
@@ -58,7 +58,7 @@ class ForkRun(config: ForkOptions) extends ScalaRun {
   }
 
   private def configLogged(log: Logger): ForkOptions = {
-    if (config.outputStrategy.isDefined) config
+    if (config.outputStrategy.isDefined || config.connectInput) config
     else config.withOutputStrategy(OutputStrategy.LoggedOutput(log))
   }
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8047
This is an offshoot from https://github.com/sbt/sbt/pull/8040

## Problem
When ForkOptions outputStrategy is None, Run code currently tries to use LoggedOutput, which buffers the output when connectInput is true, which effectively breaks the experience.

## Solution
This stops falling back to LoggedOutput when connectInput is true.