### PR TITLE
[2.x] Fix debug options breaking launcher on Windows

### DIFF
--- a/launcher-package/integration-test/src/test/scala/ScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ScriptTest.scala
@@ -208,6 +208,17 @@ object SbtScriptTest extends SimpleTestSuite with PowerAssertions {
     )
   }
 
+  // Regression test for https://github.com/sbt/sbt/issues/8100
+  // Debug agent output in SBT_OPTS should not break the launcher on Windows
+  makeTest(
+    "sbt with debug agent in SBT_OPTS",
+    sbtOpts = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12346"
+  )("-v") { out: List[String] =>
+    assert(
+      out.contains[String]("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=12346")
+    )
+  }
+
   makeTest("sbt --no-share adds three system properties")("--no-share") { out: List[String] =>
     assert(out.contains[String]("-Dsbt.global.base=project/.sbtboot"))
     assert(out.contains[String]("-Dsbt.boot.directory=project/.boot"))

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -980,7 +980,9 @@ exit /B 1
 :copyrt
 if /I !JAVA_VERSION! GEQ 9 (
   "!_JAVACMD!" !_JAVA_OPTS! !_SBT_OPTS! -jar "!sbt_jar!" --rt-ext-dir > "%TEMP%.\rtext.txt"
-  set /p java9_ext= < "%TEMP%.\rtext.txt"
+  rem Filter for the line containing java9-rt-ext- to avoid picking up debug agent output
+  set "java9_ext="
+  for /f "tokens=*" %%a in ('findstr /c:"java9-rt-ext-" "%TEMP%.\rtext.txt"') do set "java9_ext=%%a"
   set "java9_rt=!java9_ext!\rt.jar"
 
   if not exist "!java9_rt!" (


### PR DESCRIPTION
## Fix debug options breaking launcher on Windows

Fixes #8100

### Steps

On Windows with sbt 1.10.11, setting debug options via `SBT_OPTS` breaks the launcher:

```batch
set SBT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=localhost:1234
sbt.bat
```

### Problems

When the JVM debug agent starts, it prints `Listening for transport dt_socket at address: 1234` to stdout. The `copyrt` function captures this output and tries to parse it as a file path, which fails with `InvalidPathException` due to the colon character.

The root cause is that the Windows batch script reads the first line of `--rt-ext-dir` output without any filtering:

```batch
set /p java9_ext= < "%TEMP%.\rtext.txt"
```

### Expectations

sbt should launch normally even when debug options are set, allowing developers to attach a debugger.

### Solution

I added filtering to the Windows batch script so it only picks up the line containing `java9-rt-ext-`, which is the actual path we care about. This matches what the Unix script already does with `grep java9-rt-ext-`.

```batch
for /f "tokens=*" %%a in ('findstr /c:"java9-rt-ext-" "%TEMP%.\rtext.txt"') do set "java9_ext=%%a"
```

Now any debug agent noise gets ignored, and only the rt.jar path is captured.

### Notes

As discussed with @eed3si9n in #8100, this is a minimal fix that brings the Windows script in line with the Unix behavior. A more robust solution (using a `RTJAR=` prefix) could be done later if needed, but this should address the immediate issue.

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147