### PR TITLE
[2.x] test: Migrate UpdateReportSpec to verify.BasicTestSuite

### DIFF
--- a/lm-core/src/test/scala/UpdateReportSpec.scala
+++ b/lm-core/src/test/scala/UpdateReportSpec.scala
@@ -2,12 +2,11 @@ package sbt.librarymanagement
 
 import java.io.File
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import verify.BasicTestSuite
 
-class UpdateReportSpec extends AnyFlatSpec with Matchers {
-  "UpdateReport.toString" should "have a nice toString" in {
-    assert(updateReport.toString === s"""
+object UpdateReportSpec extends BasicTestSuite:
+  test("UpdateReport.toString should have a nice toString"):
+    assert(updateReport.toString == s"""
       |Update report:
       |	Resolve time: 0 ms, Download time: 0 ms, Download size: 0 bytes
       |	compile:
@@ -17,9 +16,8 @@ class UpdateReportSpec extends AnyFlatSpec with Matchers {
       |			evicted: false
       |
       |""".stripMargin.drop(1))
-  }
 
-  lazy val updateReport =
+  lazy val updateReport: UpdateReport =
     UpdateReport(
       new File("cachedDescriptor.data"),
       Vector(configurationReport),
@@ -27,25 +25,24 @@ class UpdateReportSpec extends AnyFlatSpec with Matchers {
       Map.empty
     )
 
-  lazy val configurationReport =
+  lazy val configurationReport: ConfigurationReport =
     ConfigurationReport(
       ConfigRef("compile"),
       Vector(moduleReport),
       Vector(organizationArtifactReport)
     )
 
-  lazy val moduleReport = (
+  lazy val moduleReport: ModuleReport =
     ModuleReport(ModuleID("org", "name", "1.0"), Vector.empty, Vector.empty)
       .withPublicationDate(Some(epochCalendar))
-  )
 
-  lazy val organizationArtifactReport =
+  lazy val organizationArtifactReport: OrganizationArtifactReport =
     OrganizationArtifactReport("org", "name", Vector(moduleReport))
 
-  val epochCalendar: java.util.Calendar = {
+  val epochCalendar: java.util.Calendar =
     val utc = java.util.TimeZone.getTimeZone("UTC")
     val c = new java.util.GregorianCalendar(utc, java.util.Locale.ENGLISH)
     c.setTimeInMillis(0L)
     c
-  }
-}
+
+end UpdateReportSpec

--- a/lm-core/src/test/scala/UpdateReportSpec.scala
+++ b/lm-core/src/test/scala/UpdateReportSpec.scala
@@ -6,7 +6,7 @@ import verify.BasicTestSuite
 
 object UpdateReportSpec extends BasicTestSuite:
   test("UpdateReport.toString should have a nice toString"):
-    assert(updateReport.toString == s"""
+    Predef.assert(updateReport.toString == s"""
       |Update report:
       |	Resolve time: 0 ms, Download time: 0 ms, Download size: 0 bytes
       |	compile:


### PR DESCRIPTION
## Summary
Fixes #8543 - Migrate UpdateReportSpec to verify.BasicTestSuite

## Changes
Migrated `lm-core/src/test/scala/UpdateReportSpec.scala` from ScalaTest's `AnyFlatSpec` with `Matchers` to `verify.BasicTestSuite`, following the pattern established by other test files in the lm-core module (e.g., `CrossVersionCompatTest.scala`).

### Specific changes:
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Remove ScalaTest `Matchers` dependency
- Convert `"..." should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Change `===` to `==` for assertions (BasicTestSuite style)
- Add explicit types for `lazy val` definitions
- Add `end UpdateReportSpec` marker

## Before
```scala
import org.scalatest.flatspec.AnyFlatSpec
import org.scalatest.matchers.should.Matchers

class UpdateReportSpec extends AnyFlatSpec with Matchers {
  "UpdateReport.toString" should "have a nice toString" in {
    assert(updateReport.toString === s"""...""")
  }
}
```

## After
```scala
import verify.BasicTestSuite

object UpdateReportSpec extends BasicTestSuite:
  test("UpdateReport.toString should have a nice toString"):
    assert(updateReport.toString == s"""...""")
end UpdateReportSpec
```