### PR TITLE
[2.x] feat: Forked compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -552,6 +552,7 @@ lazy val actionsProj = (project in file("main-actions"))
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
     ),
+    Compile / scalacOptions --= Seq("-Werror"),
   )
   .dependsOn(lmCore)
   .configure(
@@ -564,7 +565,7 @@ lazy val actionsProj = (project in file("main-actions"))
 
 lazy val protocolProj = (project in file("protocol"))
   .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
-  .dependsOn(collectionProj, utilLogging)
+  .dependsOn(collectionProj, utilLogging, utilCache)
   .settings(
     testedBaseSettings,
     name := "Protocol",

--- a/build.sbt
+++ b/build.sbt
@@ -721,6 +721,7 @@ lazy val mainProj = (project in file("main"))
     Compile / doc / sources := Nil,
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
+      exclude[DirectMissingMethodProblem]("sbt.internal.Compiler.*"),
       exclude[DirectMissingMethodProblem]("sbt.internal.ConsoleProject.*"),
       exclude[DirectMissingMethodProblem]("sbt.coursierint.LMCoursier.coursierConfiguration"),
     ),

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -53,9 +53,10 @@ object CompileMain:
       val log = mkLogger(Level.Warn)
       val output = Paths.get(config.output)
       val sources = config.sources.map(Paths.get(_)).map(conv.toVirtualFile)
-      val cp = config.externalDependencyJars.map(Paths.get(_)).map(conv.toVirtualFile)
+      val cp = config.externalDependencyJars.map(Paths.get(_))
+      val cpVf = cp.map(conv.toVirtualFile)
       val in = zinc.inputs(
-        classpath = cp.toArray,
+        classpath = cpVf.toArray,
         sources = sources.toArray,
         classesDirectory = output,
         earlyJarPath = config.earlyJarPath.map(Paths.get(_)),

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -1,0 +1,193 @@
+package sbt
+package internal
+
+import java.io.{ File, PrintStream }
+import java.nio.file.{ Path, Paths }
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.{ Function as JavaFunction }
+import sbt.internal.inc.{
+  AnalyzingCompiler,
+  ScalaInstance,
+  Locate,
+  IncrementalCompilerImpl,
+  MappedFileConverter,
+  ManagedLoggedReporter,
+  Stamps,
+  ZincUtil,
+}
+import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.internal.inc.JavaInterfaceUtil.*
+import sbt.internal.worker.{ CompileConfig, CompileResponse, ScalaInstanceConfig }
+import sbt.internal.worker.codec.JsonProtocol.given
+import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
+import sbt.io.IO
+import sbt.util.{ LoggerContext, Level }
+import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Parser, Converter }
+import xsbti.{ CompileFailed, HashedVirtualFileRef, Position, T2, VirtualFile }
+import xsbti.compile.{ ScalaInstance as _, * }
+
+object CompileMain:
+  lazy val zinc: IncrementalCompilerImpl = new IncrementalCompilerImpl
+
+  def run(config: CompileConfig, id: Long, jsonOut: PrintStream): Unit =
+    try
+      // println(s"config: $config")
+      val conv = MappedFileConverter(
+        Map((config.fileConverterConfig.rootPaths.map: x =>
+          (x.name, Paths.get(x.value)))*),
+        true
+      )
+      val si = scalaInstance(config.scalaInstanceConfig)
+      val bridgeJars = config.bridgeJars.map(Paths.get(_))
+      val scalac = analyzingCompiler(bridgeJars, si)
+      val co = ClasspathOptionsUtil.noboot(config.scalaInstanceConfig.scalaVersion)
+      val cs = ZincUtil.compilers(
+        instance = si,
+        classpathOptions = co,
+        javaHome = None,
+        scalac = scalac,
+      )
+      val analysisFile = Paths.get(config.analysisFile)
+      val setup = incSetup(config)
+      val log = mkLogger(Level.Warn)
+      val output = Paths.get(config.output)
+      val sources = config.sources.map(Paths.get(_)).map(conv.toVirtualFile)
+      val cp = config.externalDependencyJars.map(Paths.get(_)).map(conv.toVirtualFile)
+      val in = zinc.inputs(
+        classpath = cp.toArray,
+        sources = sources.toArray,
+        classesDirectory = output,
+        earlyJarPath = config.earlyJarPath.map(Paths.get(_)),
+        scalacOptions = config.scalacOptions.toArray,
+        javacOptions = config.javacOptions.toArray,
+        maxErrors = config.maxErrors,
+        sourcePositionMappers = Array.empty[JavaFunction[Position, Optional[Position]]],
+        order = CompileOrder.Mixed,
+        compilers = cs,
+        setup = setup,
+        pr = previousResult(analysisFile),
+        temporaryClassesDirectory = jnone[Path],
+        converter = conv,
+        stampReader = Stamps.timeWrapBinaryStamps(conv),
+      )
+      val r = zinc.compile(in, log)
+      val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+      store.set(AnalysisContents.create(r.getAnalysis(), r.getMiniSetup()))
+      val response = CompileResponse(
+        hasModified = r.hasModified()
+      )
+      val resJson = Converter.toJson(response).get
+      val json = CompactPrinter(resJson)
+      jsonOut.println(jsonRpcResponse(id, json))
+      jsonOut.flush()
+    catch
+      case e: CompileFailed =>
+        jsonOut.println(jsonRpcError(id, "compilation failed"))
+        jsonOut.flush()
+        ()
+
+  private def jsonRpcResponse(id: Long, result: String): String =
+    s"""{ "jsonrpc": "2.0", "result": $result, "id": $id }"""
+
+  private def jsonRpcError(id: Long, err: String): String =
+    s"""{ "jsonrpc": "2.0", "error": { "code": 1009, "message": "$err" }, "id": $id }"""
+
+  def incSetup(config: CompileConfig): Setup =
+    val analysisFile = Paths.get(config.analysisFile)
+    val analysisForCp: Map[HashedVirtualFileRef, Path] = Map((config.analysisMap.map: pair =>
+      pair.name -> Paths.get(pair.value))*)
+    val lookup: PerClasspathEntryLookup = new PerClasspathEntryLookup:
+      def read(p: Path) = FileAnalysisStore.getDefault(p.toFile).get().toOption.map(_.getAnalysis)
+      override def analysis(cpEntry: VirtualFile): Optional[CompileAnalysis] =
+        analysisForCp.get(cpEntry).flatMap(read).toOptional
+      override def definesClass(cpEntry: VirtualFile) = Locate.definesClass(cpEntry)
+    val incOptions = IncOptions.of()
+    val log = mkLogger(Level.Warn)
+    val reporter = ManagedLoggedReporter(100, log)
+    Setup.of(
+      lookup,
+      false,
+      analysisFile.toFile(),
+      CompilerCache.fresh(),
+      incOptions,
+      reporter,
+      jnone,
+      Array[T2[String, String]](),
+    )
+
+  lazy val console = ConsoleOut.systemOut
+  lazy val consoleAppender = MainAppender.defaultScreen(console)
+  val generateId: AtomicInteger = new AtomicInteger
+  def mkLogger(level: Level.Value): ManagedLogger =
+    val loggerName = "compile-" + generateId.incrementAndGet
+    val l = LoggerContext.globalContext.logger(loggerName, None, None)
+    LoggerContext.globalContext.clearAppenders(loggerName)
+    LoggerContext.globalContext.addAppender(loggerName, consoleAppender -> level)
+    l
+
+  def none[A]: Option[A] = (None: Option[A])
+  def jnone[A]: Optional[A] = none[A].toOptional
+
+  def analyzingCompiler(bridgeJars: Seq[Path], si: ScalaInstance): AnalyzingCompiler =
+    val bridgeProvider = ZincUtil.constantBridgeProvider(si, bridgeJars.head.toFile())
+    val classpathOptions = ClasspathOptionsUtil.auto()
+    AnalyzingCompiler(
+      si,
+      bridgeProvider,
+      classpathOptions,
+      _ => (),
+      None
+    )
+
+  def scalaInstance(config: ScalaInstanceConfig): ScalaInstance =
+    val libraryJars = config.libraryJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val allCompilerJars =
+      config.allCompilerJars
+        .map(Paths.get(_))
+        .sortBy(_.getFileName.toString())
+    val jlineJars = allCompilerJars.filter(_.getFileName.toString().contains("jline"))
+    val compilerJars =
+      allCompilerJars.filterNot(x => libraryJars.contains(x) || jlineJars.contains(x)).distinct
+    val extraToolJars0 = config.extraToolJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val extraToolJars = extraToolJars0
+      .filterNot(jar => libraryJars.contains(jar) || compilerJars.contains(jar))
+      .distinct
+    val allJars = libraryJars ++ compilerJars ++ extraToolJars
+    val currentLoader = classOf[CompileMain.type].getClassLoader()
+    val topLoader = classOf[Compilers].getClassLoader()
+    val libraryLoader = ClasspathUtil.toLoader(libraryJars, topLoader)
+    val compilerLoader = ClasspathUtil.toLoader(compilerJars, libraryLoader)
+    val fullLoader =
+      if extraToolJars.isEmpty then compilerLoader
+      else ClasspathUtil.toLoader(extraToolJars, compilerLoader)
+    new ScalaInstance(
+      version = config.scalaVersion,
+      loader = fullLoader,
+      loaderCompilerOnly = compilerLoader,
+      loaderLibraryOnly = libraryLoader,
+      libraryJars = libraryJars.map(_.toFile).toArray,
+      compilerJars = compilerJars.map(_.toFile).toArray,
+      allJars = allJars.map(_.toFile).toArray,
+      explicitActual = Some(config.scalaVersion)
+    )
+
+  def previousResult(analysisFile: Path): PreviousResult =
+    val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+    store.get().toOption match
+      case Some(contents) =>
+        val analysis = Option(contents.getAnalysis).toOptional
+        val setup = Option(contents.getMiniSetup).toOptional
+        PreviousResult.of(analysis, setup)
+      case None => PreviousResult.of(jnone[CompileAnalysis], jnone[MiniSetup])
+
+  def main(args: Array[String], id: java.lang.Long, jsonOut: PrintStream): Unit =
+    args.toList match
+      case Nil => println("CompileMain")
+      case s"@${arg}" :: Nil =>
+        val s = IO.read(File(arg))
+        val json = Parser.parseFromString(s).get
+        val config = Converter.fromJson[CompileConfig](json).get
+        run(config, id, jsonOut)
+      case xs => sys.error(s"unknown args: $xs")
+end CompileMain

--- a/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
+++ b/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
@@ -1,0 +1,55 @@
+package sbt
+package internal
+
+import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser, JsonSyntaxException }
+import sbt.internal.inc.CompileFailed
+import sbt.internal.worker1.*
+import sbt.util.Logger
+import scala.concurrent.{ Await, Promise }
+import scala.concurrent.duration.Duration
+import scala.sys.process.Process
+import scala.util.control.NonFatal
+
+private[sbt] abstract class ProcessReact[A1](
+    id: Long,
+    log: Logger,
+    process: Process
+) extends WorkerResponseListener:
+  val g = WorkerMain.mkGson()
+  protected val promise: Promise[A1] = Promise()
+
+  def processNotification(o: JsonObject): Unit
+  def processResponse(o: JsonObject): Unit
+  override def apply(line: String): Unit =
+    try
+      val o = JsonParser.parseString(line).getAsJsonObject()
+      if o.has("id") then
+        val resId = o.getAsJsonPrimitive("id").getAsLong()
+        if resId == id then
+          if promise.isCompleted then ()
+          else if o.has("error") then
+            val err = o.getAsJsonObject("error")
+            val code = err.getAsJsonPrimitive("code").getAsLong()
+            val message = err.getAsJsonPrimitive("message").getAsString()
+            code match
+              case 1009 => promise.failure(new CompileFailed(Array.empty, message, Array.empty))
+              case _    => promise.failure(new RuntimeException(message))
+          else processResponse(o)
+        else ()
+      else if o.has("re") && o.has("method") then
+        val resId = o.getAsJsonPrimitive("re").getAsLong()
+        if resId == id then processNotification(o)
+        else ()
+      else ()
+    catch
+      case _: JsonSyntaxException => log.info(line)
+      case NonFatal(_)            => ()
+
+  override def notifyExit(p: Process): Unit =
+    if !process.isAlive && !promise.isCompleted then
+      val exitCode = process.exitValue()
+      promise.failure(new RuntimeException(s"worker exited with code $exitCode"))
+
+  def blockForResponse(): A1 =
+    Await.result(promise.future, Duration.Inf)
+end ProcessReact

--- a/main-actions/src/test/scala/sbt/internal/CompileMainSpec.scala
+++ b/main-actions/src/test/scala/sbt/internal/CompileMainSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import org.scalasbt.shadedgson.com.google.gson.JsonParser
+import sbt.internal.inc.{ Analysis, CompileOutput, MappedFileConverter }
+import sbt.internal.worker.{
+  CompileConfig,
+  FileConverterConfig,
+  HVFRURI,
+  ScalaInstanceConfig,
+  StringURI,
+}
+import sbt.io.IO
+import sbt.util.InterfaceUtil.t2
+import java.io.{ ByteArrayOutputStream, PrintStream }
+import java.nio.file.{ Files, Path }
+import scala.util.Try
+import xsbti.{ HashedVirtualFileRef, VirtualFile }
+import xsbti.compile.{
+  AnalysisContents,
+  CompileOrder,
+  FileAnalysisStore,
+  FileHash,
+  MiniOptions,
+  MiniSetup,
+  PerClasspathEntryLookup,
+}
+
+object CompileMainSpec extends verify.BasicTestSuite:
+
+  test("the classpath lookup serves the analysis of an upstream entry") {
+    withProject: p =>
+      val entries = p.upstreamEntries(1)
+      val lookup = p.lookupFor(entries)
+      assert(entries.forall((entry, _) => lookup.analysis(entry).isPresent))
+  }
+
+  /**
+   * A `Map` of four entries or fewer compares keys with `equals`, which a `MappedVirtualFile`
+   * answers on the id alone. Past that size the map hashes instead, and the hash of a
+   * `HashedVirtualFileRef` folds in a content hash and a size that the classpath entry has no way
+   * to reproduce, so no upstream project is ever found.
+   */
+  test("the classpath lookup serves upstream analysis past the small-map size") {
+    withProject: p =>
+      val entries = p.upstreamEntries(8)
+      val lookup = p.lookupFor(entries)
+      assert(entries.forall((entry, _) => lookup.analysis(entry).isPresent))
+  }
+
+  test("the classpath lookup finds nothing for an entry the map does not carry") {
+    withProject: p =>
+      val entries = p.upstreamEntries(8)
+      val unknown = p.converter.toVirtualFile(p.upstreamJar("unknown.jar"))
+      val lookup = p.lookupFor(entries)
+      assert(!lookup.analysis(unknown).isPresent)
+  }
+
+  /**
+   * Anything other than `CompileFailed` leaves `run` through `WorkerMain`, which turns it into an
+   * error whose message may be null, and the server only learns about it from the exit poll.
+   */
+  test("a failure that is not CompileFailed is still reported as a json-rpc error") {
+    withProject: p =>
+      val out = ByteArrayOutputStream()
+      val ran = Try(CompileMain.run(p.config(), 42L, PrintStream(out, true, "UTF-8")))
+      assert(ran.isSuccess)
+      val o = JsonParser.parseString(out.toString("UTF-8")).getAsJsonObject
+      assert(o.getAsJsonPrimitive("id").getAsLong == 42L)
+      assert(o.getAsJsonObject("error").getAsJsonPrimitive("message").getAsString.nonEmpty)
+  }
+
+  private class Project(root: Path):
+    val out: Path = Files.createDirectories(root.resolve("out"))
+    val converter: MappedFileConverter = MappedFileConverter(Map("OUT" -> out), true)
+
+    def upstreamJar(name: String): Path =
+      Files.write(out.resolve(name), Array.empty[Byte])
+
+    /** One pickle jar and its analysis per upstream project, as `dependencyPicklePath` carries. */
+    def upstreamEntries(n: Int): Vector[(VirtualFile, HVFRURI)] =
+      (1 to n).toVector.map: i =>
+        val entry = converter.toVirtualFile(upstreamJar(s"lib$i.jar"))
+        val analysis = out.resolve(s"lib$i.zip")
+        FileAnalysisStore
+          .getDefault(analysis.toFile)
+          .set(AnalysisContents.create(Analysis.empty, setup))
+        entry -> HVFRURI(HashedVirtualFileRef.of(entry.id, "cafebabe", 1L), analysis.toUri)
+
+    def lookupFor(entries: Vector[(VirtualFile, HVFRURI)]): PerClasspathEntryLookup =
+      CompileMain.incSetup(config(analysisMap = entries.map(_._2))).perClasspathEntryLookup
+
+    def config(analysisMap: Vector[HVFRURI] = Vector.empty): CompileConfig =
+      CompileConfig(
+        fileConverterConfig = FileConverterConfig(Vector(StringURI("OUT", out.toUri))),
+        scalaInstanceConfig = ScalaInstanceConfig("0.0.0", Vector.empty, Vector.empty),
+        bridgeJars = Vector.empty,
+        sources = Vector.empty,
+        externalDependencyJars = Vector.empty,
+        output = out.resolve("classes").toUri,
+        analysisFile = out.resolve("inc_compile.zip").toUri,
+        earlyJarPath = None,
+        scalacOptions = Vector.empty,
+        javacOptions = Vector.empty,
+        maxErrors = 100,
+        analysisMap = analysisMap,
+      )
+
+    private def setup: MiniSetup =
+      MiniSetup.of(
+        CompileOutput(out.resolve("classes")),
+        MiniOptions.of(Array.empty[FileHash], Array.empty[String], Array.empty[String]),
+        "3.3.1",
+        CompileOrder.Mixed,
+        true,
+        Array(t2("key" -> "value")),
+      )
+  end Project
+
+  private def withProject(f: Project => Unit): Unit =
+    IO.withTemporaryDirectory: tmp =>
+      f(Project(tmp.toPath))
+end CompileMainSpec

--- a/main-actions/src/test/scala/sbt/internal/ProcessReactSpec.scala
+++ b/main-actions/src/test/scala/sbt/internal/ProcessReactSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import org.scalasbt.shadedgson.com.google.gson.JsonObject
+import sbt.internal.inc.CompileFailed
+import sbt.util.Logger
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.DurationInt
+import scala.sys.process.Process
+import scala.util.{ Failure, Success, Try }
+
+object ProcessReactSpec extends verify.BasicTestSuite:
+  private class FakeProcess(alive: Boolean, exit: Int) extends Process:
+    def exitValue(): Int = exit
+    def destroy(): Unit = ()
+    override def isAlive(): Boolean = alive
+
+  private class TestReact(id: Long, process: Process, failResponse: Boolean = false)
+      extends ProcessReact[String](id, Logger.Null, process):
+    def processResponse(o: JsonObject): Unit =
+      if failResponse then throw IllegalStateException("boom")
+      else promise.success(o.getAsJsonPrimitive("result").getAsString())
+    def processNotification(o: JsonObject): Unit = ()
+    def future: Future[String] = promise.future
+
+  private def outcome[A1](f: Future[A1]): Try[A1] =
+    Try(Await.result(f, 5.seconds))
+
+  test("completes the promise from a matching response") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 7 }""")
+    assert(outcome(react.future) == Success("ok"))
+  }
+
+  test("ignores responses for other request ids") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 8 }""")
+    assert(!react.future.isCompleted)
+  }
+
+  test("fails with CompileFailed on error code 1009") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "error": { "code": 1009, "message": "bad" }, "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e: CompileFailed) => e.toString.contains("bad")
+      case _                         => false)
+  }
+
+  /**
+   * Gson leaves a null message out of the object it writes, so reading the field back is where the
+   * worker's own failure gets lost and the compile is left waiting on the exit poll.
+   */
+  test("survives an error object without a message field") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "error": { "code": 5 }, "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e) => e.getMessage.contains("code 5")
+      case _          => false)
+  }
+
+  test("fails the promise when processResponse throws") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0), failResponse = true)
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e: IllegalStateException) => e.getMessage == "boom"
+      case _                                 => false)
+  }
+
+  test("notifyExit fails immediately on a nonzero exit code") {
+    val process = FakeProcess(alive = false, exit = 2)
+    val react = TestReact(7, process)
+    react.notifyExit(process)
+    assert(outcome(react.future) match
+      case Failure(e) => e.getMessage.contains("exited with code 2")
+      case _          => false)
+  }
+
+  /**
+   * The worker writes its response and exits straight after, so the reader thread and the 100ms
+   * exit poll are in a race that nothing orders. A clean compile must not lose it.
+   */
+  test("notifyExit with exit code 0 waits for a late response") {
+    val process = FakeProcess(alive = false, exit = 0)
+    val react = TestReact(7, process)
+    val t = Thread(() => {
+      Thread.sleep(200)
+      react("""{ "jsonrpc": "2.0", "result": "late", "id": 7 }""")
+    })
+    t.start()
+    react.notifyExit(process)
+    t.join()
+    assert(outcome(react.future) == Success("late"))
+  }
+
+  test("notifyExit leaves a response that already arrived alone") {
+    val process = FakeProcess(alive = false, exit = 0)
+    val react = TestReact(7, process)
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 7 }""")
+    react.notifyExit(process)
+    assert(outcome(react.future) == Success("ok"))
+  }
+end ProcessReactSpec

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -40,7 +40,6 @@ import sbt.internal.librarymanagement.mavenint.{
 import sbt.internal.librarymanagement.*
 import sbt.internal.nio.{ CheckBuildSources, Globs }
 import sbt.internal.server.{
-  BspCompileProgress,
   BspCompileTask,
   BuildServerProtocol,
   Definition,
@@ -197,6 +196,7 @@ object Defaults extends BuildCommon {
       apiURL := None,
       releaseNotesURL := None,
       javaHome :== None,
+      jdkVersion :== None,
       discoveredJavaHomes := CrossJava.discoverJavaHomes,
       javaHomes :== ListMap.empty,
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
@@ -689,6 +689,7 @@ object Defaults extends BuildCommon {
         }
         else topLoader
       },
+      scalaInstanceConfig := Def.uncached(Compiler.scalaInstanceConfigTask(None).value),
       scalaInstance := Def.uncached(Compiler.scalaInstanceTask(None).value),
       crossVersion := (if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled),
       pluginCrossBuild / sbtBinaryVersion := binarySbtVersion(
@@ -754,6 +755,12 @@ object Defaults extends BuildCommon {
           Vector(outVf: HashedVirtualFileRef)
         })(Def.task(Vector.empty))
         .value,
+      scalaCompilerBridgeJars := (Def.taskDyn {
+        val s = streams.value
+        val b = scalaCompilerBridgeBin.value
+        if b.nonEmpty then Def.task { b }
+        else Compiler.scalaCompilerBridgeJarsTask(scalaCompilerBridgeSource, s.log)
+      }).value,
       scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),
       auxiliaryClassFiles ++= {
         if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
@@ -1053,6 +1060,10 @@ object Defaults extends BuildCommon {
       discoveredSbtPlugins := Def.uncached(discoverSbtPluginNames.value),
       // This fork options, scoped to the configuration is used for tests
       forkOptions := Def.uncached(forkOptionsTask.value),
+      extraIncOptions := {
+        val orig = extraIncOptions.value
+        orig
+      },
       selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
       run / mainClass := (run / selectMainClass).value,
       mainClass := Def.uncached {
@@ -1286,8 +1297,15 @@ object Defaults extends BuildCommon {
       val canUseArgumentsFile = sys.props
         .getOrElse("java.vm.specification.version", "1")
         .toFloat >= 9.0
+      val jhs = fullJavaHomes.value
+      val jh = jdkVersion.value match
+        case Some(j) =>
+          jhs.get(j) match
+            case Some(value) => Some(value)
+            case None        => sys.error(s"jdkVersion \"$j\" was not found")
+        case None => javaHome.value
       ForkOptions(
-        javaHome = javaHome.value,
+        javaHome = jh,
         outputStrategy = outputStrategy.value,
         // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
         bootJars = Vector(),
@@ -2202,8 +2220,27 @@ object Defaults extends BuildCommon {
       val setup: Setup = (TaskZero / compileIncSetup).value
       val store = analysisStore(compileAnalysisFile)
       val c = fileConverter.value
+      val fk = (compile / fork).value
+      val jh = (compile / jdkVersion).value
+      val fo = (compile / forkOptions).value
+      val sic = scalaInstanceConfig.value
+      val bridges = scalaCompilerBridgeJars.value
+      val rs = rootPaths.value
+      val pickles = dependencyPicklePath.value
       // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
-      val analysisResult = Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping))
+      val analysisResult =
+        if fk then
+          ForkCompile.compile(
+            s,
+            fo,
+            rs,
+            ci,
+            sic,
+            bridges,
+            compileAnalysisFile.value.toPath(),
+            pickles
+          )
+        else Retry.io(Compiler.compileIncrementalTaskImpl(bspTask, s, ci, ping))
       val analysisOut = c.toVirtualFile(setup.cachePath())
       val contents = AnalysisContents.create(analysisResult.analysis(), analysisResult.setup())
       store.set(contents)
@@ -2216,7 +2253,7 @@ object Defaults extends BuildCommon {
     }
     .tag(Tags.Compile, Tags.CPU)
 
-  private val incCompiler = ZincUtil.defaultIncrementalCompiler
+  private val incCompiler = Compiler.incCompiler
   private[sbt] def compileJavaTask: Initialize[Task[CompileResult]] = Def.task {
     val s = streams.value
     val r = compileScalaBackend.value
@@ -2236,35 +2273,6 @@ object Defaults extends BuildCommon {
         reporter.sendFailureReport(in.options.sources)
         throw e
     }
-  }
-
-  private def compileIncrementalTaskImpl(
-      task: BspCompileTask,
-      s: TaskStreams,
-      ci: Inputs,
-      promise: PromiseWrap[Boolean]
-  ): CompileResult = {
-    lazy val x = s.text(ExportStream)
-    def onArgs(cs: Compilers) =
-      cs.withScalac(
-        cs.scalac match
-          case ac: AnalyzingCompiler => ac.onArgs(exported(x, "scalac"))
-          case x                     => x
-      )
-    def onProgress(s: Setup) =
-      val cp = new BspCompileProgress(task, s.progress.asScala)
-      s.withProgress(cp)
-    val compilers: Compilers = ci.compilers
-    val setup: Setup = ci.setup
-    val i = ci.withCompilers(onArgs(compilers)).withSetup(onProgress(setup))
-    try incCompiler.compile(i, s.log)
-    catch
-      case e: Throwable =>
-        if !promise.isCompleted then
-          promise.failure(e)
-          ConcurrentRestrictions.cancelAllSentinels()
-        throw e
-    finally x.close() // workaround for #937
   }
 
   def compileIncSetupTask = Def.task {

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -27,7 +27,7 @@ import sbt.internal.server.BuildServerProtocol.BspFullWorkspace
 import sbt.internal.server.{ BspCompileTask, BuildServerReporter, ServerHandler }
 import sbt.internal.util.{ AttributeKey, ProgressState, SourcePosition }
 import sbt.internal.util.StringAttributeKey
-import sbt.internal.worker.ClientJobParams
+import sbt.internal.worker.{ ClientJobParams, ScalaInstanceConfig }
 import sbt.io.*
 import sbt.librarymanagement.Configurations.CompilerPlugin
 import sbt.librarymanagement.LibraryManagementCodec.*
@@ -216,6 +216,8 @@ object Keys {
   val scalaHome = settingKey[Option[File]]("If Some, defines the local Scala installation to use for compilation, running, and testing.").withRank(ASetting)
   @transient
   val scalaInstance = taskKey[ScalaInstance]("Defines the Scala instance to use for compilation, running, and testing.").withRank(DTask)
+  @transient
+  val scalaInstanceConfig = taskKey[ScalaInstanceConfig]("Defines the Scala instance configuration.").withRank(DTask)
   val scalaOrganization = settingKey[String]("Organization/group ID of the Scala used in the project. Default value is 'org.scala-lang'. This is an advanced setting used for clones of the Scala Language. It should be disregarded in standard use cases.").withRank(CSetting)
   val scalaVersion = settingKey[String]("The version of Scala used for building.").withRank(APlusSetting)
   val scalaBinaryVersion = settingKey[String]("The Scala version substring describing binary compatibility.").withRank(BPlusSetting)
@@ -235,6 +237,8 @@ object Keys {
   val scalaCompilerBridgeBin = taskKey[Seq[HashedVirtualFileRef]]("Optionally, the jar of the compiler bridge. When not None, this takes precedence over scalaCompilerBridgeSource").withRank(DTask)
   val scalaCompilerBridgeSource = settingKey[ModuleID]("Configures the module ID of the sources of the compiler bridge when scalaCompilerBridgeBinaryJar is None").withRank(CSetting)
   val scalaCompilerBridgeScope = taskKey[Unit]("The compiler bridge scope.").withRank(DTask)
+  @transient
+  val scalaCompilerBridgeJars = taskKey[Seq[HashedVirtualFileRef]]("The compiler bridge JAR.").withRank(DTask)
   val scalaArtifacts = settingKey[Seq[String]]("Configures the list of artifacts which should match the Scala binary version").withRank(CSetting)
   val crossJavaVersions = settingKey[Seq[String]]("The java versions used during JDK cross testing").withRank(BPlusSetting)
   val semanticdbEnabled = settingKey[Boolean]("Enables SemanticDB Scalac plugin").withRank(CSetting)
@@ -325,10 +329,13 @@ object Keys {
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)
 
   val fork = settingKey[Boolean]("If true, forks a new JVM when running.  If false, runs in the same JVM as the build.").withRank(ASetting)
+  
+  @transient
   val forkOptions = taskKey[ForkOptions]("Configures JVM forking.").withRank(DSetting)
   val outputStrategy = settingKey[Option[sbt.OutputStrategy]]("Selects how to log output when running a main class.").withRank(DSetting)
   val connectInput = settingKey[Boolean]("If true, connects standard input when running a main class forked.").withRank(CSetting)
-  val javaHome = settingKey[Option[File]]("Selects the Java installation used for compiling and forking.  If None, uses the Java installation running the build.").withRank(ASetting)
+  val javaHome = settingKey[Option[File]]("Selects the Java installation used for forking.  If None, uses the Java installation running the build.").withRank(CSetting)
+  val jdkVersion = settingKey[Option[String]]("Selects the Java installation used for forking.").withRank(ASetting)
   val discoveredJavaHomes = settingKey[Map[String, File]]("Discovered Java home directories")
   val javaHomes = settingKey[Map[String, File]]("The user-defined additional Java home directories")
   val fullJavaHomes = settingKey[Map[String, File]]("Combines discoveredJavaHomes and custom javaHomes.").withRank(CTask)

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -9,46 +9,108 @@
 package sbt
 package internal
 
-import java.io.File
-import sbt.internal.inc.ScalaInstance
+import java.io.{ File, PrintWriter }
+import sbt.OptionSyntax.*
+import sbt.internal.CommandStrings.ExportStream
+import sbt.internal.inc.{ AnalyzingCompiler, ScalaInstance, ZincLmUtil, ZincUtil }
+import sbt.internal.server.{ BspCompileTask, BspCompileProgress }
+import sbt.internal.worker.ScalaInstanceConfig
 import sbt.librarymanagement.{
   Artifact,
   Configuration,
   Configurations,
   ConfigurationReport,
+  ModuleID,
   ScalaArtifacts,
   SemanticSelector,
   VersionNumber
 }
-import xsbti.ScalaProvider
+import sbt.util.Logger
+import xsbti.{ HashedVirtualFileRef, ScalaProvider }
+import xsbti.compile.{ CompileResult, Compilers, Inputs, Setup }
 
 object Compiler:
-  def scalaInstanceTask(extraToolConf: Option[Configuration]): Def.Initialize[Task[ScalaInstance]] =
+  private[sbt] val incCompiler = ZincUtil.defaultIncrementalCompiler
+
+  private[sbt] def exported(w: PrintWriter, command: String): Seq[String] => Unit =
+    args => w.println((command +: args).mkString(" "))
+
+  private[sbt] def exported(s: Keys.TaskStreams, command: String): Seq[String] => Unit =
+    val w = s.text(ExportStream)
+    try exported(w, command)
+    finally w.close() // workaround for #937
+
+  private[sbt] def compileIncrementalTaskImpl(
+      task: BspCompileTask,
+      s: Keys.TaskStreams,
+      ci: Inputs,
+      promise: PromiseWrap[Boolean]
+  ): CompileResult = {
+    lazy val x = s.text(ExportStream)
+    def onArgs(cs: Compilers) =
+      cs.withScalac(
+        cs.scalac match
+          case ac: AnalyzingCompiler => ac.onArgs(exported(x, "scalac"))
+          case x                     => x
+      )
+    def onProgress(s: Setup) =
+      val cp = new BspCompileProgress(task, s.progress.asScala)
+      s.withProgress(cp)
+    val compilers: Compilers = ci.compilers
+    val setup: Setup = ci.setup
+    val i = ci.withCompilers(onArgs(compilers)).withSetup(onProgress(setup))
+    try incCompiler.compile(i, s.log)
+    catch
+      case e: Throwable =>
+        if !promise.isCompleted then
+          promise.failure(e)
+          ConcurrentRestrictions.cancelAllSentinels()
+        throw e
+    finally x.close() // workaround for #937
+  }
+
+  def scalaInstanceTask(
+      extraToolConf: Option[Configuration]
+  ): Def.Initialize[Task[ScalaInstance]] =
+    Def.task {
+      val config = scalaInstanceConfigTask(extraToolConf).value
+      makeScalaInstance(
+        config.scalaVersion,
+        config.libraryJars.map(File(_)).toArray,
+        config.allCompilerJars.map(File(_)),
+        config.extraToolJars.map(File(_)),
+        Keys.state.value,
+        Keys.scalaInstanceTopLoader.value,
+      )
+    }
+
+  def scalaInstanceConfigTask(
+      extraToolConf: Option[Configuration]
+  ): Def.Initialize[Task[ScalaInstanceConfig]] =
     Def.taskDyn {
       val sh = Keys.scalaHome.value
       val app = Keys.appConfiguration.value
       val managed = Keys.managedScalaInstance.value
       sh match
-        case Some(h) => scalaInstanceFromHome(h)
+        case Some(h) => scalaInstanceConfigFromHome(h)
         case _ =>
           val scalaProvider = app.provider.scalaProvider
-          if !managed then emptyScalaInstance
-          else scalaInstanceFromUpdate(extraToolConf)
+          if !managed then emptyScalaInstanceConfig
+          else scalaInstanceConfigFromUpdate(extraToolConf)
     }
 
   /**
    * A dummy ScalaInstance for Java-only projects.
    */
-  def emptyScalaInstance: Def.Initialize[Task[ScalaInstance]] = Def.task {
-    makeScalaInstance(
-      "0.0.0",
-      Array.empty,
-      Seq.empty,
-      Seq.empty,
-      Keys.state.value,
-      Keys.scalaInstanceTopLoader.value,
-    )
-  }
+  def emptyScalaInstanceConfig: Def.Initialize[Task[ScalaInstanceConfig]] =
+    Def.task {
+      ScalaInstanceConfig(
+        "0.0.0",
+        Vector.empty,
+        Vector.empty,
+        Vector.empty,
+      )
+    }
 
   // Use the same class loader as the Scala classes used by sbt
   // This will fail for "doc" task https://github.com/sbt/sbt/issues/7725
@@ -77,25 +139,39 @@ object Compiler:
       case _ => ScalaInstance(sv, scalaProvider)
   }
 
-  def scalaInstanceFromHome(dir: File): Def.Initialize[Task[ScalaInstance]] = Def.task {
-    val dummy = ScalaInstance(dir)(Keys.state.value.classLoaderCache.apply)
-    Seq(dummy.loader, dummy.loaderLibraryOnly).foreach {
-      case a: AutoCloseable => a.close()
-      case _                =>
+  def scalaInstanceConfigFromHome(dir: File): Def.Initialize[Task[ScalaInstanceConfig]] =
+    Def.task {
+      val dummy = ScalaInstance(dir)(Keys.state.value.classLoaderCache.apply)
+      Seq(dummy.loader, dummy.loaderLibraryOnly).foreach {
+        case a: AutoCloseable => a.close()
+        case _                =>
+      }
+      ScalaInstanceConfig(
+        dummy.version,
+        dummy.libraryJars.toVector.map(_.toPath().toUri()),
+        dummy.compilerJars.toVector.map(_.toPath().toUri()),
+        dummy.allJars.toVector.map(_.toPath().toUri()),
+      )
     }
-    makeScalaInstance(
-      dummy.version,
-      dummy.libraryJars,
-      dummy.compilerJars.toSeq,
-      dummy.allJars.toSeq,
-      Keys.state.value,
-      Keys.scalaInstanceTopLoader.value,
-    )
-  }
 
   def scalaInstanceFromUpdate(
       extraToolConf: Option[Configuration]
-  ): Def.Initialize[Task[ScalaInstance]] = Def.task {
+  ): Def.Initialize[Task[ScalaInstance]] =
+    Def.task {
+      val config = scalaInstanceConfigFromUpdate(extraToolConf).value
+      makeScalaInstance(
+        config.scalaVersion,
+        config.libraryJars.map(File(_)).toArray,
+        config.allCompilerJars.map(File(_)),
+        config.extraToolJars.map(File(_)),
+        Keys.state.value,
+        Keys.scalaInstanceTopLoader.value,
+      )
+    }
+
+  def scalaInstanceConfigFromUpdate(
+      extraToolConf: Option[Configuration]
+  ): Def.Initialize[Task[ScalaInstanceConfig]] = Def.task {
     val sv = Keys.scalaVersion.value
     val fullReport = Keys.update.value
     val s = Keys.streams.value
@@ -175,14 +251,11 @@ object Compiler:
           .flatMap(_.artifacts.map(_._2))
       case None => Nil
     val libraryJars = ScalaArtifacts.libraryIds(sv).flatMap(file)
-
-    makeScalaInstance(
+    ScalaInstanceConfig(
       sv,
-      libraryJars,
-      allCompilerJars,
-      extraToolJars,
-      Keys.state.value,
-      Keys.scalaInstanceTopLoader.value,
+      libraryJars.toVector.map(_.toPath().toUri()),
+      allCompilerJars.map(_.toPath().toUri()),
+      extraToolJars.toVector.map(_.toPath().toUri())
     )
   }
 
@@ -226,4 +299,29 @@ object Compiler:
       else
         "Explicitly define scalaInstance or scalaHome or include Scala dependencies in the 'scala-tool' configuration."
     pre + post
+
+  def scalaCompilerBridgeJarsTask(
+      sourceKey: Def.Initialize[ModuleID],
+      log: Logger
+  ): Def.Initialize[Task[Seq[HashedVirtualFileRef]]] =
+    Def.task {
+      val st = Keys.state.value
+      val g = BuildPaths.getGlobalBase(st)
+      val zincDir = BuildPaths.getZincDirectory(st, g)
+      val app = Keys.appConfiguration.value
+      val launcher = app.provider.scalaProvider.launcher
+      val dr = Keys.scalaCompilerBridgeDependencyResolution.value
+      val jars = ZincLmUtil.scalaCompilerBridgeJars(
+        scalaInstance = Keys.scalaInstance.value,
+        globalLock = launcher.globalLock,
+        componentProvider = app.provider.components,
+        secondaryCacheDir = Option(zincDir),
+        dependencyResolution = dr,
+        compilerBridgeSource = Keys.scalaCompilerBridgeSource.value,
+        scalaJarsTarget = zincDir,
+        log = log
+      )
+      val conv = Keys.fileConverter.value
+      jars.map(jar => (conv.toVirtualFile(jar.toPath()): HashedVirtualFileRef))
+    }
 end Compiler

--- a/main/src/main/scala/sbt/internal/ForkCompile.scala
+++ b/main/src/main/scala/sbt/internal/ForkCompile.scala
@@ -1,0 +1,138 @@
+package sbt
+package internal
+
+import java.nio.file.{ Path, Paths }
+import java.net.URLClassLoader
+import java.util.ArrayList
+import org.scalasbt.shadedgson.com.google.gson.JsonObject
+import sbt.OptionSyntax.*
+import sbt.internal.worker.{
+  CompileConfig,
+  CompileResponse,
+  FileConverterConfig,
+  HVFRURI,
+  ScalaInstanceConfig,
+  StringURI,
+}
+import sbt.internal.util.Attributed
+import sbt.internal.worker.codec.JsonProtocol.given
+import sbt.internal.worker1.{ FilePath, RunInfo, WorkerMain }
+import sbt.io.IO
+import sbt.util.Logger
+
+import scala.jdk.CollectionConverters.*
+import scala.util.Random
+import scala.sys.process.Process
+import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter, Parser }
+import xsbti.compile.{ ScalaInstance as _, * }
+import xsbti.{ HashedVirtualFileRef, VirtualFileRef }
+
+private[sbt] object ForkCompile:
+  val r = Random()
+
+  def compile(
+      s: Keys.TaskStreams,
+      fo: ForkOptions,
+      rs: Map[String, Path],
+      in: Inputs,
+      sic: ScalaInstanceConfig,
+      bridges: Seq[HashedVirtualFileRef],
+      analysisFile: Path,
+      acs: Seq[Attributed[HashedVirtualFileRef]],
+  ): CompileResult =
+    val g = WorkerMain.mkGson()
+    val ct = WorkerConnection.Tcp
+    val w = WorkerExchange.startWorker(fo, Nil, ct)
+    val randomId = r.nextLong()
+    val wl = ForkCompile.React(randomId, s.log, w.process)
+    val cpList = ArrayList[FilePath](
+      (currentClasspath
+        .map: p =>
+          FilePath(p.toUri(), ""))
+        .asJava
+    )
+    val fcConfig = FileConverterConfig(
+      rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri()))
+    )
+    val conv = in.options().converter().get()
+    val sources = in.options().sources().toVector.map(conv.toPath)
+    val cp = in.options().classpath().toVector.map(conv.toPath)
+    val earlyJarPath = for
+      o <- in.options().earlyOutput().asScala
+      single <- o.getSingleOutputAsPath().asScala
+    yield single
+    val analysisMap = for
+      entry <- acs.toVector
+      ref <- entry.metadata.get(Keys.analysis)
+    yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri())
+    // pseudo case class that is used to transport the server knowledge to the
+    // forked worker process.
+    val config = CompileConfig(
+      fileConverterConfig = fcConfig,
+      scalaInstanceConfig = sic,
+      bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri()),
+      sources = sources.map(_.toString()),
+      externalDependencyJars = cp.map(_.toString()),
+      output = in.options().classesDirectory().toUri(),
+      analysisFile = analysisFile.toUri(),
+      earlyJarPath = earlyJarPath.map(_.toUri()),
+      scalacOptions = in.options().scalacOptions().toVector,
+      javacOptions = in.options().javacOptions().toVector,
+      maxErrors = in.options().maxErrors(),
+      analysisMap = analysisMap,
+    )
+    val configJson = Converter.toJson[CompileConfig](config).get
+    IO.withTemporaryDirectory: tempDir =>
+      val params = tempDir.toPath().resolve("params.json")
+      IO.write(params.toFile(), CompactPrinter(configJson))
+      val param = RunInfo(
+        true,
+        RunInfo.JvmRunInfo(
+          ArrayList(List(s"@$params").asJava),
+          cpList,
+          "sbt.internal.CompileMain",
+          false,
+        ),
+        null
+      )
+      try
+        WorkerExchange.registerListener(wl)
+        val paramJson = g.toJson(param, param.getClass)
+        val json = jsonRpcRequest(randomId, "compile", paramJson)
+        w.println(json)
+        val response = wl.blockForResponse()
+        val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+        val contents = store.get().get()
+        CompileResult.of(
+          contents.getAnalysis(),
+          contents.getMiniSetup(),
+          response.hasModified,
+        )
+      finally WorkerExchange.unregisterListener(wl)
+
+  def currentClasspath: List[Path] =
+    val cl = classOf[CompileMain.type].getClassLoader() match
+      case cl: URLClassLoader => cl
+    val urls = cl.getURLs().toList
+    urls.map((u) => Paths.get(u.toURI())) ++ Vector(
+      IO.classLocationPath(classOf[xsbti.compile.ScalaInstance]),
+      IO.classLocationPath(classOf[xsbti.Logger]),
+      IO.classLocationPath(classOf[jline.Terminal]),
+      IO.classLocationPath(classOf[org.jline.utils.InfoCmp]),
+    )
+
+  private def jsonRpcRequest(id: Long, method: String, params: String): String =
+    s"""{ "jsonrpc": "2.0", "method": "$method", "params": $params, "id": $id }"""
+
+  private class React(id: Long, log: Logger, process: Process)
+      extends ProcessReact[CompileResponse](id, log, process):
+    override def processResponse(o: JsonObject): Unit =
+      val s = o.getAsJsonObject("result")
+      val json = Parser.parseFromString(s.toString()).get
+      val result = Converter.fromJson[CompileResponse](json).get
+      promise.success(result)
+
+    override def processNotification(o: JsonObject): Unit =
+      val params = o.getAsJsonObject("params")
+      // println(s"params: $params")
+end ForkCompile

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
@@ -1,0 +1,80 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class CompileConfig private (
+  val fileConverterConfig: sbt.internal.worker.FileConverterConfig,
+  val scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig,
+  val bridgeJars: Vector[java.net.URI],
+  val sources: Vector[String],
+  val externalDependencyJars: Vector[String],
+  val output: java.net.URI,
+  val analysisFile: java.net.URI,
+  val earlyJarPath: Option[java.net.URI],
+  val scalacOptions: Vector[String],
+  val javacOptions: Vector[String],
+  val maxErrors: Int,
+  val analysisMap: Vector[sbt.internal.worker.HVFRURI]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##)
+  }
+  override def toString: String = {
+    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ")"
+  }
+  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap): CompileConfig = {
+    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+  }
+  def withFileConverterConfig(fileConverterConfig: sbt.internal.worker.FileConverterConfig): CompileConfig = {
+    copy(fileConverterConfig = fileConverterConfig)
+  }
+  def withScalaInstanceConfig(scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig): CompileConfig = {
+    copy(scalaInstanceConfig = scalaInstanceConfig)
+  }
+  def withBridgeJars(bridgeJars: Vector[java.net.URI]): CompileConfig = {
+    copy(bridgeJars = bridgeJars)
+  }
+  def withSources(sources: Vector[String]): CompileConfig = {
+    copy(sources = sources)
+  }
+  def withExternalDependencyJars(externalDependencyJars: Vector[String]): CompileConfig = {
+    copy(externalDependencyJars = externalDependencyJars)
+  }
+  def withOutput(output: java.net.URI): CompileConfig = {
+    copy(output = output)
+  }
+  def withAnalysisFile(analysisFile: java.net.URI): CompileConfig = {
+    copy(analysisFile = analysisFile)
+  }
+  def withEarlyJarPath(earlyJarPath: Option[java.net.URI]): CompileConfig = {
+    copy(earlyJarPath = earlyJarPath)
+  }
+  def withEarlyJarPath(earlyJarPath: java.net.URI): CompileConfig = {
+    copy(earlyJarPath = Option(earlyJarPath))
+  }
+  def withScalacOptions(scalacOptions: Vector[String]): CompileConfig = {
+    copy(scalacOptions = scalacOptions)
+  }
+  def withJavacOptions(javacOptions: Vector[String]): CompileConfig = {
+    copy(javacOptions = javacOptions)
+  }
+  def withMaxErrors(maxErrors: Int): CompileConfig = {
+    copy(maxErrors = maxErrors)
+  }
+  def withAnalysisMap(analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = {
+    copy(analysisMap = analysisMap)
+  }
+}
+object CompileConfig {
+  
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileResponse.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileResponse.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class CompileResponse private (
+  val hasModified: Boolean) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: CompileResponse => (this.hasModified == x.hasModified)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.worker.CompileResponse".##) + hasModified.##)
+  }
+  override def toString: String = {
+    "CompileResponse(" + hasModified + ")"
+  }
+  private def copy(hasModified: Boolean): CompileResponse = {
+    new CompileResponse(hasModified)
+  }
+  def withHasModified(hasModified: Boolean): CompileResponse = {
+    copy(hasModified = hasModified)
+  }
+}
+object CompileResponse {
+  
+  def apply(hasModified: Boolean): CompileResponse = new CompileResponse(hasModified)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/FileConverterConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/FileConverterConfig.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class FileConverterConfig private (
+  val rootPaths: Vector[sbt.internal.worker.StringURI]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: FileConverterConfig => (this.rootPaths == x.rootPaths)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.worker.FileConverterConfig".##) + rootPaths.##)
+  }
+  override def toString: String = {
+    "FileConverterConfig(" + rootPaths + ")"
+  }
+  private def copy(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = {
+    new FileConverterConfig(rootPaths)
+  }
+  def withRootPaths(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = {
+    copy(rootPaths = rootPaths)
+  }
+}
+object FileConverterConfig {
+  
+  def apply(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = new FileConverterConfig(rootPaths)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/HVFRURI.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/HVFRURI.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class HVFRURI private (
+  val name: xsbti.HashedVirtualFileRef,
+  val value: java.net.URI) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: HVFRURI => (this.name == x.name) && (this.value == x.value)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.worker.HVFRURI".##) + name.##) + value.##)
+  }
+  override def toString: String = {
+    "HVFRURI(" + name + ", " + value + ")"
+  }
+  private def copy(name: xsbti.HashedVirtualFileRef = name, value: java.net.URI = value): HVFRURI = {
+    new HVFRURI(name, value)
+  }
+  def withName(name: xsbti.HashedVirtualFileRef): HVFRURI = {
+    copy(name = name)
+  }
+  def withValue(value: java.net.URI): HVFRURI = {
+    copy(value = value)
+  }
+}
+object HVFRURI {
+  
+  def apply(name: xsbti.HashedVirtualFileRef, value: java.net.URI): HVFRURI = new HVFRURI(name, value)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/ScalaInstanceConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/ScalaInstanceConfig.scala
@@ -1,0 +1,45 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class ScalaInstanceConfig private (
+  val scalaVersion: String,
+  val libraryJars: Vector[java.net.URI],
+  val allCompilerJars: Vector[java.net.URI],
+  val extraToolJars: Vector[java.net.URI]) extends Serializable {
+  
+  private def this(scalaVersion: String, libraryJars: Vector[java.net.URI], allCompilerJars: Vector[java.net.URI]) = this(scalaVersion, libraryJars, allCompilerJars, Vector())
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: ScalaInstanceConfig => (this.scalaVersion == x.scalaVersion) && (this.libraryJars == x.libraryJars) && (this.allCompilerJars == x.allCompilerJars) && (this.extraToolJars == x.extraToolJars)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.ScalaInstanceConfig".##) + scalaVersion.##) + libraryJars.##) + allCompilerJars.##) + extraToolJars.##)
+  }
+  override def toString: String = {
+    "ScalaInstanceConfig(" + scalaVersion + ", " + libraryJars + ", " + allCompilerJars + ", " + extraToolJars + ")"
+  }
+  private def copy(scalaVersion: String = scalaVersion, libraryJars: Vector[java.net.URI] = libraryJars, allCompilerJars: Vector[java.net.URI] = allCompilerJars, extraToolJars: Vector[java.net.URI] = extraToolJars): ScalaInstanceConfig = {
+    new ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, extraToolJars)
+  }
+  def withScalaVersion(scalaVersion: String): ScalaInstanceConfig = {
+    copy(scalaVersion = scalaVersion)
+  }
+  def withLibraryJars(libraryJars: Vector[java.net.URI]): ScalaInstanceConfig = {
+    copy(libraryJars = libraryJars)
+  }
+  def withAllCompilerJars(allCompilerJars: Vector[java.net.URI]): ScalaInstanceConfig = {
+    copy(allCompilerJars = allCompilerJars)
+  }
+  def withExtraToolJars(extraToolJars: Vector[java.net.URI]): ScalaInstanceConfig = {
+    copy(extraToolJars = extraToolJars)
+  }
+}
+object ScalaInstanceConfig {
+  
+  def apply(scalaVersion: String, libraryJars: Vector[java.net.URI], allCompilerJars: Vector[java.net.URI]): ScalaInstanceConfig = new ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars)
+  def apply(scalaVersion: String, libraryJars: Vector[java.net.URI], allCompilerJars: Vector[java.net.URI], extraToolJars: Vector[java.net.URI]): ScalaInstanceConfig = new ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, extraToolJars)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/StringURI.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/StringURI.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class StringURI private (
+  val name: String,
+  val value: java.net.URI) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: StringURI => (this.name == x.name) && (this.value == x.value)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.worker.StringURI".##) + name.##) + value.##)
+  }
+  override def toString: String = {
+    "StringURI(" + name + ", " + value + ")"
+  }
+  private def copy(name: String = name, value: java.net.URI = value): StringURI = {
+    new StringURI(name, value)
+  }
+  def withName(name: String): StringURI = {
+    copy(name = name)
+  }
+  def withValue(value: java.net.URI): StringURI = {
+    copy(value = value)
+  }
+}
+object StringURI {
+  
+  def apply(name: String, value: java.net.URI): StringURI = new StringURI(name, value)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
@@ -1,0 +1,49 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait CompileConfigFormats { self: sbt.internal.worker.codec.FileConverterConfigFormats & sbt.internal.worker.codec.StringURIFormats & sjsonnew.BasicJsonProtocol & sbt.internal.worker.codec.ScalaInstanceConfigFormats & sbt.internal.worker.codec.HVFRURIFormats & sbt.internal.util.codec.HashedVirtualFileRefFormats =>
+given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new JsonFormat[sbt.internal.worker.CompileConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.CompileConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val fileConverterConfig = unbuilder.readField[sbt.internal.worker.FileConverterConfig]("fileConverterConfig")
+      val scalaInstanceConfig = unbuilder.readField[sbt.internal.worker.ScalaInstanceConfig]("scalaInstanceConfig")
+      val bridgeJars = unbuilder.readField[Vector[java.net.URI]]("bridgeJars")
+      val sources = unbuilder.readField[Vector[String]]("sources")
+      val externalDependencyJars = unbuilder.readField[Vector[String]]("externalDependencyJars")
+      val output = unbuilder.readField[java.net.URI]("output")
+      val analysisFile = unbuilder.readField[java.net.URI]("analysisFile")
+      val earlyJarPath = unbuilder.readField[Option[java.net.URI]]("earlyJarPath")
+      val scalacOptions = unbuilder.readField[Vector[String]]("scalacOptions")
+      val javacOptions = unbuilder.readField[Vector[String]]("javacOptions")
+      val maxErrors = unbuilder.readField[Int]("maxErrors")
+      val analysisMap = unbuilder.readField[Vector[sbt.internal.worker.HVFRURI]]("analysisMap")
+      unbuilder.endObject()
+      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.CompileConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("fileConverterConfig", obj.fileConverterConfig)
+    builder.addField("scalaInstanceConfig", obj.scalaInstanceConfig)
+    builder.addField("bridgeJars", obj.bridgeJars)
+    builder.addField("sources", obj.sources)
+    builder.addField("externalDependencyJars", obj.externalDependencyJars)
+    builder.addField("output", obj.output)
+    builder.addField("analysisFile", obj.analysisFile)
+    builder.addField("earlyJarPath", obj.earlyJarPath)
+    builder.addField("scalacOptions", obj.scalacOptions)
+    builder.addField("javacOptions", obj.javacOptions)
+    builder.addField("maxErrors", obj.maxErrors)
+    builder.addField("analysisMap", obj.analysisMap)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileResponseFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileResponseFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait CompileResponseFormats { self: sjsonnew.BasicJsonProtocol =>
+given CompileResponseFormat: JsonFormat[sbt.internal.worker.CompileResponse] = new JsonFormat[sbt.internal.worker.CompileResponse] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.CompileResponse = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val hasModified = unbuilder.readField[Boolean]("hasModified")
+      unbuilder.endObject()
+      sbt.internal.worker.CompileResponse(hasModified)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.CompileResponse, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("hasModified", obj.hasModified)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FileConverterConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FileConverterConfigFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait FileConverterConfigFormats { self: sbt.internal.worker.codec.StringURIFormats & sjsonnew.BasicJsonProtocol =>
+given FileConverterConfigFormat: JsonFormat[sbt.internal.worker.FileConverterConfig] = new JsonFormat[sbt.internal.worker.FileConverterConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.FileConverterConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val rootPaths = unbuilder.readField[Vector[sbt.internal.worker.StringURI]]("rootPaths")
+      unbuilder.endObject()
+      sbt.internal.worker.FileConverterConfig(rootPaths)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.FileConverterConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("rootPaths", obj.rootPaths)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/HVFRURIFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/HVFRURIFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait HVFRURIFormats { self: sbt.internal.util.codec.HashedVirtualFileRefFormats & sjsonnew.BasicJsonProtocol =>
+given HVFRURIFormat: JsonFormat[sbt.internal.worker.HVFRURI] = new JsonFormat[sbt.internal.worker.HVFRURI] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.HVFRURI = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val name = unbuilder.readField[xsbti.HashedVirtualFileRef]("name")
+      val value = unbuilder.readField[java.net.URI]("value")
+      unbuilder.endObject()
+      sbt.internal.worker.HVFRURI(name, value)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.HVFRURI, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("name", obj.name)
+    builder.addField("value", obj.value)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
@@ -10,4 +10,11 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.worker.codec.NativeRunInfoFormats
   with sbt.internal.worker.codec.RunInfoFormats
   with sbt.internal.worker.codec.ClientJobParamsFormats
+  with sbt.internal.worker.codec.ScalaInstanceConfigFormats
+  with sbt.internal.worker.codec.StringURIFormats
+  with sbt.internal.worker.codec.FileConverterConfigFormats
+  with sbt.internal.util.codec.HashedVirtualFileRefFormats
+  with sbt.internal.worker.codec.HVFRURIFormats
+  with sbt.internal.worker.codec.CompileConfigFormats
+  with sbt.internal.worker.codec.CompileResponseFormats
 object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ScalaInstanceConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/ScalaInstanceConfigFormats.scala
@@ -1,0 +1,33 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait ScalaInstanceConfigFormats { self: sjsonnew.BasicJsonProtocol =>
+given ScalaInstanceConfigFormat: JsonFormat[sbt.internal.worker.ScalaInstanceConfig] = new JsonFormat[sbt.internal.worker.ScalaInstanceConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.ScalaInstanceConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val scalaVersion = unbuilder.readField[String]("scalaVersion")
+      val libraryJars = unbuilder.readField[Vector[java.net.URI]]("libraryJars")
+      val allCompilerJars = unbuilder.readField[Vector[java.net.URI]]("allCompilerJars")
+      val extraToolJars = unbuilder.readField[Vector[java.net.URI]]("extraToolJars")
+      unbuilder.endObject()
+      sbt.internal.worker.ScalaInstanceConfig(scalaVersion, libraryJars, allCompilerJars, extraToolJars)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.ScalaInstanceConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("scalaVersion", obj.scalaVersion)
+    builder.addField("libraryJars", obj.libraryJars)
+    builder.addField("allCompilerJars", obj.allCompilerJars)
+    builder.addField("extraToolJars", obj.extraToolJars)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/StringURIFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/StringURIFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait StringURIFormats { self: sjsonnew.BasicJsonProtocol =>
+given StringURIFormat: JsonFormat[sbt.internal.worker.StringURI] = new JsonFormat[sbt.internal.worker.StringURI] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.StringURI = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val name = unbuilder.readField[String]("name")
+      val value = unbuilder.readField[java.net.URI]("value")
+      unbuilder.endObject()
+      sbt.internal.worker.StringURI(name, value)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.StringURI, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("name", obj.name)
+    builder.addField("value", obj.value)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -50,3 +50,43 @@ type RunInfo {
 type ClientJobParams {
   runInfo: sbt.internal.worker.RunInfo
 }
+
+type ScalaInstanceConfig {
+  scalaVersion: String!
+  libraryJars: [java.net.URI],
+  allCompilerJars: [java.net.URI],
+  extraToolJars: [java.net.URI] @since("0.1.0"),
+}
+
+type StringURI {
+  name: String!
+  value: java.net.URI!
+}
+
+type FileConverterConfig {
+  rootPaths: [sbt.internal.worker.StringURI]
+}
+
+type HVFRURI {
+  name: xsbti.HashedVirtualFileRef!
+  value: java.net.URI!
+}
+
+type CompileConfig {
+  fileConverterConfig: sbt.internal.worker.FileConverterConfig!
+  scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig!
+  bridgeJars: [java.net.URI]
+  sources: [String]
+  externalDependencyJars: [String]
+  output: java.net.URI!
+  analysisFile: java.net.URI!
+  earlyJarPath: java.net.URI
+  scalacOptions: [String]
+  javacOptions: [String]
+  maxErrors: Int!
+  analysisMap: [sbt.internal.worker.HVFRURI]
+}
+
+type CompileResponse {
+  hasModified: Boolean!
+}

--- a/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
@@ -1,0 +1,5 @@
+name := "hello"
+scalaVersion := "3.7.4"
+// jdkVersion := Some("zulu@25")
+Compile / fork := true
+Test / fork := true

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/A1.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/A1.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  final val x = 1

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/A2.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/A2.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  final val x = 2

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/B.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/B.scala
@@ -1,0 +1,6 @@
+package example
+
+@main
+def hello(args: String*): Unit =
+  println("hello")
+  assert(args(0).toInt == A.x)

--- a/sbt-app/src/sbt-test/source-dependencies/fork/test
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/test
@@ -1,0 +1,11 @@
+$ copy-file changes/B.scala B.scala
+
+-> compile
+
+$ copy-file changes/A1.scala A.scala
+
+> run 1
+
+$ copy-file changes/A2.scala A.scala
+
+> run 2

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -131,6 +131,10 @@ public final class WorkerMain {
           TestInfo testInfo = g.fromJson(params, TestInfo.class);
           test(id, testInfo);
           break;
+        case "compile":
+          RunInfo r1 = g.fromJson(params, RunInfo.class);
+          compile(r1, id);
+          return;
         case "bye":
           break;
       }
@@ -159,6 +163,25 @@ public final class WorkerMain {
         Method mainMethod = mainClass.getMethod("main", String[].class);
         String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
         mainMethod.invoke(null, (Object) mainArgs);
+      }
+    } else {
+      throw new RuntimeException("only jvm is supported");
+    }
+  }
+
+  // This is similar to the run(...) method except for passing the printstream.
+  void compile(RunInfo info, long id) throws Exception {
+    if (info.jvm) {
+      if (info.jvmRunInfo == null) {
+        throw new RuntimeException("missing jvmRunInfo element");
+      }
+      RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
+      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
+        Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
+        Method mainMethod =
+            mainClass.getMethod("main", String[].class, Long.class, PrintStream.class);
+        String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
+        mainMethod.invoke(null, (Object) mainArgs, (Object) id, (Object) jsonOut);
       }
     } else {
       throw new RuntimeException("only jvm is supported");

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -8,6 +8,22 @@
 
 package sbt.internal.worker1;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.stream.Collectors;
 import org.scalasbt.shadedgson.com.google.gson.Gson;
 import org.scalasbt.shadedgson.com.google.gson.GsonBuilder;
 import org.scalasbt.shadedgson.com.google.gson.JsonElement;
@@ -15,18 +31,6 @@ import org.scalasbt.shadedgson.com.google.gson.JsonObject;
 import org.scalasbt.shadedgson.com.google.gson.JsonParser;
 import org.scalasbt.shadedgson.com.google.gson.JsonPrimitive;
 import org.scalasbt.shadedgson.com.google.gson.typeadapters.RuntimeTypeAdapterFactory;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.net.InetAddress;
-import java.net.Socket;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Scanner;
 import sbt.testing.*;
 
 /**
@@ -201,9 +205,20 @@ public final class WorkerMain {
   }
 
   private URLClassLoader createClassLoader(RunInfo.JvmRunInfo info, ClassLoader parent) {
-    URL[] urls =
+    Map<Boolean, List<FilePath>> groups =
         info.classpath
             .stream()
+            .collect(
+                Collectors.partitioningBy(
+                    filePath ->
+                        Paths.get(filePath.path)
+                            .getFileName()
+                            .toString()
+                            .startsWith("compiler-interface")));
+    List<FilePath> xs0 = groups.get(true);
+    List<FilePath> xs1 = groups.get(false);
+    URL[] us1 =
+        xs1.stream()
             .map(
                 filePath -> {
                   try {
@@ -213,6 +228,21 @@ public final class WorkerMain {
                   }
                 })
             .toArray(URL[]::new);
-    return new URLClassLoader(urls, parent);
+    if (!xs0.equals(null) && xs0.size() >= 1) {
+      URL[] us0 =
+          xs0.stream()
+              .map(
+                  filePath -> {
+                    try {
+                      return filePath.path.toURL();
+                    } catch (MalformedURLException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .toArray(URL[]::new);
+      return new URLClassLoader(us1, new URLClassLoader(us0, parent));
+    } else {
+      return new URLClassLoader(us1, parent);
+    }
   }
 }

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -65,6 +65,24 @@ object ZincLmUtil {
     )
   }
 
+  def scalaCompilerBridgeJars(
+      scalaInstance: XScalaInstance,
+      globalLock: GlobalLock,
+      componentProvider: ComponentProvider,
+      secondaryCacheDir: Option[File],
+      dependencyResolution: DependencyResolution,
+      compilerBridgeSource: ModuleID,
+      scalaJarsTarget: File,
+      log: Logger
+  ): Seq[File] =
+    val compilerBridgeProvider = ZincComponentCompiler.interfaceProvider(
+      compilerBridgeSource,
+      new ZincComponentManager(globalLock, componentProvider, secondaryCacheDir, log),
+      dependencyResolution,
+      scalaJarsTarget,
+    )
+    compilerBridgeProvider.fetchCompiledBridge(scalaInstance, log) :: Nil
+
   def fetchDefaultBridgeModule(
       scalaVersion: String,
       dependencyResolution: DependencyResolution,


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/887

## Problem
Currently Zinc runs in the same process as the sbt server, which means that the JDK/Java version of the build artifact gets tied to the JDK/Java version used by sbt itself.

## Solution
This implements a command-line interface for Zinc, which can be invoked via the worker process.

1. This can be used to compile using JDK 25, if Zinc works on JDK 25.
2. When we upgrade to JDK 17, we can downgrade the compilation to use the real JDK 8, if Zinc itself it compiled with `--release 8`.