### PR TITLE
[2.x] test: Test transitive cached task

### DIFF
--- a/sbt-app/src/sbt-test/cache/transitive/build.sbt
+++ b/sbt-app/src/sbt-test/cache/transitive/build.sbt
@@ -1,0 +1,27 @@
+import sbt.internal.util.StringVirtualFile1
+
+val task2 = taskKey[Unit]("Upstream cached task that produces t2.txt")
+val task1 = taskKey[Unit]("Downstream cached task that depends on task2 and produces t1.txt")
+val checkTask = taskKey[Unit]("Check that files exist")
+
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+task2 := {
+  val output = StringVirtualFile1("target/out/t2.txt", "task2 output")
+  Def.declareOutput(output)
+  ()
+}
+
+task1 := {
+  task2.value
+  val output = StringVirtualFile1("target/out/t1.txt", "task1 output")
+  Def.declareOutput(output)
+  ()
+}
+
+checkTask := Def.uncached {
+  val t1File = baseDirectory.value / "target" / "out" / "t1.txt"
+  val t2File = baseDirectory.value / "target" / "out" / "t2.txt"
+  assert(t1File.exists(), s"t1.txt should exist")
+  assert(t2File.exists(), s"t2.txt should exist")
+}

--- a/sbt-app/src/sbt-test/cache/transitive/test
+++ b/sbt-app/src/sbt-test/cache/transitive/test
@@ -1,0 +1,18 @@
+# Test for transitive cached task side effects
+# See https://github.com/sbt/sbt/issues/8578
+
+# First run: both tasks execute and produce outputs
+> startServer
+> task1
+$ exists target/out/t1.txt
+$ exists target/out/t2.txt
+> checkTask
+
+# Test cache restoration after clean
+> clean
+
+# After clean, running task1 should restore both t1.txt and t2.txt from cache
+> task1
+$ exists target/out/t1.txt
+$ exists target/out/t2.txt
+> checkTask


### PR DESCRIPTION
## Summary

Adds a scripted test that verifies transitive cached task side effects work correctly, as discussed in #8578.

The test confirms that when a cached task (`task1`) depends on another cached task (`task2`), both tasks' declared outputs are properly restored from cache after `clean`.

## Test scenario

1. `task1` depends on `task2.value`
2. Both tasks use `Def.declareOutput` to declare output files
3. Run `task1` → both `t1.txt` and `t2.txt` are created
4. Run `clean`
5. Run `task1` again → both files are restored from cache ✓

Fixes #8578