### PR TITLE
[2.x] test: Add scripted test for #6175

### DIFF
--- a/sbt-app/src/sbt-test/java/method-handle-release/build.sbt
+++ b/sbt-app/src/sbt-test/java/method-handle-release/build.sbt
@@ -1,0 +1,2 @@
+ThisBuild / scalaVersion := "2.13.16"
+scalacOptions += "-release:11"

--- a/sbt-app/src/sbt-test/java/method-handle-release/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/java/method-handle-release/src/main/scala/Main.scala
@@ -1,0 +1,19 @@
+import java.lang.invoke.{ MethodHandle, MethodHandles }
+
+object Main {
+  case class TestClass(number: Int)
+  def testMethod(): TestClass = {
+    TestClass(10)
+  }
+
+  def wrappedMethod(handle: MethodHandle): TestClass = {
+    handle.invokeExact()
+  }
+
+  def main(args: Array[String]): Unit = {
+    val method = classOf[Main.type].getDeclaredMethod("testMethod")
+    method.setAccessible(true)
+    val handle = MethodHandles.lookup.unreflect(method)
+    println(wrappedMethod(handle))
+  }
+}

--- a/sbt-app/src/sbt-test/java/method-handle-release/test
+++ b/sbt-app/src/sbt-test/java/method-handle-release/test
@@ -1,0 +1,3 @@
+# https://github.com/sbt/sbt/issues/6175
+# MethodHandle.invokeExact fails to compile on JDK 15+ when targeting Java 11
+> compile


### PR DESCRIPTION
This PR adds a scripted test to prevent regression of issue #6175, where `MethodHandle.invokeExact` failed to compile on JDK 15+ when using `-release 11`.

#### Changes:
- Added `sbt-app/src/sbt-test/java/method-handle-release/` scripted test
- Test uses Scala 2.13.16 with `-release:11` to reproduce the original issue scenario
- Verifies that polymorphic signature methods compile correctly under cross-version targeting

#### Testing:
- Run `sbt "scripted java/method-handle-release"` to verify the test passes
- Test runs in CI jobtype 3 on JDK 25

Fixes #6175