### PR TITLE
[2.x] Fix #8441: Allow system JNA on OpenBSD by making jna.nosys conditional

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -61,6 +61,7 @@ private[sbt] object xMain:
 
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = boundary {
     try {
+      if (!sys.props.contains("jna.nosys")) sys.props.put("jna.nosys", "true")
       import BasicCommandStrings.{ JavaClient, DashDashClient, DashDashServer, runEarly }
       import BasicCommands.early
       import BuiltinCommands.defaults
@@ -265,7 +266,7 @@ object StandardMain {
       preCommands: Seq[String]
   ): State = {
     // This is to workaround https://github.com/sbt/io/issues/110
-    sys.props.put("jna.nosys", "true")
+    if (!sys.props.contains("jna.nosys")) sys.props.put("jna.nosys", "true")
 
     import BasicCommandStrings.{ DashDashDetachStdio, DashDashServer, isEarlyCommand }
     val userCommands =

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -25,7 +25,7 @@ trait ScriptedKeys {
 
 object Scripted {
   // This is to workaround https://github.com/sbt/io/issues/110
-  sys.props.put("jna.nosys", "true")
+  if (!sys.props.contains("jna.nosys")) sys.props.put("jna.nosys", "true")
 
   val RepoOverrideTest = config("repoOverrideTest") extend Compile
 

--- a/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
@@ -56,7 +56,7 @@ object RunFromSourceMain {
         s"Must specify working directory, scala version and sbt version and classpath as the first three arguments"
       )
     case Array(wd, scalaVersion, sbtVersion, classpath, args*) =>
-      System.setProperty("jna.nosys", "true")
+      if (System.getProperty("jna.nosys") == null) System.setProperty("jna.nosys", "true")
       if (args.exists(_.startsWith("<"))) System.setProperty("sbt.io.virtual", "false")
       val context = LoggerContext()
       try run(file(wd), scalaVersion, sbtVersion, classpath, args, context)


### PR DESCRIPTION
## Fix #8441: Allow system JNA on OpenBSD

### Problem

On OpenBSD 7.8+, sbt fails with `undefined symbol '__sF'` because the bundled JNA native library (`libjnidispatch.so`) is incompatible with recent OpenBSD ABI changes.

sbt unconditionally sets `jna.nosys=true` which prevents users from using a system-installed JNA library as a workaround.

### Solution

Only set `jna.nosys=true` if not already specified by the user. This allows OpenBSD users (and others with similar issues) to use `-Djna.nosys=false` to load JNA from the system path instead of the bundled version.

### Changes

- `Main.scala`: Added conditional check at the start of `xMain.run` (before `bootServerSocket` triggers JNA initialization)
- `Main.scala`: Changed `StandardMain.initialState` to conditional
- `Scripted.scala`: Changed to conditional
- `RunFromSourceMain.scala`: Changed to conditional

### Usage

OpenBSD 7.8+ users can now work around the issue with:
```bash
sbt -Djna.nosys=false
```

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234