### PR TITLE
[2.x] fix: Suppress "Multiple main classes" warning for runMain commands

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1066,14 +1066,19 @@ object Defaults extends BuildCommon {
       selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
       run / mainClass := (run / selectMainClass).value,
       mainClass := Def.uncached {
+        // Suppress warning for run commands (user is actively running, warning is noise)
+        def isRunCommand(s: String): Boolean = s match
+          case "run" | "runMain" | "bgRun" | "bgRunMain" | "fgRun" | "fgRunMain" => true
+          case _                                                                 => false
         val logWarning = state.value.currentCommand.forall(!_.commandLine.split(" ").exists {
-          case "run" | "runMain" => true
-          case r =>
-            r.split("/") match {
+          case s if isRunCommand(s) => true
+          case r                    =>
+            // Handle both "/" (new syntax like Test/run) and ":" (old syntax like test:run)
+            r.split("[/:]") match {
               case Array(parts*) =>
                 parts.lastOption match {
-                  case Some("run" | "runMain") => true
-                  case _                       => false
+                  case Some(s) if isRunCommand(s) => true
+                  case _                          => false
                 }
             }
         })

--- a/sbt-app/src/sbt-test/run/run-main-warning/build.sbt
+++ b/sbt-app/src/sbt-test/run/run-main-warning/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.13.16"

--- a/sbt-app/src/sbt-test/run/run-main-warning/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/run/run-main-warning/src/main/scala/Main.scala
@@ -1,0 +1,19 @@
+package foo
+
+object MainA {
+  def main(args: Array[String]): Unit = {
+    println("MainA")
+  }
+}
+
+object MainB {
+  def main(args: Array[String]): Unit = {
+    println("MainB")
+  }
+}
+
+object MainC {
+  def main(args: Array[String]): Unit = {
+    println("MainC")
+  }
+}

--- a/sbt-app/src/sbt-test/run/run-main-warning/test
+++ b/sbt-app/src/sbt-test/run/run-main-warning/test
@@ -1,0 +1,18 @@
+# Test that run commands work with multiple main classes without showing useless warning
+# This tests issue #3739
+
+# First compile to discover main classes
+> compile
+
+# Test runMain - user explicitly specifies main class, no warning needed
+> runMain foo.MainA
+> runMain foo.MainB
+
+# Test scoped runMain with slash syntax (new syntax)
+> Compile/runMain foo.MainA
+
+# Test bgRunMain - background run with explicit main class
+> bgRunMain foo.MainA
+
+# Test fgRunMain - foreground run with explicit main class
+> fgRunMain foo.MainB


### PR DESCRIPTION
## Summary
- Fix warning appearing for scoped runMain commands using colon syntax (`test:runMain`)
- Extend warning suppression to all run command variants (`bgRunMain`, `fgRunMain`)

## Problem
When running `runMain` (especially scoped like `test:runMain`), the "Multiple main classes detected" warning was printed even though the user explicitly specified which main class to run.

## Solution
Changed the scope separator parsing from `/` only to `[/:]` to handle both new slash syntax (`Test/runMain`) and old colon syntax (`test:runMain`).

## Test
Added scripted test `run/run-main-warning` covering `runMain`, `bgRunMain`, `fgRunMain`, and scoped variants.

Fixes #3739