### PR TITLE
[2.x] fix: Prevent forked test cross talk

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -204,7 +204,11 @@ private class React(
           else if o.has("error") then promise.failure(new RuntimeException(line))
           else promise.success(0)
         else ()
-      else if o.has("method") then processNotification(o)
+      // per JSON-PRC notifications do not have "id" field, so we use "re"
+      else if o.has("re") && o.has("method") then
+        val resId = o.getAsJsonPrimitive("re").getAsLong()
+        if resId == id then processNotification(o)
+        else ()
       else ()
     catch
       case _: JsonSyntaxException => log.info(line)

--- a/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
@@ -238,7 +238,8 @@ public class ForkTestMain {
       String params = this.gson.toJson(info, ForkErrorInfo.class);
       String notification =
           String.format(
-              "{ \"jsonrpc\": \"2.0\", \"method\": \"forkError\", \"params\": %s }", params);
+              "{ \"jsonrpc\": \"2.0\", \"method\": \"forkError\", \"params\": %s, \"re\": %d }",
+              params, this.id);
       this.originalOut.println(notification);
       this.originalOut.flush();
     }
@@ -248,7 +249,8 @@ public class ForkTestMain {
       String params = this.gson.toJson(info, TestLogInfo.class);
       String notification =
           String.format(
-              "{ \"jsonrpc\": \"2.0\", \"method\": \"testLog\", \"params\": %s }", params);
+              "{ \"jsonrpc\": \"2.0\", \"method\": \"testLog\", \"params\": %s, \"re\": %d }",
+              params, this.id);
       this.originalOut.println(notification);
       this.originalOut.flush();
     }
@@ -306,7 +308,8 @@ public class ForkTestMain {
       String params = this.gson.toJson(info, ForkEventsInfo.class);
       String notification =
           String.format(
-              "{ \"jsonrpc\": \"2.0\", \"method\": \"testEvents\", \"params\": %s }", params);
+              "{ \"jsonrpc\": \"2.0\", \"method\": \"testEvents\", \"params\": %s, \"re\": %d }",
+              params, this.id);
       this.originalOut.println(notification);
       this.originalOut.flush();
     }


### PR DESCRIPTION
## Problem
currently all notifications go to all listeners.

## Solution
This adds "re" field so we can check if it matches with the id.