### PR TITLE
[1.x] fix: Use Retry.io for compilation

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
+++ b/main/src/main/scala/sbt/internal/server/BspCompileTask.scala
@@ -16,7 +16,6 @@ import sbt.internal.server.BspCompileTask.exchange
 import sbt.librarymanagement.Configuration
 import sbt.util.InterfaceUtil
 import sjsonnew.support.scalajson.unsafe.Converter
-import xsbti.CompileCancelled
 import xsbti.CompileFailed
 import xsbti.Problem
 import xsbti.Severity
@@ -39,7 +38,7 @@ object BspCompileTask {
     val task = BspCompileTask(targetId, project, config, ci)
     try {
       task.notifyStart()
-      val result = Retry(compile(task), classOf[CompileCancelled], classOf[CompileFailed])
+      val result = Retry.io(compile(task))
       task.notifySuccess(result)
       result
     } catch {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")
 
   // sbt modules
-  private val ioVersion = nightlyVersion.getOrElse("1.10.4")
+  private val ioVersion = nightlyVersion.getOrElse("1.10.5")
   private val lmVersion =
     sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.10.4")
   val zincVersion = nightlyVersion.getOrElse("1.10.8")


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8058

## Problem
sbt 1.10.10 still has retry problem with compilation.

## Solution
Revert the retry logic back to the time when we only retried IOExceptions.