### PR TITLE
[2.x] fix: Fix qual lookup

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
@@ -266,7 +266,15 @@ trait Cont:
                     (name: String, tpe: Type[x], qual: Term, oldTree: Term) =>
                       given Type[x] = tpe
                       convert[x](name, qual) transform { (replacement: Term) =>
-                        val idx = inputs.indexWhere(input => input.qual == qual)
+                        val idxEq = inputs.indexWhere(input => input.qual == qual)
+                        // use show to compare trees for Def.task comparison
+                        val idx =
+                          if idxEq < 0 then inputs.indexWhere(input => input.qual.show == qual.show)
+                          else idxEq
+                        if idx < 0 then
+                          sys.error(
+                            s"qual (${qual}) not found in ${inputs.map(_.qual)}"
+                          )
                         applyTuple(p0, br.inputTupleTypeRepr, idx)
                     }
                   val modifiedBody =

--- a/sbt-app/src/sbt-test/project/nested-macro/build.sbt
+++ b/sbt-app/src/sbt-test/project/nested-macro/build.sbt
@@ -1,0 +1,11 @@
+lazy val a1 = settingKey[Boolean]("")
+
+scalaVersion := "3.6.4"
+a1 := true
+
+Compile / sourceGenerators += {
+  val _ = a1.value
+  Def.task {
+    Seq.empty[File]
+  }.taskValue
+}

--- a/sbt-app/src/sbt-test/project/nested-macro/test
+++ b/sbt-app/src/sbt-test/project/nested-macro/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/7772

## Problem
Nested macro that expands to `map` or `mapN` fails to find the `qual` because the trees end up being different between the record scan and actual replacement.

This is one of the problems that can be reproduced via  https://github.com/sbt/sbt/issues/7772 although it's not the primary issue.

## Solution
First try for equals normally, then compare the show strings.
