### PR TITLE
[2.x] fix: Prevent evicted output from interleaving

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3335,8 +3335,11 @@ object Classpaths {
       val log = streams.value.log
       val ew =
         EvictionWarning(ivyModule.value, (evicted / evictionWarningOptions).value, report)
-      ew.lines foreach { log.warn(_) }
-      ew.infoAllTheThings foreach { log.info(_) }
+      // Log all lines at once to prevent interleaving (fixes #6084)
+      val warnLines = ew.lines
+      if (warnLines.nonEmpty) log.warn(warnLines.mkString("\n"))
+      val infoLines = ew.infoAllTheThings
+      if (infoLines.nonEmpty) log.info(infoLines.mkString("\n"))
       ew
     },
   ) ++


### PR DESCRIPTION
## Summary

Fixes #6084

When running `sbt evicted`, the warn and info messages were being printed line-by-line using separate `foreach` calls, which could cause interleaving when stdout and stderr buffers flush at different times.

## Problem

Output was scrambled like this:
```
[warn]     +- de.sciss:audiofile_sjs1_2.13:2.3.0                 (depends on 1.3.0)
[info] Here are other dependency conflicts that were resolved:
[warn]     +- de.sciss:asyncfile_sjs1_2.13:0.1.1                 (depends on 1.3.0)
```

## Solution

Changed from logging each line individually:
```scala
ew.lines foreach { log.warn(_) }
ew.infoAllTheThings foreach { log.info(_) }
```

To batching all lines into single log calls:
```scala
val warnLines = ew.lines
if (warnLines.nonEmpty) log.warn(warnLines.mkString("\n"))
val infoLines = ew.infoAllTheThings
if (infoLines.nonEmpty) log.info(infoLines.mkString("\n"))
```

This ensures the 'binary incompatible' warnings appear together, followed by the 'other dependency conflicts' info messages.

---
This is a Gittensor contribution.
gittensor:user:GlobalStar117