### PR TITLE
[2.x] Update Giter8TemplatePlugin

### DIFF
--- a/main/src/main/scala/sbt/plugins/Giter8TemplatePlugin.scala
+++ b/main/src/main/scala/sbt/plugins/Giter8TemplatePlugin.scala
@@ -27,7 +27,7 @@ object Giter8TemplatePlugin extends AutoPlugin {
           ModuleID(
             "org.scala-sbt.sbt-giter8-resolver",
             "sbt-giter8-resolver",
-            "0.17.0"
+            "0.18.0"
           ).cross(CrossVersion.binary),
           "sbtgiter8resolver.Giter8TemplateResolver"
         )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8297

Update to reference sbt-giter8-resolver 0.18.0.
