### PR TITLE
[2.x] Always create symlinks to the cache in the target locations #8445

### DIFF
--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/build.sbt
@@ -1,0 +1,4 @@
+lazy val root = (project in file(".")).
+  dependsOn(a)
+
+lazy val a = (project in file("a"))

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A1.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A1.scala
@@ -1,0 +1,1 @@
+object A { val x = 1 }

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A2.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A2.scala
@@ -1,0 +1,1 @@
+object A { val x = 2 }

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A3.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/A3.scala
@@ -1,0 +1,1 @@
+object A { def x = 3 }

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/B.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/B.scala
@@ -1,0 +1,3 @@
+object B {
+	def main(args: Array[String]) = assert(args(0).toInt == A.x, s"actual A.x is ${A.x}")
+}

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/build2.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/changes/build2.sbt
@@ -1,0 +1,1 @@
+exportJars := true

--- a/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/test
+++ b/sbt-app/src/sbt-test/source-dependencies/cache-immutability-when-package/test
@@ -1,0 +1,24 @@
+$ copy-file changes/B.scala B.scala
+
+$ copy-file changes/A1.scala a/A.scala
+$ sleep 1000
+
+> run 1
+$ copy-file changes/A2.scala a/A.scala
+$ sleep 1000
+
+# done this way because last modified times often have ~1s resolution
+> run 2
+$ copy-file changes/A1.scala a/A.scala
+$ sleep 1000
+
+> run 1
+
+$ copy-file changes/A3.scala a/A.scala
+$ sleep 1000
+
+> run 3
+$ copy-file changes/A1.scala a/A.scala
+$ sleep 1000
+
+> run 1

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -10,7 +10,7 @@ package sbt.util
 
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Path, Paths }
+import java.nio.file.{ Files, Path, Paths, StandardCopyOption }
 import sbt.internal.util.{ ActionCacheEvent, CacheEventLog, StringVirtualFile1 }
 import sbt.io.syntax.*
 import sbt.io.IO
@@ -268,7 +268,15 @@ object ActionCache:
             case p if p == dirPath => Nil
             case p if p == mPath   => (mPath.toFile() -> manifestFileName) :: Nil
             case f                 => (f.toFile() -> outputDirectory.relativize(f).toString) :: Nil
-      IO.zip((allPaths ++ Seq(mPath)).flatMap(rebase), zipPath.toFile(), Some(default2010Timestamp))
+      // Create the zip in a temp directory to avoid overwriting the cache if `zipPath` is a symlink to the CAS
+      val tempZipPath = (tempDir / (dirPath.getFileName.toString + dirZipExt)).toPath()
+      IO.zip(
+        (allPaths ++ Seq(mPath)).flatMap(rebase),
+        tempZipPath.toFile(),
+        Some(default2010Timestamp)
+      )
+      Files.copy(tempZipPath, zipPath, StandardCopyOption.REPLACE_EXISTING)
+
       conv.toVirtualFile(zipPath)
 
   inline def actionResult[A1](inline value: A1): InternalActionResult[A1] =

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -318,7 +318,9 @@ class DiskActionCacheStore(base: Path, converter: FileConverter) extends Abstrac
         writeFileAndNotify(p)
       case p =>
         try
-          if Digest.sameDigest(p, d) then p
+          // `!symlinkSupported` prevents unnecessary deletion of files and then copying them again
+          // in #writeFileAndNotify on machines that don't support symlinks.
+          if Digest.sameDigest(p, d) && (!symlinkSupported.get() || Files.isSymbolicLink(p)) then p
           else
             // println(s"- syncFile: $p has different digest")
             IO.delete(p.toFile())


### PR DESCRIPTION
The problem described in #8445 is not only tied to `scalaCompilerBridgeBin`, for which it was initially reported, but also affects other tasks like `exportedProductJars`, `packageBin`, and likely more.  

I've tested the proposed approach, and it seems to work - it always creates symlinks. 
However, I think I don't have enough broad knowledge to confidently say that it won't have negative side effects in some other use cases.