### PR TITLE
[2.x] test: Migrate ProgressStateSpec.scala to verify.BasicTestSuite

### DIFF
--- a/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/ProgressStateSpec.scala
@@ -10,34 +10,30 @@ package sbt.internal.util
 
 import java.io.{ File, PrintStream }
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.BeforeAndAfterAll
+import verify.BasicTestSuite
 import sbt.internal.util.Terminal.SimpleTerminal
 
 import scala.io.Source
+import scala.util.Using
 
-class ProgressStateSpec extends AnyFlatSpec with BeforeAndAfterAll {
+object ProgressStateSpec extends BasicTestSuite:
 
-  private lazy val fileIn = new File("/tmp/tmp.txt")
-  private lazy val fileOut = Source.fromFile("/tmp/tmp.txt")
+  test("test should not clear after carriage return (\\r)"):
+    val fileIn = new File("/tmp/tmp.txt")
+    try
+      val ps = new ProgressState(1, 8)
+      val in = "Hello\r\nWorld".getBytes()
 
-  override def afterAll(): Unit = {
-    fileIn.delete()
-    fileOut.close()
-    super.afterAll()
-  }
+      ps.write(SimpleTerminal, in, new PrintStream(fileIn), hasProgress = true)
 
-  "test" should "not clear after carriage return (\\r) " in {
-    val ps = new ProgressState(1, 8)
-    val in = "Hello\r\nWorld".getBytes()
-
-    ps.write(SimpleTerminal, in, new PrintStream(fileIn), hasProgress = true)
-
-    val clearScreenBytes = ConsoleAppender.ClearScreenAfterCursor.getBytes("UTF-8")
-    val check = fileOut.getLines().toList.map { line =>
-      line.getBytes("UTF-8").endsWith(clearScreenBytes)
-    }
-
-    assert(check === List(false, true))
-  }
-}
+      Using.resource(Source.fromFile("/tmp/tmp.txt")) { fileOut =>
+        val clearScreenBytes = ConsoleAppender.ClearScreenAfterCursor.getBytes("UTF-8")
+        val check = fileOut.getLines().toList.map { line =>
+          line.getBytes("UTF-8").endsWith(clearScreenBytes)
+        }
+        assert(check == List(false, true))
+      }
+    finally
+      fileIn.delete()
+      ()
+end ProgressStateSpec


### PR DESCRIPTION
## Summary
Migrates `ProgressStateSpec.scala` from ScalaTest's `AnyFlatSpec` with `BeforeAndAfterAll` to `verify.BasicTestSuite`, following the pattern established by other test files in the sbt codebase.

Related to the ongoing test migration effort.

## Changes
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Remove `BeforeAndAfterAll` trait and convert `afterAll` cleanup to `try-finally` block
- Use `scala.util.Using.resource` for proper resource management
- Convert `"..." should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Change `===` to `==` for assertions
- Add `end ProgressStateSpec` marker

## Before
```scala
class ProgressStateSpec extends AnyFlatSpec with BeforeAndAfterAll {
  private lazy val fileIn = new File("/tmp/tmp.txt")
  private lazy val fileOut = Source.fromFile("/tmp/tmp.txt")

  override def afterAll(): Unit = {
    fileIn.delete()
    fileOut.close()
  }

  "test" should "not clear after carriage return" in {
    // ...
  }
}
```

## After
```scala
object ProgressStateSpec extends BasicTestSuite:
  test("test should not clear after carriage return"):
    val fileIn = new File("/tmp/tmp.txt")
    try
      // ...
    finally
      fileIn.delete()
end ProgressStateSpec
```