### PR TITLE
[2.x] test: Test -Werror in metabuild

### DIFF
--- a/sbt-app/src/sbt-test/project-load/werror/build.sbt
+++ b/sbt-app/src/sbt-test/project-load/werror/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "3.7.4"
+
+@deprecated
+def foo = true
+
+fork := foo

--- a/sbt-app/src/sbt-test/project-load/werror/changes/build.sbt
+++ b/sbt-app/src/sbt-test/project-load/werror/changes/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "3.7.4"
+
+@deprecated
+def foo = true
+
+fork := !foo

--- a/sbt-app/src/sbt-test/project-load/werror/changes/p.sbt
+++ b/sbt-app/src/sbt-test/project-load/werror/changes/p.sbt
@@ -1,0 +1,1 @@
+scalacOptions += "-Werror"

--- a/sbt-app/src/sbt-test/project-load/werror/test
+++ b/sbt-app/src/sbt-test/project-load/werror/test
@@ -1,0 +1,6 @@
+> name
+
+$ copy-file changes/p.sbt project/p.sbt
+$ copy-file changes/build.sbt build.sbt
+
+-> reload


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6433

## Problem
-Werror in the metabuild didn't work on sbt 1.x.

## Solution
This adds test for it on sbt 2.x.