### PR TITLE
[2.x] test: Migrate parser specs to verify.BasicTestSuite

### DIFF
--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
@@ -8,57 +8,57 @@
 
 package sbt.internal.util.complete
 
-import org.scalatest.flatspec.AnyFlatSpec
+import verify.BasicTestSuite
 
-class SizeParserSpec extends AnyFlatSpec {
-  "SizeParser" should "handle raw bytes" in {
+object SizeParserSpec extends BasicTestSuite:
+  test("SizeParser should handle raw bytes"):
     assert(Parser.parse(str = "123456", SizeParser.value) == Right(123456L))
-  }
-  it should "handle bytes" in {
+
+  test("SizeParser should handle bytes"):
     assert(Parser.parse(str = "123456b", SizeParser.value) == Right(123456L))
     assert(Parser.parse(str = "123456B", SizeParser.value) == Right(123456L))
     assert(Parser.parse(str = "123456 b", SizeParser.value) == Right(123456L))
     assert(Parser.parse(str = "123456 B", SizeParser.value) == Right(123456L))
-  }
-  it should "handle kilobytes" in {
+
+  test("SizeParser should handle kilobytes"):
     assert(Parser.parse(str = "123456k", SizeParser.value) == Right(123456L * 1024))
     assert(Parser.parse(str = "123456K", SizeParser.value) == Right(123456L * 1024))
     assert(Parser.parse(str = "123456 K", SizeParser.value) == Right(123456L * 1024))
     assert(Parser.parse(str = "123456 K", SizeParser.value) == Right(123456L * 1024))
-  }
-  it should "handle megabytes" in {
+
+  test("SizeParser should handle megabytes"):
     assert(Parser.parse(str = "123456m", SizeParser.value) == Right(123456L * 1024 * 1024))
     assert(Parser.parse(str = "123456M", SizeParser.value) == Right(123456L * 1024 * 1024))
     assert(Parser.parse(str = "123456 M", SizeParser.value) == Right(123456L * 1024 * 1024))
     assert(Parser.parse(str = "123456 M", SizeParser.value) == Right(123456L * 1024 * 1024))
-  }
-  it should "handle gigabytes" in {
+
+  test("SizeParser should handle gigabytes"):
     assert(Parser.parse(str = "123456g", SizeParser.value) == Right(123456L * 1024 * 1024 * 1024))
     assert(Parser.parse(str = "123456G", SizeParser.value) == Right(123456L * 1024 * 1024 * 1024))
     assert(Parser.parse(str = "123456 G", SizeParser.value) == Right(123456L * 1024 * 1024 * 1024))
     assert(Parser.parse(str = "123456 G", SizeParser.value) == Right(123456L * 1024 * 1024 * 1024))
-  }
-  it should "handle doubles" in {
+
+  test("SizeParser should handle doubles"):
     assert(Parser.parse(str = "1.25g", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
     assert(Parser.parse(str = "1.25 g", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
     assert(Parser.parse(str = "1.25 g", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
     assert(Parser.parse(str = "1.25 G", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
-  }
-  private val expectedCompletions = Set("", "b", "B", "g", "G", "k", "K", "m", "M", " ")
-  it should "have completions for long" in {
+
+  private val expectedCompletions: Set[String] = Set("", "b", "B", "g", "G", "k", "K", "m", "M", " ")
+
+  test("SizeParser should have completions for long"):
     val completions = Parser.completions(SizeParser.value, "123", level = 0).get.map(_.display)
     assert(completions == expectedCompletions)
-  }
-  it should "have completions for long with spaces" in {
+
+  test("SizeParser should have completions for long with spaces"):
     val completions = Parser.completions(SizeParser.value, "123", level = 0).get.map(_.display)
     assert(completions == expectedCompletions)
-  }
-  it should "have completions for double " in {
+
+  test("SizeParser should have completions for double"):
     val completions = Parser.completions(SizeParser.value, "1.25", level = 0).get.map(_.display)
     assert(completions == expectedCompletions)
-  }
-  it should "have completions for double with spaces" in {
+
+  test("SizeParser should have completions for double with spaces"):
     val completions = Parser.completions(SizeParser.value, "1.25  ", level = 0).get.map(_.display)
     assert(completions == expectedCompletions + "")
-  }
-}
+end SizeParserSpec

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala
@@ -44,7 +44,8 @@ object SizeParserSpec extends BasicTestSuite:
     assert(Parser.parse(str = "1.25 g", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
     assert(Parser.parse(str = "1.25 G", SizeParser.value) == Right(5L * 1024 * 1024 * 1024 / 4))
 
-  private val expectedCompletions: Set[String] = Set("", "b", "B", "g", "G", "k", "K", "m", "M", " ")
+  private val expectedCompletions: Set[String] =
+    Set("", "b", "B", "g", "G", "k", "K", "m", "M", " ")
 
   test("SizeParser should have completions for long"):
     val completions = Parser.completions(SizeParser.value, "123", level = 0).get.map(_.display)

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -91,7 +91,8 @@ object MultiParserSpec extends BasicTestSuite:
   val twoBrace: String = "set foo := { val x = { val y = 2; y + 2 }; x + 1 }"
   val threeBrace: String = "set foo := { val x = { val y = 2; { val z = 3; y + 2 } }; x + 1 }"
   val doubleBrace: String = "set foo := { val x = { val y = 2; y + 2 }; { x + 1 } }"
-  val tripleBrace: String = "set foo := { val x = { val y = 2; y + 2 }; val y = { x + 1 }; { z + y } }"
+  val tripleBrace: String =
+    "set foo := { val x = { val y = 2; y + 2 }; val y = { x + 1 }; { z + y } }"
   val emptyBraces: String = "{{{{}}}}"
 
   test("parsing should parse commands with braces"):

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -96,25 +96,27 @@ object MultiParserSpec extends BasicTestSuite:
   val emptyBraces: String = "{{{{}}}}"
 
   test("parsing should parse commands with braces"):
-    assert(s"$consecutive;".parse == consecutive :: Nil)
-    assert(s"$oneBrace;".parse == oneBrace :: Nil)
-    assert(s"$twoBrace;".parse == twoBrace :: Nil)
-    assert(s"$threeBrace;".parse == threeBrace :: Nil)
-    assert(s"$doubleBrace;".parse == doubleBrace :: Nil)
-    assert(s"$tripleBrace;".parse == tripleBrace :: Nil)
-    assert(s"$emptyBraces;".parse == emptyBraces :: Nil)
+    Predef.assert(s"$consecutive;".parse == consecutive :: Nil)
+    Predef.assert(s"$oneBrace;".parse == oneBrace :: Nil)
+    Predef.assert(s"$twoBrace;".parse == twoBrace :: Nil)
+    Predef.assert(s"$threeBrace;".parse == threeBrace :: Nil)
+    Predef.assert(s"$doubleBrace;".parse == doubleBrace :: Nil)
+    Predef.assert(s"$tripleBrace;".parse == tripleBrace :: Nil)
+    Predef.assert(s"$emptyBraces;".parse == emptyBraces :: Nil)
 
   test("parsing should parse multiple commands with braces"):
-    assert(s"compile; $consecutive".parse == "compile" :: consecutive :: Nil)
-    assert(s"compile; $consecutive ; test".parse == "compile" :: consecutive :: "test" :: Nil)
+    Predef.assert(s"compile; $consecutive".parse == "compile" :: consecutive :: Nil)
+    Predef.assert(
+      s"compile; $consecutive ; test".parse == "compile" :: consecutive :: "test" :: Nil
+    )
 
   test("parsing should not parse unclosed braces"):
     val extraRight = "{ { val x = 1}}{ val x = 2 } }"
-    assert(s"compile; $extraRight".parseEither.isLeft)
+    Predef.assert(s"compile; $extraRight".parseEither.isLeft)
     val extraLeft = "{{{ val x = 1}{ val x = 2 } }"
-    assert(s"compile; $extraLeft".parseEither.isLeft)
+    Predef.assert(s"compile; $extraLeft".parseEither.isLeft)
     val unmatchedEmptyBraces = "{{{{}}}"
-    assert(s"compile; $unmatchedEmptyBraces".parseEither.isLeft)
+    Predef.assert(s"compile; $unmatchedEmptyBraces".parseEither.isLeft)
 
   test("parsing should handle cosmetic whitespace"):
     val commands = (1 to 100).map(_ => "compile")
@@ -128,15 +130,15 @@ object MultiParserSpec extends BasicTestSuite:
 
   test("parsing should exclude alias"):
     val alias = """alias scalacFoo = ; set scalacOptions ++= Seq("-foo")"""
-    assert(alias.parseEither.isLeft)
-    assert(s"   $alias".parseEither.isLeft)
-    assert(s"   $alias;".parseEither.isLeft)
-    assert(s";$alias".parseEither.isLeft)
-    assert(s";   $alias".parseEither.isLeft)
-    assert(s";$alias;".parseEither.isLeft)
-    assert(s";   $alias;".parseEither.isLeft)
-    assert(s"foo; $alias".parseEither.isLeft)
-    assert(s"; foo;$alias".parseEither.isLeft)
-    assert(s"; foo;$alias; ".parseEither.isLeft)
-    assert(s"; foo;   $alias; ".parseEither.isLeft)
+    Predef.assert(alias.parseEither.isLeft)
+    Predef.assert(s"   $alias".parseEither.isLeft)
+    Predef.assert(s"   $alias;".parseEither.isLeft)
+    Predef.assert(s";$alias".parseEither.isLeft)
+    Predef.assert(s";   $alias".parseEither.isLeft)
+    Predef.assert(s";$alias;".parseEither.isLeft)
+    Predef.assert(s";   $alias;".parseEither.isLeft)
+    Predef.assert(s"foo; $alias".parseEither.isLeft)
+    Predef.assert(s"; foo;$alias".parseEither.isLeft)
+    Predef.assert(s"; foo;$alias; ".parseEither.isLeft)
+    Predef.assert(s"; foo;   $alias; ".parseEither.isLeft)
 end MultiParserSpec

--- a/main-command/src/test/scala/sbt/MultiParserSpec.scala
+++ b/main-command/src/test/scala/sbt/MultiParserSpec.scala
@@ -9,46 +9,44 @@
 package sbt
 
 import scala.concurrent.duration.*
-import org.scalatest.flatspec.AnyFlatSpec
 import sbt.internal.util.complete.Parser
+import verify.BasicTestSuite
 
-object MultiParserSpec {
+object MultiParserSpec extends BasicTestSuite:
   val parser: Parser[Seq[String]] = BasicCommands.multiParserImpl(None)
+
   extension (s: String)
-    def parse: Seq[String] = Parser.parse(s, parser) match {
+    def parse: Seq[String] = Parser.parse(s, parser) match
       case Right(x) => x
       case Left(x)  => sys.error(s)
-    }
     def parseEither: Either[String, Seq[String]] = Parser.parse(s, parser)
-}
-import sbt.MultiParserSpec.*
-class MultiParserSpec extends AnyFlatSpec {
-  "parsing" should "parse single commands" in {
+
+  test("parsing should parse single commands"):
     assert(";foo".parse == Seq("foo"))
     assert(";   foo".parse == Seq("foo"))
-  }
-  it should "parse multiple commands" in {
+
+  test("parsing should parse multiple commands"):
     assert(";foo;bar".parse == Seq("foo", "bar"))
-  }
-  it should "parse single command with leading spaces" in {
+
+  test("parsing should parse single command with leading spaces"):
     assert(";     foo".parse == Seq("foo"))
     assert("     ;     foo".parse == Seq("foo"))
     assert("      foo;".parse == Seq("foo"))
-  }
-  it should "parse single command with trailing spaces" in {
+
+  test("parsing should parse single command with trailing spaces"):
     assert(";     foo      ".parse == Seq("foo"))
     assert(";foo      ".parse == Seq("foo"))
     assert("foo;      ".parse == Seq("foo"))
     assert("    foo;    ".parse == Seq("foo"))
     assert("      foo   ;    ".parse == Seq("foo"))
-  }
-  it should "parse multiple commands with leading spaces" in {
+
+  test("parsing should parse multiple commands with leading spaces"):
     assert(";     foo;bar".parse == Seq("foo", "bar"))
     assert(";     foo;    bar".parse == Seq("foo", "bar"))
     assert(";foo; bar".parse == Seq("foo", "bar"))
     assert("; foo ; bar ; baz".parse == Seq("foo", "bar", "baz"))
-  }
-  it should "parse command with string literal" in {
+
+  test("parsing should parse command with string literal"):
     assert("; foo \"barbaz\"".parse == Seq("foo \"barbaz\""))
     assert("; foo \"bar;baz\"".parse == Seq("foo \"bar;baz\""))
     assert("; foo \"barbaz\"; bar".parse == Seq("foo \"barbaz\"", "bar"))
@@ -63,8 +61,8 @@ class MultiParserSpec extends AnyFlatSpec {
       """; setStringValue "foo;bar"; checkStringValue "foo;bar"""".parse ==
         Seq("""setStringValue "foo;bar"""", """checkStringValue "foo;bar"""")
     )
-  }
-  it should "parse commands without leading ';'" in {
+
+  test("parsing should parse commands without leading ';'"):
     assert(
       "setStringValue foo; setStringValue bar".parse == Seq(
         "setStringValue foo",
@@ -75,27 +73,28 @@ class MultiParserSpec extends AnyFlatSpec {
     assert("foo bar ;bar".parse == Seq("foo bar", "bar"))
     assert("foo \"a;b\"; bar".parse == Seq("foo \"a;b\"", "bar"))
     assert(" foo ; bar \"b;c\"".parse == Seq("foo", "bar \"b;c\""))
-  }
-  it should "not parse single commands without leading ';'" in {
+
+  test("parsing should not parse single commands without leading ';'"):
     assert("foo".parseEither == Left("Expected ';'\nfoo\n   ^"))
     assert("foo bar baz".parseEither == Left("Expected ';'\nfoo bar baz\n           ^"))
-  }
-  it should "not parse empty commands" in {
+
+  test("parsing should not parse empty commands"):
     assert(";;;".parseEither.isLeft)
     assert("; ; ;".parseEither.isLeft)
-  }
-  it should "parse commands with trailing semi-colon" in {
+
+  test("parsing should parse commands with trailing semi-colon"):
     assert("foo;bar;".parse == Seq("foo", "bar"))
     assert("foo;   bar    ;".parse == Seq("foo", "bar"))
-  }
-  val consecutive = "{ { val x = 1}; { val x = 2 } }"
-  val oneBrace = "set foo := { val x = 1; x + 1 }"
-  val twoBrace = "set foo := { val x = { val y = 2; y + 2 }; x + 1 }"
-  val threeBrace = "set foo := { val x = { val y = 2; { val z = 3; y + 2 } }; x + 1 }"
-  val doubleBrace = "set foo := { val x = { val y = 2; y + 2 }; { x + 1 } }"
-  val tripleBrace = "set foo := { val x = { val y = 2; y + 2 }; val y = { x + 1 }; { z + y } }"
-  val emptyBraces = "{{{{}}}}"
-  it should "parse commands with braces" in {
+
+  val consecutive: String = "{ { val x = 1}; { val x = 2 } }"
+  val oneBrace: String = "set foo := { val x = 1; x + 1 }"
+  val twoBrace: String = "set foo := { val x = { val y = 2; y + 2 }; x + 1 }"
+  val threeBrace: String = "set foo := { val x = { val y = 2; { val z = 3; y + 2 } }; x + 1 }"
+  val doubleBrace: String = "set foo := { val x = { val y = 2; y + 2 }; { x + 1 } }"
+  val tripleBrace: String = "set foo := { val x = { val y = 2; y + 2 }; val y = { x + 1 }; { z + y } }"
+  val emptyBraces: String = "{{{{}}}}"
+
+  test("parsing should parse commands with braces"):
     assert(s"$consecutive;".parse == consecutive :: Nil)
     assert(s"$oneBrace;".parse == oneBrace :: Nil)
     assert(s"$twoBrace;".parse == twoBrace :: Nil)
@@ -103,20 +102,20 @@ class MultiParserSpec extends AnyFlatSpec {
     assert(s"$doubleBrace;".parse == doubleBrace :: Nil)
     assert(s"$tripleBrace;".parse == tripleBrace :: Nil)
     assert(s"$emptyBraces;".parse == emptyBraces :: Nil)
-  }
-  it should "parse multiple commands with braces" in {
+
+  test("parsing should parse multiple commands with braces"):
     assert(s"compile; $consecutive".parse == "compile" :: consecutive :: Nil)
     assert(s"compile; $consecutive ; test".parse == "compile" :: consecutive :: "test" :: Nil)
-  }
-  it should "not parse unclosed braces" in {
+
+  test("parsing should not parse unclosed braces"):
     val extraRight = "{ { val x = 1}}{ val x = 2 } }"
     assert(s"compile; $extraRight".parseEither.isLeft)
     val extraLeft = "{{{ val x = 1}{ val x = 2 } }"
     assert(s"compile; $extraLeft".parseEither.isLeft)
     val unmatchedEmptyBraces = "{{{{}}}"
     assert(s"compile; $unmatchedEmptyBraces".parseEither.isLeft)
-  }
-  it should "handle cosmetic whitespace" in {
+
+  test("parsing should handle cosmetic whitespace"):
     val commands = (1 to 100).map(_ => "compile")
     val multiLine = commands.mkString("      \n      ;", "       \n       ;", "    \n        ")
     val start = System.nanoTime
@@ -125,8 +124,8 @@ class MultiParserSpec extends AnyFlatSpec {
     // Make sure this took less than 10 seconds. It takes about 30 milliseconds to run with
     // 100 commands and 3 milliseconds with 3 commands. With a bad parser, it will run indefinitely.
     assert(elapsed.nanoseconds < 10.seconds)
-  }
-  it should "exclude alias" in {
+
+  test("parsing should exclude alias"):
     val alias = """alias scalacFoo = ; set scalacOptions ++= Seq("-foo")"""
     assert(alias.parseEither.isLeft)
     assert(s"   $alias".parseEither.isLeft)
@@ -139,5 +138,4 @@ class MultiParserSpec extends AnyFlatSpec {
     assert(s"; foo;$alias".parseEither.isLeft)
     assert(s"; foo;$alias; ".parseEither.isLeft)
     assert(s"; foo;   $alias; ".parseEither.isLeft)
-  }
-}
+end MultiParserSpec


### PR DESCRIPTION
## Summary

Migrates the following test files from ScalaTest's `AnyFlatSpec` to `verify.BasicTestSuite`, following the pattern established by other test files in the sbt codebase.

### Migrated Files

- `internal/util-complete/src/test/scala/sbt/internal/util/complete/SizeParserSpec.scala`
- `main-command/src/test/scala/sbt/MultiParserSpec.scala`

Related to the ongoing test migration effort.

## Changes

- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Convert `"..." should "..." in` syntax to `test("...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Add `end` markers
- Add explicit types where needed

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=146701565