### PR TITLE
Add `sonaDeploymentName` to `excludeLintKeys`

### DIFF
--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -44,6 +44,7 @@ object LintUnused {
       serverConnectionType,
       serverIdleTimeout,
       shellPrompt,
+      sonaDeploymentName,
     ),
     includeLintKeys := Set(
       scalacOptions,


### PR DESCRIPTION
`sbt` added the `sonaDeploymentName` key with https://github.com/sbt/sbt/pull/8126, released recently with [v1.11.0](https://github.com/sbt/sbt/releases/tag/v1.11.0) - in use, this seems to be getting lint warnings (linting introduced by https://github.com/sbt/sbt/pull/5153):

https://github.com/rtyley/scala-collection-plus/actions/runs/15326291872/job/43121748535#step:6:19

```
[warn] there's a key that's not used by any other settings/tasks:
[warn]  
[warn] * scala-collection-plus / sonaDeploymentName
[warn]   +- /home/runner/work/scala-collection-plus/scala-collection-plus/build.sbt:3
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```

...https://github.com/sbt/sbt/pull/5153 does say that _"notable exceptions are settings used exclusively by a command"_ - I _think_ that maybe `sonaDeploymentName` is only used by the commands `sonaRelease` & `sonaUpload`, so it's necessary to add it to `excludeLintKeys`?