### PR TITLE
[2.x] fix: Start server when explicitly requested via BSP/thin client

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -153,7 +153,8 @@ private[sbt] final class CommandExchange {
 
   def run(s: State): State = run(s, s.get(autoStartServer).getOrElse(true))
   def run(s: State, autoStart: Boolean): State = {
-    if (autoStartServerSysProp && autoStart) runServer(s)
+    val startedByRemote = Terminal.startedByRemoteClient
+    if (autoStartServerSysProp && (autoStart || startedByRemote)) runServer(s)
     else s
   }
   private[sbt] def setState(s: State): Unit = lastState.set(s)


### PR DESCRIPTION
# Fix: sbt -bsp exits silently when autoStartServer := false

## Problem

When users set `autoStartServer := false` in their build configuration, running `sbt -bsp` (used by IntelliJ for BSP project import) would silently exit without starting the server. This made it impossible to import projects in IntelliJ when this setting was enabled, with no obvious error message to indicate what went wrong.

This was particularly frustrating because:
- The failure was silent with no helpful error message
- Users had no way of knowing that `autoStartServer` was the culprit
- The setting name suggests it controls *automatic* server startup, not *all* server startup

## Root Cause

The `autoStartServer` setting was being checked even when the server was explicitly requested via the `--server` flag (which BSP mode uses internally). The original logic in `CommandExchange.run()` was:

```scala
if (autoStartServerSysProp && autoStart) runServer(s)
```

This meant that when `autoStartServer := false`, the server would never start - even when explicitly requested by a remote client like IntelliJ's BSP integration.

## Solution

The fix distinguishes between automatic and explicit server startup. When sbt is started by a remote client (BSP or thin client via `--server` flag), the server now starts regardless of the `autoStartServer` setting:

```scala
val startedByRemote = Terminal.startedByRemoteClient
if (autoStartServerSysProp && (autoStart || startedByRemote)) runServer(s)
```

This preserves the intended behavior of `autoStartServer`:
- When set to `false`, sbt won't automatically start a server during normal interactive use
- When explicitly requested (via BSP or `--server`), the server starts as expected

## Testing

- Verified compilation succeeds
- The fix is minimal and surgical - only one condition changed
- The `Terminal.startedByRemoteClient` flag is already used elsewhere in the codebase for similar purposes

## Related

Fixes #7481

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147