### PR TITLE
[2.x] fix: Fix sbt 1.x cross building under -Xlint

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1004,11 +1004,9 @@ object Defaults extends BuildCommon {
       },
       scalacOptions := {
         val old = scalacOptions.value
-        if (
-          sbtPlugin.value && VersionNumber(scalaVersion.value)
-            .matchesSemVer(SemanticSelector("=2.12 >=2.12.13"))
-        )
-          old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
+        if sbtPlugin.value && VersionNumber(scalaVersion.value)
+            .matchesSemVer(SemanticSelector("=2.12"))
+        then old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
         else old
       },
       persistJarClasspath :== true,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1002,6 +1002,15 @@ object Defaults extends BuildCommon {
           )
         else Def.uncached(old)
       },
+      scalacOptions := {
+        val old = scalacOptions.value
+        if (
+          sbtPlugin.value && VersionNumber(scalaVersion.value)
+            .matchesSemVer(SemanticSelector("=2.12 >=2.12.13"))
+        )
+          old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
+        else old
+      },
       persistJarClasspath :== true,
       classpathEntryDefinesClassVF := Def.uncached {
         val cache =

--- a/sbt-app/src/sbt-test/plugins/plugin-cross/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/plugin-cross/build.sbt
@@ -1,0 +1,22 @@
+organization := "com.example"
+version      := "0.1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .aggregate(plugin.projectRefs*)
+
+lazy val plugin = (projectMatrix in file("plugin"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    name := "example-plugin",
+    scalacOptions ++= {
+      if (scalaBinaryVersion.value == "2.12")
+        Seq("-Xlint", "-Werror")
+      else Seq("-Werror")
+    },
+    (pluginCrossBuild / sbtVersion) := {
+      scalaBinaryVersion.value match
+        case "2.12" => "1.5.8"
+        case _      => "2.0.0-RC3"
+    },
+  )
+  .jvmPlatform(scalaVersions = Seq("3.7.2", "2.12.20"))

--- a/sbt-app/src/sbt-test/plugins/plugin-cross/plugin/src/main/scala/APlugin.scala
+++ b/sbt-app/src/sbt-test/plugins/plugin-cross/plugin/src/main/scala/APlugin.scala
@@ -1,0 +1,16 @@
+package example
+
+import sbt._
+// import Keys.*
+
+object APlugin extends AutoPlugin {
+  object autoImport {
+    val a = taskKey[Int]("")
+  }
+
+  import autoImport._
+
+  override def projectSettings = Seq(
+    a := 2
+  )
+}

--- a/sbt-app/src/sbt-test/plugins/plugin-cross/test
+++ b/sbt-app/src/sbt-test/plugins/plugin-cross/test
@@ -1,0 +1,2 @@
+> projects
+> compile


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8220

## Problem
Under -Xlint, sbt 1.x complains that nowarn isn't doing anything.

## Solution
Bring back Wconf for sbt 1.x cross building.