### PR TITLE
[1.x] fix: Avoid creating target on sbt -V

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerTest.scala
@@ -33,19 +33,32 @@ object SbtRunnerTest extends SimpleTestSuite with PowerAssertions {
     ()
   }
 
+  def testVersion(lines: List[String]): Unit = {
+    assert(lines.size >= 2)
+    val expected0 = s"(?m)^sbt version in this project: $versionRegEx(\\r)?"
+    assert(lines(0).matches(expected0))
+    val expected1 = s"sbt runner version: $versionRegEx$$"
+    assert(lines(1).matches(expected1))
+  }
+
   test("sbt -V|-version|--version should print sbtVersion") {
     val out = sbtProcess("-version").!!.trim
-    val expectedVersion =
-      s"""|(?m)^sbt version in this project: $versionRegEx(\\r)?
-          |sbt script version: $versionRegEx$$
-          |""".stripMargin.trim.replace("\n", "\\n")
-    assert(out.matches(expectedVersion))
+    testVersion(out.linesIterator.toList)
 
     val out2 = sbtProcess("--version").!!.trim
-    assert(out2.matches(expectedVersion))
+    testVersion(out2.linesIterator.toList)
 
     val out3 = sbtProcess("-V").!!.trim
-    assert(out3.matches(expectedVersion))
+    testVersion(out3.linesIterator.toList)
+  }
+
+  test("sbt -V in empty directory") {
+    IO.withTemporaryDirectory { tmp =>
+      val out = sbtProcessInDir(tmp)("-V").!!.trim
+      val expectedVersion = "^"+versionRegEx+"$"
+      val targetDir = new File(tmp, "target")
+      assert(!targetDir.exists, "expected target directory to not exist, but existed")
+    }
     ()
   }
 

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -51,6 +51,7 @@ set sbt_args_sbt_version=
 set sbt_args_mem=
 set sbt_args_client=
 set sbt_args_no_server=
+set is_this_dir_sbt=0
 
 rem users can set SBT_OPTS via .sbtopts
 if exist .sbtopts for /F %%A in (.sbtopts) do (
@@ -532,11 +533,18 @@ set SBT_ARGS=!SBT_ARGS! %0
 goto args_loop
 :args_end
 
+if exist build.sbt (
+  set is_this_dir_sbt=1
+)
+if exist project\build.properties (
+  set is_this_dir_sbt=1
+)
+
 rem Confirm a user's intent if the current directory does not look like an sbt
 rem top-level directory and the "new" command was not given.
 
-if not defined sbt_args_allow_empty if not defined sbt_args_print_version if not defined sbt_args_print_sbt_version if not defined sbt_args_print_sbt_script_version if not defined shutdownall if not exist build.sbt (
-  if not exist project\ (
+if not defined sbt_args_allow_empty if not defined sbt_args_print_version if not defined sbt_args_print_sbt_version if not defined sbt_args_print_sbt_script_version if not defined shutdownall (
+  if not !is_this_dir_sbt! equ 1 (
     if not defined sbt_new (
       echo [error] Neither build.sbt nor a 'project' directory in the current directory: "%CD%"
       echo [error] run 'sbt new', touch build.sbt, or run 'sbt --allow-empty'.
@@ -667,9 +675,14 @@ if !sbt_args_print_sbt_version! equ 1 (
 )
 
 if !sbt_args_print_version! equ 1 (
-  call :set_sbt_version
-  echo sbt version in this project: !sbt_version!
-  echo sbt script version: !init_sbt_version!
+  if !is_this_dir_sbt! equ 1 (
+    call :set_sbt_version
+    echo sbt version in this project: !sbt_version!
+  )
+  echo sbt runner version: !init_sbt_version!
+  echo.
+  echo [info] sbt runner ^(sbt-the-batch-script^) is a runner to run any declared version of sbt.
+  echo [info] Actual version of the sbt is declared using project\build.properties for each build.
   goto :eof
 )
 

--- a/sbt
+++ b/sbt
@@ -26,6 +26,7 @@ declare no_server=
 declare sbtn_command="$SBTN_CMD"
 declare sbtn_version="1.10.8"
 declare use_colors=1
+declare is_this_dir_sbt=""
 
 ###  ------------------------------- ###
 ###  Helper methods for BASH scripts ###
@@ -494,11 +495,17 @@ copyRt() {
   fi
 }
 
+detect_working_directory() {
+  if [[ -f ./build.sbt || -f ./project/build.properties ]]; then
+    is_this_dir_sbt=1
+  fi
+}
+
 # Confirm a user's intent if the current directory does not look like an sbt
 # top-level directory and neither the --allow-empty option nor the "new" command was given.
 checkWorkingDirectory() {
   if [[ ! -n "$allow_empty" ]]; then
-    [[ -f ./build.sbt || -d ./project || -n "$sbt_new" ]] || {
+    [[ -n "$is_this_dir_sbt" || -n "$sbt_new" ]] || {
       echoerr_error "Neither build.sbt nor a 'project' directory in the current directory: $(pwd)"
       echoerr_error "run 'sbt new', touch build.sbt, or run 'sbt --allow-empty'."
       echoerr_error ""
@@ -531,13 +538,19 @@ run() {
     addJava "-Dsbt.cygwin=true"
   fi
 
+  detect_working_directory
   if [[ $print_sbt_version ]]; then
     execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
   elif [[ $print_sbt_script_version ]]; then
     echo "$init_sbt_version"
   elif [[ $print_version ]]; then
-    execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
-    echo "sbt script version: $init_sbt_version"
+    if [[ -n "$is_this_dir_sbt" ]]; then
+      execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
+    fi
+    echo "sbt runner version: $init_sbt_version"
+    echoerr ""
+    echoerr "[info] sbt runner (sbt-the-shell-script) is a runner to run any declared version of sbt."
+    echoerr "[info] Actual version of the sbt is declared using project/build.properties for each build."
   elif [[ $shutdownall ]]; then
     local sbt_processes=( $(jps -v | grep sbt-launch | cut -f1 -d ' ') )
     for procId in "${sbt_processes[@]}"; do


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8065

## Problem
`sbt -V` tries to show both the sbt version and the runner version, and ends up creating target directory even on a non-sbt directory.

## Solution
If the current directory doesn't have a build, just display the runner version.