### PR TITLE
fix: Handle JVM parameters with spaces in sbtopts files

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -194,4 +194,26 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
         s"Machine config should appear before project config. machineIndex=$machineIndex, projectIndex=$projectIndex"
       )
 
+  // Test for issue #7333: sbtopts should handle JVM parameters with spaces
+  testOutput(
+    "sbtopts handles JVM parameters with spaces",
+    sbtOptsFileContents = """-J-Dtest.property="value with spaces""""
+  )("-v"): (out: List[String]) =>
+    if (isWindows) cancel("Test not supported on windows")
+    else
+      // The property should be passed to Java with the full value including spaces
+      val found = out.exists(_.contains("-Dtest.property=value with spaces"))
+      assert(found, s"Expected to find '-Dtest.property=value with spaces' in output:\n${out.mkString("\n")}")
+
+  testOutput(
+    "sbtopts handles multiple JVM parameters on same line",
+    sbtOptsFileContents = """-J--enable-preview -J--add-modules jdk.incubator.concurrent"""
+  )("-v"): (out: List[String]) =>
+    if (isWindows) cancel("Test not supported on windows")
+    else
+      val hasEnablePreview = out.exists(_.contains("--enable-preview"))
+      val hasAddModules = out.exists(_.contains("--add-modules"))
+      assert(hasEnablePreview, s"Expected to find '--enable-preview' in output:\n${out.mkString("\n")}")
+      assert(hasAddModules, s"Expected to find '--add-modules' in output:\n${out.mkString("\n")}")
+
 end RunnerScriptTest

--- a/sbt
+++ b/sbt
@@ -775,6 +775,22 @@ loadConfigFile() {
   done
 }
 
+# Load config file into an array, properly handling quoted arguments with spaces
+# Usage: loadConfigFileArray arrayname filename
+loadConfigFileArray() {
+  local -n arr=$1
+  local file=$2
+  arr=()
+  # Read file line by line, skipping comments and empty lines
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+    # Use eval to properly parse the line respecting quotes
+    # This handles cases like: -J-Dkey="value with spaces"
+    eval "arr+=( $line )"
+  done < <(cat "$file" | sed $'/^\#/d;s/\r$//')
+}
+
 loadPropFile() {
   # trim key and value so as to be more forgiving with spaces around the '=':
   k=$(trimString $k)
@@ -857,19 +873,39 @@ runNativeClient() {
 original_args=("$@")
 
 # Pull in the machine-wide settings configuration.
+# Using loadConfigFileArray to properly handle arguments with spaces
 if [[ -f "$machine_sbt_opts_file" ]]; then
-  set -- "$@" $(loadConfigFile "$machine_sbt_opts_file")
+  declare -a machine_opts
+  loadConfigFileArray machine_opts "$machine_sbt_opts_file"
+  set -- "$@" "${machine_opts[@]}"
 else
   # Otherwise pull in the default settings configuration.
-  [[ -f "$dist_sbt_opts_file" ]] && set -- "$@" $(loadConfigFile "$dist_sbt_opts_file")
+  if [[ -f "$dist_sbt_opts_file" ]]; then
+    declare -a dist_opts
+    loadConfigFileArray dist_opts "$dist_sbt_opts_file"
+    set -- "$@" "${dist_opts[@]}"
+  fi
 fi
 
 # Pull in the project-level config file, if it exists (highest priority, overrides machine/dist).
 # Append so it appears last in command line and wins for duplicate properties.
-[[ -f "$sbt_opts_file" ]] && set -- "$@" $(loadConfigFile "$sbt_opts_file")
+if [[ -f "$sbt_opts_file" ]]; then
+  declare -a sbt_opts
+  loadConfigFileArray sbt_opts "$sbt_opts_file"
+  set -- "$@" "${sbt_opts[@]}"
+fi
 
 # Pull in the project-level java config, if it exists.
-[[ -f ".jvmopts" ]] && export JAVA_OPTS="$JAVA_OPTS $(loadConfigFile .jvmopts)"
+if [[ -f ".jvmopts" ]]; then
+  declare -a jvm_opts
+  loadConfigFileArray jvm_opts ".jvmopts"
+  # Properly quote and join array elements for JAVA_OPTS
+  for opt in "${jvm_opts[@]}"; do
+    # Use printf %q to properly escape the option for shell expansion
+    JAVA_OPTS="$JAVA_OPTS $(printf '%q' "$opt")"
+  done
+  export JAVA_OPTS
+fi
 
 # Pull in default JAVA_OPTS
 [[ -z "${JAVA_OPTS// }" ]] && export JAVA_OPTS="$default_java_opts"


### PR DESCRIPTION
This change fixes issue #7333 where `.sbtopts` and `.jvmopts` files could not properly handle JVM parameters containing spaces, such as:
- `-J-Dsome.thing="foo bar"`
- `-J--add-modules jdk.incubator.concurrent`

The fix introduces a new `loadConfigFileArray` function that:
- Reads config files line by line into a bash array
- Uses eval to properly parse quoted strings, preserving spaces
- Properly expands the array when setting command line arguments

This ensures that arguments like `-Dkey="value with spaces"` are passed to the JVM as a single argument rather than being split on whitespace.

Fixes #7333

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=146701565