### PR TITLE
[2.x] fix: Prevent server subprocess hang on Linux (#8442)

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -390,10 +390,17 @@ class NetworkClient(
           if (Util.isEmacs && !Util.isWindows) List("nohup")
           else Nil
 
+        // https://github.com/sbt/sbt/issues/8442
+        // On Linux, if stdout/stderr are inherited and the buffer fills up (~64KB),
+        // the server process will block on writes. Discard output since the server
+        // communicates via the boot socket, not stdout/stderr.
+        val nullFile = new File(if (Util.isWindows) "NUL" else "/dev/null")
         val processBuilder =
           new ProcessBuilder((nohup ++ cmd)*)
             .directory(arguments.baseDirectory)
             .redirectInput(Redirect.PIPE)
+            .redirectOutput(nullFile)
+            .redirectError(nullFile)
         processBuilder.environment.put(Terminal.TERMINAL_PROPS, props)
         Try(processBuilder.start()) match {
           case Success(process) =>


### PR DESCRIPTION
## Summary
- Fix hang when sbt client spawns server subprocess on Linux
- When the server is forked with `--detach-stdio`, stdout/stderr now redirect to `DISCARD` instead of inheriting from parent
- On Linux, inherited pipes have ~64KB buffers that block writes when full, causing the server to hang during initialization (e.g., when printing lint warnings for projects with 45+ subprojects)

## Root Cause
When `NetworkClient.waitForServer` spawns the server process:
1. stdout/stderr were inherited from the parent process
2. The client communicates with the server via socket, never consuming stdout/stderr
3. On Linux, once the pipe buffer fills (~64KB), `FileOutputStream.writeBytes` blocks indefinitely
4. This caused the server to hang before creating `active.json`

Workarounds that worked (confirming the diagnosis):
- `--debug` flag (affects logging behavior)
- `-Dsbt.log.noformat=true` (reduces output volume)

## Fix
Add `.redirectOutput(Redirect.DISCARD).redirectError(Redirect.DISCARD)` to the ProcessBuilder, which redirects to `/dev/null` on Unix.

## Test plan
- [x] Code compiles successfully
- [x] Verified client doesn't read from process stdout/stderr (communicates via socket)
- [ ] Manual test on Linux with 45+ subproject build (cannot reproduce on macOS due to different pipe buffering)

Fixes #8442

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234