### PR TITLE
[1.x] fix `run/daemon-exit` test

### DIFF
--- a/sbt-app/src/sbt-test/run/daemon-exit/build.sbt
+++ b/sbt-app/src/sbt-test/run/daemon-exit/build.sbt
@@ -1,0 +1,1 @@
+run / fork := true


### PR DESCRIPTION
scripted test share same JVM instance.

`run/daemon-exit` test call `System.exit(0)` after 1 second.

https://github.com/sbt/sbt/blob/028248f73e953dc2353294dd04d32ec1a867306a/sbt-app/src/sbt-test/run/daemon-exit/src/main/scala/Daemon.scala#L8-L9

`System.exit(0)` affect another scripted tests.


I think we should set `run / fork := true` or delete `run/daemon-exit` test because [TrapExit no longer exists](https://github.com/sbt/sbt/pull/6665)

### before

- test 1
- test 2
- `run/daemon-exit` 
- test 4
- test 5
- test 6 // after 1 second exit JVM by `daemon-exit` and then fail 😢 


### after

- test 1
- test 2
- `run/daemon-exit`  // set fork
- test 4
- test 5
- test 6