### PR TITLE
[2.x] test: Migrate CacheSpec to verify.BasicTestSuite

### DIFF
--- a/util-cache/src/test/scala/CacheSpec.scala
+++ b/util-cache/src/test/scala/CacheSpec.scala
@@ -10,61 +10,50 @@ package sbt.util
 
 import sbt.io.IO
 import sbt.io.syntax.*
+import verify.BasicTestSuite
 
 import CacheImplicits.given
 
-import org.scalatest.flatspec.AnyFlatSpec
+object CacheSpec extends BasicTestSuite:
 
-class CacheSpec extends AnyFlatSpec {
-
-  "A cache" should "NOT throw an exception if read without being written previously" in {
+  test("A cache should NOT throw an exception if read without being written previously"):
     testCache[String, Int] { (cache, store) =>
-      cache(store)("missing") match {
-        case Hit(_)  => fail()
+      cache(store)("missing") match
+        case Hit(_)  => assert(false, "Expected Miss but got Hit")
         case Miss(_) => ()
-      }
     }
-  }
 
-  it should "write a very simple value" in {
+  test("A cache should write a very simple value"):
     testCache[String, Int] { (cache, store) =>
-      cache(store)("missing") match {
-        case Hit(_)       => fail()
+      cache(store)("missing") match
+        case Hit(_)       => assert(false, "Expected Miss but got Hit")
         case Miss(update) => update(5)
-      }
     }
-  }
 
-  it should "be updatable" in {
+  test("A cache should be updatable"):
     testCache[String, Int] { (cache, store) =>
       val value = 5
-      cache(store)("someKey") match {
-        case Hit(_)       => fail()
+      cache(store)("someKey") match
+        case Hit(_)       => assert(false, "Expected Miss but got Hit")
         case Miss(update) => update(value)
-      }
 
-      cache(store)("someKey") match {
-        case Hit(read) => assert(read === value); ()
-        case Miss(_)   => fail()
-      }
+      cache(store)("someKey") match
+        case Hit(read) => assert(read == value)
+        case Miss(_)   => assert(false, "Expected Hit but got Miss")
     }
-  }
 
-  it should "return the value that has been previously written" in {
+  test("A cache should return the value that has been previously written"):
     testCache[String, Int] { (cache, store) =>
       val key = "someKey"
       val value = 5
-      cache(store)(key) match {
-        case Hit(_)       => fail()
+      cache(store)(key) match
+        case Hit(_)       => assert(false, "Expected Miss but got Hit")
         case Miss(update) => update(value)
-      }
 
-      cache(store)(key) match {
-        case Hit(read) => assert(read === value); ()
-        case Miss(_)   => fail()
-      }
+      cache(store)(key) match
+        case Hit(read) => assert(read == value)
+        case Miss(_)   => assert(false, "Expected Hit but got Miss")
     }
-  }
 
   private def testCache[K, V](f: (Cache[K, V], CacheStore) => Unit)(using
       cache: Cache[K, V]
@@ -74,4 +63,4 @@ class CacheSpec extends AnyFlatSpec {
       f(cache, store)
     }
 
-}
+end CacheSpec


### PR DESCRIPTION
Migrate CacheSpec from ScalaTest AnyFlatSpec to verify.BasicTestSuite following the project's test framework standardization.

Changes:
- Convert class to object extending BasicTestSuite
- Replace ScalaTest 'should/in' syntax with test() method
- Replace fail() with assert(false, message)
- Replace === with ==
- Use Scala 3 indentation-based syntax
- Remove ScalaTest import, add verify.BasicTestSuite import

All tests pass successfully.

Fixes #8466

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147