### PR TITLE
Fix print command output with --no-color flag

### DIFF
--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -489,7 +489,7 @@ object Act {
             Aggregation.ShowConfig(
               settingValues = true,
               taskValues = true,
-              print = println,
+              print = scala.Console.out.println,
               success = false
             )
           case _ => Aggregation.defaultShow(state, showTasks = action == ShowAction)


### PR DESCRIPTION
Fixes #8075

Problem:
When using --no-color flag with the print command, output was suppressed. For example:
  sbt --batch --error --no-color 'print svc/run/mainClass'
would return empty output instead of the expected value.

Root Cause:
The print command's ShowConfig was using the bare 'println' function which writes to System.out. With --no-color, System.out may be redirected or configured differently, causing output to be lost.

Solution:
Changed print command to use 'scala.Console.out.println' instead of bare 'println'. Console.out properly respects the configured output stream and works correctly with terminal flags like --no-color.

This ensures print command output is always visible regardless of color/terminal settings while maintaining the direct output behavior that distinguishes it from the show command.

Changes:
- Updated Act.scala line 492 to use scala.Console.out.println