### PR TITLE
Implementing Scala.latestRC

### DIFF
--- a/main/src/main/scala/sbt/Scala.scala
+++ b/main/src/main/scala/sbt/Scala.scala
@@ -1,0 +1,87 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import java.net.{ HttpURLConnection, URL }
+import scala.util.control.NonFatal
+import scala.util.Using
+import scala.xml.XML
+
+object Scala:
+  private val MavenMetadataUrl =
+    "https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/maven-metadata.xml"
+  private val RCPattern = """3\.\d+\.\d+-RC\d+""".r
+
+  /**
+   * Returns the latest Scala 3 Release Candidate version available on Maven Central.
+   *
+   * This method fetches version information from Maven Central and returns the latest
+   * RC version matching the pattern `3.x.x-RC*`.
+   *
+   * @example
+   * {{{
+   * ThisBuild / scalaVersion := Scala.latestRC
+   * }}}
+   *
+   * @throws RuntimeException if the latest RC version cannot be fetched
+   * @return the latest Scala 3 RC version string (e.g., "3.8.1-RC1")
+   */
+  def latestRC: String =
+    fetchLatestRC.getOrElse:
+      sys.error(
+        "Failed to fetch latest Scala 3 RC version. Please specify an explicit version or check your internet connection."
+      )
+
+  private def fetchLatestRC: Option[String] =
+    try
+      val url = URL(MavenMetadataUrl)
+      val connection = url.openConnection.asInstanceOf[HttpURLConnection]
+      connection.setRequestMethod("GET")
+      connection.setConnectTimeout(5000)
+      connection.setReadTimeout(5000)
+
+      if connection.getResponseCode == HttpURLConnection.HTTP_OK then
+        Using.resource(connection.getInputStream): stream =>
+          val xml = XML.load(stream)
+          parseVersionsFromXml(xml)
+      else None
+    catch
+      case NonFatal(_) => None
+
+  private def parseVersionsFromXml(xml: scala.xml.Elem): Option[String] =
+    val versions = (xml \ "versioning" \ "versions" \ "version")
+      .map(_.text)
+      .filter(RCPattern.matches)
+      .toSeq
+    if versions.nonEmpty then
+      val sorted = versions.sortWith(compareVersions)
+      Some(sorted.last)
+    else None
+
+  private def compareVersions(v1: String, v2: String): Boolean =
+    val parts1 = parseVersionParts(v1)
+    val parts2 = parseVersionParts(v2)
+    compareVersionParts(parts1, parts2) < 0
+
+  private def parseVersionParts(version: String): (Int, Int, Int, Int) =
+    val pattern = """3\.(\d+)\.(\d+)-RC(\d+)""".r
+    version match
+      case pattern(major, minor, rc) =>
+        (major.toInt, minor.toInt, rc.toInt, 0)
+      case _ => (0, 0, 0, 0)
+
+  private def compareVersionParts(
+      v1: (Int, Int, Int, Int),
+      v2: (Int, Int, Int, Int)
+  ): Int =
+    if v1._1 != v2._1 then v1._1.compareTo(v2._1)
+    else if v1._2 != v2._2 then v1._2.compareTo(v2._2)
+    else if v1._3 != v2._3 then v1._3.compareTo(v2._3)
+    else v1._4.compareTo(v2._4)
+end Scala

--- a/main/src/main/scala/sbt/Scala.scala
+++ b/main/src/main/scala/sbt/Scala.scala
@@ -14,31 +14,34 @@ import scala.util.Using
 import scala.xml.XML
 
 object Scala:
+  private val ScalaNightliesBaseUrl = "https://repo.scala-lang.org/artifactory/maven-nightlies"
   private val MavenMetadataUrl =
-    "https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/maven-metadata.xml"
+    s"$ScalaNightliesBaseUrl/org/scala-lang/scala3-library_3/maven-metadata.xml"
   private val RCPattern = """3\.\d+\.\d+-RC\d+""".r
+  private val NightlyPattern = """3\.\d+\.\d+.*-NIGHTLY""".r
 
   /**
-   * Returns the latest Scala 3 Release Candidate version available on Maven Central.
+   * Returns the latest Scala 3 Release Candidate version available from the Scala nightlies repository.
    *
-   * This method fetches version information from Maven Central and returns the latest
+   * This method fetches version information from repo.scala-lang.org and returns the latest
    * RC version matching the pattern `3.x.x-RC*`.
    *
    * @example
    * {{{
    * ThisBuild / scalaVersion := Scala.latestRC
+   * ThisBuild / resolvers += Resolver.scalaNightlyRepository
    * }}}
    *
    * @throws RuntimeException if the latest RC version cannot be fetched
    * @return the latest Scala 3 RC version string (e.g., "3.8.1-RC1")
    */
   def latestRC: String =
-    fetchLatestRC.getOrElse:
+    fetchLatestVersion(RCPattern, "RC").getOrElse:
       sys.error(
         "Failed to fetch latest Scala 3 RC version. Please specify an explicit version or check your internet connection."
       )
 
-  private def fetchLatestRC: Option[String] =
+  private def fetchLatestVersion(pattern: scala.util.matching.Regex, versionType: String): Option[String] =
     try
       val url = URL(MavenMetadataUrl)
       val connection = url.openConnection.asInstanceOf[HttpURLConnection]
@@ -49,15 +52,15 @@ object Scala:
       if connection.getResponseCode == HttpURLConnection.HTTP_OK then
         Using.resource(connection.getInputStream): stream =>
           val xml = XML.load(stream)
-          parseVersionsFromXml(xml)
+          parseVersionsFromXml(xml, pattern)
       else None
     catch
       case NonFatal(_) => None
 
-  private def parseVersionsFromXml(xml: scala.xml.Elem): Option[String] =
+  private def parseVersionsFromXml(xml: scala.xml.Elem, pattern: scala.util.matching.Regex): Option[String] =
     val versions = (xml \ "versioning" \ "versions" \ "version")
       .map(_.text)
-      .filter(RCPattern.matches)
+      .filter(pattern.matches)
       .toSeq
     if versions.nonEmpty then
       val sorted = versions.sortWith(compareVersions)
@@ -70,10 +73,13 @@ object Scala:
     compareVersionParts(parts1, parts2) < 0
 
   private def parseVersionParts(version: String): (Int, Int, Int, Int) =
-    val pattern = """3\.(\d+)\.(\d+)-RC(\d+)""".r
+    val rcPattern = """3\.(\d+)\.(\d+)-RC(\d+)""".r
+    val nightlyPattern = """3\.(\d+)\.(\d+).*-NIGHTLY""".r
     version match
-      case pattern(major, minor, rc) =>
+      case rcPattern(major, minor, rc) =>
         (major.toInt, minor.toInt, rc.toInt, 0)
+      case nightlyPattern(major, minor) =>
+        (major.toInt, minor.toInt, Int.MaxValue, 0)
       case _ => (0, 0, 0, 0)
 
   private def compareVersionParts(

--- a/main/src/test/scala/sbt/ScalaTest.scala
+++ b/main/src/test/scala/sbt/ScalaTest.scala
@@ -1,0 +1,97 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import scala.xml.XML
+import verify.BasicTestSuite
+
+object ScalaTest extends BasicTestSuite:
+
+  test("parseVersionsFromXml should extract RC versions from Maven metadata") {
+    val xmlContent = """<?xml version="1.0" encoding="UTF-8"?>
+      <metadata>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala3-library_3</artifactId>
+        <versioning>
+          <versions>
+            <version>3.8.0</version>
+            <version>3.8.0-RC1</version>
+            <version>3.8.0-RC2</version>
+            <version>3.8.1-RC1</version>
+            <version>3.8.1</version>
+          </versions>
+        </versioning>
+      </metadata>"""
+    val xml = XML.loadString(xmlContent)
+    val result = ScalaTestHelper.parseVersionsFromXml(xml)
+    assert(result.contains("3.8.1-RC1"))
+    val versions = result.toSeq
+    assert(versions.contains("3.8.0-RC1"))
+    assert(versions.contains("3.8.0-RC2"))
+    assert(versions.contains("3.8.1-RC1"))
+    assert(!versions.contains("3.8.0"))
+    assert(!versions.contains("3.8.1"))
+  }
+
+  test("compareVersions should correctly order RC versions") {
+    assert(ScalaTestHelper.compareVersions("3.8.0-RC1", "3.8.0-RC2"))
+    assert(ScalaTestHelper.compareVersions("3.8.0-RC2", "3.8.1-RC1"))
+    assert(ScalaTestHelper.compareVersions("3.7.4-RC1", "3.8.0-RC1"))
+    assert(!ScalaTestHelper.compareVersions("3.8.1-RC1", "3.8.0-RC2"))
+  }
+
+  test("parseVersionParts should correctly parse RC version strings") {
+    val (major, minor, rc, _) = ScalaTestHelper.parseVersionParts("3.8.1-RC2")
+    assert(major == 3)
+    assert(minor == 8)
+    assert(rc == 2)
+  }
+
+  test("parseVersionParts should handle invalid version strings") {
+    val (major, minor, rc, _) = ScalaTestHelper.parseVersionParts("invalid")
+    assert(major == 0)
+    assert(minor == 0)
+    assert(rc == 0)
+  }
+end ScalaTest
+
+object ScalaTestHelper:
+  import scala.xml.Elem
+  private val RCPattern = """3\.\d+\.\d+-RC\d+""".r
+
+  def parseVersionsFromXml(xml: Elem): Option[String] =
+    val versions = (xml \ "versioning" \ "versions" \ "version")
+      .map(_.text)
+      .filter(RCPattern.matches)
+      .toSeq
+    if versions.nonEmpty then
+      val sorted = versions.sortWith(compareVersions)
+      Some(sorted.last)
+    else None
+
+  def compareVersions(v1: String, v2: String): Boolean =
+    val parts1 = parseVersionParts(v1)
+    val parts2 = parseVersionParts(v2)
+    compareVersionParts(parts1, parts2) < 0
+
+  def parseVersionParts(version: String): (Int, Int, Int, Int) =
+    val pattern = """3\.(\d+)\.(\d+)-RC(\d+)""".r
+    version match
+      case pattern(major, minor, rc) =>
+        (major.toInt, minor.toInt, rc.toInt, 0)
+      case _ => (0, 0, 0, 0)
+
+  private def compareVersionParts(
+      v1: (Int, Int, Int, Int),
+      v2: (Int, Int, Int, Int)
+  ): Int =
+    if v1._1 != v2._1 then v1._1.compareTo(v2._1)
+    else if v1._2 != v2._2 then v1._2.compareTo(v2._2)
+    else if v1._3 != v2._3 then v1._3.compareTo(v2._3)
+    else v1._4.compareTo(v2._4)


### PR DESCRIPTION
Implemented Scala.latestRC that automatically fetches the latest Scala 3 RC version from Maven Central, allowing users to easily
test against the newest compiler changes.

- Add Scala object with latestRC method
- Fetch versions from Maven Central metadata XML
- Add unit tests for version parsing and comparison
- Include ScalaDoc documentation

#8587