### PR TITLE
[2.x] fix: Filter out JAR paths in BSP diagnostics on Windows

### DIFF
--- a/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerReporter.scala
@@ -92,9 +92,11 @@ final class BuildServerReporterImpl(
   private val problemsByFile = mutable.Map[Path, Vector[Problem]]()
 
   // sometimes the compiler returns a fake position such as <macro>
-  // on Windows, this causes InvalidPathException (see #5994 and #6720)
+  // or a JAR file path like jar:file:///C:/...
+  // on Windows, this causes InvalidPathException (see #5994, #6720, and #7665)
   private def toDocument(ref: VirtualFileRef): Option[TextDocumentIdentifier] =
-    if (ref.id().contains("<")) None
+    val id = ref.id()
+    if id.contains("<") || id.startsWith("jar:") then None
     else Some(TextDocumentIdentifier(converter.toPath(ref).toUri))
 
   /**


### PR DESCRIPTION
When Java compiler generates warnings about missing annotations from JAR files, the path format is jar:file:///C:/... which causes InvalidPathException on Windows due to the : character.

The fix filters out jar: paths in toDocument(), similar to how fake positions like <macro> are already filtered out. This prevents the exception and allows compilation to continue.

Diagnostics for files inside JARs are not shown in the IDE, which is correct behavior since they cannot be edited.

Fixes #7665

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147