### PR TITLE
[1.x] fix: Parse with -Xsource:3

### DIFF
--- a/main/src/main/scala/sbt/internal/parser/SbtParser.scala
+++ b/main/src/main/scala/sbt/internal/parser/SbtParser.scala
@@ -129,7 +129,7 @@ private[sbt] object SbtParser {
   private[sbt] var scalacGlobalInitReporter: Option[ConsoleReporter] = None
 
   private[sbt] final val (defaultGlobalForParser, globalReporter) = {
-    val options = "-cp" :: s"$defaultClasspath" :: "-Yrangepos" :: Nil
+    val options = "-cp" :: s"$defaultClasspath" :: "-Yrangepos" :: "-Xsource:3" :: Nil
     val reportError = (msg: String) => System.err.println(msg)
     val command = new CompilerCommand(options, reportError)
     val settings = command.settings

--- a/main/src/test/resources/xsource3/1.sbt.txt
+++ b/main/src/test/resources/xsource3/1.sbt.txt
@@ -1,0 +1,7 @@
+ThisBuild / scalaVersion := "3.3.4"
+
+def foo(): Unit = {
+  List("") match { case List(path@_*) => () }
+  List("") match { case List(path *) => () }
+  List("") match { case List(path*) => () }
+}

--- a/main/src/test/scala/sbt/internal/parser/Xsource3Spec.scala
+++ b/main/src/test/scala/sbt/internal/parser/Xsource3Spec.scala
@@ -1,0 +1,33 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package parser
+
+import java.io.File
+
+import scala.io.Source
+
+object Xsource3Spec extends AbstractSpec {
+  implicit val splitter: SplitExpressions.SplitExpression = EvaluateConfigurations.splitExpressions
+
+  test("Parser should handle -Xsource:3 syntax") {
+    val rootPath = getClass.getResource("/xsource3").getPath
+    println(s"Reading files from: $rootPath")
+    val allFiles = new File(rootPath).listFiles.toList
+    allFiles foreach { path =>
+      println(s"$path")
+      val lines = Source.fromFile(path).getLines().toList
+      val (_, statements) = splitter(path, lines)
+      assert(statements.nonEmpty, s"""
+           |***should contains statements***
+           |$lines """.stripMargin)
+    }
+  }
+}


### PR DESCRIPTION
Ref https://youtrack.jetbrains.com/issue/SCL-24570

## Problem
On IntelliJ the users are getting the hint to upgrade to -Xsource:3 style, however the supported syntax do not parse.

## Solution
This adds -Xsource:3 to the parser. The metabuild compilation uses -Xsource:3 since sbt 1.6.0.