### PR TITLE
[2.x] feat: Display waiting message when sbtn is blocked by running command

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -1015,11 +1015,31 @@ class NetworkClient(
   private def sendAndWait(cmd: String, limit: Option[Deadline]): Int = {
     val queue = sendExecCommand(cmd)
     var result: Integer = null
+    var waitMessagePrinted = false
+    val initialWaitMs = 2000L // Wait 2 seconds before showing the "waiting" message
+    val pollIntervalMs = 500L // Poll interval after initial wait
     while (running.get && result == null && limit.fold(true)(!_.isOverdue())) {
       try {
         result = limit match {
           case Some(l) => queue.poll((l - Deadline.now).toMillis, TimeUnit.MILLISECONDS)
-          case _       => queue.take
+          case _ =>
+            // First, try a short poll to see if result is immediately available
+            val initialResult = queue.poll(initialWaitMs, TimeUnit.MILLISECONDS)
+            if (initialResult != null) initialResult
+            else {
+              // Result not immediately available - server might be busy with another command
+              if (!waitMessagePrinted) {
+                errorStream.println("[info] waiting for server to become available...")
+                errorStream.println("[info] (hint: another command may be running, e.g., console or shell)")
+                waitMessagePrinted = true
+              }
+              // Continue polling until result arrives
+              var polledResult: Integer = null
+              while (running.get && polledResult == null) {
+                polledResult = queue.poll(pollIntervalMs, TimeUnit.MILLISECONDS)
+              }
+              polledResult
+            }
         }
       } catch {
         case _: InterruptedException if cmd == Shutdown => result = 0


### PR DESCRIPTION
## Summary

When the sbtn thin client sends a command to a server that is already executing another command (like `console`), the client would block silently without any feedback to the user.

This change adds a message to stderr after 2 seconds of waiting:

```
[info] waiting for server to become available...
[info] (hint: another command may be running, e.g., console or shell)
```

The message is printed once per command to avoid spamming the terminal.

## Changes

- Modified `sendAndWait` in `NetworkClient.scala` to use `poll` with a timeout instead of blocking indefinitely with `take`
- After 2 seconds of waiting, prints a helpful message to stderr
- Message is only printed once per command

## Testing

Manual testing:
1. Start sbt server and run `console`
2. In another terminal, run `sbt --client compile`
3. After 2 seconds, message appears

Fixes https://github.com/sbt/sbt/issues/8356

---
This is a Gittensor contribution.
gittensor:user:GlobalStar117