### PR TITLE
[2.x] fix: Race condition in WorkerExchangeTest.propBye

### DIFF
--- a/main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala
@@ -41,6 +41,7 @@ object WorkerExchangeTest extends Properties:
     yield withListener: l =>
       w.println(s"""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": $i}""")
       val exitCode = w.blockForExitCode()
+      l.awaitResponse()
       Result
         .assert(exitCode == 0)
         .and(Result.assert(l.sb.toString() == s"""{ "jsonrpc": "2.0", "result": 0, "id": $i }"""))
@@ -54,7 +55,12 @@ object WorkerExchangeTest extends Properties:
     finally WorkerExchange.unregisterListener(l)
 
   class ConcreteListener extends WorkerResponseListener:
+    import java.util.concurrent.{ CountDownLatch, TimeUnit }
     val sb = StringBuilder()
+    private val latch = CountDownLatch(1)
     def notifyExit(p: Process): Unit = ()
-    def apply(line: String): Unit = sb.append(line)
+    def apply(line: String): Unit =
+      sb.append(line)
+      latch.countDown()
+    def awaitResponse(): Unit = latch.await(30, TimeUnit.SECONDS)
 end WorkerExchangeTest


### PR DESCRIPTION
## Summary
- Fix flaky test `bye should return response json with a result` in WorkerExchangeTest
- Root cause: race condition between process exit and async response delivery
- Solution: use CountDownLatch to wait for the listener to receive the response

## Test plan
- [x] Verified with originally failing seed: `HEDGEHOG_SEED=323644772289`
- [x] Ran test 10 times (100 iterations) without failures
- [x] Full `actionsProj/test` suite passes

Fixes #8605