### PR TITLE
[2.x] ci: Handle undefined crossScalaVersions in publishLocalAllModule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1060,7 +1060,8 @@ def customCommands: Seq[Setting[?]] = Seq(
       }).toList :::
       (zincOpt map { case ProjectRef(build, _) =>
         val zincSv = get((ProjectRef(build, "zinc") / scalaVersion))
-        val csv = getOpt((ProjectRef(build, "compilerBridge") / crossScalaVersions)).getOrElse(Nil).toList
+        val csv =
+          getOpt((ProjectRef(build, "compilerBridge") / crossScalaVersions)).getOrElse(Nil).toList
         (csv flatMap { bridgeSv =>
           s"++$bridgeSv" :: ("{" + build.toString + "}compilerBridge/publishLocal") :: Nil
         }) :::

--- a/build.sbt
+++ b/build.sbt
@@ -1060,7 +1060,7 @@ def customCommands: Seq[Setting[?]] = Seq(
       }).toList :::
       (zincOpt map { case ProjectRef(build, _) =>
         val zincSv = get((ProjectRef(build, "zinc") / scalaVersion))
-        val csv = get((ProjectRef(build, "compilerBridge") / crossScalaVersions)).toList
+        val csv = getOpt((ProjectRef(build, "compilerBridge") / crossScalaVersions)).getOrElse(Nil).toList
         (csv flatMap { bridgeSv =>
           s"++$bridgeSv" :: ("{" + build.toString + "}compilerBridge/publishLocal") :: Nil
         }) :::


### PR DESCRIPTION
# Fix: Handle undefined crossScalaVersions in publishLocalAllModule

## Problem

The `publishLocalAllModule` command fails with a `RuntimeException` when the zinc submodule's `compilerBridge` project doesn't have `crossScalaVersions` defined:

```
java.lang.RuntimeException: ProjectRef(..., "compilerBridge") / crossScalaVersions is undefined.
```

This is a long-standing issue:
- Originally reported in #4387 (2018)
- "Magically resolved" in 2020 when zinc happened to define the setting
- Resurfaced in #7607 (2024) when zinc changed

## Solution

Change `get()` to `getOpt().getOrElse(Nil)` to handle undefined settings gracefully:

```scala
// Before
val csv = get((ProjectRef(build, "compilerBridge") / crossScalaVersions)).toList

// After  
val csv = getOpt((ProjectRef(build, "compilerBridge") / crossScalaVersions)).getOrElse(Nil).toList
```

## Testing

- Build loads successfully
- `scalafmtCheckAll` passes

## Related

Fixes #7607

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147