### PR TITLE
[1.x] fix: Fix sbt --client on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,8 @@ jobs:
         # test building sbtn on Linux
         sbt "-Dsbt.io.virtual=false" nativeImage
         # smoke test native Image
-        ./client/target/bin/sbtn shutdown
+        ./client/target/bin/sbtn --sbt-script=$(pwd)/sbt about
+        ./client/target/bin/sbtn --sbt-script=$(pwd)/sbt shutdown
         # test launcher script
         echo build using JDK 8 test using JDK 8 and JDK 11
         cd launcher-package
@@ -189,6 +190,9 @@ jobs:
       run: |
         # test building sbtn on Windows
         sbt "-Dsbt.io.virtual=false" nativeImage
+        # smoke test native Image
+        ./client/target/bin/sbtn --sbt-script=$(pwd)/launcher-package/src/universal/bin/sbt.bat about
+        ./client/target/bin/sbtn --sbt-script=$(pwd)/launcher-package/src/universal/bin/sbt.bat shutdown
         # test launcher script
         echo build using JDK 8, test using JDK 8, on Windows
         cd launcher-package

--- a/sbt
+++ b/sbt
@@ -805,7 +805,12 @@ runNativeClient() {
       unset 'original_args[i]'
     fi
   done
-  sbt_script=$0
+
+  if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    sbt_script="$0.bat"
+  else
+    sbt_script="$0"
+  fi
   sbt_script=${sbt_script/ /%20}
   execRunner "$sbtn_command" "--sbt-script=$sbt_script" "${original_args[@]}"
 }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8064

## Problem
`sbt --client` doens't work on Windows because the runner script passes itself to the server, but it's unable to launch Bash script.

## Solution
Pass in the bat version instead on Windows.