### PR TITLE
fix: Default sbtPluginPublishLegacyMavenStyle to false

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import scala.util.Try
 // ThisBuild settings take lower precedence,
 // but can be shared across the multi projects.
 ThisBuild / version := {
-  val v = "1.11.0-SNAPSHOT"
+  val v = "1.11.1-SNAPSHOT"
   nightlyVersion.getOrElse(v)
 }
 ThisBuild / version2_13 := "2.0.0-SNAPSHOT"
@@ -671,6 +671,7 @@ lazy val dependencyTreeProj = (project in file("dependency-tree"))
     crossScalaVersions := Seq(baseScalaVersion),
     name := "sbt-dependency-tree",
     publishMavenStyle := true,
+    sbtPluginPublishLegacyMavenStyle := false,
     // mimaSettings,
     mimaPreviousArtifacts := Set.empty,
   )
@@ -1495,7 +1496,8 @@ ThisBuild / pomIncludeRepository := { _ =>
 }
 ThisBuild / publishTo := {
   val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
-  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+  val v = (ThisBuild / version).value
+  if (v.endsWith("SNAPSHOT")) Some("central-snapshots" at centralSnapshots)
   else localStaging.value
 }
 ThisBuild / publishMavenStyle := true

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2986,7 +2986,7 @@ object Classpaths {
     Defaults.globalDefaults(
       Seq(
         publishMavenStyle :== true,
-        sbtPluginPublishLegacyMavenStyle :== true,
+        sbtPluginPublishLegacyMavenStyle :== false,
         publishArtifact :== true,
         (Test / publishArtifact) :== false
       )

--- a/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/sbt-plugin-publish/build.sbt
@@ -10,8 +10,8 @@ lazy val sbtPlugin1 = project.in(file("sbt-plugin-1"))
     name := "sbt-plugin-1",
     addSbtPlugin("ch.epfl.scala" % "sbt-plugin-example-diamond" % "0.5.0"),
     publishTo := Some(resolver),
-    checkPackagedArtifacts := checkPackagedArtifactsDef("sbt-plugin-1", true).value,
-    checkPublish := checkPublishDef("sbt-plugin-1", true).value
+    checkPackagedArtifacts := checkPackagedArtifactsDef("sbt-plugin-1", false).value,
+    checkPublish := checkPublishDef("sbt-plugin-1", false).value
   )
 
 lazy val testMaven1 = project.in(file("test-maven-1"))


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8137

## Problem
Central Portal no longer supports the legacy sbt plugin layout.

## Solution
Make the default more friendly by setting sbtPluginPublishLegacyMavenStyle to false.