### PR TITLE
fix: create missing project directory for nested builds

### DIFF
--- a/main/src/main/scala/sbt/Resolvers.scala
+++ b/main/src/main/scala/sbt/Resolvers.scala
@@ -34,7 +34,12 @@ object Resolvers {
     if (from.isDirectory) Some { () =>
       if (from.canWrite) from else creates(to) { IO.copyDirectory(from, to) }
     }
-    else None
+    else if (!from.exists && from.getParentFile != null && from.getParentFile.isDirectory) {
+      Some { () =>
+        IO.createDirectory(from)
+        from
+      }
+    } else None
   }
 
   val remote: Resolver = (info: ResolveInfo) => {

--- a/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/build.sbt
+++ b/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/build.sbt
@@ -1,0 +1,6 @@
+ThisBuild / scalaVersion := "2.13.16"
+
+lazy val root = (project in file("."))
+  .aggregate(c1)
+
+lazy val c1 = project

--- a/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/c1/build.sbt
+++ b/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/c1/build.sbt
@@ -1,0 +1,1 @@
+lazy val c1 = (project in file("."))

--- a/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/extra.sbt
+++ b/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/extra.sbt
@@ -1,0 +1,1 @@
+// This is an extra sbt file added via --addPluginSbtFile

--- a/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/test
+++ b/sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/test
@@ -1,0 +1,3 @@
+# Test that --addPluginSbtFile works with multi-build setup when nested project directory is missing
+# Fixes https://github.com/sbt/sbt/issues/8570
+> --addPluginSbtFile=extra.sbt compile


### PR DESCRIPTION
## Summary

When using `--addPluginSbtFile` with a multi-build setup, sbt would fail with `Invalid build URI (no handler available)` if the nested build's `project` directory doesn't exist.

## Problem

The issue occurs when:
1. A multi-build setup is used (e.g., `lazy val c1 = project`)
2. The nested build directory (`c1/`) exists but doesn't have a `project` subdirectory
3. `--addPluginSbtFile` option is used

The error message is:
```
java.lang.RuntimeException: Invalid build URI (no handler available): file:~/bug2Projects/c1/project/
```

## Root Cause

In `Resolvers.local`, when the URI points to a directory that doesn't exist, it returns `None`, causing the `fail` function to be called with the "no handler available" error.

## Solution

Modified `Resolvers.local` to create the directory if:
- It doesn't exist
- Its parent directory exists and is a directory

This matches the behavior of `checkDirectory` in `Load.scala` which already creates missing directories.

## Changes

- `main/src/main/scala/sbt/Resolvers.scala`: Added logic to create missing directory if parent exists
- `sbt-app/src/sbt-test/project/add-plugin-sbt-file-nested/`: Added scripted test

## Testing

Added a scripted test that verifies the fix works correctly.

Fixes https://github.com/sbt/sbt/issues/8570

---
This is a Gittensor contribution: [33f77537e7f32b9ddb9db247def29ada03f31fc9]