### PR TITLE
[2.x] fix: Format Seq values consistently in multi-project builds

### DIFF
--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -55,7 +55,17 @@ object Aggregation {
       case KeyValue(_, x: Seq[?]) :: Nil => print(x.mkString("* ", "\n* ", ""))
       case KeyValue(_, x) :: Nil         => print(x.toString)
       case _ =>
-        xs foreach (kv => print(display.show(kv.key) + "\n\t" + kv.value.toString))
+        xs foreach { kv =>
+          print(display.show(kv.key))
+          kv.value match {
+            case seq: Seq[?] if seq.nonEmpty =>
+              seq.foreach(item => print("\t* " + item.toString))
+            case seq: Seq[?] =>
+              print("\t(empty)")
+            case x =>
+              print("\t" + x.toString)
+          }
+        }
     }
 
   type Values[T] = Seq[KeyValue[T]]


### PR DESCRIPTION
## Summary

Fixes #7339

When running commands like `Test/definedTests` on multi-project builds, the output was showing raw `Vector(...)` format instead of nicely formatted per-item output.

## Before (multi-project build)

```
[info] svc / Test / definedTests
[info] 	Vector(Test integration.UserDeactivationsSpec : subclass(false, org.scalatest.Suite), Test integration.middleware.BearerTokenLookupSpec : subclass(false, org.scalatest.Suite), ...)
```

## After

```
[info] svc / Test / definedTests
[info] 	* Test integration.UserDeactivationsSpec : subclass(false, org.scalatest.Suite)
[info] 	* Test integration.middleware.BearerTokenLookupSpec : subclass(false, org.scalatest.Suite)
[info] 	...
```

This now matches the flat/single-project build output:
```
[info] * Test integration.LeadFunnelForSupplySpec : subclass(false, org.scalatest.Suite)
[info] * Test integration.SavingsReportingSpec : subclass(false, org.scalatest.Suite)
```

## Changes

Modified `printSettings` in `Aggregation.scala` to check if values are `Seq` types in the multi-project case and format each item on its own line with a `* ` prefix.

---
This is a Gittensor contribution.
gittensor:user:GlobalStar117