### PR TITLE
[2.x] feat: Cache failed compilation to avoid repeated failures

### DIFF
--- a/util-cache/src/main/contraband-scala/sbt/util/GenericFailure.scala
+++ b/util-cache/src/main/contraband-scala/sbt/util/GenericFailure.scala
@@ -1,0 +1,55 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.util
+/**
+ * A GenericFailure represents a cached task failure.
+ * This allows caching failures so that repeated builds don't re-run failed tasks.
+ * The kind field indicates the type of failure (e.g., "CompileFailed").
+ * 
+ * Fixes https://github.com/sbt/sbt/issues/7662
+ */
+final class GenericFailure private (
+  val kind: Option[String],
+  val message: Option[String],
+  val problems: Vector[xsbti.Problem]) extends Serializable {
+  
+  private def this() = this(None, None, Vector())
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: GenericFailure => (this.kind == x.kind) && (this.message == x.message) && (this.problems == x.problems)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (17 + "sbt.util.GenericFailure".##) + kind.##) + message.##) + problems.##)
+  }
+  override def toString: String = {
+    "GenericFailure(" + kind + ", " + message + ", " + problems + ")"
+  }
+  private def copy(kind: Option[String] = kind, message: Option[String] = message, problems: Vector[xsbti.Problem] = problems): GenericFailure = {
+    new GenericFailure(kind, message, problems)
+  }
+  def withKind(kind: Option[String]): GenericFailure = {
+    copy(kind = kind)
+  }
+  def withKind(kind: String): GenericFailure = {
+    copy(kind = Option(kind))
+  }
+  def withMessage(message: Option[String]): GenericFailure = {
+    copy(message = message)
+  }
+  def withMessage(message: String): GenericFailure = {
+    copy(message = Option(message))
+  }
+  def withProblems(problems: Vector[xsbti.Problem]): GenericFailure = {
+    copy(problems = problems)
+  }
+}
+object GenericFailure {
+  
+  def apply(): GenericFailure = new GenericFailure()
+  def apply(kind: Option[String], message: Option[String], problems: Vector[xsbti.Problem]): GenericFailure = new GenericFailure(kind, message, problems)
+  def apply(kind: String, message: String, problems: Vector[xsbti.Problem]): GenericFailure = new GenericFailure(Option(kind), Option(message), problems)
+}

--- a/util-cache/src/main/contraband/actionresult.contra
+++ b/util-cache/src/main/contraband/actionresult.contra
@@ -15,3 +15,14 @@ type ActionResult {
   contents: [java.nio.ByteBuffer] @since("0.4.0")
   isExecutable: [Boolean] @since("0.5.0")
 }
+
+## A GenericFailure represents a cached task failure.
+## This allows caching failures so that repeated builds don't re-run failed tasks.
+## The kind field indicates the type of failure (e.g., "CompileFailed").
+##
+## Fixes https://github.com/sbt/sbt/issues/7662
+type GenericFailure @generateCodec(false) {
+  kind: String @since("0.1.0")
+  message: String @since("0.1.0")
+  problems: [xsbti.Problem] @since("0.1.0")
+}

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -24,11 +24,13 @@ import sjsonnew.{ HashWriter, JsonFormat }
 import sjsonnew.support.murmurhash.Hasher
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser }
 import scala.quoted.{ Expr, FromExpr, ToExpr, Quotes }
-import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile, VirtualFileRef }
+import xsbti.{ CompileFailed, FileConverter, HashedVirtualFileRef, VirtualFile, VirtualFileRef }
 
 object ActionCache:
   private[sbt] val dirZipExt = ".sbtdir.zip"
   private[sbt] val manifestFileName = "sbtdir_manifest.json"
+  private[sbt] val failureFileName = "failure.json"
+  private[sbt] val failureExitCode = 1
 
   /**
    * This is a key function that drives remote caching.
@@ -54,11 +56,29 @@ object ActionCache:
       action: I => InternalActionResult[O],
   ): O =
     import config.*
+
+    def cacheFailure(e: CompileFailed): Nothing =
+      // Cache the failure so subsequent builds don't re-run failed compilation
+      // This fixes https://github.com/sbt/sbt/issues/7662
+      cacheEventLog.append(ActionCacheEvent.OnsiteTask)
+      val (input, failurePath) = mkFailureInput(key, codeContentHash, extraHash)
+      val cachedFailure = CachedCompileFailure.fromException(e)
+      val json = Converter.toJsonUnsafe(cachedFailure)
+      val failureFile = StringVirtualFile1(failurePath, CompactPrinter(json))
+      store.put(
+        UpdateActionResultRequest(input, Vector(failureFile), exitCode = failureExitCode)
+      ) match
+        case Right(_) => ()
+        case Left(_)  => () // Ignore cache storage errors for failures
+      throw e
+
     def organicTask: O =
       // run action(...) and combine the newResult with outputs
       val InternalActionResult(result, outputs) =
         try action(key): @unchecked
         catch
+          case e: CompileFailed =>
+            cacheFailure(e)
           case e: Exception =>
             cacheEventLog.append(ActionCacheEvent.Error)
             throw e
@@ -83,9 +103,15 @@ object ActionCache:
             result
           case Left(e) => throw e
 
-    get(key, codeContentHash, extraHash, tags, config) match
-      case Some(value) => value
-      case None        => organicTask
+    // Check for cached failure first
+    getCachedFailure(key, codeContentHash, extraHash, config) match
+      case Some(failure) =>
+        config.cacheEventLog.append(ActionCacheEvent.Found("cached-failure"))
+        throw failure.toException
+      case None =>
+        get(key, codeContentHash, extraHash, tags, config) match
+          case Some(value) => value
+          case None        => organicTask
   end cache
 
   /**
@@ -174,6 +200,44 @@ object ActionCache:
     val input =
       Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
     (input, s"$${OUT}/value/$input.json")
+
+  private inline def mkFailureInput[I: HashWriter](
+      key: I,
+      codeContentHash: Digest,
+      extraHash: Digest
+  ): (Digest, String) =
+    val input =
+      Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
+    // Use a different path for failures to avoid conflicts with success cache
+    (Digest.sha256Hash(input, Digest.dummy(failureExitCode)), s"$${OUT}/failure/$input.json")
+
+  /**
+   * Retrieves a cached compilation failure, if any.
+   */
+  private def getCachedFailure[I: HashWriter](
+      key: I,
+      codeContentHash: Digest,
+      extraHash: Digest,
+      config: BuildWideCacheConfiguration,
+  ): Option[CachedCompileFailure] =
+    val (input, failurePath) = mkFailureInput(key, codeContentHash, extraHash)
+    val getRequest =
+      GetActionResultRequest(input, inlineStdout = false, inlineStderr = false, Vector(failurePath))
+    config.store.get(getRequest) match
+      case Right(result) if result.exitCode.contains(failureExitCode) =>
+        result.contents.headOption match
+          case Some(head) =>
+            val str = String(head.array(), StandardCharsets.UTF_8)
+            val json = Parser.parseUnsafe(str)
+            Some(Converter.fromJsonUnsafe[CachedCompileFailure](json))
+          case None =>
+            val paths = config.store.syncBlobs(result.outputFiles, config.outputDirectory)
+            if paths.isEmpty then None
+            else
+              val str = IO.read(paths.head.toFile())
+              val json = Parser.parseUnsafe(str)
+              Some(Converter.fromJsonUnsafe[CachedCompileFailure](json))
+      case _ => None
 
   def manifestFromFile(manifest: Path): Manifest =
     import sbt.internal.util.codec.ManifestCodec.given

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -60,11 +60,12 @@ object ActionCache:
     def cacheFailure(e: CompileFailed): Nothing =
       // Cache the failure so subsequent builds don't re-run failed compilation
       // This fixes https://github.com/sbt/sbt/issues/7662
+      // Use the same input digest as success, distinguished by exitCode
       cacheEventLog.append(ActionCacheEvent.OnsiteTask)
-      val (input, failurePath) = mkFailureInput(key, codeContentHash, extraHash)
+      val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
       val cachedFailure = CachedCompileFailure.fromException(e)
       val json = Converter.toJsonUnsafe(cachedFailure)
-      val failureFile = StringVirtualFile1(failurePath, CompactPrinter(json))
+      val failureFile = StringVirtualFile1(valuePath, CompactPrinter(json))
       store.put(
         UpdateActionResultRequest(input, Vector(failureFile), exitCode = failureExitCode)
       ) match
@@ -103,16 +104,79 @@ object ActionCache:
             result
           case Left(e) => throw e
 
-    // Check for cached failure first
-    getCachedFailure(key, codeContentHash, extraHash, config) match
-      case Some(failure) =>
+    // Single cache lookup - use exitCode to distinguish success from failure
+    getWithFailure(key, codeContentHash, extraHash, tags, config) match
+      case Right(value) => value
+      case Left(Some(failure)) =>
         config.cacheEventLog.append(ActionCacheEvent.Found("cached-failure"))
         throw failure.toException
-      case None =>
-        get(key, codeContentHash, extraHash, tags, config) match
-          case Some(value) => value
-          case None        => organicTask
+      case Left(None) => organicTask
   end cache
+
+  /**
+   * Retrieves the cached value or failure with a single cache lookup.
+   * Returns Right(value) for cached success, Left(Some(failure)) for cached failure,
+   * or Left(None) for cache miss.
+   */
+  private def getWithFailure[I: HashWriter, O: JsonFormat](
+      key: I,
+      codeContentHash: Digest,
+      extraHash: Digest,
+      tags: List[CacheLevelTag],
+      config: BuildWideCacheConfiguration,
+  ): Either[Option[CachedCompileFailure], O] =
+    import config.store
+    def valueFromStr(str: String, origin: Option[String]): O =
+      config.cacheEventLog.append(ActionCacheEvent.Found(origin.getOrElse("unknown")))
+      val json = Parser.parseUnsafe(str)
+      Converter.fromJsonUnsafe[O](json)
+
+    def failureFromStr(str: String): CachedCompileFailure =
+      val json = Parser.parseUnsafe(str)
+      Converter.fromJsonUnsafe[CachedCompileFailure](json)
+
+    // Optimization: Check if we can read directly from symlinked value file
+    val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
+    val resolvedValuePath = config.fileConverter.toPath(VirtualFileRef.of(valuePath))
+
+    def readFromSymlink(): Option[Either[Option[CachedCompileFailure], O]] =
+      if java.nio.file.Files.isSymbolicLink(resolvedValuePath) && java.nio.file.Files
+          .exists(resolvedValuePath)
+      then
+        Exception.nonFatalCatch
+          .opt(IO.read(resolvedValuePath.toFile(), StandardCharsets.UTF_8))
+          .flatMap: str =>
+            // We still need to sync output files for side effects and check exitCode
+            findActionResult(key, codeContentHash, extraHash, config) match
+              case Right(result) =>
+                store.syncBlobs(result.outputFiles, config.outputDirectory)
+                if result.exitCode.contains(failureExitCode) then
+                  Some(Left(Some(failureFromStr(str))))
+                else Some(Right(valueFromStr(str, Some("symlink"))))
+              case Left(_) => None
+      else None
+
+    readFromSymlink() match
+      case Some(result) => result
+      case None =>
+        findActionResult(key, codeContentHash, extraHash, config) match
+          case Right(result) =>
+            // Check exitCode to determine if this is a cached failure
+            val isFailure = result.exitCode.contains(failureExitCode)
+            result.contents.headOption match
+              case Some(head) =>
+                store.syncBlobs(result.outputFiles, config.outputDirectory)
+                val str = String(head.array(), StandardCharsets.UTF_8)
+                if isFailure then Left(Some(failureFromStr(str)))
+                else Right(valueFromStr(str, result.origin))
+              case _ =>
+                val paths = store.syncBlobs(result.outputFiles, config.outputDirectory)
+                if paths.isEmpty then Left(None)
+                else
+                  val str = IO.read(paths.head.toFile())
+                  if isFailure then Left(Some(failureFromStr(str)))
+                  else Right(valueFromStr(str, result.origin))
+          case Left(_) => Left(None)
 
   /**
    * Retrieves the cached value.
@@ -124,47 +188,9 @@ object ActionCache:
       tags: List[CacheLevelTag],
       config: BuildWideCacheConfiguration,
   ): Option[O] =
-    import config.store
-    def valueFromStr(str: String, origin: Option[String]): O =
-      config.cacheEventLog.append(ActionCacheEvent.Found(origin.getOrElse("unknown")))
-      val json = Parser.parseUnsafe(str)
-      Converter.fromJsonUnsafe[O](json)
-
-    // Optimization: Check if we can read directly from symlinked value file
-    val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
-    val resolvedValuePath = config.fileConverter.toPath(VirtualFileRef.of(valuePath))
-
-    def readFromSymlink(): Option[O] =
-      if java.nio.file.Files.isSymbolicLink(resolvedValuePath) && java.nio.file.Files
-          .exists(resolvedValuePath)
-      then
-        Exception.nonFatalCatch
-          .opt(IO.read(resolvedValuePath.toFile(), StandardCharsets.UTF_8))
-          .map: str =>
-            // We still need to sync output files for side effects
-            findActionResult(key, codeContentHash, extraHash, config) match
-              case Right(result) =>
-                store.syncBlobs(result.outputFiles, config.outputDirectory)
-              case Left(_) => // Ignore if we can't find ActionResult
-            valueFromStr(str, Some("symlink"))
-      else None
-
-    readFromSymlink() match
-      case Some(value) => Some(value)
-      case None =>
-        findActionResult(key, codeContentHash, extraHash, config) match
-          case Right(result) =>
-            // some protocol can embed values into the result
-            result.contents.headOption match
-              case Some(head) =>
-                store.syncBlobs(result.outputFiles, config.outputDirectory)
-                val str = String(head.array(), StandardCharsets.UTF_8)
-                Some(valueFromStr(str, result.origin))
-              case _ =>
-                val paths = store.syncBlobs(result.outputFiles, config.outputDirectory)
-                if paths.isEmpty then None
-                else Some(valueFromStr(IO.read(paths.head.toFile()), result.origin))
-          case Left(_) => None
+    getWithFailure(key, codeContentHash, extraHash, tags, config) match
+      case Right(value) => Some(value)
+      case Left(_)      => None
 
   /**
    * Checks if the ActionResult exists in the cache.
@@ -200,44 +226,6 @@ object ActionCache:
     val input =
       Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
     (input, s"$${OUT}/value/$input.json")
-
-  private inline def mkFailureInput[I: HashWriter](
-      key: I,
-      codeContentHash: Digest,
-      extraHash: Digest
-  ): (Digest, String) =
-    val input =
-      Digest.sha256Hash(codeContentHash, extraHash, Digest.dummy(Hasher.hashUnsafe[I](key)))
-    // Use a different path for failures to avoid conflicts with success cache
-    (Digest.sha256Hash(input, Digest.dummy(failureExitCode)), s"$${OUT}/failure/$input.json")
-
-  /**
-   * Retrieves a cached compilation failure, if any.
-   */
-  private def getCachedFailure[I: HashWriter](
-      key: I,
-      codeContentHash: Digest,
-      extraHash: Digest,
-      config: BuildWideCacheConfiguration,
-  ): Option[CachedCompileFailure] =
-    val (input, failurePath) = mkFailureInput(key, codeContentHash, extraHash)
-    val getRequest =
-      GetActionResultRequest(input, inlineStdout = false, inlineStderr = false, Vector(failurePath))
-    config.store.get(getRequest) match
-      case Right(result) if result.exitCode.contains(failureExitCode) =>
-        result.contents.headOption match
-          case Some(head) =>
-            val str = String(head.array(), StandardCharsets.UTF_8)
-            val json = Parser.parseUnsafe(str)
-            Some(Converter.fromJsonUnsafe[CachedCompileFailure](json))
-          case None =>
-            val paths = config.store.syncBlobs(result.outputFiles, config.outputDirectory)
-            if paths.isEmpty then None
-            else
-              val str = IO.read(paths.head.toFile())
-              val json = Parser.parseUnsafe(str)
-              Some(Converter.fromJsonUnsafe[CachedCompileFailure](json))
-      case _ => None
 
   def manifestFromFile(manifest: Path): Manifest =
     import sbt.internal.util.codec.ManifestCodec.given

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -109,6 +109,8 @@ object ActionCache:
       case Right(value) => value
       case Left(Some(failure)) =>
         config.cacheEventLog.append(ActionCacheEvent.Found("cached-failure"))
+        // Replay problems to the logger so users see the cached errors/warnings
+        failure.replay(config.logger)
         throw failure.toException
       case Left(None) => organicTask
   end cache

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -68,9 +68,7 @@ object ActionCache:
       val failureFile = StringVirtualFile1(valuePath, CompactPrinter(json))
       store.put(
         UpdateActionResultRequest(input, Vector(failureFile), exitCode = failureExitCode)
-      ) match
-        case Right(_) => ()
-        case Left(_)  => () // Ignore cache storage errors for failures
+      )
       throw e
 
     def organicTask: O =

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -217,7 +217,7 @@ class DiskActionCacheStore(base: Path, converter: FileConverter) extends Abstrac
     try
       val acFile = acBase.toFile / request.actionDigest.toString.replace("/", "-")
       val refs = putBlobsIfNeeded(request.outputFiles).toVector
-      val v = ActionResult(refs, storeName)
+      val v = ActionResult(refs, Some(storeName), request.exitCode)
       val json = Converter.toJsonUnsafe(v)
       IO.write(acFile, CompactPrinter(json))
       Right(v)

--- a/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
+++ b/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
@@ -13,20 +13,17 @@ import sbt.internal.util.codec.{ ProblemFormats, SeverityFormats, PositionFormat
 import xsbti.{ CompileFailed, Problem }
 
 /**
- * A serializable representation of a CompileFailed exception.
+ * A wrapper around GenericFailure for CompileFailed exceptions.
  * This allows caching compilation failures so that repeated builds
  * don't re-run failed compilations unnecessarily.
  *
  * Fixes https://github.com/sbt/sbt/issues/7662
  */
-final case class CachedCompileFailure(
-    problems: Vector[Problem],
-    message: String
-):
+final case class CachedCompileFailure(underlying: GenericFailure):
   def toException: CompileFailed = new CompileFailed:
     override def arguments(): Array[String] = Array.empty
-    override def problems(): Array[Problem] = CachedCompileFailure.this.problems.toArray
-    override def getMessage(): String = CachedCompileFailure.this.message
+    override def problems(): Array[Problem] = underlying.problems.toArray
+    override def getMessage(): String = underlying.message.getOrElse("")
 end CachedCompileFailure
 
 object CachedCompileFailure
@@ -35,27 +32,42 @@ object CachedCompileFailure
     with PositionFormats
     with sjsonnew.BasicJsonProtocol:
 
+  private val CompileFailedKind = "CompileFailed"
+
   def fromException(e: CompileFailed): CachedCompileFailure =
     CachedCompileFailure(
-      problems = e.problems().toVector,
-      message = Option(e.getMessage).getOrElse("")
+      GenericFailure(
+        kind = CompileFailedKind,
+        message = Option(e.getMessage).getOrElse(""),
+        problems = e.problems().toVector
+      )
     )
 
-  given JsonFormat[CachedCompileFailure] = new JsonFormat[CachedCompileFailure]:
-    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedCompileFailure =
+  // Custom JsonFormat for GenericFailure since we disabled automatic codec generation
+  given JsonFormat[GenericFailure] = new JsonFormat[GenericFailure]:
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): GenericFailure =
       jsOpt match
         case Some(js) =>
           unbuilder.beginObject(js)
+          val kind = unbuilder.readField[Option[String]]("kind")
+          val message = unbuilder.readField[Option[String]]("message")
           val problems = unbuilder.readField[Vector[Problem]]("problems")
-          val message = unbuilder.readField[String]("message")
           unbuilder.endObject()
-          CachedCompileFailure(problems, message)
+          GenericFailure(kind, message, problems)
         case None =>
           deserializationError("Expected JsObject but found None")
 
-    override def write[J](obj: CachedCompileFailure, builder: Builder[J]): Unit =
+    override def write[J](obj: GenericFailure, builder: Builder[J]): Unit =
       builder.beginObject()
-      builder.addField("problems", obj.problems)
+      builder.addField("kind", obj.kind)
       builder.addField("message", obj.message)
+      builder.addField("problems", obj.problems)
       builder.endObject()
+
+  given JsonFormat[CachedCompileFailure] = new JsonFormat[CachedCompileFailure]:
+    private val gf = summon[JsonFormat[GenericFailure]]
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedCompileFailure =
+      CachedCompileFailure(gf.read(jsOpt, unbuilder))
+    override def write[J](obj: CachedCompileFailure, builder: Builder[J]): Unit =
+      gf.write(obj.underlying, builder)
 end CachedCompileFailure

--- a/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
+++ b/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
@@ -9,8 +9,8 @@
 package sbt.util
 
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
-import xsbti.{ CompileFailed, Problem, Position, Severity }
-import java.util.Optional
+import sbt.internal.util.codec.{ ProblemFormats, SeverityFormats, PositionFormats }
+import xsbti.{ CompileFailed, Problem }
 
 /**
  * A serializable representation of a CompileFailed exception.
@@ -20,21 +20,24 @@ import java.util.Optional
  * Fixes https://github.com/sbt/sbt/issues/7662
  */
 final case class CachedCompileFailure(
-    problems: Vector[CachedProblem],
+    problems: Vector[Problem],
     message: String
 ):
   def toException: CompileFailed = new CompileFailed:
     override def arguments(): Array[String] = Array.empty
-    override def problems(): Array[Problem] = CachedCompileFailure.this.problems
-      .map(_.toProblem)
-      .toArray
+    override def problems(): Array[Problem] = CachedCompileFailure.this.problems.toArray
     override def getMessage(): String = CachedCompileFailure.this.message
 end CachedCompileFailure
 
-object CachedCompileFailure:
+object CachedCompileFailure
+    extends ProblemFormats
+    with SeverityFormats
+    with PositionFormats
+    with sjsonnew.BasicJsonProtocol:
+
   def fromException(e: CompileFailed): CachedCompileFailure =
     CachedCompileFailure(
-      problems = e.problems().map(CachedProblem.fromProblem).toVector,
+      problems = e.problems().toVector,
       message = Option(e.getMessage).getOrElse("")
     )
 
@@ -43,7 +46,7 @@ object CachedCompileFailure:
       jsOpt match
         case Some(js) =>
           unbuilder.beginObject(js)
-          val problems = unbuilder.readField[Vector[CachedProblem]]("problems")
+          val problems = unbuilder.readField[Vector[Problem]]("problems")
           val message = unbuilder.readField[String]("message")
           unbuilder.endObject()
           CachedCompileFailure(problems, message)
@@ -56,132 +59,3 @@ object CachedCompileFailure:
       builder.addField("message", obj.message)
       builder.endObject()
 end CachedCompileFailure
-
-/**
- * A serializable representation of a compiler Problem.
- */
-final case class CachedProblem(
-    category: String,
-    severity: String,
-    message: String,
-    position: CachedPosition,
-    rendered: Option[String]
-):
-  def toProblem: Problem = new Problem:
-    override def category(): String = CachedProblem.this.category
-    override def severity(): Severity = CachedProblem.this.severity match
-      case "Error" => Severity.Error
-      case "Warn"  => Severity.Warn
-      case _       => Severity.Info
-    override def message(): String = CachedProblem.this.message
-    override def position(): Position = CachedProblem.this.position.toPosition
-    override def rendered(): Optional[String] =
-      CachedProblem.this.rendered.map(Optional.of).getOrElse(Optional.empty())
-end CachedProblem
-
-object CachedProblem:
-  def fromProblem(p: Problem): CachedProblem =
-    CachedProblem(
-      category = p.category(),
-      severity = p.severity().toString,
-      message = p.message(),
-      position = CachedPosition.fromPosition(p.position()),
-      rendered = if p.rendered().isPresent then Some(p.rendered().get()) else None
-    )
-
-  given JsonFormat[CachedProblem] = new JsonFormat[CachedProblem]:
-    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedProblem =
-      jsOpt match
-        case Some(js) =>
-          unbuilder.beginObject(js)
-          val category = unbuilder.readField[String]("category")
-          val severity = unbuilder.readField[String]("severity")
-          val message = unbuilder.readField[String]("message")
-          val position = unbuilder.readField[CachedPosition]("position")
-          val rendered = unbuilder.readField[Option[String]]("rendered")
-          unbuilder.endObject()
-          CachedProblem(category, severity, message, position, rendered)
-        case None =>
-          deserializationError("Expected JsObject but found None")
-
-    override def write[J](obj: CachedProblem, builder: Builder[J]): Unit =
-      builder.beginObject()
-      builder.addField("category", obj.category)
-      builder.addField("severity", obj.severity)
-      builder.addField("message", obj.message)
-      builder.addField("position", obj.position)
-      builder.addField("rendered", obj.rendered)
-      builder.endObject()
-end CachedProblem
-
-/**
- * A serializable representation of a compiler Position.
- */
-final case class CachedPosition(
-    line: Option[Int],
-    lineContent: String,
-    offset: Option[Int],
-    pointer: Option[Int],
-    pointerSpace: Option[String],
-    sourcePath: Option[String],
-    sourceFile: Option[String]
-):
-  def toPosition: Position = new Position:
-    override def line(): Optional[Integer] =
-      CachedPosition.this.line.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
-    override def lineContent(): String = CachedPosition.this.lineContent
-    override def offset(): Optional[Integer] =
-      CachedPosition.this.offset.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
-    override def pointer(): Optional[Integer] =
-      CachedPosition.this.pointer.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
-    override def pointerSpace(): Optional[String] =
-      CachedPosition.this.pointerSpace.map(Optional.of).getOrElse(Optional.empty())
-    override def sourcePath(): Optional[String] =
-      CachedPosition.this.sourcePath.map(Optional.of).getOrElse(Optional.empty())
-    override def sourceFile(): Optional[java.io.File] =
-      CachedPosition.this.sourceFile
-        .map(p => new java.io.File(p))
-        .map(Optional.of)
-        .getOrElse(Optional.empty())
-end CachedPosition
-
-object CachedPosition:
-  def fromPosition(p: Position): CachedPosition =
-    CachedPosition(
-      line = if p.line().isPresent then Some(p.line().get()) else None,
-      lineContent = p.lineContent(),
-      offset = if p.offset().isPresent then Some(p.offset().get()) else None,
-      pointer = if p.pointer().isPresent then Some(p.pointer().get()) else None,
-      pointerSpace = if p.pointerSpace().isPresent then Some(p.pointerSpace().get()) else None,
-      sourcePath = if p.sourcePath().isPresent then Some(p.sourcePath().get()) else None,
-      sourceFile = if p.sourceFile().isPresent then Some(p.sourceFile().get().getPath) else None
-    )
-
-  given JsonFormat[CachedPosition] = new JsonFormat[CachedPosition]:
-    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedPosition =
-      jsOpt match
-        case Some(js) =>
-          unbuilder.beginObject(js)
-          val line = unbuilder.readField[Option[Int]]("line")
-          val lineContent = unbuilder.readField[String]("lineContent")
-          val offset = unbuilder.readField[Option[Int]]("offset")
-          val pointer = unbuilder.readField[Option[Int]]("pointer")
-          val pointerSpace = unbuilder.readField[Option[String]]("pointerSpace")
-          val sourcePath = unbuilder.readField[Option[String]]("sourcePath")
-          val sourceFile = unbuilder.readField[Option[String]]("sourceFile")
-          unbuilder.endObject()
-          CachedPosition(line, lineContent, offset, pointer, pointerSpace, sourcePath, sourceFile)
-        case None =>
-          deserializationError("Expected JsObject but found None")
-
-    override def write[J](obj: CachedPosition, builder: Builder[J]): Unit =
-      builder.beginObject()
-      builder.addField("line", obj.line)
-      builder.addField("lineContent", obj.lineContent)
-      builder.addField("offset", obj.offset)
-      builder.addField("pointer", obj.pointer)
-      builder.addField("pointerSpace", obj.pointerSpace)
-      builder.addField("sourcePath", obj.sourcePath)
-      builder.addField("sourceFile", obj.sourceFile)
-      builder.endObject()
-end CachedPosition

--- a/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
+++ b/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
@@ -1,0 +1,187 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.util
+
+import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
+import xsbti.{ CompileFailed, Problem, Position, Severity }
+import java.util.Optional
+
+/**
+ * A serializable representation of a CompileFailed exception.
+ * This allows caching compilation failures so that repeated builds
+ * don't re-run failed compilations unnecessarily.
+ *
+ * Fixes https://github.com/sbt/sbt/issues/7662
+ */
+final case class CachedCompileFailure(
+    problems: Vector[CachedProblem],
+    message: String
+):
+  def toException: CompileFailed = new CompileFailed:
+    override def arguments(): Array[String] = Array.empty
+    override def problems(): Array[Problem] = CachedCompileFailure.this.problems
+      .map(_.toProblem)
+      .toArray
+    override def getMessage(): String = CachedCompileFailure.this.message
+end CachedCompileFailure
+
+object CachedCompileFailure:
+  def fromException(e: CompileFailed): CachedCompileFailure =
+    CachedCompileFailure(
+      problems = e.problems().map(CachedProblem.fromProblem).toVector,
+      message = Option(e.getMessage).getOrElse("")
+    )
+
+  given JsonFormat[CachedCompileFailure] = new JsonFormat[CachedCompileFailure]:
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedCompileFailure =
+      jsOpt match
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val problems = unbuilder.readField[Vector[CachedProblem]]("problems")
+          val message = unbuilder.readField[String]("message")
+          unbuilder.endObject()
+          CachedCompileFailure(problems, message)
+        case None =>
+          deserializationError("Expected JsObject but found None")
+
+    override def write[J](obj: CachedCompileFailure, builder: Builder[J]): Unit =
+      builder.beginObject()
+      builder.addField("problems", obj.problems)
+      builder.addField("message", obj.message)
+      builder.endObject()
+end CachedCompileFailure
+
+/**
+ * A serializable representation of a compiler Problem.
+ */
+final case class CachedProblem(
+    category: String,
+    severity: String,
+    message: String,
+    position: CachedPosition,
+    rendered: Option[String]
+):
+  def toProblem: Problem = new Problem:
+    override def category(): String = CachedProblem.this.category
+    override def severity(): Severity = CachedProblem.this.severity match
+      case "Error" => Severity.Error
+      case "Warn"  => Severity.Warn
+      case _       => Severity.Info
+    override def message(): String = CachedProblem.this.message
+    override def position(): Position = CachedProblem.this.position.toPosition
+    override def rendered(): Optional[String] =
+      CachedProblem.this.rendered.map(Optional.of).getOrElse(Optional.empty())
+end CachedProblem
+
+object CachedProblem:
+  def fromProblem(p: Problem): CachedProblem =
+    CachedProblem(
+      category = p.category(),
+      severity = p.severity().toString,
+      message = p.message(),
+      position = CachedPosition.fromPosition(p.position()),
+      rendered = if p.rendered().isPresent then Some(p.rendered().get()) else None
+    )
+
+  given JsonFormat[CachedProblem] = new JsonFormat[CachedProblem]:
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedProblem =
+      jsOpt match
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val category = unbuilder.readField[String]("category")
+          val severity = unbuilder.readField[String]("severity")
+          val message = unbuilder.readField[String]("message")
+          val position = unbuilder.readField[CachedPosition]("position")
+          val rendered = unbuilder.readField[Option[String]]("rendered")
+          unbuilder.endObject()
+          CachedProblem(category, severity, message, position, rendered)
+        case None =>
+          deserializationError("Expected JsObject but found None")
+
+    override def write[J](obj: CachedProblem, builder: Builder[J]): Unit =
+      builder.beginObject()
+      builder.addField("category", obj.category)
+      builder.addField("severity", obj.severity)
+      builder.addField("message", obj.message)
+      builder.addField("position", obj.position)
+      builder.addField("rendered", obj.rendered)
+      builder.endObject()
+end CachedProblem
+
+/**
+ * A serializable representation of a compiler Position.
+ */
+final case class CachedPosition(
+    line: Option[Int],
+    lineContent: String,
+    offset: Option[Int],
+    pointer: Option[Int],
+    pointerSpace: Option[String],
+    sourcePath: Option[String],
+    sourceFile: Option[String]
+):
+  def toPosition: Position = new Position:
+    override def line(): Optional[Integer] =
+      CachedPosition.this.line.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
+    override def lineContent(): String = CachedPosition.this.lineContent
+    override def offset(): Optional[Integer] =
+      CachedPosition.this.offset.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
+    override def pointer(): Optional[Integer] =
+      CachedPosition.this.pointer.map(Integer.valueOf).map(Optional.of).getOrElse(Optional.empty())
+    override def pointerSpace(): Optional[String] =
+      CachedPosition.this.pointerSpace.map(Optional.of).getOrElse(Optional.empty())
+    override def sourcePath(): Optional[String] =
+      CachedPosition.this.sourcePath.map(Optional.of).getOrElse(Optional.empty())
+    override def sourceFile(): Optional[java.io.File] =
+      CachedPosition.this.sourceFile
+        .map(p => new java.io.File(p))
+        .map(Optional.of)
+        .getOrElse(Optional.empty())
+end CachedPosition
+
+object CachedPosition:
+  def fromPosition(p: Position): CachedPosition =
+    CachedPosition(
+      line = if p.line().isPresent then Some(p.line().get()) else None,
+      lineContent = p.lineContent(),
+      offset = if p.offset().isPresent then Some(p.offset().get()) else None,
+      pointer = if p.pointer().isPresent then Some(p.pointer().get()) else None,
+      pointerSpace = if p.pointerSpace().isPresent then Some(p.pointerSpace().get()) else None,
+      sourcePath = if p.sourcePath().isPresent then Some(p.sourcePath().get()) else None,
+      sourceFile = if p.sourceFile().isPresent then Some(p.sourceFile().get().getPath) else None
+    )
+
+  given JsonFormat[CachedPosition] = new JsonFormat[CachedPosition]:
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): CachedPosition =
+      jsOpt match
+        case Some(js) =>
+          unbuilder.beginObject(js)
+          val line = unbuilder.readField[Option[Int]]("line")
+          val lineContent = unbuilder.readField[String]("lineContent")
+          val offset = unbuilder.readField[Option[Int]]("offset")
+          val pointer = unbuilder.readField[Option[Int]]("pointer")
+          val pointerSpace = unbuilder.readField[Option[String]]("pointerSpace")
+          val sourcePath = unbuilder.readField[Option[String]]("sourcePath")
+          val sourceFile = unbuilder.readField[Option[String]]("sourceFile")
+          unbuilder.endObject()
+          CachedPosition(line, lineContent, offset, pointer, pointerSpace, sourcePath, sourceFile)
+        case None =>
+          deserializationError("Expected JsObject but found None")
+
+    override def write[J](obj: CachedPosition, builder: Builder[J]): Unit =
+      builder.beginObject()
+      builder.addField("line", obj.line)
+      builder.addField("lineContent", obj.lineContent)
+      builder.addField("offset", obj.offset)
+      builder.addField("pointer", obj.pointer)
+      builder.addField("pointerSpace", obj.pointerSpace)
+      builder.addField("sourcePath", obj.sourcePath)
+      builder.addField("sourceFile", obj.sourceFile)
+      builder.endObject()
+end CachedPosition

--- a/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
+++ b/util-cache/src/main/scala/sbt/util/CachedCompileFailure.scala
@@ -10,7 +10,7 @@ package sbt.util
 
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
 import sbt.internal.util.codec.{ ProblemFormats, SeverityFormats, PositionFormats }
-import xsbti.{ CompileFailed, Problem }
+import xsbti.{ CompileFailed, Problem, Severity }
 
 /**
  * A wrapper around GenericFailure for CompileFailed exceptions.
@@ -24,6 +24,15 @@ final case class CachedCompileFailure(underlying: GenericFailure):
     override def arguments(): Array[String] = Array.empty
     override def problems(): Array[Problem] = underlying.problems.toArray
     override def getMessage(): String = underlying.message.getOrElse("")
+
+  /** Replay problems to the logger so users see the cached errors/warnings. */
+  def replay(logger: Logger): Unit =
+    underlying.problems.foreach: problem =>
+      val msg = CachedCompileFailure.formatProblem(problem)
+      problem.severity match
+        case Severity.Error => logger.error(msg)
+        case Severity.Warn  => logger.warn(msg)
+        case Severity.Info  => logger.info(msg)
 end CachedCompileFailure
 
 object CachedCompileFailure
@@ -33,6 +42,33 @@ object CachedCompileFailure
     with sjsonnew.BasicJsonProtocol:
 
   private val CompileFailedKind = "CompileFailed"
+
+  /**
+   * Format a problem for display. Uses the `rendered` field if available (Scala 3),
+   * otherwise constructs a message from position and message (Scala 2.13).
+   */
+  private[util] def formatProblem(problem: Problem): String =
+    import sbt.util.InterfaceUtil.toOption
+    toOption(problem.rendered).getOrElse:
+      val pos = problem.position
+      val file = toOption(pos.sourcePath).getOrElse("unknown")
+      val line = toOption(pos.line).map(l => s":$l").getOrElse("")
+      val pointer = toOption(pos.pointer).map(p => s":$p").getOrElse("")
+      val lineContent = Option(pos.lineContent).filter(_.nonEmpty).map(c => s"\n$c").getOrElse("")
+      val pointerLine = toOption(pos.pointerSpace).map(s => s"\n$s^").getOrElse("")
+      s"$file$line$pointer: ${problem.message}$lineContent$pointerLine"
+
+  /**
+   * Check if the problems contain enough information to be useful when replayed.
+   * For Scala 2.13, the `rendered` field is empty, so we check if position info exists.
+   */
+  def hasSufficientInfo(e: CompileFailed): Boolean =
+    import sbt.util.InterfaceUtil.toOption
+    e.problems()
+      .forall: problem =>
+        // Either has rendered text (Scala 3) or has position info (Scala 2.13)
+        toOption(problem.rendered).isDefined ||
+          (toOption(problem.position.sourcePath).isDefined && problem.message.nonEmpty)
 
   def fromException(e: CompileFailed): CachedCompileFailure =
     CachedCompileFailure(

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -5,12 +5,19 @@ import sbt.internal.util.StringVirtualFile1
 import sbt.io.IO
 import sbt.io.syntax.*
 import verify.BasicTestSuite
-import xsbti.VirtualFile
-import xsbti.FileConverter
-import xsbti.VirtualFileRef
+import xsbti.{
+  CompileFailed,
+  Problem,
+  Position,
+  Severity,
+  VirtualFile,
+  FileConverter,
+  VirtualFileRef
+}
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.Files
+import java.util.Optional
 import ActionCache.InternalActionResult
 
 object ActionCacheTest extends BasicTestSuite:
@@ -83,6 +90,9 @@ object ActionCacheTest extends BasicTestSuite:
   test("Disk cache can recover gracefully from invalid JSON"):
     withDiskCache(testActionCacheInvalidJson)
 
+  test("Disk cache caches CompileFailed exceptions"):
+    withDiskCache(testCachedCompileFailure)
+
   def testActionCacheInvalidJson(cache: DiskActionCacheStore): Unit =
     import sjsonnew.BasicJsonProtocol.*
     var called = 0
@@ -104,6 +114,59 @@ object ActionCacheTest extends BasicTestSuite:
       assert(v2 == 2)
       // check that the action has been invoked twice
       assert(called == 2)
+
+  def testCachedCompileFailure(cache: DiskActionCacheStore): Unit =
+    import sjsonnew.BasicJsonProtocol.*
+    var called = 0
+    val testProblem = new Problem:
+      override def category(): String = "Test"
+      override def severity(): Severity = Severity.Error
+      override def message(): String = "Test error message"
+      override def position(): Position = new Position:
+        override def line(): Optional[Integer] = Optional.of(42)
+        override def lineContent(): String = "val x = 1"
+        override def offset(): Optional[Integer] = Optional.empty()
+        override def pointer(): Optional[Integer] = Optional.empty()
+        override def pointerSpace(): Optional[String] = Optional.empty()
+        override def sourcePath(): Optional[String] = Optional.of("/test/file.scala")
+        override def sourceFile(): Optional[java.io.File] = Optional.empty()
+
+    val testException = new CompileFailed:
+      override def arguments(): Array[String] = Array.empty
+      override def problems(): Array[Problem] = Array(testProblem)
+      override def getMessage(): String = "Compilation failed"
+
+    val action: ((Int, Int)) => InternalActionResult[Int] = { (a, b) =>
+      called += 1
+      throw testException
+    }
+    IO.withTemporaryDirectory: tempDir =>
+      val config = getCacheConfig(cache, tempDir)
+
+      // First call should throw and cache the failure
+      var caught1: CompileFailed = null
+      try
+        ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(false, "Expected CompileFailed to be thrown")
+      catch case e: CompileFailed => caught1 = e
+
+      assert(caught1 != null)
+      assert(called == 1)
+
+      // Second call should throw cached failure without calling action again
+      var caught2: CompileFailed = null
+      try
+        ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(false, "Expected CompileFailed to be thrown")
+      catch case e: CompileFailed => caught2 = e
+
+      assert(caught2 != null)
+      // Action should NOT have been called again - failure was cached
+      assert(called == 1)
+      // Verify the cached exception has the same data
+      assert(caught2.problems().length == 1)
+      assert(caught2.problems()(0).message() == "Test error message")
+      assert(caught2.getMessage() == "Compilation failed")
 
   def withInMemoryCache(f: InMemoryActionCacheStore => Unit): Unit =
     val cache = InMemoryActionCacheStore()


### PR DESCRIPTION
When a compilation fails with CompileFailed, the failure is now cached so that subsequent builds with the same inputs don't re-run the failed compilation. This significantly improves the experience when using BSP clients like Metals that may trigger many compilations in a row.

The implementation:
- Adds CachedCompileFailure, CachedProblem, and CachedPosition types to serialize compilation failures
- Modifies ActionCache.cache to catch CompileFailed exceptions and store them in the cache with exitCode=1
- On cache lookup, checks for cached failures first and re-throws the cached exception if found
- Fixes DiskActionCacheStore.put to preserve exitCode from request
- Adds unit test to verify cached failure behavior

Fixes #7662

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147