### PR TITLE
delete internal/ProjectMatrixReference.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -735,6 +735,9 @@ lazy val mainProj = (project in file("main"))
     Compile / doc / sources := Nil,
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
+      ProblemFilters.exclude[MissingClassProblem]("sbt.internal.LocalProjectMatrix"),
+      ProblemFilters.exclude[MissingClassProblem]("sbt.internal.LocalProjectMatrix$"),
+      ProblemFilters.exclude[MissingClassProblem]("sbt.internal.ProjectMatrixReference"),
       ProblemFilters.exclude[MissingClassProblem]("sbt.internal.ConfigData"),
       ProblemFilters.exclude[MissingClassProblem]("sbt.internal.ConfigData$"),
       ProblemFilters.exclude[MissingClassProblem]("sbt.internal.graph.backend.IvyReport"),

--- a/main/src/main/scala/sbt/internal/ProjectMatrixReference.scala
+++ b/main/src/main/scala/sbt/internal/ProjectMatrixReference.scala
@@ -1,8 +1,0 @@
-package sbt
-package internal
-
-/** Identifies a project matrix. */
-sealed trait ProjectMatrixReference
-
-/** Identifies a project in the current build context. */
-final case class LocalProjectMatrix(id: String) extends ProjectMatrixReference


### PR DESCRIPTION
maybe merge mistake because there is `sbt/ProjectMatrixReference.scala`

https://github.com/sbt/sbt/blob/36f3dfbaafa2796958678ea50c5685c50680e0c0/main/src/main/scala/sbt/ProjectMatrixReference.scala


```diff
$ diff main/src/main/scala/sbt/internal/ProjectMatrixReference.scala main/src/main/scala/sbt/ProjectMatrixReference.scala 
2d1
< package internal
```