### PR TITLE
[2.x] fix: Fix sbt new argument parsing on Windows

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -547,6 +547,21 @@ if not "%g:~0,5%" == "-XX:+" if not "%g:~0,5%" == "-XX:-" if "%g:~0,3%" == "-XX"
   )
 )
 
+if defined sbt_new if "%g:~0,2%" == "--" (
+  rem special handling for -- template arguments since '=' gets parsed away on Windows
+  for /F "tokens=1 delims==" %%a in ("%g%") do (
+    rem make sure it doesn't have the '=' already
+    if "%g%" == "%%a" (
+      if not "%~1" == "" (
+        call :dlog [args_loop] -- argument %~0=%~1
+        set "SBT_ARGS=!SBT_ARGS! %~0=%~1"
+        shift
+        goto args_loop
+      )
+    )
+  )
+)
+
 rem the %0 (instead of %~0) preserves original argument quoting
 set SBT_ARGS=!SBT_ARGS! %0
 
@@ -772,6 +787,18 @@ if "%p:~0,2%" == "-D" (
 
 if not "%p:~0,5%" == "-XX:+" if not "%p:~0,5%" == "-XX:-" if "%p:~0,3%" == "-XX" (
   rem special handling for -XX since '=' gets parsed away
+  for /F "tokens=1 delims==" %%a in ("%p%") do (
+    rem make sure it doesn't have the '=' already
+    if "%p%" == "%%a" if not "%~1" == "" (
+      echo %0=%1
+      shift
+      goto echolist
+    )
+  )
+)
+
+if defined sbt_new if "%p:~0,2%" == "--" (
+  rem special handling for -- template arguments since '=' gets parsed away on Windows
   for /F "tokens=1 delims==" %%a in ("%p%") do (
     rem make sure it doesn't have the '=' already
     if "%p%" == "%%a" if not "%~1" == "" (


### PR DESCRIPTION
# Fix sbt new argument parsing on Windows

This is a long-standing Windows issue where arguments containing `=` get split by the command line parser.

When running something like:
```
sbt new foundweekends/giter8.g8 --name=example.g8
```

Windows splits `--name=example.g8` into two separate arguments (`--name` and `example.g8`), causing sbt to fail with "Unknown option" errors.

The batch script already handles this for `-D` and `-XX` JVM arguments by detecting when an argument was split and recombining it. This PR extends that same approach to `--` style arguments used by giter8 templates.

Related to #2695.

Fixes #7507

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147