### PR TITLE
Revert "fix: BSP error status code in more cases"

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -789,19 +789,11 @@ object BuildServerProtocol {
     Keys.compile.result.value match {
       case Value(_) => StatusCode.Success
       case Inc(cause) =>
-        var statusCodeOpt: Option[Int]
-        def updateCode(code: Int): Unit =
-          statusCodeOpt = Some(statusCodeOpt match {
-            case None => code
-            case Some(oldCode) => oldCode.max(code)
-          })
-
-        Incomplete.visitAll(cause.getCause) {
-          case _: CompileFailed        => updateCode(StatusCode.Error)
-          case _: InterruptedException => updateCode(StatusCode.Cancelled)
+        cause.getCause match {
+          case _: CompileFailed        => StatusCode.Error
+          case _: InterruptedException => StatusCode.Cancelled
+          case err                     => throw cause
         }
-
-        statusCodeOpt.getOrElse(throw cause)
     }
   }
 


### PR DESCRIPTION
Reverts sbt/sbt#8109

```
[error] /home/runner/work/sbt/sbt/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala:792:13: only traits and abstract classes can have declared but undefined members
[error]         var statusCodeOpt: Option[Int]
[error]             ^
[error] /home/runner/work/sbt/sbt/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala:799:35: type mismatch;
[error]  found   : Throwable
[error]  required: sbt.Incomplete
[error]         Incomplete.visitAll(cause.getCause) {
[error]                                   ^
[error] /home/runner/work/sbt/sbt/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala:793:13: local method updateCode in method bspCompileTask is never used
[error]         def updateCode(code: Int): Unit =
[error]             ^
[error] three errors found
```