### PR TITLE
[2.x] fix: Preserve user-defined scalacOptions in doc task scope

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1992,19 +1992,14 @@ object Defaults extends BuildCommon {
           else Map.empty[HashedVirtualFileRef, URI]
         },
         fileInputOptions := Seq("-doc-root-content", "-diagrams-dot-path"),
-        scalacOptions := {
-          val compileOptions = scalacOptions.value
+        scalacOptions ++= {
           val sv = scalaVersion.value
           val config = configuration.value
           val projectName = name.value
           if (ScalaArtifacts.isScala3(sv)) {
             val project = if (config == Compile) projectName else s"$projectName-$config"
-            if (scalaVersion.value.startsWith("3.0.0")) {
-              Seq("-project", project)
-            } else {
-              compileOptions ++ Seq("-project", project)
-            }
-          } else compileOptions
+            Seq("-project", project)
+          } else Seq.empty
         },
         (TaskZero / key) := Def.uncached {
           val s = streams.value

--- a/sbt-app/src/sbt-test/actions/doc-scalac-options/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc-scalac-options/build.sbt
@@ -1,0 +1,9 @@
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.12",
+    Compile / doc / scalacOptions += "-no-link-warnings",
+    TaskKey[Unit]("checkDocOptions") := {
+      val opts = (Compile / doc / scalacOptions).value
+      assert(opts.contains("-no-link-warnings"), s"Expected -no-link-warnings in doc scalacOptions but got: $opts")
+    }
+  )

--- a/sbt-app/src/sbt-test/actions/doc-scalac-options/test
+++ b/sbt-app/src/sbt-test/actions/doc-scalac-options/test
@@ -1,0 +1,3 @@
+# Verify that Compile / doc / scalacOptions += works correctly
+# This tests the fix for issue #7482
+> checkDocOptions


### PR DESCRIPTION
Fixes #7482

Changed scalacOptions from := to ++= in docTaskSettings to preserve user-defined options like -no-link-warnings. Previously, the := operator was overriding any user customizations to Compile / doc / scalacOptions.

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147