### PR TITLE
[2.x] fix: Fixes command logs

### DIFF
--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -262,6 +262,8 @@ object LogManager {
     val s1 = s.put(BasicKeys.explicitGlobalLogLevels, true).put(Keys.logLevel.key, level)
     val gl = s1.globalLogging
     LoggerContext.globalContext.clearAppenders(gl.full.name)
+    val consoleAppender = MainAppender.defaultScreen(gl.console)
+    LoggerContext.globalContext.addAppender(gl.full.name, consoleAppender -> level)
     LoggerContext.globalContext.addAppender(gl.full.name, gl.backed -> level)
     s1
   }


### PR DESCRIPTION
Fixes #7971 

## Problem

When running sbt with `--warn` or `--error` log levels, logs created from commands using `state.log` were not displayed on the console. This affected:
- Warning and error logs from custom commands
- Error messages from `MessageOnlyException` thrown in commands

Example:
```bash
# Expected warnings and errors to show, but console was empty
$ sbt --warn logCommand
$ sbt --error logCommand
```

## Root Cause

In `LogManager.setGlobalLogLevel`, when updating the global log level:
1. All appenders were cleared from the global logger
2. Only the `backed` (file) appender was re-added with the new level
3. **The console appender was not re-added**, causing all console output to disappear

This meant logs were only written to the backing file (`target/global-logging/*.log`), not displayed on the console.

## Solution

Modified `setGlobalLogLevel` to preserve the console appender when changing log levels:

```scala
def setGlobalLogLevel(s: State, level: Level.Value): State = {
  val s1 = s.put(BasicKeys.explicitGlobalLogLevels, true).put(Keys.logLevel.key, level)
  val gl = s1.globalLogging
  LoggerContext.globalContext.clearAppenders(gl.full.name)
  val consoleAppender = MainAppender.defaultScreen(gl.console)
  LoggerContext.globalContext.addAppender(gl.full.name, consoleAppender -> level)
  LoggerContext.globalContext.addAppender(gl.full.name, gl.backed -> level)
  s1
}
```

Now both the console and file appenders are properly configured with the new log level.

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=147358252