### PR TITLE
Add runTaskUnhandled to Extracted

### DIFF
--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -67,6 +67,15 @@ final case class Extracted(
   }
 
   /**
+   * Runs the task specified by `key` and returns the unhandled direct result of EvaluateTask.
+   * 
+   * This method differs from `runTask` in that it does not unwrap the option, or process results.
+   */
+  def runTaskUnhandled[T](key: TaskKey[T], state: State): Option[(State, Result[T])] =
+    val config = extractedTaskConfig(this, structure, state)
+    EvaluateTask(structure, key.scopedKey, state, currentRef, config)
+
+  /**
    * Runs the input task specified by `key`, using the `input` as the input to it, and returns the transformed State
    * and the resulting value of the input task.
    *

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -68,7 +68,7 @@ final case class Extracted(
 
   /**
    * Runs the task specified by `key` and returns the unhandled direct result of EvaluateTask.
-   * 
+   *
    * This method differs from `runTask` in that it does not unwrap the option, or process results.
    */
   def runTaskUnhandled[T](key: TaskKey[T], state: State): Option[(State, Result[T])] =


### PR DESCRIPTION
# Description
Adds `runTaskUnhandled` to `Extracted`. This leaves the `Option` and `Result` intact.

## Context

In SBT 2.0, `Project` removes its `runTask` method. That method had the following signature:
``` scala
    def runTask[T](
        taskKey: ScopedKey[Task[T]],
        state: State,
        checkCycles: Boolean = false
    ): Option[(State, Result[T])]
```

There's an additional signature that allows you to provide the `EvaluateTaskConfig` instead of `checkCycles`.

The remaining `runTask` implementations (namely, `Extracted.runTask`) omit the `Option` and `Result` - instead returning `(State, T)`. This means that all iterations of `runTask` in 2.0 will automatically process the `Option` and `Result`.

When working on PlayFramework's `sbt` plugin, I noticed that there could be valid reasons to want the `Result` or `Option`, and to process the failure case above `sbt` in your own plugin. This adds a method to `Extracted` that improves on the old `Project.runTask` in a couple of ways.
* It generates the config from within `Extracted`, instead of constructing it from scratch.
* It sits inside `Extracted`, so it doesn't continually suffer from re-runs of `Project.extract(state)`

It does have one drawback though - it doesn't expose `checkCycles` or `EvaluateTaskConfig` to customize the config.