### PR TITLE
Return build targets sources from `buildTarget/dependencySources` request

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -26,7 +26,7 @@ import sbt.internal.protocol.JsonRpcRequestMessage
 import sbt.internal.util.{ Attributed, ErrorHandling }
 import sbt.internal.util.complete.{ Parser, Parsers }
 import sbt.librarymanagement.CrossVersion.binaryScalaVersion
-import sbt.librarymanagement.{ Configuration, ScalaArtifacts }
+import sbt.librarymanagement.{ Configuration, ScalaArtifacts, UpdateReport }
 import sbt.std.TaskExtra
 import sbt.util.Logger
 import sjsonnew.shaded.scalajson.ast.unsafe.{ JNull, JValue }
@@ -158,7 +158,18 @@ object BuildServerProtocol {
         import sbt.internal.bsp.codec.JsonProtocol._
         val items = bspBuildTargetDependencySourcesItem.result.all(filter).value
         val successfulItems = anyOrThrow(items)
-        val result = DependencySourcesResult(successfulItems.toVector)
+
+        val buildItems = workspace.builds
+          .map {
+            case (targetId, loadedBuildUnit) =>
+              val projRef = ProjectRef(loadedBuildUnit.unit.uri, loadedBuildUnit.root)
+              (projRef / updateSbtClassifiers).map(getDependencySourceItem(targetId, _))
+          }
+          .toSeq
+          .join
+          .value
+
+        val result = DependencySourcesResult((successfulItems ++ buildItems).toVector)
         state.respondEvent(result)
       }
     }.evaluated,
@@ -770,8 +781,16 @@ object BuildServerProtocol {
   }
 
   private def dependencySourcesItemTask: Def.Initialize[Task[DependencySourcesItem]] = Def.task {
-    val targetId = Keys.bspTargetIdentifier.value
-    val updateReport = Keys.updateClassifiers.value
+    getDependencySourceItem(
+      Keys.bspTargetIdentifier.value,
+      Keys.updateClassifiers.value
+    )
+  }
+
+  private def getDependencySourceItem(
+      targetId: BuildTargetIdentifier,
+      updateReport: UpdateReport
+  ): DependencySourcesItem = {
     val sources = for {
       configuration <- updateReport.configurations.view
       module <- configuration.modules.view


### PR DESCRIPTION
It's basically the same as #8404, but for the 1.12 branch. 