### PR TITLE
[2.x] test: Migrate FileStampJsonSpec.scala to verify.BasicTestSuite

### DIFF
--- a/main/src/test/scala/sbt/internal/FileStampJsonSpec.scala
+++ b/main/src/test/scala/sbt/internal/FileStampJsonSpec.scala
@@ -10,14 +10,14 @@ package sbt.internal
 
 import java.nio.file.{ Path, Paths }
 
-import org.scalatest.flatspec.AnyFlatSpec
+import verify.BasicTestSuite
 import sbt.nio.FileStamp
 import sbt.nio.FileStamp.Formats
 import sjsonnew.JsonFormat
 import sjsonnew.support.scalajson.unsafe.Converter
 
-class FileStampJsonSpec extends AnyFlatSpec {
-  "file hashes" should "be serializable" in {
+object FileStampJsonSpec extends BasicTestSuite:
+  test("file hashes should be serializable"):
     val hashes = Seq(
       Paths.get("foo") -> FileStamp.hash("bar"),
       Paths.get("bar") -> FileStamp.hash("buzz")
@@ -27,8 +27,8 @@ class FileStampJsonSpec extends AnyFlatSpec {
     val json = Converter.toJsonUnsafe(hashes)
     val deserialized = Converter.fromJsonUnsafe(json)
     assert(hashes == deserialized)
-  }
-  "file last modified times" should "be serializable" in {
+
+  test("file last modified times should be serializable"):
     val lastModifiedTimes = Seq(
       Paths.get("foo") -> FileStamp.LastModified(1234),
       Paths.get("bar") -> FileStamp.LastModified(5678)
@@ -38,8 +38,8 @@ class FileStampJsonSpec extends AnyFlatSpec {
     val json = Converter.toJsonUnsafe(lastModifiedTimes)
     val deserialized = Converter.fromJsonUnsafe(json)
     assert(lastModifiedTimes == deserialized)
-  }
-  "both" should "be serializable" in {
+
+  test("both should be serializable"):
     val hashes = Seq(
       Paths.get("foo") -> FileStamp.hash("bar"),
       Paths.get("bar") -> FileStamp.hash("buzz")
@@ -53,5 +53,4 @@ class FileStampJsonSpec extends AnyFlatSpec {
     val json = Converter.toJsonUnsafe(both)
     val deserialized = Converter.fromJsonUnsafe(json)
     assert(both == deserialized)
-  }
-}
+end FileStampJsonSpec


### PR DESCRIPTION
## Summary
Migrates `main/src/test/scala/sbt/internal/FileStampJsonSpec.scala` from ScalaTest's `AnyFlatSpec` to `verify.BasicTestSuite`, following the pattern established by other test files in the sbt codebase.

## Changes
- Replace `AnyFlatSpec` class with `BasicTestSuite` object
- Convert `"..." should "..." in` syntax to `test("... should ...")` syntax
- Use Scala 3 syntax with colon-based indentation
- Add `end` marker

Related to the ongoing test migration effort.