### PR TITLE
[2.x] Support debug output for macros

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Cont.scala
@@ -436,8 +436,12 @@ trait Cont:
       val exprWithConfig =
         cacheConfigExprOpt.map(config => '{ $config; $expr }).getOrElse(expr)
       val body = transformWrappers(exprWithConfig.asTerm, record, Symbol.spliceOwner)
-      inputBuf.toList match
+      val r = inputBuf.toList match
         case Nil      => pure(body)
         case x :: Nil => genMap(body, x)
         case xs       => genMapN(body, xs)
+      if hasVprintMacroSetting then
+        if hasPrintTreeMacroSetting then Console.err.println(Printer.TreeStructure.show(r.asTerm))
+        else Console.err.println(r.show)
+      r
 end Cont

--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/ContextUtil.scala
@@ -9,10 +9,12 @@
 package sbt.internal.util
 package appmacro
 
+import scala.jdk.CollectionConverters.*
 import scala.quoted.*
 import scala.collection.mutable
 import sbt.util.cacheLevel
 import sbt.util.CacheLevelTag
+import xsbti.Attic
 
 trait ContextUtil[C <: Quotes & scala.Singleton](val valStart: Int):
   val qctx: C
@@ -166,4 +168,15 @@ trait ContextUtil[C <: Quotes & scala.Singleton](val valStart: Int):
     end traverser
     traverser.traverseTree(tree)(Symbol.spliceOwner)
     defs.toSet
+
+  private lazy val atticValues = Attic.getItems().asScala.toSet
+  def hasVprintMacroSetting: Boolean =
+    atticValues.contains("-Xmacro-settings:sbt:Vprint")
+  def hasPrintTreeMacroSetting: Boolean =
+    atticValues.contains("-Xmacro-settings:sbt:print-tree-structure")
+end ContextUtil
+
+object ContextUtil:
+  def appendScalacOptions(options: Seq[String]): Unit =
+    Attic.appendItems(options.asJava);
 end ContextUtil

--- a/internal/util-interface/src/main/java/xsbti/Attic.java
+++ b/internal/util-interface/src/main/java/xsbti/Attic.java
@@ -1,0 +1,26 @@
+package xsbti;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** A global in-memory storage to pass information. */
+public class Attic {
+  private static List<String> _items = new ArrayList<String>();
+
+  /**
+   * This is used to collect scalacOptions of metabuild. This works around the fact that
+   * CompilationInfo.XmacroSettings is experimental.
+   */
+  public static void appendItems(Collection<String> values) {
+    _items.addAll(values);
+  }
+
+  /**
+   * This is used to return scalacOptions of metabuild. This works around the fact that
+   * CompilationInfo.XmacroSettings is experimental.
+   */
+  public static Collection<String> getItems() {
+    return _items;
+  }
+}

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -23,6 +23,7 @@ import sbt.internal.inc.{ MappedFileConverter, ScalaInstance, ZincLmUtil, ZincUt
 import sbt.internal.util.Attributed.data
 import sbt.internal.util.Types.const
 import sbt.internal.util.Attributed
+import sbt.internal.util.appmacro.ContextUtil
 import sbt.internal.server.BuildServerEvalReporter
 import sbt.io.{ GlobFilter, IO }
 import sbt.librarymanagement.ivy.{ InlineIvyConfiguration, IvyDependencyResolution, IvyPaths }
@@ -775,6 +776,8 @@ private[sbt] object Load {
         d.value.extraProjects map { _.setProjectOrigin(ProjectOrigin.ExtraProject) }
       }
       val converter = config.converter
+
+      ContextUtil.appendScalacOptions(plugs.pluginData.scalacOptions)
 
       // NOTE - because we create an eval here, we need a clean-eval later for this URI.
       lazy val eval = timed("Load.loadUnit: mkEval", log) {


### PR DESCRIPTION
It's sometimes useful to get the output of the macro-generated code. This adds a mechanism to allow plugins.sbt to pass in scalacOptions, which we can later check from the macro.

1. -Xmacro-settings:sbt:Vprint prints out the code.
2. Adding -Xmacro-settings:sbt:print-tree-structure prints out the tree structure.