### PR TITLE
[2.x] test: migrate SonaClientTest from ScalaTest to verify.BasicTestSuite

### DIFF
--- a/main-actions/src/test/scala/sbt/internal/sona/SonaClientTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/sona/SonaClientTest.scala
@@ -8,21 +8,20 @@
 
 package sbt.internal.sona
 
-import org.scalatest.flatspec.AnyFlatSpec
-import sbt.internal.sona.SonaClientTest.RecordingLogger
+import verify.BasicTestSuite
 import sbt.internal.util.BasicLogger
 import sbt.util.*
 import sjsonnew.support.scalajson.unsafe.Parser
 
 import scala.collection.immutable
 
-class SonaClientTest extends AnyFlatSpec {
+object SonaClientTest extends BasicTestSuite:
 
   private def doTest(
       errorsJsonText: Option[String],
       expectedErrorMessage: String,
       expectedLogText: String = ""
-  ): Unit = {
+  ): Unit =
     val logger = new RecordingLogger()
     val errorsNode = errorsJsonText.map(Parser.parseUnsafe)
     val result = SonaClient.failedDeploymentErrorText(
@@ -35,88 +34,85 @@ class SonaClientTest extends AnyFlatSpec {
     val actualLogText = logger.getLogMessages.mkString("\n")
     assert(actualLogText == expectedLogText)
 
-    () // to avoid the "discarded non-Unit" value warning
-  }
+  test("construct a failed deployment error message without errors"):
+    doTest(
+      None,
+      """deployment 12345 failed""".stripMargin
+    )
 
-  it should "construct a failed deployment error message without errors" in doTest(
-    None,
-    """deployment 12345 failed""".stripMargin
-  )
+  test("construct a failed deployment error message with validation errors"):
+    doTest(
+      Some(
+        """{
+          |    "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6": [
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"
+          |    ],
+          |    "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6": [
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1",
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"
+          |    ]
+          |}""".stripMargin
+      ),
+      """deployment 12345 failed with validation errors:
+        |  - pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6
+        |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists
+        |  - pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6
+        |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1
+        |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2""".stripMargin
+    )
 
-  it should "construct a failed deployment error message with validation errors" in doTest(
-    Some(
-      """{
-        |    "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6": [
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"
-        |    ],
-        |    "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6": [
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1",
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"
-        |    ]
-        |}""".stripMargin
-    ),
-    """deployment 12345 failed with validation errors:
-      |  - pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6
-      |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists
-      |  - pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6
-      |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1
-      |    - Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2""".stripMargin
-  )
+  test("construct a failed deployment error message with validation errors in an unknown format"):
+    doTest(
+      Some(
+        """[
+          |  {
+          |    "package" : "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6",
+          |    "errors" : [
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"
+          |    ]
+          |  },
+          |  {
+          |    "package" : "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6",
+          |    "errors" : [
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1",
+          |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"
+          |    ]
+          |  }
+          |]""".stripMargin
+      ),
+      """deployment 12345 failed with validation errors:
+        |[{
+        |  "package": "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6",
+        |  "errors": ["Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"]
+        |}, {
+        |  "package": "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6",
+        |  "errors": ["Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1", "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"]
+        |}]""".stripMargin,
+      expectedLogText =
+        "[warn] Sonatype deployment validation errors JSON format has changed. Please update to the latest sbt version or report the issue to the sbt project"
+    )
 
-  it should "construct a failed deployment error message with validation errors in an unknown format" in doTest(
-    Some(
-      """[
-        |  {
-        |    "package" : "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6",
-        |    "errors" : [
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"
-        |    ]
-        |  },
-        |  {
-        |    "package" : "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6",
-        |    "errors" : [
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1",
-        |      "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"
-        |    ]
-        |  }
-        |]""".stripMargin
-    ),
-    """deployment 12345 failed with validation errors:
-      |[{
-      |  "package": "pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6",
-      |  "errors": ["Component with package url: 'pkg:maven/org.example.company/sbt-plugin-core_2.12_1.0@0.0.6' already exists"]
-      |}, {
-      |  "package": "pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6",
-      |  "errors": ["Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 1", "Component with package url: 'pkg:maven/org.example.company/sbt-plugin-extra_2.12_1.0@0.0.6' some reason 2"]
-      |}]""".stripMargin,
-    expectedLogText =
-      "[warn] Sonatype deployment validation errors JSON format has changed. Please update to the latest sbt version or report the issue to the sbt project"
-  )
-}
+end SonaClientTest
 
-object SonaClientTest {
+extension (value: RecordingLogger)
+  def getLogMessages: immutable.Seq[String] =
+    value.getEvents.collect { case l: Log => s"[${l.level}] ${l.msg}" }
 
-  implicit class RecordingLoggerOps(private val value: RecordingLogger) extends AnyVal {
-    def getLogMessages: immutable.Seq[String] =
-      value.getEvents.collect { case l: Log => s"[${l.level}] ${l.msg}" }
-  }
+/**
+ * Records logging events for later retrieval.
+ *
+ * @note This is a copy of a logger from the "util-logging" module tests.
+ *       Instead of copying we could depend on the module test directly or extract it into some test-utilities module.
+ */
+final class RecordingLogger extends BasicLogger:
+  private var events: List[LogEvent] = Nil
 
-  /**
-   * Records logging events for later retrieval.
-   *
-   * @note This is a copy of a logger from the "util-logging" module tests.
-   *       Instead of copying we could depend on the module test directly or extract it into some test-utilities module.
-   */
-  final class RecordingLogger extends BasicLogger {
-    private var events: List[LogEvent] = Nil
+  def getEvents: List[LogEvent] = events.reverse
+  def trace(t: => Throwable): Unit = { events ::= new Trace(t) }
+  def log(level: Level.Value, message: => String): Unit = { events ::= new Log(level, message) }
+  def success(message: => String): Unit = { events ::= new Success(message) }
+  def logAll(es: Seq[LogEvent]): Unit = { events :::= es.toList }
 
-    def getEvents = events.reverse
-    def trace(t: => Throwable): Unit = { events ::= new Trace(t) }
-    def log(level: Level.Value, message: => String): Unit = { events ::= new Log(level, message) }
-    def success(message: => String): Unit = { events ::= new Success(message) }
-    def logAll(es: Seq[LogEvent]): Unit = { events :::= es.toList }
-
-    def control(event: ControlEvent.Value, message: => String): Unit =
-      events ::= new ControlEvent(event, message)
-  }
-}
+  def control(event: ControlEvent.Value, message: => String): Unit =
+    events ::= new ControlEvent(event, message)
+end RecordingLogger


### PR DESCRIPTION
- Convert class to object with BasicTestSuite
- Use test() syntax instead of 'should ... in'
- Move RecordingLogger and extension to top-level
- Use Scala 3 colon indentation syntax

---
gittensor::146701565