### PR TITLE
[2.x] feat: testOnly as a command

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -149,7 +149,9 @@ object Defaults extends BuildCommon {
       )
     )
   private[sbt] lazy val globalCore: Seq[Setting[?]] = globalDefaults(
-    defaultTestTasks(test) ++ defaultTestTasks(testOnly) ++ defaultTestTasks(testQuick) ++ Seq(
+    defaultTestTasks(test) ++ defaultTestTasks(testOnly) ++ defaultTestTasks(
+      testSelected
+    ) ++ defaultTestTasks(testQuick) ++ Seq(
       excludeFilter :== HiddenFileFilter,
       fileInputs :== Nil,
       fileInputIncludeFilter :== AllPassFilter.toNio,
@@ -1129,12 +1131,14 @@ object Defaults extends BuildCommon {
         testOptionDigests :== Nil,
         testResultLogger :== TestResultLogger.Default,
         testOnly / testFilter :== (IncrementalTest.selectedFilter),
+        testSelected / testFilter :== (IncrementalTest.selectedFilter),
         extraTestDigests :== Nil,
       )
     )
   lazy val testTasks: Seq[Setting[?]] = Def.settings(
     testTaskOptions(test),
     testTaskOptions(testOnly),
+    testTaskOptions(testSelected),
     testTaskOptions(testQuick),
     testDefaults,
     testLoader := Def.uncached(ClassLoaders.testTask.value),
@@ -1184,8 +1188,12 @@ object Defaults extends BuildCommon {
         output.overall
       finally close(testLoader.value)
     },
+    testSelected := {
+      try inputTests(testSelected).evaluated
+      finally close(testLoader.value)
+    },
     testOnly := {
-      try inputTests(testOnly).evaluated
+      try inputTests(testSelected).evaluated
       finally close(testLoader.value)
     },
     testQuick := {

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -363,6 +363,7 @@ object Keys {
   val test = inputKey[TestResult]("Executes the tests that either failed before, were not run or whose transitive dependencies changed, among those provided as arguments.").withRank(ATask)
   val testFull = taskKey[TestResult]("Executes all tests.").withRank(APlusTask)
   val testOnly = inputKey[TestResult]("Executes the tests provided as arguments or all tests if no arguments are provided.").withRank(ATask)
+  val testSelected = inputKey[TestResult]("Executes the tests provided as arguments or all tests if no arguments are provided. Used internally by testOnly command.").withRank(BMinusTask)
   val testQuick = inputKey[TestResult]("Alias for test.").withRank(CTask)
   @transient
   val testOptions = taskKey[Seq[TestOption]]("Options for running tests.").withRank(BPlusTask)

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -359,7 +359,7 @@ object BuiltinCommands {
       NetworkChannel.disconnect,
       waitCmd,
       promptChannel,
-      TestCommand.testOnlyCommand,
+      TestCommand.testOnly,
     ) ++
       allBasicCommands ++
       ContinuousCommands.value ++

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -359,6 +359,7 @@ object BuiltinCommands {
       NetworkChannel.disconnect,
       waitCmd,
       promptChannel,
+      TestCommand.testOnlyCommand,
     ) ++
       allBasicCommands ++
       ContinuousCommands.value ++

--- a/main/src/main/scala/sbt/internal/TestCommand.scala
+++ b/main/src/main/scala/sbt/internal/TestCommand.scala
@@ -18,20 +18,19 @@ import sbt.librarymanagement.Configurations.{ Test as TestConfig }
 /**
  * Provides commands for running tests with aggregation-aware failure semantics.
  *
- * When `testOnly` is run with test patterns, it should fail if no tests match
- * the patterns across ALL aggregated subprojects, not just silently pass.
+ * The `testOnly` command fails if no tests match the patterns across ALL
+ * aggregated subprojects, instead of silently passing.
  * See https://github.com/sbt/sbt/issues/3188
  */
 object TestCommand:
-  val TestOnlyCommand = "testOnlyCommand"
+  val TestOnly = "testOnly"
 
   private def testOnlyHelp = Help.more(
-    TestOnlyCommand,
-    """testOnlyCommand <test-pattern>... [-- <framework-options>]
+    TestOnly,
+    """testOnly <test-pattern>... [-- <framework-options>]
       |
-      |Runs tests matching the given patterns. Unlike the testOnly task,
-      |this command will fail if no tests match the patterns across all
-      |aggregated subprojects.
+      |Runs tests matching the given patterns. This command will fail if no
+      |tests match the patterns across all aggregated subprojects.
       |""".stripMargin
   )
 
@@ -43,9 +42,9 @@ object TestCommand:
    * 2. Determines all aggregated subprojects
    * 3. Runs definedTestNames to get all available tests (this also compiles tests)
    * 4. Checks if any tests match the patterns across all subprojects
-   * 5. Fails if no tests match, otherwise runs the normal testOnly task
+   * 5. Fails if no tests match, otherwise runs the testSelected task
    */
-  def testOnlyCommand: Command = Command(TestOnlyCommand, testOnlyHelp)(testOnlyParser)(runTestOnly)
+  def testOnly: Command = Command(TestOnly, testOnlyHelp)(testOnlyParser)(runTestOnly)
 
   /**
    * Parser for testOnly command arguments.
@@ -95,10 +94,10 @@ object TestCommand:
       state.log.error("No project is loaded.")
       state.fail
     else if patterns.isEmpty then
-      // No patterns specified, just run the normal testOnly task
+      // No patterns specified, just run the testSelected task
       val taskStr =
-        if frameworkOptions.isEmpty then "testOnly"
-        else s"testOnly -- ${frameworkOptions.mkString(" ")}"
+        if frameworkOptions.isEmpty then "testSelected"
+        else s"testSelected -- ${frameworkOptions.mkString(" ")}"
       taskStr :: state
     else
       // Get all test names by running definedTestNames (this also compiles)
@@ -119,10 +118,10 @@ object TestCommand:
           newState.log.error(s"  ... and ${allTestNames.size - 20} more")
         newState.fail
       else
-        // Build the testOnly command string
-        val testOnlyArgs =
+        // Build the testSelected task string
+        val testSelectedArgs =
           patterns ++ (if frameworkOptions.nonEmpty then Seq("--") ++ frameworkOptions else Nil)
-        val taskStr = s"testOnly ${testOnlyArgs.mkString(" ")}"
+        val taskStr = s"testSelected ${testSelectedArgs.mkString(" ")}"
         taskStr :: newState
 
 end TestCommand

--- a/main/src/main/scala/sbt/internal/TestCommand.scala
+++ b/main/src/main/scala/sbt/internal/TestCommand.scala
@@ -12,6 +12,7 @@ package internal
 import sbt.Keys.*
 import sbt.ProjectExtra.*
 import sbt.ScopeAxis.{ Select, Zero }
+import sbt.SessionVar
 import sbt.internal.util.complete.Parser
 import sbt.librarymanagement.Configurations.{ Test as TestConfig }
 
@@ -48,13 +49,20 @@ object TestCommand:
 
   /**
    * Parser for testOnly command arguments.
-   * Uses a simple parser since we don't have cached test names available in command context.
+   * Uses the standard testOnly parser with definedTestNames for consistent completion behavior.
    */
   private def testOnlyParser(state: State): Parser[(Seq[String], Seq[String])] =
-    import sbt.internal.util.complete.DefaultParsers.*
-    val selectTests = (token(Space) ~> token(NotSpace.examples("<test-class>"))).+
-    val options = (token(Space) ~> token("--") ~> spaceDelimited("<option>")) ?? Nil
-    selectTests ~ options
+    import Defaults.testOnlyParser as defaultParser
+    val tests = if Project.isProjectLoaded(state) then
+      val extracted = Project.extract(state)
+      val currentRef = extracted.currentRef
+      val scope = Scope(Select(currentRef), Select(ConfigKey(TestConfig.name)), Zero, Zero)
+      val scopedKey = (scope / definedTestNames).scopedKey
+      SessionVar.loadAndSet(scopedKey, state, false) match
+        case (_, Some(names)) => names.toList
+        case _                => Nil
+    else Nil
+    defaultParser(state, tests)
 
   /**
    * Get all test names from all aggregated subprojects by running definedTestNames task.
@@ -100,28 +108,40 @@ object TestCommand:
         else s"testSelected -- ${frameworkOptions.mkString(" ")}"
       taskStr :: state
     else
-      // Get all test names by running definedTestNames (this also compiles)
-      val (newState, allTestNames) = getAllTestNames(state)
-      val filters = IncrementalTest.selectedFilter(patterns)
-      val matchingTests = allTestNames.filter(name => filters.exists(f => f(name)))
+      // Separate include patterns from exclude patterns (prefixed with -)
+      val (excludePatterns, includePatterns) = patterns.partition(_.startsWith("-"))
 
-      if matchingTests.isEmpty then
-        newState.log.error(s"No tests match the patterns: ${patterns.mkString(", ")}")
-        newState.log.error(
-          "The following patterns were specified but no tests were found in any subproject:"
-        )
-        patterns.foreach(p => newState.log.error(s"  - $p"))
-        newState.log.error("")
-        newState.log.error("Available tests:")
-        allTestNames.sorted.take(20).foreach(t => newState.log.error(s"  - $t"))
-        if allTestNames.size > 20 then
-          newState.log.error(s"  ... and ${allTestNames.size - 20} more")
-        newState.fail
+      // Only check for matches if there are include patterns
+      // If only exclude patterns are specified, skip the check (user wants to exclude, not include)
+      if includePatterns.nonEmpty then
+        // Get all test names by running definedTestNames (this also compiles)
+        val (newState, allTestNames) = getAllTestNames(state)
+        val filters = IncrementalTest.selectedFilter(includePatterns)
+        val matchingTests = allTestNames.filter(name => filters.exists(f => f(name)))
+
+        if matchingTests.isEmpty then
+          newState.log.error(s"No tests match the patterns: ${includePatterns.mkString(", ")}")
+          newState.log.error(
+            "The following patterns were specified but no tests were found in any subproject:"
+          )
+          includePatterns.foreach(p => newState.log.error(s"  - $p"))
+          newState.log.error("")
+          newState.log.error("Available tests:")
+          allTestNames.sorted.take(20).foreach(t => newState.log.error(s"  - $t"))
+          if allTestNames.size > 20 then
+            newState.log.error(s"  ... and ${allTestNames.size - 20} more")
+          newState.fail
+        else
+          // Build the testSelected task string
+          val testSelectedArgs =
+            patterns ++ (if frameworkOptions.nonEmpty then Seq("--") ++ frameworkOptions else Nil)
+          val taskStr = s"testSelected ${testSelectedArgs.mkString(" ")}"
+          taskStr :: newState
       else
-        // Build the testSelected task string
+        // Only exclude patterns - just run the task without validation
         val testSelectedArgs =
           patterns ++ (if frameworkOptions.nonEmpty then Seq("--") ++ frameworkOptions else Nil)
         val taskStr = s"testSelected ${testSelectedArgs.mkString(" ")}"
-        taskStr :: newState
+        taskStr :: state
 
 end TestCommand

--- a/main/src/main/scala/sbt/internal/TestCommand.scala
+++ b/main/src/main/scala/sbt/internal/TestCommand.scala
@@ -1,0 +1,128 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import sbt.Keys.*
+import sbt.ProjectExtra.*
+import sbt.ScopeAxis.{ Select, Zero }
+import sbt.internal.util.complete.Parser
+import sbt.librarymanagement.Configurations.{ Test as TestConfig }
+
+/**
+ * Provides commands for running tests with aggregation-aware failure semantics.
+ *
+ * When `testOnly` is run with test patterns, it should fail if no tests match
+ * the patterns across ALL aggregated subprojects, not just silently pass.
+ * See https://github.com/sbt/sbt/issues/3188
+ */
+object TestCommand:
+  val TestOnlyCommand = "testOnlyCommand"
+
+  private def testOnlyHelp = Help.more(
+    TestOnlyCommand,
+    """testOnlyCommand <test-pattern>... [-- <framework-options>]
+      |
+      |Runs tests matching the given patterns. Unlike the testOnly task,
+      |this command will fail if no tests match the patterns across all
+      |aggregated subprojects.
+      |""".stripMargin
+  )
+
+  /**
+   * The testOnly command that fails when no tests match across all subprojects.
+   *
+   * This command:
+   * 1. Parses test patterns and framework options
+   * 2. Determines all aggregated subprojects
+   * 3. Runs definedTestNames to get all available tests (this also compiles tests)
+   * 4. Checks if any tests match the patterns across all subprojects
+   * 5. Fails if no tests match, otherwise runs the normal testOnly task
+   */
+  def testOnlyCommand: Command = Command(TestOnlyCommand, testOnlyHelp)(testOnlyParser)(runTestOnly)
+
+  /**
+   * Parser for testOnly command arguments.
+   * Uses a simple parser since we don't have cached test names available in command context.
+   */
+  private def testOnlyParser(state: State): Parser[(Seq[String], Seq[String])] =
+    import sbt.internal.util.complete.DefaultParsers.*
+    val selectTests = (token(Space) ~> token(NotSpace.examples("<test-class>"))).+
+    val options = (token(Space) ~> token("--") ~> spaceDelimited("<option>")) ?? Nil
+    selectTests ~ options
+
+  /**
+   * Get all test names from all aggregated subprojects by running definedTestNames task.
+   */
+  private def getAllTestNames(state: State): (State, Seq[String]) =
+    if !Project.isProjectLoaded(state) then (state, Nil)
+    else
+      val extracted = Project.extract(state)
+      val currentRef = extracted.currentRef
+      val structure = extracted.structure
+
+      // Get all aggregated project references (including current)
+      val aggregatedProjects = Aggregation.projectAggregates(
+        Some(currentRef),
+        structure.extra,
+        reverse = false
+      ) :+ currentRef
+
+      // Run definedTestNames for each project and collect all test names
+      var currentState = state
+      val allTestNames = aggregatedProjects.flatMap { projRef =>
+        val scope = Scope(Select(projRef), Select(ConfigKey(TestConfig.name)), Zero, Zero)
+        val scopedKey = scope / definedTestNames
+        try
+          val (newState, testNames) = extracted.runTask(scopedKey, currentState)
+          currentState = newState
+          testNames
+        catch case _: Exception => Nil
+      }.distinct
+
+      (currentState, allTestNames)
+
+  private def runTestOnly(state: State, args: (Seq[String], Seq[String])): State =
+    val (patterns, frameworkOptions) = args
+
+    if !Project.isProjectLoaded(state) then
+      state.log.error("No project is loaded.")
+      state.fail
+    else if patterns.isEmpty then
+      // No patterns specified, just run the normal testOnly task
+      val taskStr =
+        if frameworkOptions.isEmpty then "testOnly"
+        else s"testOnly -- ${frameworkOptions.mkString(" ")}"
+      taskStr :: state
+    else
+      // Get all test names by running definedTestNames (this also compiles)
+      val (newState, allTestNames) = getAllTestNames(state)
+      val filters = IncrementalTest.selectedFilter(patterns)
+      val matchingTests = allTestNames.filter(name => filters.exists(f => f(name)))
+
+      if matchingTests.isEmpty then
+        newState.log.error(s"No tests match the patterns: ${patterns.mkString(", ")}")
+        newState.log.error(
+          "The following patterns were specified but no tests were found in any subproject:"
+        )
+        patterns.foreach(p => newState.log.error(s"  - $p"))
+        newState.log.error("")
+        newState.log.error("Available tests:")
+        allTestNames.sorted.take(20).foreach(t => newState.log.error(s"  - $t"))
+        if allTestNames.size > 20 then
+          newState.log.error(s"  ... and ${allTestNames.size - 20} more")
+        newState.fail
+      else
+        // Build the testOnly command string
+        val testOnlyArgs =
+          patterns ++ (if frameworkOptions.nonEmpty then Seq("--") ++ frameworkOptions else Nil)
+        val taskStr = s"testOnly ${testOnlyArgs.mkString(" ")}"
+        taskStr :: newState
+
+end TestCommand

--- a/sbt-app/src/sbt-test/tests/filter-runners/test
+++ b/sbt-app/src/sbt-test/tests/filter-runners/test
@@ -1,2 +1,2 @@
-> testOnly example.MunitSpec example.ScalaTestSpec
-> testOnly example.MunitSpec -- "--tests=munit"
+> testOnly example.Spec example.ScalaTestSpec
+> testOnly example.Spec -- "--tests=munit"

--- a/sbt-app/src/sbt-test/tests/testonly-no-match/build.sbt
+++ b/sbt-app/src/sbt-test/tests/testonly-no-match/build.sbt
@@ -1,0 +1,17 @@
+ThisBuild / scalaVersion := "2.13.16"
+
+lazy val root = (project in file("."))
+  .aggregate(sub1, sub2)
+  .settings(name := "root")
+
+lazy val sub1 = (project in file("sub1"))
+  .settings(
+    name := "sub1",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
+  )
+
+lazy val sub2 = (project in file("sub2"))
+  .settings(
+    name := "sub2",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
+  )

--- a/sbt-app/src/sbt-test/tests/testonly-no-match/sub1/src/test/scala/HelloTest.scala
+++ b/sbt-app/src/sbt-test/tests/testonly-no-match/sub1/src/test/scala/HelloTest.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class HelloTest extends AnyFlatSpec {
+  "Hello" should "say hello" in {
+    assert("hello" == "hello")
+  }
+}

--- a/sbt-app/src/sbt-test/tests/testonly-no-match/sub2/src/test/scala/WorldTest.scala
+++ b/sbt-app/src/sbt-test/tests/testonly-no-match/sub2/src/test/scala/WorldTest.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class WorldTest extends AnyFlatSpec {
+  "World" should "say world" in {
+    assert("world" == "world")
+  }
+}

--- a/sbt-app/src/sbt-test/tests/testonly-no-match/test
+++ b/sbt-app/src/sbt-test/tests/testonly-no-match/test
@@ -1,0 +1,17 @@
+# Test for issue #3188: testOnly should fail when no tests match the pattern
+# https://github.com/sbt/sbt/issues/3188
+
+# Test that testOnlyCommand succeeds when matching tests exist in sub1
+> testOnlyCommand example.HelloTest
+
+# Test that testOnlyCommand succeeds when matching tests exist in sub2
+> testOnlyCommand example.WorldTest
+
+# Test that testOnlyCommand fails when no tests match the pattern
+-> testOnlyCommand NonExistentTest
+
+# Test that testOnlyCommand fails when no tests match a glob pattern
+-> testOnlyCommand *NonExistent*
+
+# The normal testOnly task should still silently pass (backwards compatibility)
+> testOnly NonExistentTest

--- a/sbt-app/src/sbt-test/tests/testonly-no-match/test
+++ b/sbt-app/src/sbt-test/tests/testonly-no-match/test
@@ -1,17 +1,17 @@
 # Test for issue #3188: testOnly should fail when no tests match the pattern
 # https://github.com/sbt/sbt/issues/3188
 
-# Test that testOnlyCommand succeeds when matching tests exist in sub1
-> testOnlyCommand example.HelloTest
+# Test that testOnly succeeds when matching tests exist in sub1
+> testOnly example.HelloTest
 
-# Test that testOnlyCommand succeeds when matching tests exist in sub2
-> testOnlyCommand example.WorldTest
+# Test that testOnly succeeds when matching tests exist in sub2
+> testOnly example.WorldTest
 
-# Test that testOnlyCommand fails when no tests match the pattern
--> testOnlyCommand NonExistentTest
+# Test that testOnly fails when no tests match the pattern
+-> testOnly NonExistentTest
 
-# Test that testOnlyCommand fails when no tests match a glob pattern
--> testOnlyCommand *NonExistent*
+# Test that testOnly fails when no tests match a glob pattern
+-> testOnly *NonExistent*
 
-# The normal testOnly task should still silently pass (backwards compatibility)
-> testOnly NonExistentTest
+# The testSelected task should still silently pass (backwards compatibility)
+> testSelected NonExistentTest

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -156,6 +156,7 @@ class ClientTest extends AbstractServerTest {
       "testOnly",
       "testOnly/",
       "testOnly;",
+      "testOnlyCommand",
     )
     assert(complete("testOnly") == testOnlyExpected)
 

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -156,7 +156,6 @@ class ClientTest extends AbstractServerTest {
       "testOnly",
       "testOnly/",
       "testOnly;",
-      "testOnlyCommand",
     )
     assert(complete("testOnly") == testOnlyExpected)
 


### PR DESCRIPTION
## Summary

Adds `testOnly` command that fails when no tests match the specified patterns across all aggregated subprojects.

## Problem

Running `testOnly somePattern` from a root project that aggregates multiple subprojects silently passes even when no tests match the pattern anywhere. This is a CI reliability issue - typos in test names go undetected for days.

## Solution

New command `testOnly` that:
- Runs `definedTestNames` across all aggregated subprojects
- Fails if no tests match, showing available tests
- Runs `testSelected` if matches found

```
> testOnly NonExistentTest
[error] No tests match the patterns: NonExistentTest
[error] Available tests:
[error]   - example.HelloTest
[error]   - example.WorldTest
```

Fixes #3188