### PR TITLE
[2.x] fix: Allow ++ command to accept projects not in current state

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -58,7 +58,11 @@ object Cross {
       }
       val spacedVersion = if (spacePresent) version else version & spacedFirst(SwitchCommand)
       val verboseOpt = Parser.opt(token(Space ~> "-v"))
-      val optionalCommand = Parser.opt(token(Space ~> matched(state.combinedParser)))
+      // Accept valid commands, or project/command patterns that may reference projects
+      // not yet available after version switch (fixes #7574)
+      val slashCommand = (NotSpace ~ ('/' ~> any.+)).map { case p ~ c => p + "/" + c.mkString }
+      val commandParser = state.combinedParser | slashCommand
+      val optionalCommand = Parser.opt(token(Space ~> matched(commandParser)))
       val switch1 = (token(Space ~> "-v") ~> (Space ~> version) ~ optionalCommand) map {
         case v ~ command =>
           Switch(v, true, command)


### PR DESCRIPTION
# Fix: Allow `++` command to work with projects that don't exist yet

## Problem

When you run `sbt '++2.12.19 docs/publishSite'`, it fails with "Project not found" if the `docs` project only exists after switching to Scala 2.12.19. 

The workaround has been to use a semicolon to separate commands: `sbt '++2.12.19; docs/publishSite'`. This works because the semicolon forces sbt to execute the version switch first, then parse the second command in the new state where `docs` exists.

## Solution

The parser now accepts `project/task` patterns even when the project isn't available in the current state. It works like this:

1. First, try to parse the command normally using `state.combinedParser` (validates against current project structure)
2. If that fails, fall back to accepting any `project/task` pattern using a simple slash-delimited parser
3. The command validation happens later during execution, after the Scala version switch completes

By the time the command actually runs, the project exists in the new Scala version's state.

## Implementation

Added a `slashCommand` fallback parser that matches `project/task` patterns:

```scala
val slashCommand = (NotSpace ~ ('/' ~> any.+)).map { case p ~ c => p + "/" + c.mkString }
val commandParser = state.combinedParser | slashCommand
val optionalCommand = Parser.opt(token(Space ~> matched(commandParser)))
```

The fix is targeted to only accept slash-delimited patterns, which avoids interfering with other parser components like the `-v` verbose flag.

## Testing

The fix passes the existing `actions/cross-advanced` scripted test, which includes various cross-build scenarios with project-scoped commands.

Fixes #7574

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147