### PR TITLE
[2.x] fix: Fix snapshot sbt version invalidation 7713

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -59,8 +59,7 @@ class Eval(
       snapshotJars.sorted.foreach { path =>
         val file = path.toFile
         digester.update(bytes(path.toString))
-        if file.exists then
-          digester.update(bytes(file.lastModified.toString))
+        if file.exists then digester.update(bytes(file.lastModified.toString))
       }
       Hash.toHex(digester.digest())
 

--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -45,6 +45,25 @@ class Eval(
     .map(_.toString)
     .mkString(java.io.File.pathSeparator)
 
+  // Compute a hash of SNAPSHOT jars to invalidate cache when sbt SNAPSHOT version changes.
+  // Include modification time to detect republished snapshots with the same version string.
+  // This fixes #7713: build.sbt not recompiled when SNAPSHOT sbt breaks binary compatibility.
+  private val snapshotClasspathHash: String =
+    val snapshotJars = classpath.filter { path =>
+      val name = path.getFileName.toString
+      name.contains("SNAPSHOT") || name.contains("-bin-")
+    }
+    if snapshotJars.isEmpty then ""
+    else
+      val digester = MessageDigest.getInstance("SHA")
+      snapshotJars.sorted.foreach { path =>
+        val file = path.toFile
+        digester.update(bytes(path.toString))
+        if file.exists then
+          digester.update(bytes(file.lastModified.toString))
+      }
+      Hash.toHex(digester.digest())
+
   final class EvalDriver(reporter: EvalReporter) extends Driver:
     val compileCtx0 = initCtx.fresh
     val options = nonCpOptions ++ Seq("-classpath", classpathString, "dummy.scala")
@@ -196,6 +215,8 @@ class Eval(
       digester.update(bytes(tpe))
     }
     digester.update(bytes(ev.extraHash))
+    // Include SNAPSHOT classpath hash to invalidate cache when sbt version changes (fixes #7713)
+    digester.update(bytes(snapshotClasspathHash))
     val d = digester.digest()
     val hash = Hash.toHex(d)
     val moduleName = makeModuleName(hash)


### PR DESCRIPTION
# Fix: Invalidate build.sbt cache when sbt SNAPSHOT version changes

## Problem

When developing with a SNAPSHOT version of sbt, there's a frustrating issue: if you republish sbt with breaking changes and then reload your build, it fails with a cryptic `java.lang.NoSuchMethodError`.

This happens because sbt caches the compiled build definition (the `.class` files in `project/target/config-classes/`), but the cache key doesn't account for changes to sbt itself. So even though the sbt jars have changed, sbt happily reuses the old cached classes that were compiled against the previous version.

## Solution

This PR adds a hash of SNAPSHOT jars to the cache key used for build definition compilation. When sbt detects that any SNAPSHOT or `-bin-` jars have changed (by checking their modification times), it will recompile the build definition instead of using stale cached classes.

The fix is intentionally targeted:
- Only SNAPSHOT and `-bin-` jars are tracked (development versions)
- Stable releases are unaffected, so there's no unnecessary cache invalidation
- Modification times are included to catch republished snapshots with the same version string

## Testing

- All existing unit tests pass
- Scalafmt check passes

## Related

Fixes #7713

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147