### PR TITLE
[2.x] fix: Scala 3.8 REPL support

### DIFF
--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -165,20 +165,22 @@ object Compiler:
       yield file
 
     val allCompilerJars = toolReport.modules.flatMap(_.artifacts.map(_._2))
-    val allDocJars =
-      fullReport
-        .configuration(Configurations.ScalaDocTool)
-        .map(updateLibraryToCompileConfiguration)
-        .toSeq
-        .flatMap(_.modules)
-        .flatMap(_.artifacts.map(_._2))
+    val extraToolJars = extraToolConf match
+      case Some(extra) =>
+        fullReport
+          .configuration(extra)
+          .map(updateLibraryToCompileConfiguration)
+          .toSeq
+          .flatMap(_.modules)
+          .flatMap(_.artifacts.map(_._2))
+      case None => Nil
     val libraryJars = ScalaArtifacts.libraryIds(sv).flatMap(file)
 
     makeScalaInstance(
       sv,
       libraryJars,
       allCompilerJars,
-      allDocJars,
+      extraToolJars,
       Keys.state.value,
       Keys.scalaInstanceTopLoader.value,
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.10.5")
-  val zincVersion = nightlyVersion.getOrElse("2.0.0-M9")
+  val zincVersion = nightlyVersion.getOrElse("2.0.0-M10")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8416
See also https://github.com/sbt/sbt/pull/8349

## Problem
Scala 3.8 console task doesn't work on 2.0.0-RC7.

## Solution
This fixes it.
