### PR TITLE
[2.x] test: Migrate util-logging specs to verify.BasicTestSuite

### DIFF
--- a/internal/util-logging/src/test/scala/sbt/internal/util/StackTraceSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/StackTraceSpec.scala
@@ -25,14 +25,18 @@ object StackTraceSpec extends BasicTestSuite:
     assert(lines.exists(_.contains("Caused by:")))
     assert(lines.exists(_.contains("cause exception")))
 
-  test("StackTrace.trimmedLines should handle self-referencing exceptions without StackOverflowError"):
+  test(
+    "StackTrace.trimmedLines should handle self-referencing exceptions without StackOverflowError"
+  ):
     val exception = new SelfReferencingException("self-referencing exception")
     val lines = StackTrace.trimmedLines(exception, 3)
     assert(lines.nonEmpty)
     assert(lines.head.contains("self-referencing exception"))
     assert(lines.exists(_.contains("[CIRCULAR REFERENCE:")))
 
-  test("StackTrace.trimmedLines should handle circular exception chains without StackOverflowError"):
+  test(
+    "StackTrace.trimmedLines should handle circular exception chains without StackOverflowError"
+  ):
     val exception1 = new ChainableException("exception 1")
     val exception2 = new ChainableException("exception 2")
     exception1.setCauseException(exception2)

--- a/internal/util-logging/src/test/scala/sbt/internal/util/StackTraceSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/StackTraceSpec.scala
@@ -8,34 +8,31 @@
 
 package sbt.internal.util
 
-import org.scalatest.flatspec.AnyFlatSpec
+import verify.BasicTestSuite
 
-class StackTraceSpec extends AnyFlatSpec {
-  "StackTrace.trimmedLines" should "handle normal exceptions" in {
+object StackTraceSpec extends BasicTestSuite:
+  test("StackTrace.trimmedLines should handle normal exceptions"):
     val exception = new RuntimeException("test exception")
     val lines = StackTrace.trimmedLines(exception, 3)
     assert(lines.nonEmpty)
     assert(lines.head.contains("test exception"))
-  }
 
-  it should "handle exceptions with causes" in {
+  test("StackTrace.trimmedLines should handle exceptions with causes"):
     val cause = new RuntimeException("cause exception")
     val exception = new RuntimeException("test exception", cause)
     val lines = StackTrace.trimmedLines(exception, 3)
     assert(lines.exists(_.contains("test exception")))
     assert(lines.exists(_.contains("Caused by:")))
     assert(lines.exists(_.contains("cause exception")))
-  }
 
-  it should "handle self-referencing exceptions without StackOverflowError" in {
+  test("StackTrace.trimmedLines should handle self-referencing exceptions without StackOverflowError"):
     val exception = new SelfReferencingException("self-referencing exception")
     val lines = StackTrace.trimmedLines(exception, 3)
     assert(lines.nonEmpty)
     assert(lines.head.contains("self-referencing exception"))
     assert(lines.exists(_.contains("[CIRCULAR REFERENCE:")))
-  }
 
-  it should "handle circular exception chains without StackOverflowError" in {
+  test("StackTrace.trimmedLines should handle circular exception chains without StackOverflowError"):
     val exception1 = new ChainableException("exception 1")
     val exception2 = new ChainableException("exception 2")
     exception1.setCauseException(exception2)
@@ -45,16 +42,13 @@ class StackTraceSpec extends AnyFlatSpec {
     assert(lines.exists(_.contains("exception 1")))
     assert(lines.exists(_.contains("exception 2")))
     assert(lines.exists(_.contains("[CIRCULAR REFERENCE:")))
-  }
-}
+end StackTraceSpec
 
-class SelfReferencingException(message: String) extends RuntimeException(message) {
+class SelfReferencingException(message: String) extends RuntimeException(message):
   override def getCause: Throwable = this
-}
 
-class ChainableException(message: String) extends RuntimeException(message) {
+class ChainableException(message: String) extends RuntimeException(message):
   import scala.compiletime.uninitialized
   private var causeException: Throwable = uninitialized
   def setCauseException(cause: Throwable): Unit = causeException = cause
   override def getCause: Throwable = causeException
-}

--- a/internal/util-logging/src/test/scala/sbt/internal/util/TerminalColorSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/TerminalColorSpec.scala
@@ -8,10 +8,10 @@
 
 package sbt.internal.util
 
-import org.scalatest.flatspec.AnyFlatSpec
 import java.io.{ ByteArrayOutputStream, InputStream }
+import verify.BasicTestSuite
 
-class TerminalColorSpec extends AnyFlatSpec {
+object TerminalColorSpec extends BasicTestSuite:
   private def createTerminal(
       colorEnabled: Boolean,
       ansiSupported: Boolean,
@@ -22,7 +22,7 @@ class TerminalColorSpec extends AnyFlatSpec {
       out,
       new ByteArrayOutputStream(),
       "test"
-    ) {
+    ):
       private[sbt] def getSizeImpl: (Int, Int) = (80, 24)
       override def isColorEnabled: Boolean = colorEnabled
       override def isAnsiSupported: Boolean = ansiSupported
@@ -39,12 +39,11 @@ class TerminalColorSpec extends AnyFlatSpec {
       override private[sbt] def setSize(width: Int, height: Int): Unit = ()
       override private[sbt] def enterRawMode(): Unit = ()
       override private[sbt] def exitRawMode(): Unit = ()
-    }
 
-  private val ESC = "\u001b"
-  private val coloredText = s"$ESC[31mred text$ESC[0m"
+  private val ESC: String = "\u001b"
+  private val coloredText: String = s"$ESC[31mred text$ESC[0m"
 
-  "Terminal with colors disabled" should "strip color codes from output" in {
+  test("Terminal with colors disabled should strip color codes from output"):
     val out = new ByteArrayOutputStream()
     val term = createTerminal(colorEnabled = false, ansiSupported = true, out)
     term.outputStream.write(coloredText.getBytes("UTF-8"))
@@ -52,9 +51,8 @@ class TerminalColorSpec extends AnyFlatSpec {
     val output = out.toString("UTF-8")
     assert(!output.contains(ESC))
     assert(output.contains("red text"))
-  }
 
-  "Terminal with colors enabled" should "preserve color codes in output" in {
+  test("Terminal with colors enabled should preserve color codes in output"):
     val out = new ByteArrayOutputStream()
     val term = createTerminal(colorEnabled = true, ansiSupported = true, out)
     term.outputStream.write(coloredText.getBytes("UTF-8"))
@@ -62,5 +60,4 @@ class TerminalColorSpec extends AnyFlatSpec {
     val output = out.toString("UTF-8")
     assert(output.contains(ESC))
     assert(output.contains("red text"))
-  }
-}
+end TerminalColorSpec

--- a/internal/util-logging/src/test/scala/sbt/internal/util/UTF8DecoderSpec.scala
+++ b/internal/util-logging/src/test/scala/sbt/internal/util/UTF8DecoderSpec.scala
@@ -10,33 +10,30 @@ package sbt.internal.util
 
 import java.io.InputStream
 import java.nio.charset.Charset
-import org.scalatest.flatspec.AnyFlatSpec
 import java.util.concurrent.LinkedBlockingQueue
+import verify.BasicTestSuite
 
-class UTF8DecoderSpec extends AnyFlatSpec {
-  val decoder = Charset.forName("UTF-8").newDecoder
-  "ascii characters" should "not be modified" in {
-    val inputStream = new InputStream {
+object UTF8DecoderSpec extends BasicTestSuite:
+  val decoder: java.nio.charset.CharsetDecoder = Charset.forName("UTF-8").newDecoder
+
+  test("ascii characters should not be modified"):
+    val inputStream = new InputStream:
       override def read(): Int = 'c'.toInt
-    }
     assert(JLine3.decodeInput(decoder, inputStream) == 'c'.toInt)
-  }
-  "swedish characters" should "be handled" in {
+
+  test("swedish characters should be handled"):
     val bytes = new LinkedBlockingQueue[Int]
     // these are the utf-8 codes for an umlauted a in swedish
     Seq(195, 164).foreach(b => bytes.put(b))
-    val inputStream = new InputStream {
+    val inputStream = new InputStream:
       override def read(): Int = Option(bytes.poll).getOrElse(-1)
-    }
     assert(JLine3.decodeInput(decoder, inputStream) == 228)
-  }
-  "emoji" should "be handled" in {
+
+  test("emoji should be handled"):
     val bytes = new LinkedBlockingQueue[Int]
     // laughing and crying emoji in utf8
     Seq(0xf0, 0x9f, 0x98, 0x82).foreach(b => bytes.put(b))
-    val inputStream = new InputStream {
+    val inputStream = new InputStream:
       override def read(): Int = Option(bytes.poll).getOrElse(-1)
-    }
     assert(JLine3.decodeInput(decoder, inputStream) == 128514)
-  }
-}
+end UTF8DecoderSpec


### PR DESCRIPTION
## Summary
Migrates the following test files from ScalaTest's `AnyFlatSpec` to `verify.BasicTestSuite`, following the pattern established by other test files in the sbt codebase.

### Migrated Files
- `internal/util-logging/src/test/scala/sbt/internal/util/UTF8DecoderSpec.scala`
- `internal/util-logging/src/test/scala/sbt/internal/util/StackTraceSpec.scala`
- `internal/util-logging/src/test/scala/sbt/internal/util/TerminalColorSpec.scala`

Related to the ongoing test migration effort.

## Changes
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Convert `"..." should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Add `end` markers
- Add explicit types where needed

## Before (example from UTF8DecoderSpec)
```scala
class UTF8DecoderSpec extends AnyFlatSpec {
  "ascii characters" should "not be modified" in {
    // ...
  }
}
```

## After
```scala
object UTF8DecoderSpec extends BasicTestSuite:
  test("ascii characters should not be modified"):
    // ...
end UTF8DecoderSpec
```