### PR TITLE
[2.x] Breaking change: Disable delegation of scoped keys on shell

### DIFF
--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -573,8 +573,14 @@ object Act {
   private def anyKeyValues(structure: BuildStructure, keys: Seq[ScopedKey[?]]): Seq[KeyValue[?]] =
     keys.flatMap(key => getValue(structure.data, key).map(KeyValue(key, _)))
 
+  /**
+   * Starting sbt 2.0.0, we will not delegate when a non-existent scoping
+   * such as Compile / update is required.
+   */
   private def getValue[T](data: Def.Settings, key: ScopedKey[T]): Option[T] =
-    if (java.lang.Boolean.getBoolean("sbt.cli.nodelegation")) data.getDirect(key)
+    if key.scope.config.isSelect ||
+      key.scope.task.isSelect
+    then data.getDirect(key)
     else data.get(key)
 
   def requireSession[T](s: State, p: => Parser[T]): Parser[T] =

--- a/sbt-app/src/sbt-test/project/no-delegate/build.sbt
+++ b/sbt-app/src/sbt-test/project/no-delegate/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "3.7.4"

--- a/sbt-app/src/sbt-test/project/no-delegate/test
+++ b/sbt-app/src/sbt-test/project/no-delegate/test
@@ -1,0 +1,6 @@
+> compile
+> test
+
+# Fail on non-existent scoping
+-> Compile / update
+


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/3679

## Problem
Currently the shell delegates request tasks even when a non-existent task like Compile / update is requested.

## Solution
This removes the delegation, if the input key is scoped, so it will fail. We will, however, continue to delegate on the subproject axis, since it's useful to use Global or ThisBuild scoping.
