### PR TITLE
[2.x] fix: trim whitespace from sbt.version in build.properties

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -933,7 +933,7 @@ object BuiltinCommands {
     val sbtVersionBuildOpt = if (buildProps.exists) {
       val buildProperties = new Properties()
       IO.load(buildProperties, buildProps)
-      Option(buildProperties.getProperty(sbtVersionProperty))
+      Option(buildProperties.getProperty(sbtVersionProperty)).map(_.trim)
     } else None
 
     val sbtVersionOpt = sbtVersionSystemOpt.orElse(sbtVersionBuildOpt)

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -99,7 +99,7 @@ private[sbt] object MainLoop:
     val sbtVersionOpt = if (buildProps.exists) {
       val buildProperties = new Properties()
       IO.load(buildProperties, buildProps)
-      Option(buildProperties.getProperty("sbt.version"))
+      Option(buildProperties.getProperty("sbt.version")).map(_.trim)
     } else None
     val sbtVersion = sbtVersionOpt.getOrElse(appId.version)
     val currentArtDirs = defaultBoot * "*" / appId.groupID / appId.name / sbtVersion

--- a/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -676,7 +676,7 @@ class ScriptedRunner {
 
     IO.load(buildProperties, buildPropertiesFile)
 
-    Option(buildProperties.getProperty("sbt.version")) match {
+    Option(buildProperties.getProperty("sbt.version")).map(_.trim) match {
       case Some(version) => binarySbtVersion(version) == binarySbtVersion(sbtVersion)
       case None          => true
     }


### PR DESCRIPTION
When `sbt.version` in `build.properties` has trailing whitespace, sbt incorrectly reports a version mismatch even after reboot.

## Problem

As reported in #8103, when `project/build.properties` contains:
```
sbt.version=2.0.0-M3 
```
(note the trailing space)

SBT shows the warning:
```
sbt version mismatch, using: 2.0.0-M3, in build.properties: "2.0.0-M3 ", use 'reboot' to use the new value.
```

This warning persists even after `reboot` and `reload` commands.

## Solution

This PR trims whitespace from the `sbt.version` property value in all places where it's read from `build.properties`:

- **Main.scala** - fixes the version mismatch warning (the main issue)
- **MainLoop.scala** - fixes clean command version detection
- **ScriptedTests.scala** - fixes test compatibility check

The fix adds `.map(_.trim)` after reading the property, ensuring whitespace is removed before any comparison.

## Testing

The fix can be verified by:
1. Creating a project with `sbt.version=2.0.0-M3 ` (with trailing space) in `project/build.properties`
2. Starting sbt
3. Confirming the version mismatch warning no longer appears

Fixes #8103

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292