### PR TITLE
[2.x] fix: Fix pipelining flags applied to unsupported Scala versions

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1015,15 +1015,12 @@ object Defaults extends BuildCommon {
       },
       scalacOptions := {
         val old = scalacOptions.value
-        if (exportPipelining.value)
-          Def.uncached(
-            Vector(
-              "-Ypickle-java",
-              "-Ypickle-write",
-              earlyOutput.value.toString
-            ) ++ old
-          )
-        else Def.uncached(old)
+        if (exportPipelining.value) {
+          val sv = scalaVersion.value
+          if (ScalaArtifacts.isScala3(sv) && VersionNumber(sv).matchesSemVer(SemanticSelector(">=3.5.0")))
+            Def.uncached(Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old)
+          else Def.uncached(old)
+        } else Def.uncached(old)
       },
       scalacOptions := {
         val old = scalacOptions.value

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1017,7 +1017,8 @@ object Defaults extends BuildCommon {
         val old = scalacOptions.value
         if (exportPipelining.value) {
           val sv = scalaVersion.value
-          if (ScalaArtifacts.isScala3(sv) && VersionNumber(sv).matchesSemVer(SemanticSelector(">=3.5.0")))
+          val shouldApplyFlags = !ScalaArtifacts.isScala3(sv) || VersionNumber(sv).matchesSemVer(SemanticSelector(">=3.5.0"))
+          if (shouldApplyFlags)
             Def.uncached(Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old)
           else Def.uncached(old)
         } else Def.uncached(old)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1017,9 +1017,13 @@ object Defaults extends BuildCommon {
         val old = scalacOptions.value
         if (exportPipelining.value) {
           val sv = scalaVersion.value
-          val shouldApplyFlags = !ScalaArtifacts.isScala3(sv) || VersionNumber(sv).matchesSemVer(SemanticSelector(">=3.5.0"))
+          val shouldApplyFlags = !ScalaArtifacts.isScala3(sv) || VersionNumber(sv).matchesSemVer(
+            SemanticSelector(">=3.5.0")
+          )
           if (shouldApplyFlags)
-            Def.uncached(Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old)
+            Def.uncached(
+              Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old
+            )
           else Def.uncached(old)
         } else Def.uncached(old)
       },


### PR DESCRIPTION
## Problem

When `usePipelining := true` is set with Scala 3.3.x or 3.4.x, sbt applies `-Ypickle-java` and `-Ypickle-write` compiler flags even though pipelining is only supported in Scala 3.5.0+. This causes confusing warnings:

```
[warn] bad option '-Ypickle-java' was ignored
[warn] bad option '-Ypickle-write' was ignored
```

## Solution

Added version check to only apply pipelining compiler flags when Scala 3.5.0 or later is detected. The check uses existing utilities (`ScalaArtifacts.isScala3` and `VersionNumber.matchesSemVer`) following the pattern already used elsewhere in the codebase.

## Changes

- Modified `scalacOptions` setting in `Defaults.scala` to check Scala version before applying pipelining flags
- Flags are now only added for Scala 3.5.0+
- For earlier versions, `usePipelining` setting is silently ignored

Fixes #8433

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292