### PR TITLE
[2.x] fix: Only disable symlinks when truly not supported

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -293,15 +293,21 @@ class DiskActionCacheStore(base: Path, converter: FileConverter) extends Abstrac
       IO.createDirectory(outPath.getParent().toFile())
       val result = Retry:
         if Files.exists(outPath) then IO.delete(outPath.toFile())
-        if symlinkSupported.get() then
+        if symlinkSupported.get() && Files.exists(casFile) then
           try Files.createSymbolicLink(outPath, casFile)
           catch
             case e: FileSystemException =>
-              if Util.isWindows then
-                scala.Console.err.println(
-                  "[info] failed to a create symbolic link. consider enabling Developer Mode"
-                )
-              symlinkSupported.set(false)
+              val msg = Option(e.getMessage).getOrElse("")
+              val isSymlinkNotSupported =
+                msg.contains("privilege") ||
+                  msg.contains("Operation not permitted") ||
+                  msg.contains("A required privilege is not held")
+              if isSymlinkNotSupported then
+                if Util.isWindows then
+                  scala.Console.err.println(
+                    "[info] failed to a create symbolic link. consider enabling Developer Mode"
+                  )
+                symlinkSupported.set(false)
               copyFile(outPath)
         else copyFile(outPath)
       afterFileWrite(ref, result, outputDirectory)


### PR DESCRIPTION
# fix: Only disable symlinks when truly not supported

## What's the problem?

When you delete the disk cache while sbt is running and then recompile, symlinks stop being created. Instead, sbt copies files directly. This happens because the `symlinkSupported` flag gets permanently set to `false` during the session.

As @azdrojowa123 discovered through debugging, a `FileAlreadyExistsException` is thrown during step 5 of the reproduction, and this incorrectly disables symlink support.

## Why does this happen?

The current code catches any `FileSystemException` and assumes it means "symlinks aren't supported on this system." But `FileAlreadyExistsException` is a subclass of `FileSystemException`, and it has nothing to do with symlink support - it just means the file already exists (likely a race condition).

## What's the fix?

Instead of disabling symlinks on any `FileSystemException`, we now only disable them when the error message specifically indicates a permission or privilege issue:
- "privilege"
- "Operation not permitted"  
- "A required privilege is not held"

This way, transient errors like `FileAlreadyExistsException` will fall back to copying the file, but won't permanently disable symlinks for the rest of the session.

I also added a check to verify the CAS file exists before attempting to create a symlink, which helps avoid some edge cases.

Fixes #8478

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147