### PR TITLE
remove `Selectable.reflectiveSelectable` in dependency-graph

### DIFF
--- a/main/src/main/scala/sbt/internal/graph/backend/SbtUpdateReport.scala
+++ b/main/src/main/scala/sbt/internal/graph/backend/SbtUpdateReport.scala
@@ -12,13 +12,14 @@ package graph
 package backend
 
 import scala.language.implicitConversions
-import scala.reflect.Selectable.reflectiveSelectable
-import sbt.librarymanagement.{ ModuleID, ModuleReport, ConfigurationReport }
+import sbt.librarymanagement.{
+  ModuleID,
+  ModuleReport,
+  ConfigurationReport,
+  OrganizationArtifactReport
+}
 
 object SbtUpdateReport {
-  type OrganizationArtifactReport = {
-    def modules: Seq[ModuleReport]
-  }
 
   def fromConfigurationReport(report: ConfigurationReport, rootInfo: ModuleID): ModuleGraph = {
     implicit def id(sbtId: ModuleID): GraphModuleId =


### PR DESCRIPTION
Maybe no longer needed
https://github.com/sbt/sbt-dependency-graph/commit/83a311b4af5584080c913798dbfb76d690137445