### PR TITLE
Migrate weaver group id to `org.typelevel`

### DIFF
--- a/sbt-app/src/sbt-test/tests/weaver-cats/build.sbt
+++ b/sbt-app/src/sbt-test/tests/weaver-cats/build.sbt
@@ -1,3 +1,3 @@
 ThisBuild / scalaVersion := "2.13.12"
 
-libraryDependencies += "com.disneystreaming" %% "weaver-cats" % "0.8.3" % Test
+libraryDependencies += "org.typelevel" %% "weaver-cats" % "0.10.1" % Test


### PR DESCRIPTION
The weaver test framework is now released under `org.typelevel`.