### PR TITLE
fix: do not treat values "1.x" of "pluginCrossBuild/sbtBinaryVersion" as sbt 2 (fixes #8166)

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2996,7 +2996,7 @@ object Classpaths {
   private lazy val packagedDefaultArtifacts = packaged(defaultArtifactTasks)
   private lazy val sbt2Plus: Def.Initialize[Boolean] = Def.setting {
     val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
-    sbtV != "1.0" && !sbtV.startsWith("0.")
+    !sbtV.startsWith("1.") && !sbtV.startsWith("0.")
   }
   val jvmPublishSettings: Seq[Setting[_]] = Seq(
     artifacts := artifactDefs(defaultArtifactTasks).value,


### PR DESCRIPTION
As a consequence, this fixes artifact name contraction for maven style and thus fixes publishing to Sonatype when a cross-built sbt version is different from 1.0

Fixes #8166