### PR TITLE
[2.x] fix: Prevent sbt test from hanging when forked process crashes

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -211,7 +211,11 @@ private class React(
       case NonFatal(_)            => ()
 
   override def notifyExit(p: Process): Unit =
-    if !process.isAlive then promise.success(process.exitValue())
+    if !process.isAlive && !promise.isCompleted then
+      val exitCode = process.exitValue()
+      if exitCode != 0 then
+        promise.failure(new RuntimeException(s"Forked test process exited with code $exitCode"))
+      else promise.success(exitCode)
 
   def processNotification(o: JsonObject): Unit =
     val method = o.getAsJsonPrimitive("method").getAsString()


### PR DESCRIPTION
When a forked test process crashes (e.g., due to UnsupportedClassVersionError), sbt would hang forever waiting for test results. This happened because notifyExit only completed the promise with success, regardless of the exit code.

This fix checks the exit code and fails the promise if the process exited with a non-zero code, allowing sbt to properly report the failure and exit.

Fixes #7429

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147