### PR TITLE
 Fix #8341: Create Migration Guide file

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration Guide from sbt 1 to sbt 2
+
+In principle, migrating your build from sbt 1 to sbt 2 should be a matter of updating the sbt version in `build.properties`. However, there are some changes in behavior that you may need to account for.
+
+This document will outline possible changes in behavior that affect your build when migrating from sbt 1 to sbt 2. Implement them in case out-of-the-box migration does not work.
+
+## Changes in behavior
+
+- `exportJars` defaults to `true`, was `false`. This might break `getResource("/")` and `resource.toURI`. Set `exportJars := false` if this logic is broken in your build, producing `NullPointerException`s and `FileSystemNotFoundException`s. Set `exportJars := false` in your build if you want to keep the old behavior. The change was introduced by [sbt/sbt#7464](https://github.com/sbt/sbt/pull/7464), see also [blog](https://eed3si9n.com/sbt-remote-cache/).


### PR DESCRIPTION
In sbt 2, classes are now packaged into JARs before running from sbt by default (whereas in sbt 1 they were run directly from the classpath), the `exportJars` is `true` by default. This change was introduced by the [remote caching PR](https://github.com/sbt/sbt/pull/7464). This change in default behavior causes resource access code that worked in sbt 1.x to fail when running tests in sbt 2.

The behavior described in the issue can be reproduced also on sbt 1 with `exportJars := true`.

### Issue 1: `getResource("/")` returns `null` in JARs
- **From extracted directory**: `getResource("/")` returns a `file:` URL pointing to the directory root (e.g., `file:/path/to/test-classes/`)
- **From JAR**: `getResource("/")` returns `null` because JARs don't have a root directory entry

### Issue 2: `Paths.get()` cannot handle `jar:` URLs

- **From extracted directory**: `getResource("/foo")` returns a `file:` URL (e.g., `file:/path/to/test-classes/foo`)
- **From JAR**: `getResource("/foo")` returns a `jar:` URL (e.g., `jar:file:/path/to.jar!/foo`)

### Migration strategy

Was this change in defaults intentional? If so, no codebase changes are needed for this issue. However, we should document this new behavior and migration strategy for affected projects `exportJars := false`. This PR adds a migration guide file that documents this change.
