### PR TITLE
[2.x] fix: Handle -X JVM options on command line

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
@@ -74,4 +74,13 @@ object RunnerMemoryScriptTest extends verify.BasicTestSuite with ShellScriptUtil
     assert(out.contains[String]("-Xms111m"))
     assert(out.contains[String]("-Xss12m"))
 
+  // Test for issue #5742: -X options passed directly on command line
+  testOutput("sbt -Xmx1G directly on command line")("-Xmx1G", "-v"): (out: List[String]) =>
+    assert(out.contains[String]("-Xmx1G"))
+
+  testOutput("sbt -Xms512M -Xmx1G directly on command line")("-Xms512M", "-Xmx1G", "-v"):
+    (out: List[String]) =>
+      assert(out.contains[String]("-Xms512M"))
+      assert(out.contains[String]("-Xmx1G"))
+
 end RunnerMemoryScriptTest

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -547,6 +547,13 @@ if not "%g:~0,5%" == "-XX:+" if not "%g:~0,5%" == "-XX:-" if "%g:~0,3%" == "-XX"
   )
 )
 
+rem handle -X JVM options (e.g., -Xmx1G, -Xms512M, -Xss4M) - fixes #5742
+if "%g:~0,2%" == "-X" (
+  call :dlog [args_loop] -X JVM argument %~0
+  call :addJava %~0
+  goto args_loop
+)
+
 if defined sbt_new if "%g:~0,2%" == "--" (
   rem special handling for -- template arguments since '=' gets parsed away on Windows
   for /F "tokens=1 delims==" %%a in ("%g%") do (
@@ -1098,6 +1105,8 @@ echo                       are prepended to the runner args
 echo   !SBT_CONFIG!
 echo                       if this file exists, it is prepended to the runner args
 echo   -Dkey=val           pass -Dkey=val directly to the java runtime
+echo   -X^<flag^>            pass -X^<flag^> directly to the java runtime
+echo                       ^(e.g., -Xmx1G, -Xms512M, -Xss4M^)
 rem echo   -J-X                pass option -X directly to the java runtime
 rem echo                       ^(-J is stripped^)
 rem echo   -S-X                add -X to sbt's scalacOptions ^(-S is stripped^)


### PR DESCRIPTION
## Summary

Fixes #5742

Previously, passing JVM options like `-Xmx1G` directly on the command line would result in an error:

```bash
sbt -v -Xmx1G
[error] Expected ';'
[error] -Xmx1G
[error]       ^
```

This was because `-X` options were being passed to sbt as commands instead of being recognized as JVM arguments.

## Changes

- Added handling for `-X` options in `sbt.bat` to pass them to the JVM via `:addJava`
- Updated help text to document this feature:
  ```
  -X<flag>            pass -X<flag> directly to the java runtime
                      (e.g., -Xmx1G, -Xms512M, -Xss4M)
  ```
- Added integration tests for the new functionality

## Testing

With this fix:
```bash
sbt -v -Xmx1G
# Executing command line:
# ... -Xmx1G ...
```

The `-Xmx1G` is now correctly passed to the JVM.

---
This is a Gittensor contribution.
gittensor:user:GlobalStar117