### PR TITLE
retry Windows client test

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -75,12 +75,20 @@ jobs:
         sbt -Dsbt.build.version=$TEST_SBT_VER integrationTest/test
         # This fails due to the JLine issue
         # cd citest && ./test.sh
+    - name: build image (Windows)
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        shell: bash
+        command: |
+          # test building sbtn on Windows
+          sbt "-Dsbt.io.virtual=false" nativeImage
     - name: Client test (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
       shell: bash
       run: |
-        # test building sbtn on Windows
-        sbt "-Dsbt.io.virtual=false" nativeImage
         # smoke test native Image
         ./client/target/bin/sbtn --sbt-script=$(pwd)/launcher-package/src/universal/bin/sbt.bat about
         ./client/target/bin/sbtn --sbt-script=$(pwd)/launcher-package/src/universal/bin/sbt.bat shutdown


### PR DESCRIPTION
Windows client test is flaky 😢

https://github.com/nick-fields/retry
 
```
[info] compiling 33 Scala sources and 3 Java sources to D:\a\sbt\sbt\main-command\target\scala-2.12\classes ...
[info] done compiling
[info] compiling 1 Java source to D:\a\sbt\sbt\client\target\classes ...
[info] done compiling
[error] java.lang.RuntimeException: Nonzero exit value: 1
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:138)
[error] 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:108)
[error] 	at sbtnativeimage.NativeImagePlugin$.$anonfun$projectSettings$21(NativeImagePlugin.scala:167)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:750)
[error] (sbtClientProj / nativeImageGraalHome) Nonzero exit value: 1
```