### PR TITLE
[2.x] fix: prevent server boot when --no-server is used

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -77,14 +77,9 @@ private[sbt] object xMain:
       val isBsp: String => Boolean = cmd => (cmd == "-bsp") || (cmd == "--bsp")
       val isNew: String => Boolean = cmd => (cmd == "new") || (cmd == "init")
       lazy val isServer = !userCommands.exists(c => isBsp(c) || isClient(c))
-      // Check if server autostart is disabled via sbt.server.autostart property
-      // This prevents creating boot server socket when --no-server is used
-      lazy val serverAutostart = sys.props.get("sbt.server.autostart") match {
-        case Some(value) => value.toLowerCase == "true"
-        case None        => true // Default to true if not set
-      }
       // keep this lazy to prevent project directory created prematurely
-      lazy val bootServerSocket = if (isServer && serverAutostart) getSocketOrExit(configuration) match {
+      // Only create boot server socket if server mode is enabled and server autostart is enabled
+      lazy val bootServerSocket = if (isServer && SysProp.serverAutoStart) getSocketOrExit(configuration) match {
         case (_, Some(e)) => boundary.break(e)
         case (s, _)       => s
       }

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -79,11 +79,12 @@ private[sbt] object xMain:
       lazy val isServer = !userCommands.exists(c => isBsp(c) || isClient(c))
       // keep this lazy to prevent project directory created prematurely
       // Only create boot server socket if server mode is enabled and server autostart is enabled
-      lazy val bootServerSocket = if (isServer && SysProp.serverAutoStart) getSocketOrExit(configuration) match {
-        case (_, Some(e)) => boundary.break(e)
-        case (s, _)       => s
-      }
-      else None
+      lazy val bootServerSocket =
+        if (isServer && SysProp.serverAutoStart) getSocketOrExit(configuration) match {
+          case (_, Some(e)) => boundary.break(e)
+          case (s, _)       => s
+        }
+        else None
       lazy val detachStdio = userCommands.exists(_ == BasicCommandStrings.DashDashDetachStdio)
       def withStreams[A](f: => A): A =
         try {

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -77,8 +77,14 @@ private[sbt] object xMain:
       val isBsp: String => Boolean = cmd => (cmd == "-bsp") || (cmd == "--bsp")
       val isNew: String => Boolean = cmd => (cmd == "new") || (cmd == "init")
       lazy val isServer = !userCommands.exists(c => isBsp(c) || isClient(c))
+      // Check if server autostart is disabled via sbt.server.autostart property
+      // This prevents creating boot server socket when --no-server is used
+      lazy val serverAutostart = sys.props.get("sbt.server.autostart") match {
+        case Some(value) => value.toLowerCase == "true"
+        case None        => true // Default to true if not set
+      }
       // keep this lazy to prevent project directory created prematurely
-      lazy val bootServerSocket = if (isServer) getSocketOrExit(configuration) match {
+      lazy val bootServerSocket = if (isServer && serverAutostart) getSocketOrExit(configuration) match {
         case (_, Some(e)) => boundary.break(e)
         case (s, _)       => s
       }

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -100,6 +100,7 @@ object SysProp {
   def legacyTestReport: Boolean = getOrFalse("sbt.testing.legacyreport")
   def semanticdb: Boolean = getOrFalse("sbt.semanticdb")
   def forceServerStart: Boolean = getOrFalse("sbt.server.forcestart")
+  def serverAutoStart: Boolean = getOrTrue("sbt.server.autostart")
   def remoteCache: Option[URI] = sys.props
     .get("sbt.remote_cache")
     .map(URI(_))


### PR DESCRIPTION
Fix --no-server flag not preventing boot server socket creation

Check sbt.server.autostart property before creating BootServerSocket.
When --no-server is used, it sets sbt.server.autostart=false, but
Main.scala was still attempting to create the boot server socket
based only on isServer check.

This caused ServerAlreadyBootingException on Windows when multiple
sbt instances tried to create the same named pipe simultaneously.

Fixes #8177

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=102175066