### PR TITLE
[1.x] Skip retry on CompileCancelled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import scala.util.Try
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 ThisBuild / version := {
-  val v = "1.10.8-SNAPSHOT"
+  val v = "1.10.10-SNAPSHOT"
   nightlyVersion.getOrElse(v)
 }
 ThisBuild / version2_13 := "2.0.0-SNAPSHOT"

--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -16,6 +16,7 @@ import sbt.internal.server.BspCompileTask.exchange
 import sbt.librarymanagement.Configuration
 import sbt.util.InterfaceUtil
 import sjsonnew.support.scalajson.unsafe.Converter
+import xsbti.CompileCancelled
 import xsbti.CompileFailed
 import xsbti.Problem
 import xsbti.Severity
@@ -38,7 +39,7 @@ object BspCompileTask {
     val task = BspCompileTask(targetId, project, config, ci)
     try {
       task.notifyStart()
-      val result = Retry(compile(task))
+      val result = Retry(compile(task), classOf[CompileCancelled], classOf[CompileFailed])
       task.notifySuccess(result)
       result
     } catch {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8053

## Problem
When compilation fails, it's retrying 10 times since Retry now retries on non-IOExceptions.

## Solution
This adds CompileFailed to excluded exception list.