### PR TITLE
[1.x] scala-library 3.8.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,11 @@ jobs:
         python-version: 3.12
     - name: Coursier cache
       uses: coursier/cache-action@v6
-    - name: Cache sbt
-      uses: actions/cache@v4
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-cache-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+    # - name: Cache sbt
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ~/.sbt
+    #     key: ${{ runner.os }}-sbt-cache-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
     - name: Setup Windows C++ toolchain
       uses: ilammy/msvc-dev-cmd@v1
       if: ${{ matrix.os == 'windows-latest' }}
@@ -105,7 +105,6 @@ jobs:
       if: ${{ matrix.jobtype == 1 }}
       shell: bash
       run: |
-        rm -rf "$HOME/.sbt/boot/" || true
         ./sbt -v --client mimaReportBinaryIssues
         ./sbt -v --client javafmtCheck
         ./sbt -v --client "Test/javafmtCheck"

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -268,9 +268,7 @@ object Defaults extends BuildCommon {
       csrMavenProfiles :== Set.empty,
       csrReconciliations :== LMCoursier.relaxedForAllModules,
       csrMavenDependencyOverride :== false,
-      csrSameVersions := Seq(
-        ScalaArtifacts.Artifacts.map(a => InclExclRule(scalaOrganization.value, a)).toSet
-      ),
+      csrSameVersions :== Nil,
       stagingDirectory := (ThisBuild / baseDirectory).value / "target" / "sona-staging",
       localStaging := Some(Resolver.file("local-staging", stagingDirectory.value)),
       sonaBundle := Publishing
@@ -3245,6 +3243,21 @@ object Classpaths {
             (proj +: base).distinct
         }
       }).value,
+    csrSameVersions ++= {
+      partialVersion(scalaVersion.value) match {
+        // See https://github.com/sbt/sbt/issues/8224
+        // Scala 3.8+ should align only Scala3_8Artifacts
+        case Some((3, minor)) if minor >= 8 =>
+          ScalaArtifacts.Scala3_8Artifacts
+            .map(a => InclExclRule(scalaOrganization.value, a))
+            .toSet :: Nil
+        case Some((major, minor)) if major == 2 || major == 3 =>
+          ScalaArtifacts.Artifacts
+            .map(a => InclExclRule(scalaOrganization.value, a))
+            .toSet :: Nil
+        case _ => Nil
+      }
+    },
     moduleName := normalizedName.value,
     ivyPaths := IvyPaths(baseDirectory.value, bootIvyHome(appConfiguration.value)),
     csrCacheDirectory := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.10.5")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.11.3")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.11.4")
   val zincVersion = nightlyVersion.getOrElse("1.10.8")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8224

## Problem
Scala 3.8.0 nightly and later in-sources the scala-library for the use by Scala 3, as opposed to using Scala-2.13-bound standard library. This means that we will run into situations where scala-library should NOT align with scala-reflect, which might exist transitively.

## Solution
Adjust the `csrSameVersions` rule for Scala 3.8 so it will only try to keep scala-library and scala3-library versions aligned.