### PR TITLE
[1.x] Update scala213 to 2.13.17

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 object Dependencies {
   // WARNING: Please Scala update versions in PluginCross.scala too
   val scala212 = "2.12.20"
-  val scala213 = "2.13.16"
+  val scala213 = "2.13.17"
   val checkPluginCross = settingKey[Unit]("Make sure scalaVersion match up")
   val baseScalaVersion = scala212
   def nightlyVersion: Option[String] =


### PR DESCRIPTION
Initially, I wanted to update the `semanticdb-scalac` version, as I noticed that `4.9.9` isn't published for `2.13.17`, and if `semanticdbVersion` isn't overridden in the project, one will encounter a `semanticdb-scalac_2.13.17:4.9.9` download error. However, `semanticdbVersion` was already updated in https://github.com/sbt/sbt/pull/8342. Anyway, I think it's better to keep `semanticdbVersion` and `scala213` updated together.