### PR TITLE
[2.x] fix: Fixes reload

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2579,10 +2579,16 @@ object Classpaths {
   )
   private def classpaths: Seq[Setting[?]] =
     Seq(
-      externalDependencyClasspath := concat(unmanagedClasspath, managedClasspath).value,
-      dependencyClasspath := concat(internalDependencyClasspath, externalDependencyClasspath).value,
-      fullClasspath := concatDistinct(exportedProducts, dependencyClasspath).value,
-      internalDependencyClasspath := ClasspathImpl.internalDependencyClasspathTask.value,
+      externalDependencyClasspath := Def.uncached(
+        concat(unmanagedClasspath, managedClasspath).value
+      ),
+      dependencyClasspath := Def.uncached(
+        concat(internalDependencyClasspath, externalDependencyClasspath).value
+      ),
+      fullClasspath := Def.uncached(concatDistinct(exportedProducts, dependencyClasspath).value),
+      internalDependencyClasspath := Def.uncached(
+        ClasspathImpl.internalDependencyClasspathTask.value
+      ),
       unmanagedClasspath := Def.uncached(ClasspathImpl.unmanagedDependenciesTask.value),
       managedClasspath := Def.uncached {
         val converter = fileConverter.value


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8198

## Problem
Plugins go missing after reload.

## Solution
We need to stop caching the classpaths apparently.

## Test

```
$ sbt --server
[info] welcome to sbt 2.0.0-SNAPSHOT (Azul Systems, Inc. Java 1.8.0_402)
[info] loading project definition from /private/tmp/repro/project
[info] set current project to repro (in build file:/private/tmp/repro/)
[info] sbt server started at local:///Users/eed3si9n/.sbt/2.0.0-SNAPSHOT/server/78eef63842a3dc7ff225/sock
[info] started sbt server
sbt:repro> compile
[success] elapsed time: 1 s, cache 50%, 6 disk cache hits, 6 onsite tasks
sbt:repro> reload
[info] welcome to sbt 2.0.0-SNAPSHOT (Azul Systems, Inc. Java 1.8.0_402)
[info] loading project definition from /private/tmp/repro/project
[info] set current project to repro (in build file:/private/tmp/repro/)
sbt:repro> compile
[success] elapsed time: 0 s, cache 100%, 12 disk cache hits
sbt:repro> plugins
In build /private/tmp/repro/:
  Enabled plugins in repro:
    sbt.plugins.CorePlugin
    sbt.plugins.DependencyTreePlugin
    sbt.plugins.Giter8TemplatePlugin
    sbt.plugins.IvyPlugin
    sbt.plugins.JUnitXmlReportPlugin
    sbt.plugins.JvmPlugin
    sbt.plugins.SemanticdbPlugin
    wartremover.WartRemover
Plugins that are loaded to the build but not enabled in any subprojects:
  sbt.ScriptedPlugin
  sbt.plugins.SbtPlugin
```