### PR TITLE
[1.x] fix: sbt init

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -476,6 +476,11 @@ if "%~0" == "new" (
     set sbt_new=true
   )
 )
+if "%~0" == "init" (
+  if not defined SBT_ARGS (
+    set sbt_new=true
+  )
+)
 
 if "%g:~0,2%" == "-D" (
   rem special handling for -D since '=' gets parsed away

--- a/sbt
+++ b/sbt
@@ -639,7 +639,7 @@ process_my_args () {
 
    -allow-empty|--allow-empty|-sbt-create|--sbt-create) allow_empty=true && shift ;;
 
-                        new) sbt_new=true && addResidual "$1" && shift ;;
+                   new|init) sbt_new=true && addResidual "$1" && shift ;;
 
                           *) addResidual "$1" && shift ;;
     esac


### PR DESCRIPTION
## Problem
`sbt init` no longer works because of --allow-empty check.

## Solution
Skip allow empty check for sbt init.