### PR TITLE
[2.x] Fix --sbt-version to expand to -Dsbt.version

### DIFF
--- a/sbt
+++ b/sbt
@@ -550,7 +550,7 @@ run() {
   syncPreloaded
 
   # no jar? download it.
-  [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
+  [[ -f "$sbt_jar" ]] || acquire_sbt_jar || {
     exit 1
   }
 
@@ -746,7 +746,7 @@ process_args () {
                              sbt_cache="$2" &&
                              addJava "-Dsbt.global.localcache=$2" &&
                              shift 2 ;;
- -sbt-version|--sbt-version) require_arg version "$1" "$2" && sbt_version="$2" && shift 2 ;;
+ -sbt-version|--sbt-version) require_arg version "$1" "$2" && addJava "-Dsbt.version=$2" && shift 2 ;;
      -java-home|--java-home) require_arg path "$1" "$2" &&
                              java_cmd="$2/bin/java" &&
                              export JAVA_HOME="$2" &&


### PR DESCRIPTION
Fixes #6645

The --sbt-version flag was incorrectly trying to download an sbt launcher with the specified version, which doesn't exist for many sbt versions.

Changes:
- Modified --sbt-version handling to directly add -Dsbt.version property
- Removed sbt_version variable assignment that caused launcher mismatch
- acquire_sbt_jar now uses default launcher version instead

Now --sbt-version X.Y.Z correctly expands to -Dsbt.version=X.Y.Z without affecting the sbt launcher version used to run the build.