### PR TITLE
[2.x] remove RefThenConfig extension toString method

### DIFF
--- a/main-settings/src/main/scala/sbt/SlashSyntax.scala
+++ b/main-settings/src/main/scala/sbt/SlashSyntax.scala
@@ -44,7 +44,6 @@ trait SlashSyntax:
 
   extension (in: RefThenConfig)
     def asScope: Scope = in.project.asScope.copy(config = in.config)
-    def toString(): String = asScope.toString()
     def /[K](key: Scoped.ScopingSetting[K]): K = asScope / key
     def /(task: AttributeKey[?]): Scope = asScope.copy(task = Select(task))
 


### PR DESCRIPTION
avoid warning in latest Scala 3.x

```
[warn] 47 |    def toString(): String = asScope.toString()
[warn]    |        ^
[warn]    |Extension method toString will never be selected from type Any
[warn]    |because Any already has a member with the same name and compatible parameter types.
```