### PR TITLE
[2.x] test: Migrate ClassLoaderCacheTest to verify.BasicTestSuite

### DIFF
--- a/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
+++ b/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
@@ -17,8 +17,7 @@ import verify.BasicTestSuite
 
 object ClassLoaderCacheTest extends BasicTestSuite:
 
-  extension (c: ClassLoaderCache)
-    def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
+  extension (c: ClassLoaderCache) def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
 
   private def withCache[R](f: ClassLoaderCache => R): R =
     val cache = new ClassLoaderCache(ClassLoader.getSystemClassLoader)
@@ -49,8 +48,8 @@ object ClassLoaderCacheTest extends BasicTestSuite:
         val initLoader = cache.get(jarClassPath)
         IO.setModifiedTimeOrFalse(snapshotJar, System.currentTimeMillis + 5000L)
         val secondLoader = cache.get(jarClassPath)
-        assert(initLoader != secondLoader)
-        assert(cache.get(jarClassPath) == secondLoader)
-        assert(cache.get(jarClassPath) != initLoader)
+        Predef.assert(initLoader != secondLoader)
+        Predef.assert(cache.get(jarClassPath) == secondLoader)
+        Predef.assert(cache.get(jarClassPath) != initLoader)
 
 end ClassLoaderCacheTest

--- a/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
+++ b/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
@@ -11,47 +11,46 @@ package sbt.internal
 import java.io.File
 import java.nio.file.Files
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 import sbt.internal.classpath.ClassLoaderCache
 import sbt.io.IO
+import verify.BasicTestSuite
 
-object ClassLoaderCacheTest {
-  extension (c: ClassLoaderCache) {
+object ClassLoaderCacheTest extends BasicTestSuite:
+
+  extension (c: ClassLoaderCache)
     def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
-  }
-}
-class ClassLoaderCacheTest extends AnyFlatSpec with Matchers {
-  import ClassLoaderCacheTest.*
-  private def withCache[R](f: ClassLoaderCache => R): R = {
+
+  private def withCache[R](f: ClassLoaderCache => R): R =
     val cache = new ClassLoaderCache(ClassLoader.getSystemClassLoader)
     try f(cache)
     finally cache.close()
-  }
-  "ClassLoaderCache" should "make a new loader when full" in withCache { cache =>
-    val classPath = Seq.empty[File]
-    val firstLoader = cache.get(classPath)
-    cache.clear()
-    val secondLoader = cache.get(classPath)
-    assert(firstLoader != secondLoader)
-  }
-  it should "not make a new loader when it already exists" in withCache { cache =>
-    val classPath = Seq.empty[File]
-    val firstLoader = cache.get(classPath)
-    val secondLoader = cache.get(classPath)
-    assert(firstLoader == secondLoader)
-  }
-  "Snapshots" should "be invalidated" in IO.withTemporaryDirectory { dir =>
-    val snapshotJar = Files.createFile(dir.toPath.resolve("foo-SNAPSHOT.jar")).toFile
-    val regularJar = Files.createFile(dir.toPath.resolve("regular.jar")).toFile
-    withCache { cache =>
-      val jarClassPath = snapshotJar :: regularJar :: Nil
-      val initLoader = cache.get(jarClassPath)
-      IO.setModifiedTimeOrFalse(snapshotJar, System.currentTimeMillis + 5000L)
-      val secondLoader = cache.get(jarClassPath)
-      assert(initLoader != secondLoader)
-      assert(cache.get(jarClassPath) == secondLoader)
-      assert(cache.get(jarClassPath) != initLoader)
-    }
-  }
-}
+
+  test("ClassLoaderCache should make a new loader when cleared"):
+    withCache: cache =>
+      val classPath = Seq.empty[File]
+      val firstLoader = cache.get(classPath)
+      cache.clear()
+      val secondLoader = cache.get(classPath)
+      assert(firstLoader != secondLoader)
+
+  test("ClassLoaderCache should reuse loader for same classpath"):
+    withCache: cache =>
+      val classPath = Seq.empty[File]
+      val firstLoader = cache.get(classPath)
+      val secondLoader = cache.get(classPath)
+      assert(firstLoader == secondLoader)
+
+  test("Snapshots should be invalidated when modified"):
+    IO.withTemporaryDirectory: dir =>
+      val snapshotJar = Files.createFile(dir.toPath.resolve("foo-SNAPSHOT.jar")).toFile
+      val regularJar = Files.createFile(dir.toPath.resolve("regular.jar")).toFile
+      withCache: cache =>
+        val jarClassPath = snapshotJar :: regularJar :: Nil
+        val initLoader = cache.get(jarClassPath)
+        IO.setModifiedTimeOrFalse(snapshotJar, System.currentTimeMillis + 5000L)
+        val secondLoader = cache.get(jarClassPath)
+        assert(initLoader != secondLoader)
+        assert(cache.get(jarClassPath) == secondLoader)
+        assert(cache.get(jarClassPath) != initLoader)
+
+end ClassLoaderCacheTest


### PR DESCRIPTION
## Summary

Migrate `ClassLoaderCacheTest` from ScalaTest to `verify.BasicTestSuite` (#8502)

- Replace ScalaTest (`AnyFlatSpec` + `Matchers`) with `verify.BasicTestSuite`
- Convert test syntax from `"X" should "Y" in` to `test("X should Y"):`
- Update to Scala 3 Fewer Braces syntax throughout

## Test plan

- [ ] Run `sbt commandProj/testOnly *ClassLoaderCacheTest` to verify tests pass
- [ ] Verify no ScalaTest dependencies remain in the file

Closes #8502 

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=42954461