### PR TITLE
[1.x] Shortcut sbtn shutdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import scala.util.Try
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 ThisBuild / version := {
-  val v = "1.10.10-SNAPSHOT"
+  val v = "1.10.11-SNAPSHOT"
   nightlyVersion.getOrElse(v)
 }
 ThisBuild / version2_13 := "2.0.0-SNAPSHOT"

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -153,6 +153,7 @@ class NetworkClient(
   private lazy val noTab = arguments.completionArguments.contains("--no-tab")
   private lazy val noStdErr = arguments.completionArguments.contains("--no-stderr") &&
     !sys.env.contains("SBTN_AUTO_COMPLETE") && !sys.env.contains("SBTC_AUTO_COMPLETE")
+  private def shutdownOnly = arguments.commandArguments == Seq(Shutdown)
 
   private def mkSocket(file: File): (Socket, Option[String]) = ClientSocket.socket(file, useJNI)
 
@@ -188,7 +189,10 @@ class NetworkClient(
   ): (Socket, Option[String]) =
     try {
       if (!portfile.exists) {
-        if (promptCompleteUsers) {
+        if (shutdownOnly) {
+          console.appendLog(Level.Info, "no sbt server is running. ciao")
+          System.exit(0)
+        } else if (promptCompleteUsers) {
           val msg = if (noTab) "" else "No sbt server is running. Press <tab> to start one..."
           errorStream.print(s"\n$msg")
           if (noStdErr) System.exit(0)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/discussions/8055

## Problem
WHen portfile is not found, sbtn will try to start the server even when the desired command is shutdown.

## Solution
When the command is just shutdown, don't start the server.