### PR TITLE
[1.x] Use internal config for dependency tree (for Provided)

### DIFF
--- a/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
+++ b/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala
@@ -70,8 +70,9 @@ object DependencyTreeSettings {
       ),
       dependencyTreeModuleGraph0 := {
         val sv = scalaVersion.value
+        val internalConfig = Configurations.internalMap(configuration.value)
         val g = dependencyTreeIgnoreMissingUpdate.value
-          .configuration(configuration.value)
+          .configuration(internalConfig)
           .map(
             report =>
               SbtUpdateReport.fromConfigurationReport(report, dependencyTreeCrossProjectId.value)


### PR DESCRIPTION
See https://github.com/sbt/sbt/discussions/8354

## Problem
dependency-tree currently doesn't include `Provided` configuration, because technically it isn't part of the `Compile` configuration, however, `Provided` does become part of the `Compile` classpath during compilation.

## Solution
This changes the implementation to use the internal configuration, e.g. `CompileInternal`, which includes the auxiliary configurations.

There's a tradeoff here since it means that we lose the tree view of the platonic `Compile` configuration.