### PR TITLE
[2.x] fix: Use strict matching for scala-library jar detection

### DIFF
--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -182,8 +182,9 @@ private[sbt] object ClassLoaders {
               cpFiles
                 .filter(f => {
                   val name = f.getName
-                  name.contains(ArtifactInfo.ScalaLibraryID) || si.libraryJars
-                    .exists(_.getName == name)
+                  name == s"${ArtifactInfo.ScalaLibraryID}.jar" ||
+                  name.startsWith(s"${ArtifactInfo.ScalaLibraryID}-") ||
+                  si.libraryJars.exists(_.getName == name)
                 })
                 .toArray
             else si.libraryJars


### PR DESCRIPTION
# Fix: Strict matching for scala-library jar detection

## Problem

If you name your library something like `my-scala-library-utils`, sbt won't be able to find it at compile time. The build fails with cryptic "object not found" errors even though the jar is clearly downloaded and present.

This happens because sbt uses `name.contains("scala-library")` to detect the Scala standard library jar. Any jar with "scala-library" anywhere in its filename gets misclassified and filtered into a special classloader layer meant only for the actual Scala stdlib.

## The Fix

Changed from substring matching to strict matching:

```scala
// Before (buggy):
name.contains("scala-library")

// After:
name == "scala-library.jar" || name.startsWith("scala-library-")
```

This matches the pattern already used for `scala-reflect` detection in the same file

Fixes #7511

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147