### PR TITLE
[2.x] fix: Fix ProjectMatrix invalid project ID with CrossVersion.full

### DIFF
--- a/lm-core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
@@ -105,9 +105,10 @@ private[sbt] object ConfigurationMacro:
     @tailrec
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
-        case sym if sym.flags.is(Flags.Macro) => enclosingTerm(sym.owner)
-        case sym if !sym.isTerm               => enclosingTerm(sym.owner)
-        case _                                => sym
+        case sym if sym.flags.is(Flags.Macro) || sym.flags.is(Flags.Synthetic) =>
+          enclosingTerm(sym.owner)
+        case sym if !sym.isTerm => enclosingTerm(sym.owner)
+        case _                                    => sym
     val term = enclosingTerm(Symbol.spliceOwner)
     if !term.isValDef then
       report.error(

--- a/lm-core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala
@@ -105,9 +105,9 @@ private[sbt] object ConfigurationMacro:
     @tailrec
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
-        case sym if sym.flags.is(Flags.Macro) || sym.flags.is(Flags.Synthetic) =>
-          enclosingTerm(sym.owner)
-        case sym if !sym.isTerm => enclosingTerm(sym.owner)
+        case sym if sym.flags.is(Flags.Macro)     => enclosingTerm(sym.owner)
+        case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm(sym.owner)
+        case sym if !sym.isTerm                   => enclosingTerm(sym.owner)
         case _                                    => sym
     val term = enclosingTerm(Symbol.spliceOwner)
     if !term.isValDef then

--- a/main-settings/src/main/scala/sbt/std/KeyMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/KeyMacro.scala
@@ -72,9 +72,9 @@ private[sbt] object KeyMacro:
     @tailrec
     def enclosingTerm0(sym: Symbol): Symbol =
       sym match
-        case sym if sym.flags.is(Flags.Macro) || sym.flags.is(Flags.Synthetic) =>
-          enclosingTerm0(sym.owner)
-        case sym if !sym.isTerm => enclosingTerm0(sym.owner)
+        case sym if sym.flags.is(Flags.Macro)     => enclosingTerm0(sym.owner)
+        case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm0(sym.owner)
+        case sym if !sym.isTerm                   => enclosingTerm0(sym.owner)
         case _                                    => sym
     enclosingTerm0(Symbol.spliceOwner)
 

--- a/main-settings/src/main/scala/sbt/std/KeyMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/KeyMacro.scala
@@ -72,9 +72,10 @@ private[sbt] object KeyMacro:
     @tailrec
     def enclosingTerm0(sym: Symbol): Symbol =
       sym match
-        case sym if sym.flags.is(Flags.Macro) => enclosingTerm0(sym.owner)
-        case sym if !sym.isTerm               => enclosingTerm0(sym.owner)
-        case _                                => sym
+        case sym if sym.flags.is(Flags.Macro) || sym.flags.is(Flags.Synthetic) =>
+          enclosingTerm0(sym.owner)
+        case sym if !sym.isTerm => enclosingTerm0(sym.owner)
+        case _                                    => sym
     enclosingTerm0(Symbol.spliceOwner)
 
   private def enclosingClass(using Quotes) =


### PR DESCRIPTION
## Summary

Fixes #8458

When using `ProjectMatrix` with `CrossVersion.full` and Scala 2 versions like `2.13.18`, the project ID incorrectly became `$1$2_13_18` instead of `foo2_13_18`.

**Root cause:** The Scala 3 compiler creates synthetic intermediate vals (e.g., `$1`) during macro expansion. The `enclosingTerm` function in the macros was stopping at these synthetic symbols instead of continuing up the symbol tree to find the actual val name.

**Fix:** Added `Flags.Synthetic` check to skip compiler-generated symbols in:
- `main-settings/src/main/scala/sbt/std/KeyMacro.scala`
- `lm-core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala`

## Test

```scala
// build.sbt
val foo = projectMatrix
  .jvmPlatform(
    scalaVersions = Seq("2.13.18", "3.3.7"),
    crossVersion = CrossVersion.full
  )
```

Before: sbt projects shows $1$2_13_18, $1$3_3_7
After: sbt projects shows foo2_13_18, foo3_3_7

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=4217675