### PR TITLE
[2.x] test: Migrate ManagedLoggerSpec.scala to verify.BasicTestSuite

### DIFF
--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -32,7 +32,9 @@ object ManagedLoggerSpec extends BasicTestSuite:
     context.addAppender("foo", asyncStdout -> Level.Info)
     log.infoEvent(1)
 
-  test("ManagedLogger should validate performance improvement of disabling location calculation for async loggers"):
+  test(
+    "ManagedLogger should validate performance improvement of disabling location calculation for async loggers"
+  ):
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
     val before = System.currentTimeMillis()
@@ -79,14 +81,14 @@ object ManagedLoggerSpec extends BasicTestSuite:
     import java.util.concurrent.{ Executors, TimeUnit }
     val pool = Executors.newFixedThreadPool(100)
     for i <- 1 to 10000 do
-      pool.submit(new Runnable:
-        def run(): Unit =
-          val stringTypeTag = implicitly[StringTypeTag[List[Int]]]
-          val log = newLogger(s"foo$i")
-          context.addAppender(s"foo$i", asyncStdout -> Level.Info)
-          if i % 100 == 0 then
-            log.info(s"foo$i test $stringTypeTag")
-          Thread.sleep(1)
+      pool.submit(
+        new Runnable:
+          def run(): Unit =
+            val stringTypeTag = implicitly[StringTypeTag[List[Int]]]
+            val log = newLogger(s"foo$i")
+            context.addAppender(s"foo$i", asyncStdout -> Level.Info)
+            if i % 100 == 0 then log.info(s"foo$i test $stringTypeTag")
+            Thread.sleep(1)
       )
     pool.shutdown
     pool.awaitTermination(30, TimeUnit.SECONDS)

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -17,7 +17,7 @@ import sbt.io.Using
 object ManagedLoggerSpec extends BasicTestSuite:
   val context: LoggerContext = LoggerContext()
   // TODO create a new appender for testing purposes - 3/12/21
-  val asyncStdout: ConsoleAppender = ConsoleAppender()
+  val asyncStdout: Appender = ConsoleAppender()
   def newLogger(name: String): ManagedLogger = context.logger(name, None, None)
 
   test("ManagedLogger should log to console"):
@@ -81,17 +81,16 @@ object ManagedLoggerSpec extends BasicTestSuite:
     import java.util.concurrent.{ Executors, TimeUnit }
     val pool = Executors.newFixedThreadPool(100)
     for i <- 1 to 10000 do
-      pool.submit(
-        new Runnable:
-          def run(): Unit =
-            val stringTypeTag = implicitly[StringTypeTag[List[Int]]]
-            val log = newLogger(s"foo$i")
-            context.addAppender(s"foo$i", asyncStdout -> Level.Info)
-            if i % 100 == 0 then log.info(s"foo$i test $stringTypeTag")
-            Thread.sleep(1)
-      )
+      pool.submit((() =>
+        val stringTypeTag = implicitly[StringTypeTag[List[Int]]]
+        val log = newLogger(s"foo$i")
+        context.addAppender(s"foo$i", asyncStdout -> Level.Info)
+        if i % 100 == 0 then log.info(s"foo$i test $stringTypeTag")
+        Thread.sleep(1)
+      ): Runnable)
     pool.shutdown
     pool.awaitTermination(30, TimeUnit.SECONDS)
+    ()
 
   test("global logging should log immediately after initialization"):
     // this is passed into State normally

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -8,33 +8,31 @@
 
 package sbt.internal.util
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import verify.BasicTestSuite
 import sbt.util.*
 import sbt.internal.util.appmacro.StringTypeTag
 import java.io.{ File, PrintWriter }
 import sbt.io.Using
 
-class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
-  val context = LoggerContext()
+object ManagedLoggerSpec extends BasicTestSuite:
+  val context: LoggerContext = LoggerContext()
   // TODO create a new appender for testing purposes - 3/12/21
-  val asyncStdout = ConsoleAppender()
+  val asyncStdout: ConsoleAppender = ConsoleAppender()
   def newLogger(name: String): ManagedLogger = context.logger(name, None, None)
-  "ManagedLogger" should "log to console" in {
+
+  test("ManagedLogger should log to console"):
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
     log.info("test_info")
     log.debug("test_debug")
-  }
 
-  it should "support event logging" in {
+  test("ManagedLogger should support event logging"):
     import sjsonnew.BasicJsonProtocol.*
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
     log.infoEvent(1)
-  }
 
-  it should "validate performance improvement of disabling location calculation for async loggers" in {
+  test("ManagedLogger should validate performance improvement of disabling location calculation for async loggers"):
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
     val before = System.currentTimeMillis()
@@ -42,18 +40,15 @@ class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
       log.debug("test")
     }
     val after = System.currentTimeMillis()
-
     log.info(s"Performance test took: ${after - before}ms")
-  }
 
-  it should "support logging Throwable out of the box" in {
+  test("ManagedLogger should support logging Throwable out of the box"):
     import sbt.internal.util.codec.JsonProtocol.given
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
     log.infoEvent(SuccessEvent("yes"))
-  }
 
-  it should "allow registering Show[Int]" in {
+  test("ManagedLogger should allow registering Show[Int]"):
     import sjsonnew.BasicJsonProtocol.given
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
@@ -61,9 +56,8 @@ class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
       ShowLines((x: Int) => Vector(s"String representation of $x"))
     log.registerStringCodec[Int]
     log.infoEvent(1)
-  }
 
-  it should "allow registering Show[Array[Int]]" in {
+  test("ManagedLogger should allow registering Show[Array[Int]]"):
     import sjsonnew.BasicJsonProtocol.given
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
@@ -71,9 +65,8 @@ class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
       ShowLines((x: Array[Int]) => Vector(s"String representation of ${x.mkString}"))
     log.registerStringCodec[Array[Int]]
     log.infoEvent(Array(1, 2, 3))
-  }
 
-  it should "allow registering Show[Vector[Vector[Int]]]" in {
+  test("ManagedLogger should allow registering Show[Vector[Vector[Int]]]"):
     import sjsonnew.BasicJsonProtocol.given
     val log = newLogger("foo")
     context.addAppender("foo", asyncStdout -> Level.Info)
@@ -81,41 +74,33 @@ class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
       ShowLines((xss: Vector[Vector[Int]]) => Vector(s"String representation of $xss"))
     log.registerStringCodec[Vector[Vector[Int]]]
     log.infoEvent(Vector(Vector(1, 2, 3)))
-  }
 
-  it should "be thread safe" in {
+  test("ManagedLogger should be thread safe"):
     import java.util.concurrent.{ Executors, TimeUnit }
     val pool = Executors.newFixedThreadPool(100)
-    for {
-      i <- 1 to 10000
-    } {
-      pool.submit(new Runnable {
-        def run(): Unit = {
+    for i <- 1 to 10000 do
+      pool.submit(new Runnable:
+        def run(): Unit =
           val stringTypeTag = implicitly[StringTypeTag[List[Int]]]
           val log = newLogger(s"foo$i")
           context.addAppender(s"foo$i", asyncStdout -> Level.Info)
-          if (i % 100 == 0) {
+          if i % 100 == 0 then
             log.info(s"foo$i test $stringTypeTag")
-          }
           Thread.sleep(1)
-        }
-      })
-    }
+      )
     pool.shutdown
     pool.awaitTermination(30, TimeUnit.SECONDS)
-  }
 
-  "global logging" should "log immediately after initialization" in {
+  test("global logging should log immediately after initialization"):
     // this is passed into State normally
     val global0 = initialGlobalLogging
     val full = global0.full
     (1 to 3).toList foreach { x =>
       full.info(s"test$x")
     }
-  }
 
   // This is done in Mainloop.scala
-  it should "create a new backing with newAppender" in {
+  test("global logging should create a new backing with newAppender"):
     val global0 = initialGlobalLogging
     val logBacking0 = global0.backing
     val global1 = Using.fileWriter(append = true)(logBacking0.file) { writer =>
@@ -137,12 +122,11 @@ class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
       // System.console.readLine
       assert(logBacking1.file.exists)
     }
-  }
 
-  val console = ConsoleOut.systemOut
+  val console: ConsoleOut = ConsoleOut.systemOut
   def initialGlobalLogging: GlobalLogging = GlobalLogging.initial(
     MainAppender.globalDefault(console),
     File.createTempFile("sbt", ".log"),
     console
   )
-}
+end ManagedLoggerSpec


### PR DESCRIPTION
## Summary
Migrates `ManagedLoggerSpec.scala` from ScalaTest's `AnyFlatSpec` with `Matchers` to `verify.BasicTestSuite`, following the pattern established by other test files in the sbt codebase.

Related to the ongoing test migration effort.

## Changes
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Remove ScalaTest `Matchers` dependency
- Convert `"..." should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Add explicit types for `val` definitions
- Convert for comprehension to for-do syntax
- Add `end ManagedLoggerSpec` marker

## Before
```scala
class ManagedLoggerSpec extends AnyFlatSpec with Matchers {
  "ManagedLogger" should "log to console" in {
    // ...
  }
}
```

## After
```scala
object ManagedLoggerSpec extends BasicTestSuite:
  test("ManagedLogger should log to console"):
    // ...
end ManagedLoggerSpec
```