### PR TITLE
[2.x] fix: Cleanup child processes on sbt exit

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -29,7 +29,7 @@ import sbt.internal.server.{ BuildServerProtocol, NetworkChannel }
 import sbt.internal.util.Terminal.hasConsole
 import sbt.internal.util.Types.{ const, idFun }
 import sbt.internal.util.complete.Parser
-import sbt.internal.util.{ Terminal as ITerminal, * }
+import sbt.internal.util.{ RunningProcesses, Terminal as ITerminal, * }
 import sbt.io.*
 import sbt.io.syntax.*
 import sbt.util.{ Level, Logger, Show }
@@ -221,6 +221,7 @@ object StandardMain {
   })
 
   private val closeRunnable = () => {
+    RunningProcesses.killAll()
     exchange.shutdown()
     pool.foreach(_.shutdownNow())
   }


### PR DESCRIPTION
# Cleanup child processes on sbt exit

## Description

When using `fork := true`, sbt spawns child processes that may become stale if cancelled (e.g., via Ctrl+C). Previously, these processes were not cleaned up when running the `exit` command - they would keep running as orphans.

This fix adds `RunningProcesses.killAll()` to the shutdown hook so that all tracked forked processes are terminated when sbt exits.

## Steps to reproduce (before fix)

1. Start sbt shell with `fork := true`
2. Run a long-running forked process
3. Press Ctrl+C to cancel (process may not exit immediately)
4. Run `exit` in sbt shell
5. The stale child process keeps running

## Changes

- Call `RunningProcesses.killAll()` in the `closeRunnable` shutdown hook in `Main.scala`

## Testing

The fix uses existing, tested infrastructure (`RunningProcesses.killAll()`) that is already used for task cancellation.

Fixes #7468

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147