### PR TITLE
[1.x] Update lm-coursier-shaded to 2.1.8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompile", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.1.7"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.1.8"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.10.1") // contrabandSjsonNewVersion.value


### PR DESCRIPTION
* deps: Update Coursier from 2.1.22 → 2.1.23 by @scala-steward in https://github.com/coursier/sbt-coursier/pull/547
   - https://github.com/coursier/coursier/releases/tag/v2.1.23
* fix: Retry on OverlappingFileLockException by @eed3si9n in https://github.com/coursier/sbt-coursier/pull/558
