### PR TITLE
[1.x] Revert run switching on 1.x

### DIFF
--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -148,21 +148,6 @@ final class NetworkChannel(
       self.onCancellationRequest(execId, crp)
   }
 
-  // Take over commandline for network channel
-  private val networkCommand: PartialFunction[String, String] = {
-    case cmd if cmd.split(" ").head.split("/").last == "run" =>
-      s"clientJob $cmd"
-  }
-  override protected def appendExec(commandLine: String, execId: Option[String]): Boolean =
-    if (clientCanWork && networkCommand.isDefinedAt(commandLine))
-      super.appendExec(networkCommand(commandLine), execId)
-    else super.appendExec(commandLine, execId)
-
-  override private[sbt] def onCommandLine(cmd: String): Boolean =
-    if (clientCanWork && networkCommand.isDefinedAt(cmd))
-      appendExec(networkCommand(cmd), None)
-    else super.onCommandLine(cmd)
-
   protected def setInitializeOption(opts: InitializeOption): Unit = initializeOption.set(opts)
 
   // Returns true if sbtn has declared with canWork: true

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -68,7 +68,7 @@ object ClientTest extends AbstractServerTest {
         false
       )
     )
-  private def clientWithStdoutLines(args: String*): (Int, Seq[String]) = {
+  def clientWithStdoutLines(args: String*): (Int, Seq[String]) = {
     val out = new CachingPrintStream
     val exitCode = background(
       NetworkClient.client(
@@ -119,11 +119,6 @@ object ClientTest extends AbstractServerTest {
   }
   test("three commands with middle failure") { _ =>
     assert(client("compile;willFail;willSucceed") == 1)
-  }
-  test("run") { _ =>
-    val (exitCode, lines) = clientWithStdoutLines("run")
-    assert(exitCode == 0)
-    assert(lines.toList.exists(_.endsWith("Hello, World!")))
   }
   test("compi completions") { _ =>
     val expected = Vector(


### PR DESCRIPTION
## Problem
client-side run apparently won't work for Scala.JS, so forcing sbtn users to client-side run will break the Scala.JS users.

## Solution
This reverts the client-side run on sbt 1.x, while retaining the mechanism for sbt 2.x usages via sbtn.
Now, if `run / connectInput := true` is true, stdout will not display on sbtn.