### PR TITLE
use `java.net.UnixDomainSocketAddress` in BootServerSocket

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -14,13 +14,20 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.ProtocolFamily;
 import java.net.Socket;
 import java.net.ServerSocket;
+import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.net.StandardProtocolFamily;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -73,7 +80,7 @@ import xsbti.AppConfiguration;
  * <p>BootServerSocket is implemented in java so that it can be classloaded as quickly as possible.
  */
 public class BootServerSocket implements AutoCloseable {
-  private ServerSocket serverSocket = null;
+  private ServerSocketWrapper serverSocket = null;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final AtomicInteger threadId = new AtomicInteger(1);
@@ -88,14 +95,14 @@ public class BootServerSocket implements AutoCloseable {
   private final AtomicBoolean needInput = new AtomicBoolean(false);
 
   private class ClientSocket implements AutoCloseable {
-    final Socket socket;
+    final SocketWrapper socket;
     final AtomicBoolean alive = new AtomicBoolean(true);
     final Future<?> future;
     private final LinkedBlockingQueue<Integer> bytes = new LinkedBlockingQueue<Integer>();
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     @SuppressWarnings("deprecation")
-    ClientSocket(final Socket socket) {
+    ClientSocket(final SocketWrapper socket) {
       this.socket = socket;
       clientSockets.add(this);
       Future<?> f = null;
@@ -114,15 +121,14 @@ public class BootServerSocket implements AutoCloseable {
                               }
                               return 0;
                             });
-                    final InputStream inputStream = socket.getInputStream();
                     while (alive.get()) {
                       try {
                         synchronized (needInput) {
                           while (!needInput.get() && alive.get()) needInput.wait();
                         }
                         if (alive.get()) {
-                          socket.getOutputStream().write(5);
-                          int b = inputStream.read();
+                          socket.write(5);
+                          int b = socket.read();
                           if (b != -1) {
                             bytes.put(b);
                             clientSocketReads.put(ClientSocket.this);
@@ -146,7 +152,7 @@ public class BootServerSocket implements AutoCloseable {
 
     private void write(final int i) {
       try {
-        if (alive.get()) socket.getOutputStream().write(i);
+        if (alive.get()) socket.write(i);
       } catch (final IOException e) {
         alive.set(false);
         close();
@@ -155,7 +161,7 @@ public class BootServerSocket implements AutoCloseable {
 
     private void write(final byte[] b) {
       try {
-        if (alive.get()) socket.getOutputStream().write(b);
+        if (alive.get()) socket.write(b);
       } catch (final IOException e) {
         alive.set(false);
         close();
@@ -164,7 +170,7 @@ public class BootServerSocket implements AutoCloseable {
 
     private void write(final byte[] b, final int offset, final int len) {
       try {
-        if (alive.get()) socket.getOutputStream().write(b, offset, len);
+        if (alive.get()) socket.write(b, offset, len);
       } catch (final IOException e) {
         alive.set(false);
         close();
@@ -173,7 +179,7 @@ public class BootServerSocket implements AutoCloseable {
 
     private void flush() {
       try {
-        socket.getOutputStream().flush();
+        socket.flush();
       } catch (final IOException e) {
         alive.set(false);
         close();
@@ -194,8 +200,7 @@ public class BootServerSocket implements AutoCloseable {
         alive.set(false);
         if (future != null) future.cancel(true);
         try {
-          socket.getOutputStream().close();
-          socket.getInputStream().close();
+          socket.close();
           // Windows is very slow to close the socket for whatever reason
           // We close the server socket anyway, so this should die then.
           if (!System.getProperty("os.name", "").toLowerCase().startsWith("win")) socket.close();
@@ -342,20 +347,63 @@ public class BootServerSocket implements AutoCloseable {
   static final boolean isWindows =
       System.getProperty("os.name", "").toLowerCase().startsWith("win");
 
-  static ServerSocket newSocket(final String sock) throws ServerAlreadyBootingException {
-    ServerSocket socket = null;
+  static ServerSocketWrapper newSocket(final String sock) throws ServerAlreadyBootingException {
+    ServerSocketWrapper socket = null;
     String name = socketName(sock);
     boolean jni = requiresJNI() || System.getProperty("sbt.ipcsocket.jni", "false").equals("true");
+    boolean jdk = System.getProperty("sbt.ipcsocket.jdk", "true").equals("true");
     try {
       if (!isWindows) Files.deleteIfExists(Paths.get(sock));
       socket =
           isWindows
-              ? new Win32NamedPipeServerSocket(name, jni, Win32SecurityLevel.OWNER_DACL)
-              : new UnixDomainServerSocket(name, jni);
+              ? ServerSocketWrapper.fromServerSocket(
+                  new Win32NamedPipeServerSocket(name, jni, Win32SecurityLevel.OWNER_DACL))
+              : newUnixDomainSocket(name, jni, jdk);
       return socket;
     } catch (final IOException e) {
       throw new ServerAlreadyBootingException(e);
     }
+  }
+
+  static SocketAddress unixDomainSocketAddress(final String pathName)
+      throws ReflectiveOperationException {
+    final Class<?> clazz = Class.forName("java.net.UnixDomainSocketAddress");
+    final Method method = clazz.getMethod("of", String.class);
+    return (SocketAddress) method.invoke(null, pathName);
+  }
+
+  static ProtocolFamily unixProtocolFamily() {
+    return Arrays.stream(StandardProtocolFamily.class.getEnumConstants())
+        .filter(a -> "UNIX".equals(a.name()))
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("not found UNIX value in StandardProtocolFamily"));
+  }
+
+  static ServerSocketWrapper newJdkUnixDomainSocket(final String pathName)
+      throws ReflectiveOperationException, IOException {
+    final SocketAddress address = unixDomainSocketAddress(pathName);
+    final ProtocolFamily protocolFamily = unixProtocolFamily();
+    final Method openMethod =
+        ServerSocketChannel.class.getMethod("open", java.net.ProtocolFamily.class);
+    final ServerSocketChannel serverSocketChannel =
+        (ServerSocketChannel) openMethod.invoke(null, protocolFamily);
+    serverSocketChannel.bind(address);
+    return ServerSocketWrapper.fromServerSocketChannel(serverSocketChannel);
+  }
+
+  private static ServerSocketWrapper newUnixDomainSocket(
+      final String pathName, final boolean jni, final boolean jdk) throws IOException {
+    ServerSocketWrapper result;
+    if (jdk) {
+      try {
+        result = newJdkUnixDomainSocket(pathName);
+      } catch (ReflectiveOperationException e) {
+        result = ServerSocketWrapper.fromServerSocket(new UnixDomainServerSocket(pathName, jni));
+      }
+    } else {
+      result = ServerSocketWrapper.fromServerSocket(new UnixDomainServerSocket(pathName, jni));
+    }
+    return result;
   }
 
   public static Boolean requiresJNI() {

--- a/main-command/src/main/java/sbt/internal/ServerSocketWrapper.java
+++ b/main-command/src/main/java/sbt/internal/ServerSocketWrapper.java
@@ -1,0 +1,68 @@
+package sbt.internal;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.nio.channels.ServerSocketChannel;
+
+abstract class ServerSocketWrapper {
+  private ServerSocketWrapper() {}
+
+  abstract void setSoTimeout(int timeout) throws SocketException;
+
+  abstract SocketWrapper accept() throws IOException;
+
+  abstract void close() throws IOException;
+
+  static ServerSocketWrapper fromServerSocket(final ServerSocket socket) {
+    return new ServerSocketImpl(socket);
+  }
+
+  static ServerSocketWrapper fromServerSocketChannel(final ServerSocketChannel channel) {
+    return new ServerSocketChannelImpl(channel);
+  }
+
+  private static final class ServerSocketImpl extends ServerSocketWrapper {
+    private final ServerSocket socket;
+
+    ServerSocketImpl(ServerSocket socket) {
+      this.socket = socket;
+    }
+
+    @Override
+    void setSoTimeout(int timeout) throws SocketException {
+      socket.setSoTimeout(timeout);
+    }
+
+    @Override
+    SocketWrapper accept() throws IOException {
+      return SocketWrapper.fromSocket(socket.accept());
+    }
+
+    @Override
+    void close() throws IOException {
+      socket.close();
+    }
+  }
+
+  private static final class ServerSocketChannelImpl extends ServerSocketWrapper {
+    private final ServerSocketChannel channel;
+
+    ServerSocketChannelImpl(ServerSocketChannel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    void setSoTimeout(int timeout) throws SocketException {}
+
+    @Override
+    SocketWrapper accept() throws IOException {
+      return SocketWrapper.fromByteChannel(channel.accept());
+    }
+
+    @Override
+    void close() throws IOException {
+      channel.close();
+    }
+  }
+}

--- a/main-command/src/main/java/sbt/internal/SocketWrapper.java
+++ b/main-command/src/main/java/sbt/internal/SocketWrapper.java
@@ -1,0 +1,115 @@
+package sbt.internal;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+
+abstract class SocketWrapper {
+  private SocketWrapper() {}
+
+  abstract void write(int value) throws IOException;
+
+  abstract void write(byte[] value) throws IOException;
+
+  abstract void write(byte[] b, int offset, int len) throws IOException;
+
+  abstract void close() throws IOException;
+
+  abstract int read() throws IOException;
+
+  abstract void flush() throws IOException;
+
+  static SocketWrapper fromSocket(Socket socket) {
+    return new SocketImpl(socket);
+  }
+
+  static SocketWrapper fromByteChannel(ByteChannel channel) {
+    return new ByteChannelImpl(channel);
+  }
+
+  private static final class ByteChannelImpl extends SocketWrapper {
+    private final ByteChannel channel;
+
+    private ByteChannelImpl(ByteChannel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    void write(int value) throws IOException {
+      channel.write(ByteBuffer.wrap(new byte[] {(byte) value}));
+    }
+
+    @Override
+    void write(byte[] value) throws IOException {
+      channel.write(ByteBuffer.wrap(value));
+    }
+
+    @Override
+    void write(byte[] b, int offset, int len) throws IOException {
+      channel.write(ByteBuffer.wrap(b, offset, len));
+    }
+
+    @Override
+    void close() throws IOException {
+      channel.close();
+    }
+
+    @Override
+    int read() throws IOException {
+      final ByteBuffer buf = ByteBuffer.allocate(1);
+      int n;
+      do {
+        n = channel.read(buf);
+      } while (n == 0);
+
+      if (-1 == n) {
+        return -1;
+      } else {
+        return buf.get(0) & 0xff;
+      }
+    }
+
+    @Override
+    void flush() {}
+  }
+
+  private static final class SocketImpl extends SocketWrapper {
+    private final Socket socket;
+
+    private SocketImpl(Socket socket) {
+      this.socket = socket;
+    }
+
+    @Override
+    void write(int value) throws IOException {
+      socket.getOutputStream().write(value);
+    }
+
+    @Override
+    void write(byte[] value) throws IOException {
+      socket.getOutputStream().write(value);
+    }
+
+    @Override
+    void write(byte[] b, int offset, int len) throws IOException {
+      socket.getOutputStream().write(b, offset, len);
+    }
+
+    @Override
+    void close() throws IOException {
+      socket.getOutputStream().close();
+      socket.getInputStream().close();
+    }
+
+    @Override
+    int read() throws IOException {
+      return socket.getInputStream().read();
+    }
+
+    @Override
+    void flush() throws IOException {
+      socket.getOutputStream().flush();
+    }
+  }
+}

--- a/main-command/src/test/scala/sbt/internal/BootServerSocketTest.scala
+++ b/main-command/src/test/scala/sbt/internal/BootServerSocketTest.scala
@@ -1,0 +1,105 @@
+package sbt.internal
+
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.net.ProtocolFamily
+import java.nio.ByteBuffer
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.util.Random
+
+class BootServerSocketTest extends AnyFreeSpec {
+  private def withServerAndClient[A](action: (SocketWrapper, SocketChannel) => A): A = {
+    val tmp = Files.createTempDirectory(this.getClass.getSimpleName)
+    val path = BootServerSocket.socketLocation(tmp)
+    val dir = Paths.get(path).getParent
+    try {
+      if (!Files.isDirectory(dir)) {
+        Files.createDirectories(dir)
+      }
+      val serverSocket = BootServerSocket.newJdkUnixDomainSocket(path)
+      try {
+        val openMethod = classOf[SocketChannel].getMethod("open", classOf[ProtocolFamily])
+        val client =
+          openMethod.invoke(null, BootServerSocket.unixProtocolFamily()).asInstanceOf[SocketChannel]
+        assert(client.connect(BootServerSocket.unixDomainSocketAddress(path)))
+        val server = serverSocket.accept()
+        action(server, client)
+      } finally {
+        serverSocket.close()
+      }
+    } finally {
+      Files.deleteIfExists(Paths.get(path))
+      Files.deleteIfExists(dir)
+    }
+  }
+
+  "BootServerSocket" - {
+    "newJdkUnixDomainSocket" - {
+      if (!scala.util.Properties.isWin && scala.util.Properties.isJavaAtLeast(17)) {
+        val values: List[Byte] =
+          Random.shuffle((Byte.MinValue to Byte.MaxValue).toList.map(_.toByte))
+
+        def readAll(client: SocketChannel): List[Byte] = {
+          Iterator
+            .continually {
+              val buf = ByteBuffer.allocate(1)
+              val x = client.read(buf)
+              x -> buf.get(0)
+            }
+            .takeWhile(_._1 != -1)
+            .map(_._2)
+            .toList
+        }
+
+        "write(int)" in withServerAndClient { (server, client) =>
+          try {
+            values.foreach(x => server.write(x))
+          } finally {
+            server.close()
+          }
+          val res = readAll(client)
+          assert(res == values)
+        }
+
+        "write(byte[])" in withServerAndClient { (server, client) =>
+          try {
+            server.write(values.toArray)
+          } finally {
+            server.close()
+          }
+          val res = readAll(client)
+          assert(res == values)
+        }
+
+        "write(byte[], int, int)" in withServerAndClient { (server, client) =>
+          val offset = 10
+          val length = 20
+          try {
+            server.write(values.toArray, offset, length)
+          } finally {
+            server.close()
+          }
+          val res = readAll(client)
+          assert(res == values.slice(offset, offset + length))
+        }
+
+        "read" in withServerAndClient { (server, client) =>
+          try {
+            client.write(ByteBuffer.wrap(values.toArray))
+          } finally {
+            client.close()
+          }
+
+          val result = Iterator
+            .continually(server.read())
+            .takeWhile(_ != -1)
+            .toList
+
+          assert(result == values.map(_ & 0xff))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- https://github.com/sbt/sbt/issues/7634

avoid `java.lang.System::load has been called by org.scalasbt.ipcsocket.NativeLoader ` warning if JDK `UnixDomainSocketAddress` available