### PR TITLE
[2.x] test: Migrate FileInfoSpec.scala to verify.BasicTestSuite

### DIFF
--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -10,24 +10,25 @@ package sbt.util
 
 import sjsonnew.shaded.scalajson.ast.unsafe.*
 import sjsonnew.*, support.scalajson.unsafe.*
-import org.scalatest.flatspec.AnyFlatSpec
+import verify.BasicTestSuite
 import sbt.io.IO
 
-class FileInfoSpec extends AnyFlatSpec {
+object FileInfoSpec extends BasicTestSuite:
   val file = new java.io.File(".").getAbsoluteFile
   val fileInfo: ModifiedFileInfo = FileModified(file, IO.getModifiedTimeOrZero(file))
   val filesInfo = FilesInfo(Set(fileInfo))
 
-  it should "round trip" in assertRoundTrip(filesInfo)
+  test("round trip"):
+    assertRoundTrip(filesInfo)
 
-  def assertRoundTrip[A: JsonWriter: JsonReader](x: A) = {
+  def assertRoundTrip[A: JsonWriter: JsonReader](x: A): Unit =
     val jsonString: String = toJsonString(x)
     val jValue: JValue = Parser.parseUnsafe(jsonString)
     val y: A = Converter.fromJson[A](jValue).get
-    assert(x === y)
-  }
+    assert(x == y)
 
-  def assertJsonString[A: JsonWriter](x: A, s: String) = assert(toJsonString(x) === s)
+  def assertJsonString[A: JsonWriter](x: A, s: String): Unit = assert(toJsonString(x) == s)
 
   def toJsonString[A: JsonWriter](x: A): String = CompactPrinter(Converter.toJson(x).get)
-}
+
+end FileInfoSpec

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -27,7 +27,6 @@ object FileInfoSpec extends BasicTestSuite:
     val y: A = Converter.fromJson[A](jValue).get
     assert(x == y)
 
-
   def toJsonString[A: JsonWriter](x: A): String = CompactPrinter(Converter.toJson(x).get)
 
 end FileInfoSpec

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -27,7 +27,6 @@ object FileInfoSpec extends BasicTestSuite:
     val y: A = Converter.fromJson[A](jValue).get
     assert(x == y)
 
-  def assertJsonString[A: JsonWriter](x: A, s: String): Unit = assert(toJsonString(x) == s)
 
   def toJsonString[A: JsonWriter](x: A): String = CompactPrinter(Converter.toJson(x).get)
 


### PR DESCRIPTION
## Summary
Fixes #8542 - Migrate FileInfoSpec.scala to verify.BasicTestSuite

## Changes
Migrated `util-cache/src/test/scala/FileInfoSpec.scala` from ScalaTest's `AnyFlatSpec` to `verify.BasicTestSuite`, following the pattern established by other test files in the util-cache module (e.g., `CacheSpec.scala`, `HasherTest.scala`).

### Specific changes:
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Convert `it should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Change `===` to `==` for assertions (BasicTestSuite style)
- Add explicit `Unit` return types for helper methods
- Add `end FileInfoSpec` marker

## Before
```scala
class FileInfoSpec extends AnyFlatSpec {
  it should "round trip" in assertRoundTrip(filesInfo)
}
```

## After
```scala
object FileInfoSpec extends BasicTestSuite:
  test("round trip"):
    assertRoundTrip(filesInfo)
end FileInfoSpec
```