### PR TITLE
Use reverse topological order for configurations when resolving internal dependencies #8249

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/internal/util/Dag.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/Dag.scala
@@ -17,6 +17,15 @@ object Dag {
   import scala.collection.{ mutable, JavaConverters }
   import JavaConverters.asScalaSetConverter
 
+  /**
+   * Returns a reverse topological ordering of the graph rooted at `root`.
+   * In this ordering, each node appears before all of its ancestors (i.e., children are listed before their parents).
+   *
+   * @see [[https://github.com/sbt/sbt/issues/8249]]
+   */
+  def reverseTopologicalSort[T](root: T)(dependencies: T => Iterable[T]): List[T] =
+    topologicalSort(root)(dependencies).reverse
+
   def topologicalSort[T](root: T)(dependencies: T => Iterable[T]): List[T] =
     topologicalSort(root :: Nil)(dependencies)
 

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -406,7 +406,7 @@ private[sbt] object ClasspathImpl {
   private def trim(a: Array[String]): List[String] = a.toList.map(_.trim)
 
   def allConfigs(conf: Configuration): Seq[Configuration] =
-    Dag.topologicalSort(conf)(_.extendsConfigs)
+    Dag.reverseTopologicalSort(conf)(_.extendsConfigs)
 
   def getConfigurations(p: ResolvedReference, data: Settings[Scope]): Seq[Configuration] =
     (p / ivyConfigurations).get(data).getOrElse(Nil)


### PR DESCRIPTION
Fix #8249