### PR TITLE
fix: Avoid printing to stdout

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -546,8 +546,8 @@ rem top-level directory and the "new" command was not given.
 if not defined sbt_args_allow_empty if not defined sbt_args_print_version if not defined sbt_args_print_sbt_version if not defined sbt_args_print_sbt_script_version if not defined shutdownall (
   if not !is_this_dir_sbt! equ 1 (
     if not defined sbt_new (
-      echo [error] Neither build.sbt nor a 'project' directory in the current directory: "%CD%"
-      echo [error] run 'sbt new', touch build.sbt, or run 'sbt --allow-empty'.
+      >&2 echo [error] Neither build.sbt nor a 'project' directory in the current directory: "%CD%"
+      >&2 echo [error] run 'sbt new', touch build.sbt, or run 'sbt --allow-empty'.
       goto error
     )
   )
@@ -563,7 +563,7 @@ if !shutdownall! equ 1 (
     taskkill /F /PID %%i
     set /a count=!count!+1
   )
-  echo shutdown !count! sbt processes
+  >&2 echo shutdown !count! sbt processes
   goto :eof
 )
 
@@ -680,9 +680,9 @@ if !sbt_args_print_version! equ 1 (
     echo sbt version in this project: !sbt_version!
   )
   echo sbt runner version: !init_sbt_version!
-  echo.
-  echo [info] sbt runner ^(sbt-the-batch-script^) is a runner to run any declared version of sbt.
-  echo [info] Actual version of the sbt is declared using project\build.properties for each build.
+  >&2 echo.
+  >&2 echo [info] sbt runner ^(sbt-the-batch-script^) is a runner to run any declared version of sbt.
+  >&2 echo [info] Actual version of the sbt is declared using project\build.properties for each build.
   goto :eof
 )
 
@@ -923,14 +923,14 @@ set /a required_version=8
 if /I !JAVA_VERSION! GEQ !required_version! (
   exit /B 0
 )
-echo.
-echo The Java Development Kit ^(JDK^) installation you have is not up to date.
-echo sbt requires at least version !required_version!+, you have
-echo version "!JAVA_VERSION!"
-echo.
-echo Please go to http://www.oracle.com/technetwork/java/javase/downloads/ and download
-echo a valid JDK and install before running sbt.
-echo.
+>&2 echo.
+>&2 echo The Java Development Kit ^(JDK^) installation you have is not up to date.
+>&2 echo sbt requires at least version !required_version!+, you have
+>&2 echo version "!JAVA_VERSION!"
+>&2 echo.
+>&2 echo Go to https://adoptium.net/ etc and download
+>&2 echo a valid JDK and install before running sbt.
+>&2 echo.
 exit /B 1
 
 :copyrt

--- a/sbt
+++ b/sbt
@@ -161,7 +161,7 @@ acquire_sbt_jar () {
     sbt_jar="$download_jar"
   else
     sbt_url=$(jar_url "$launcher_sv")
-    echoerr "downloading sbt launcher $launcher_sv"
+    dlog "downloading sbt launcher $launcher_sv"
     download_url "$sbt_url" "${download_jar}.temp"
     download_url "${sbt_url}.sha1" "${download_jar}.sha1"
     if command -v shasum > /dev/null; then
@@ -197,7 +197,7 @@ acquire_sbtn () {
       archive_target="$p/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
       url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-${arch}-pc-linux-${sbtn_v}.tar.gz"
     else
-      echoerr "sbtn is not supported on $arch"
+      echoerr_error "sbtn is not supported on $arch"
       exit 2
     fi
   elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -209,14 +209,14 @@ acquire_sbtn () {
     archive_target="$p/sbtn-x86_64-pc-win32-${sbtn_v}.zip"
     url="https://github.com/sbt/sbtn-dist/releases/download/v${sbtn_v}/sbtn-x86_64-pc-win32-${sbtn_v}.zip"
   else
-    echoerr "sbtn is not supported on $OSTYPE"
+    echoerr_error "sbtn is not supported on $OSTYPE"
     exit 2
   fi
 
   if [[ -f "$target" ]]; then
     sbtn_command="$target"
   else
-    echoerr "downloading sbtn ${sbtn_v} for ${arch}"
+    dlog "downloading sbtn ${sbtn_v} for ${arch}"
     download_url "$url" "$archive_target"
     if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
       tar zxf "$archive_target" --directory "$p"
@@ -351,7 +351,7 @@ require_arg () {
   local opt="$2"
   local arg="$3"
   if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
-    echo "$opt requires <$type> argument"
+    echoerr "$opt requires <$type> argument"
     exit 1
   fi
 }
@@ -455,19 +455,19 @@ checkJava() {
   # Now check to see if it's a good enough version
   local good_enough="$(expr $java_version ">=" $required_version)"
   if [[ "$java_version" == "" ]]; then
-    echo
-    echo "No Java Development Kit (JDK) installation was detected."
-    echo Please go to http://www.oracle.com/technetwork/java/javase/downloads/ and download.
-    echo
+    echoerr
+    echoerr "No Java Development Kit (JDK) installation was detected."
+    echoerr Go to https://adoptium.net/ etc and download.
+    echoerr
     exit 1
   elif [[ "$good_enough" != "1" ]]; then
-    echo
-    echo "The Java Development Kit (JDK) installation you have is not up to date."
-    echo $script_name requires at least version $required_version+, you have
-    echo version $java_version
-    echo
-    echo Please go to http://www.oracle.com/technetwork/java/javase/downloads/ and download
-    echo a valid JDK and install before running $script_name.
+    echoerr
+    echoerr "The Java Development Kit (JDK) installation you have is not up to date."
+    echoerr $script_name requires at least version $required_version+, you have
+    echoerr version $java_version
+    echoerr
+    echoerr Go to https://adoptium.net/ etc and download
+    echoerr a valid JDK and install before running $script_name.
     echo
     exit 1
   fi
@@ -482,7 +482,6 @@ copyRt() {
     java9_rt=$(echo "$java9_ext/rt.jar")
     vlog "[copyRt] java9_rt = '$java9_rt'"
     if [[ ! -f "$java9_rt" ]]; then
-      echo copying runtime jar...
       mkdir -p "$java9_ext"
       "$java_cmd" \
         "${sbt_options[@]}" \
@@ -556,7 +555,7 @@ run() {
     for procId in "${sbt_processes[@]}"; do
       kill -9 $procId
     done
-    echo "shutdown ${#sbt_processes[@]} sbt processes"
+    echoerr "shutdown ${#sbt_processes[@]} sbt processes"
   else
     checkWorkingDirectory
     # run sbt


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8025

## Problem
The runner script prints out "copying runtime jar" etc to stdout.

## Solution
This removes the log, and moves other logs to stderr.