### PR TITLE
[2.x] fix: Fixes exportJars false support

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2614,7 +2614,9 @@ object Classpaths {
         if isMeta && !force then (mjars ++ sbtCp).distinct
         else mjars
       },
-      exportedProducts := ClasspathImpl.trackedExportedProducts(TrackLevel.TrackAlways).value,
+      exportedProducts := Def.uncached(
+        ClasspathImpl.trackedExportedProducts(TrackLevel.TrackAlways).value
+      ),
       exportedProductsIfMissing := ClasspathImpl
         .trackedExportedProducts(TrackLevel.TrackIfMissing)
         .value,

--- a/sbt-app/src/sbt-test/cache/export-jars-false/Hello.scala
+++ b/sbt-app/src/sbt-test/cache/export-jars-false/Hello.scala
@@ -1,0 +1,4 @@
+package example
+
+@main def main(args: String*): Unit =
+  println("hi")

--- a/sbt-app/src/sbt-test/cache/export-jars-false/build.sbt
+++ b/sbt-app/src/sbt-test/cache/export-jars-false/build.sbt
@@ -1,0 +1,5 @@
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+// https://github.com/sbt/sbt/issues/8225
+exportJars := false
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test

--- a/sbt-app/src/sbt-test/cache/export-jars-false/test
+++ b/sbt-app/src/sbt-test/cache/export-jars-false/test
@@ -1,0 +1,3 @@
+> compile
+
+> show Compile/fullClasspath


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8225

## Problem
Setting exportJars to false causes issues due to hashing of the directories.

## Solution
Make exportedProducts uncached for now.