### PR TITLE
fix: BSP error status code in more cases

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -789,11 +789,19 @@ object BuildServerProtocol {
     Keys.compile.result.value match {
       case Value(_) => StatusCode.Success
       case Inc(cause) =>
-        cause.getCause match {
-          case _: CompileFailed        => StatusCode.Error
-          case _: InterruptedException => StatusCode.Cancelled
-          case err                     => throw cause
+        var statusCodeOpt: Option[Int]
+        def updateCode(code: Int): Unit =
+          statusCodeOpt = Some(statusCodeOpt match {
+            case None => code
+            case Some(oldCode) => oldCode.max(code)
+          })
+
+        Incomplete.visitAll(cause.getCause) {
+          case _: CompileFailed        => updateCode(StatusCode.Error)
+          case _: InterruptedException => updateCode(StatusCode.Cancelled)
         }
+
+        statusCodeOpt.getOrElse(throw cause)
     }
   }
 


### PR DESCRIPTION
Ensures that `buildTarget/compile` returns a `StatusCode.Error` instead of a JSON-RPC error even when the compile error is buried deeper in the `Incomplete` causes.

Fixes #8104