### PR TITLE
fix: Check cache file exists before reading in Eval

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -225,7 +225,8 @@ class Eval(
     val (extra, loader) =
       try
         backingDir match
-          case Some(backing) if classExists(backing, moduleName) =>
+          case Some(backing)
+              if classExists(backing, moduleName) && cacheExists(backing, moduleName) =>
             val loader = (parent: ClassLoader) =>
               (new URLClassLoader(Array(backing.toUri.toURL), parent): ClassLoader)
             val extra = ev.read(cacheFile(backing, moduleName))
@@ -272,6 +273,9 @@ class Eval(
 
   private def classExists(dir: Path, name: String): Boolean =
     Files.exists(dir.resolve(s"$name.class"))
+
+  private def cacheExists(dir: Path, name: String): Boolean =
+    Files.exists(cacheFile(dir, name))
 
   private def getGeneratedFiles(moduleName: String): Seq[Path] =
     backingDir match


### PR DESCRIPTION
Fixes #8511

When loading a cached build definition, the code checked if the .class file exists but not the .cache file. If the .cache file was missing (deleted, corrupted, or from a partial compilation), it threw NoSuchFileException.

Now both files are checked before using the cache. If either is missing, the build definition is recompiled.

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147