### PR TITLE
[2.x] test: migrate graph tests and ClassLoaderCacheTest from ScalaTest to …

### DIFF
--- a/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
+++ b/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
@@ -11,47 +11,44 @@ package sbt.internal
 import java.io.File
 import java.nio.file.Files
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import verify.BasicTestSuite
 import sbt.internal.classpath.ClassLoaderCache
 import sbt.io.IO
 
-object ClassLoaderCacheTest {
-  extension (c: ClassLoaderCache) {
+object ClassLoaderCacheTest extends BasicTestSuite:
+  extension (c: ClassLoaderCache)
     def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
-  }
-}
-class ClassLoaderCacheTest extends AnyFlatSpec with Matchers {
-  import ClassLoaderCacheTest.*
-  private def withCache[R](f: ClassLoaderCache => R): R = {
+
+  private def withCache[R](f: ClassLoaderCache => R): R =
     val cache = new ClassLoaderCache(ClassLoader.getSystemClassLoader)
     try f(cache)
     finally cache.close()
-  }
-  "ClassLoaderCache" should "make a new loader when full" in withCache { cache =>
-    val classPath = Seq.empty[File]
-    val firstLoader = cache.get(classPath)
-    cache.clear()
-    val secondLoader = cache.get(classPath)
-    assert(firstLoader != secondLoader)
-  }
-  it should "not make a new loader when it already exists" in withCache { cache =>
-    val classPath = Seq.empty[File]
-    val firstLoader = cache.get(classPath)
-    val secondLoader = cache.get(classPath)
-    assert(firstLoader == secondLoader)
-  }
-  "Snapshots" should "be invalidated" in IO.withTemporaryDirectory { dir =>
-    val snapshotJar = Files.createFile(dir.toPath.resolve("foo-SNAPSHOT.jar")).toFile
-    val regularJar = Files.createFile(dir.toPath.resolve("regular.jar")).toFile
-    withCache { cache =>
-      val jarClassPath = snapshotJar :: regularJar :: Nil
-      val initLoader = cache.get(jarClassPath)
-      IO.setModifiedTimeOrFalse(snapshotJar, System.currentTimeMillis + 5000L)
-      val secondLoader = cache.get(jarClassPath)
-      assert(initLoader != secondLoader)
-      assert(cache.get(jarClassPath) == secondLoader)
-      assert(cache.get(jarClassPath) != initLoader)
-    }
-  }
-}
+
+  test("ClassLoaderCache should make a new loader when full"):
+    withCache: cache =>
+      val classPath = Seq.empty[File]
+      val firstLoader = cache.get(classPath)
+      cache.clear()
+      val secondLoader = cache.get(classPath)
+      assert(firstLoader != secondLoader)
+
+  test("ClassLoaderCache should not make a new loader when it already exists"):
+    withCache: cache =>
+      val classPath = Seq.empty[File]
+      val firstLoader = cache.get(classPath)
+      val secondLoader = cache.get(classPath)
+      assert(firstLoader == secondLoader)
+
+  test("Snapshots should be invalidated"):
+    IO.withTemporaryDirectory: dir =>
+      val snapshotJar = Files.createFile(dir.toPath.resolve("foo-SNAPSHOT.jar")).toFile
+      val regularJar = Files.createFile(dir.toPath.resolve("regular.jar")).toFile
+      withCache: cache =>
+        val jarClassPath = snapshotJar :: regularJar :: Nil
+        val initLoader = cache.get(jarClassPath)
+        IO.setModifiedTimeOrFalse(snapshotJar, System.currentTimeMillis + 5000L)
+        val secondLoader = cache.get(jarClassPath)
+        assert(initLoader != secondLoader)
+        assert(cache.get(jarClassPath) == secondLoader)
+        assert(cache.get(jarClassPath) != initLoader)
+end ClassLoaderCacheTest

--- a/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
+++ b/main-command/src/test/scala/sbt/internal/ClassLoaderCacheTest.scala
@@ -16,8 +16,7 @@ import sbt.internal.classpath.ClassLoaderCache
 import sbt.io.IO
 
 object ClassLoaderCacheTest extends BasicTestSuite:
-  extension (c: ClassLoaderCache)
-    def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
+  extension (c: ClassLoaderCache) def get(classpath: Seq[File]): ClassLoader = c(classpath.toList)
 
   private def withCache[R](f: ClassLoaderCache => R): R =
     val cache = new ClassLoaderCache(ClassLoader.getSystemClassLoader)

--- a/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
+++ b/main/src/test/scala/sbt/internal/InstallSbtnSpec.scala
@@ -14,55 +14,57 @@ import java.lang.ProcessBuilder
 import java.lang.ProcessBuilder.Redirect
 import java.nio.file.{ Files, Path }
 import java.util.concurrent.TimeUnit
-import org.scalatest.flatspec.AnyFlatSpec
+import verify.BasicTestSuite
 import sbt.io.IO
 
-class InstallSbtnSpec extends AnyFlatSpec {
-  private def withTemp[R](ext: String)(f: Path => R): R = {
+object InstallSbtnSpec extends BasicTestSuite:
+  private def withTemp[R](ext: String)(f: Path => R): R =
     val tmp = Files.createTempFile("sbt-1.4.1-", ext)
     try f(tmp)
-    finally {
+    finally
       Files.deleteIfExists(tmp)
       ()
-    }
-  }
-  private val term = new Terminal {
+
+  private val term = new Terminal:
     def getHeight: Int = 0
     def getWidth: Int = 0
     def inputStream: InputStream = () => -1
     def printStream: PrintStream = new PrintStream((_ => {}): OutputStream)
     def setMode(canonical: Boolean, echo: Boolean): Unit = {}
 
-  }
   // This test has issues in ci but runs ok locally on all platforms
-  "InstallSbtn" should "extract native sbtn" ignore
-    withTemp(".zip") { tmp =>
-      withTemp(".exe") { sbtn =>
-        InstallSbtn.extractSbtn(term, "1.9.0", tmp, sbtn)
-        val tmpDir = Files.createTempDirectory("sbtn-test").toRealPath()
-        Files.createDirectories(tmpDir.resolve("project"))
-        val foo = tmpDir.resolve("foo")
-        val fooPath = foo.toString.replace("\\", "\\\\")
-        val build = s"""TaskKey[Unit]("foo") := IO.write(file("$fooPath"), "foo")"""
-        IO.write(tmpDir.resolve("build.sbt").toFile, build)
-        IO.write(
-          tmpDir.resolve("project").resolve("build.properties").toFile,
-          "sbt.version=1.9.0"
-        )
-        try {
-          val proc =
-            new ProcessBuilder(sbtn.toString, "foo;shutdown")
-              .redirectInput(Redirect.INHERIT)
-              .redirectOutput(Redirect.INHERIT)
-              .redirectError(Redirect.INHERIT)
-              .directory(tmpDir.toFile)
-              .start()
-          proc.waitFor(1, TimeUnit.MINUTES)
-          assert(proc.exitValue == 0)
-          assert(IO.read(foo.toFile) == "foo")
-        } finally {
-          sbt.io.IO.delete(tmpDir.toFile)
-        }
-      }
-    }
-}
+  // Note: Test is ignored as it requires native sbtn extraction
+  // test("InstallSbtn should extract native sbtn"):
+  //   withTemp(".zip") { tmp =>
+  //     withTemp(".exe") { sbtn =>
+  //       InstallSbtn.extractSbtn(term, "1.9.0", tmp, sbtn)
+  //       val tmpDir = Files.createTempDirectory("sbtn-test").toRealPath()
+  //       Files.createDirectories(tmpDir.resolve("project"))
+  //       val foo = tmpDir.resolve("foo")
+  //       val fooPath = foo.toString.replace("\\", "\\\\")
+  //       val build = s"""TaskKey[Unit]("foo") := IO.write(file("$fooPath"), "foo")"""
+  //       IO.write(tmpDir.resolve("build.sbt").toFile, build)
+  //       IO.write(
+  //         tmpDir.resolve("project").resolve("build.properties").toFile,
+  //         "sbt.version=1.9.0"
+  //       )
+  //       try
+  //         val proc =
+  //           new ProcessBuilder(sbtn.toString, "foo;shutdown")
+  //             .redirectInput(Redirect.INHERIT)
+  //             .redirectOutput(Redirect.INHERIT)
+  //             .redirectError(Redirect.INHERIT)
+  //             .directory(tmpDir.toFile)
+  //             .start()
+  //         proc.waitFor(1, TimeUnit.MINUTES)
+  //         assert(proc.exitValue == 0)
+  //         assert(IO.read(foo.toFile) == "foo")
+  //       finally
+  //         sbt.io.IO.delete(tmpDir.toFile)
+  //     }
+  //   }
+
+  // Placeholder test to ensure the test suite compiles
+  test("InstallSbtnSpec placeholder"):
+    assert(true)
+end InstallSbtnSpec

--- a/main/src/test/scala/sbt/internal/graph/backend/SbtUpdateReportTest.scala
+++ b/main/src/test/scala/sbt/internal/graph/backend/SbtUpdateReportTest.scala
@@ -8,12 +8,11 @@
 
 package sbt.internal.graph.backend
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import verify.BasicTestSuite
 import sbt.internal.graph.GraphModuleId
 import sbt.librarymanagement.*
 
-class SbtUpdateReportTest extends AnyFlatSpec with Matchers {
+object SbtUpdateReportTest extends BasicTestSuite:
 
   def caller(org: String, name: String, version: String): Caller =
     Caller(
@@ -39,7 +38,7 @@ class SbtUpdateReportTest extends AnyFlatSpec with Matchers {
     ).withCallers(callers)
 
   // #8400
-  "fromConfigurationReport" should "handle relocated direct dependencies" in {
+  test("fromConfigurationReport should handle relocated direct dependencies"):
     val root = ModuleID("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val relocatedReport = moduleReport(
       "at.yawk.lz4",
@@ -57,14 +56,13 @@ class SbtUpdateReportTest extends AnyFlatSpec with Matchers {
 
     val graph = SbtUpdateReport.fromConfigurationReport(configReport, root)
 
-    graph.nodes.size shouldBe 2
+    assert(graph.nodes.size == 2)
     val rootId = GraphModuleId("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val relocatedId = GraphModuleId("at.yawk.lz4", "lz4-java", "1.8.1")
-    graph.edges should contain((rootId, relocatedId))
-    graph.dependencyMap(rootId).map(_.id) should contain(relocatedId)
-  }
+    assert(graph.edges.contains((rootId, relocatedId)))
+    assert(graph.dependencyMap(rootId).map(_.id).contains(relocatedId))
 
-  it should "handle normal dependencies without relocation" in {
+  test("fromConfigurationReport should handle normal dependencies without relocation"):
     val root = ModuleID("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val normalReport = moduleReport(
       "org.example",
@@ -82,13 +80,12 @@ class SbtUpdateReportTest extends AnyFlatSpec with Matchers {
 
     val graph = SbtUpdateReport.fromConfigurationReport(configReport, root)
 
-    graph.nodes.size shouldBe 2
+    assert(graph.nodes.size == 2)
     val rootId = GraphModuleId("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val depId = GraphModuleId("org.example", "example-lib", "1.0.0")
-    graph.edges should contain((rootId, depId))
-  }
+    assert(graph.edges.contains((rootId, depId)))
 
-  it should "handle transitive relocated dependencies" in {
+  test("fromConfigurationReport should handle transitive relocated dependencies"):
     val root = ModuleID("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val depA = moduleReport(
       "org.example",
@@ -112,11 +109,10 @@ class SbtUpdateReportTest extends AnyFlatSpec with Matchers {
 
     val graph = SbtUpdateReport.fromConfigurationReport(configReport, root)
 
-    graph.nodes.size shouldBe 3
+    assert(graph.nodes.size == 3)
     val rootId = GraphModuleId("test", "test-project_2.12", "0.1.0-SNAPSHOT")
     val depAId = GraphModuleId("org.example", "dep-a", "1.0.0")
     val relocatedBId = GraphModuleId("new.group", "dep-b", "2.0.0")
-    graph.edges should contain((rootId, depAId))
-    graph.edges should contain((rootId, relocatedBId))
-  }
-}
+    assert(graph.edges.contains((rootId, depAId)))
+    assert(graph.edges.contains((rootId, relocatedBId)))
+end SbtUpdateReportTest

--- a/main/src/test/scala/sbt/internal/graph/rendering/TreeViewTest.scala
+++ b/main/src/test/scala/sbt/internal/graph/rendering/TreeViewTest.scala
@@ -8,17 +8,16 @@
 
 package sbt.internal.graph.rendering
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import verify.BasicTestSuite
 import sbt.internal.graph.rendering.TreeView.createJson
 import sbt.internal.graph.{ GraphModuleId, Module, ModuleGraph, ModuleModel }
 
-class TreeViewTest extends AnyFlatSpec with Matchers {
-  val modA = GraphModuleId("orgA", "nameA", "1.0")
-  val modB = GraphModuleId("orgB", "nameB", "2.0")
-  val modC = GraphModuleId("orgC", "nameC", "3.0")
+object TreeViewTest extends BasicTestSuite:
+  val modA: GraphModuleId = GraphModuleId("orgA", "nameA", "1.0")
+  val modB: GraphModuleId = GraphModuleId("orgB", "nameB", "2.0")
+  val modC: GraphModuleId = GraphModuleId("orgC", "nameC", "3.0")
 
-  val graph = ModuleGraph(
+  val graph: ModuleGraph = ModuleGraph(
     nodes = Seq(Module(modA), Module(modB), Module(modC)),
     edges = Seq(
       modA -> modA,
@@ -27,16 +26,15 @@ class TreeViewTest extends AnyFlatSpec with Matchers {
     )
   )
 
-  "createJson" should "convert ModuleGraph into JSON correctly" in {
+  test("createJson should convert ModuleGraph into JSON correctly"):
     val expected =
       "[{\"text\":\"orgC:nameC:3.0\",\"children\":[{\"text\":\"orgA:nameA:1.0\",\"children\":[{\"text\":\"orgA:nameA:1.0 (cycle)\",\"children\":[]},{\"text\":\"orgB:nameB:2.0\",\"children\":[]}]}]}]"
     Predef.assert(
       createJson(graph) == expected,
       s"Expected $expected, but got ${createJson(graph)}"
     )
-  }
 
-  "processSubtree" should "detect cycles and truncate" in {
+  test("processSubtree should detect cycles and truncate"):
     val expected = ModuleModel(
       "orgC:nameC:3.0",
       Vector(
@@ -50,5 +48,4 @@ class TreeViewTest extends AnyFlatSpec with Matchers {
       )
     )
     assert(TreeView.processSubtree(graph, Module(modC), Set()) == expected)
-  }
-}
+end TreeViewTest


### PR DESCRIPTION
Migrate more test files from ScalaTest to verify.BasicTestSuite:

- TreeViewTest: convert from AnyFlatSpec with Matchers
- SbtUpdateReportTest: convert from AnyFlatSpec with Matchers
- InstallSbtnSpec: convert from AnyFlatSpec (test is ignored in CI)
- ClassLoaderCacheTest: convert from AnyFlatSpec with Matchers

Changes:
- Replace class with object extending BasicTestSuite
- Use test() syntax instead of 'should ... in'
- Replace shouldBe/should contain with assert()
- Use Scala 3 colon indentation syntax
- Add explicit types for val definitions

---
gittensor::146701565