### PR TITLE
[2.x] Fix #3746: Scripted should fail when no tests match the pattern

### DIFF
--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/ScriptedTests.scala
@@ -33,6 +33,9 @@ object ScriptedRunnerImpl {
       case ScriptedTest(group, name) =>
         runner.scriptedTest(group, name, logger, context)
     }
+    if (tests.nonEmpty && allTests.isEmpty) {
+      sys.error(s"No tests found matching: ${tests.mkString(", ")}")
+    }
     runAll(allTests)
   }
   def runAll(tests: Seq[() => Option[String]]): Unit = {

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -104,7 +104,7 @@ object Scripted {
       launcherJar: File,
       logger: Logger
   ): Unit = {
-    logger.info(s"About to run tests: ${args.mkString("\n * ", "\n * ", "\n")}")
+    logger.info(s"Tests selected: ${args.mkString("\n * ", "\n * ", "\n")}")
     logger.info("")
 
     // Force Log4J to not use a thread context classloader otherwise it throws a CCE

--- a/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -589,6 +589,10 @@ class ScriptedRunner {
     val groupCount = if (parallelExecution) instances else Int.MaxValue
     val scriptedRunners =
       runner.batchScriptedRunner(scriptedTests, addTestFile, groupCount, prop, logger)
+    // Fail if user provided test patterns but none matched any existing test directories
+    if (tests.nonEmpty && scriptedRunners.isEmpty) {
+      sys.error(s"No tests found matching: ${tests.mkString(", ")}")
+    }
     if (parallelExecution && instances > 1) {
       import scala.collection.parallel.CollectionConverters.*
       val parallelRunners = scriptedRunners.toArray.par


### PR DESCRIPTION
## Summary

Fixes #3746

When running `scripted foo/bar` with a non-existent test pattern, sbt previously reported success even though zero tests were executed. This could mask typos in CI scripts.

## Changes

- Add validation in `ScriptedRunner` to fail when user provides test patterns but none match existing test directories
- Change log message from "About to run tests" to "Tests selected" for clarity
- Error message: `No tests found matching: <pattern>`

## Test Plan

**Before:**
```
> scripted nonexistent/test
[info] About to run tests:
 * nonexistent/test
[success]
```

**After:**
```
> scripted nonexistent/test
[info] Tests selected:
 * nonexistent/test
[error] No tests found matching: nonexistent/test
```

- Verified existing scripted tests still pass: `sbt scripted actions/add-alias`
- Verified command fails on non-matching patterns
- Backward compatible: running `scripted` without arguments still works

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=132382032