### PR TITLE
[2.x] Fix `help` command arguments parsing

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommands.scala
+++ b/main-command/src/main/scala/sbt/BasicCommands.scala
@@ -129,25 +129,11 @@ object BasicCommands {
   }
 
   def runHelp(s: State, h: Help)(arg: Option[String]): State = {
-
-    val (extraArgs, remainingCommands) = s.remainingCommands match {
-      /*
-      exec.commandLine.endsWith(Shell) is done to allow shells other than original shell works correctly with help command.
-      It's assumed here that shell name must end with "shell" suffix which is true for e.g. shell, oldshell or idea-shell (https://github.com/JetBrains/sbt-idea-shell/blob/072b10e405860feb834402563773f12976be34b9/src/main/scala/org/jetbrains/sbt/constants.scala#L7)
-       */
-      case xs :+ exec if exec.commandLine.endsWith(Shell) => (xs, exec :: Nil)
-      case xs                                             => (xs, nil[Exec])
-    }
-
-    val topic = (arg.toList ++ extraArgs.map(_.commandLine)) match {
-      case Nil => none[String]
-      case xs  => xs.mkString(" ").some
-    }
     val message =
-      try Help.message(h, topic)
+      try Help.message(h, arg)
       catch { case NonFatal(ex) => ex.toString }
     System.out.println(message)
-    s.copy(remainingCommands = remainingCommands)
+    s
   }
 
   def completionsCommand: Command =


### PR DESCRIPTION
Previously, some additional code was used to parse the arguments to the `help` command and ensure that the remaining commands were consistent with the desired state of sbt.

While this code worked well in sbt 1.x, and was helpful in getting `sbt help new` to work as expected, this does not work in sbt 2, and is actually not required.

This patch removes the additional code, which fixes the `help` command in sbt.

See #4237