### PR TITLE
[2.x] fix: Improve GCMonitor warning message clarity

### DIFF
--- a/main/src/main/scala/sbt/internal/GCMonitor.scala
+++ b/main/src/main/scala/sbt/internal/GCMonitor.scala
@@ -62,8 +62,10 @@ class GCMonitor(logger: Logger) extends GCMonitorBase with AutoCloseable {
 
   override protected def emitWarning(total: Long, over: Option[Long]): Unit = {
     val totalSeconds = total / 1000.0
-    val amountMsg = over.fold(s"$totalSeconds seconds") { d =>
-      "In the last " + (d / 1000.0).ceil.toInt + f" seconds, $totalSeconds (${total.toDouble / d * 100}%.1f%%)"
+    val amountMsg = over.fold(f"$totalSeconds%.3f seconds") { d =>
+      val dSeconds = (d / 1000.0).ceil.toInt
+      val percentage = total.toDouble / d * 100
+      f"In the last $dSeconds seconds, $totalSeconds%.3f seconds ($percentage%.1f%%) of GC pause"
     }
     val msg = s"$amountMsg were spent in GC. " +
       s"[Heap: ${gbString(runtime.freeMemory())} free " +

--- a/main/src/main/scala/sbt/internal/GCMonitor.scala
+++ b/main/src/main/scala/sbt/internal/GCMonitor.scala
@@ -62,10 +62,10 @@ class GCMonitor(logger: Logger) extends GCMonitorBase with AutoCloseable {
 
   override protected def emitWarning(total: Long, over: Option[Long]): Unit = {
     val totalSeconds = total / 1000.0
-    val amountMsg = over.fold(f"$totalSeconds%.3f seconds") { d =>
+    val amountMsg = over.fold(f"$totalSeconds%.3f CPU seconds") { d =>
       val dSeconds = (d / 1000.0).ceil.toInt
       val percentage = total.toDouble / d * 100
-      f"In the last $dSeconds seconds, $totalSeconds%.3f seconds ($percentage%.1f%%) of GC pause"
+      f"In the last $dSeconds seconds, $totalSeconds%.3f CPU seconds ($percentage%.1f%%) of GC pause"
     }
     val msg = s"$amountMsg were spent in GC. " +
       s"[Heap: ${gbString(runtime.freeMemory())} free " +


### PR DESCRIPTION
Add 'seconds' unit to GC time and clarify that the percentage represents cumulative GC pause time across all collectors.

Fixes #8002

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147