### PR TITLE
[1.x] fix: Fix SIP-51 message

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1213,7 +1213,7 @@ object Defaults extends BuildCommon {
       for (lib <- scalaDeps.take(1)) {
         val libVer = lib.module.revision
         val libName = lib.module.name
-        val n = name.value
+        val proj = Def.displayBuildRelative(thisProjectRef.value.build, thisProjectRef.value)
         if (VersionNumber(sv).matchesSemVer(SemanticSelector(s"<$libVer"))) {
           val err = !allowUnsafeScalaLibUpgrade.value
           val fix =
@@ -1227,13 +1227,13 @@ object Defaults extends BuildCommon {
                  |Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.""".stripMargin
 
           val msg =
-            s"""Expected `$n/scalaVersion` to be $libVer or later, but found $sv.
+            s"""Expected `$proj scalaVersion` to be $libVer or later, but found $sv.
                |To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
                |should not be older than $libName on the dependency classpath.
                |
                |$fix
                |
-               |See `$n/evicted` to know why $libName $libVer is getting pulled in.
+               |See `$proj evicted` to know why $libName $libVer is getting pulled in.
                |""".stripMargin
           if (err) sys.error(msg)
           else s.log.warn(msg)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8056

## Problem
The error message uses name, which may not match the actual project id that the user can type into the shell.

## Solution
Use displayBuildRelative to calculate the proper subproject id.

## Note

```
sbt:bar-aaa> compile
[error] stack trace is suppressed; run last scalaInstance for the full output
[error] (scalaInstance) Expected `bar / scalaVersion` to be 2.13.16 or later, but found 2.13.9.
[error] To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
[error] should not be older than scala-library on the dependency classpath.
[error]
[error] Upgrade the `scalaVersion` to fix the build. If upgrading the Scala compiler version is
[error] not possible (for example due to a regression in the compiler or a missing dependency),
[error] this error can be demoted by setting `allowUnsafeScalaLibUpgrade := true`.
[error]
[error] See `bar / evicted` to know why scala-library 2.13.16 is getting pulled in.
```