### PR TITLE
Optimize KeyedInitialize to avoid unnecessary node wrapping

### DIFF
--- a/util-collection/src/main/scala/sbt/internal/util/INode.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/INode.scala
@@ -41,8 +41,8 @@ class EvaluateSettings[I <: Init](
       fa match
         case g: GetValue[s, A]     => single(getStatic(g.scopedKey), g.transform)
         case k: KeyedInitialize[A] =>
-          // TODO create a Single node with no transform?
-          single(getStatic(k.scopedKey), identity)
+          // Optimization: return the node directly when transform is identity (no wrapping needed)
+          singleIdentity(getStatic(k.scopedKey))
         case u: Uniform[s, A] => UniformNode(u.inputs.map(transform[s]), u.f)
         case a: Apply[k, A] =>
           MixedNode[k, A](TupleMapExtension.transform(a.inputs)(transform), a.f)
@@ -212,6 +212,9 @@ class EvaluateSettings[I <: Init](
 
   private def single[A1, A2](in: INode[A1], f: A1 => A2): INode[A2] =
     MixedNode[Tuple1[A1], A2](Tuple1(in), { case Tuple1(a) => f(a) })
+  
+  // Optimization: when transform is identity, return the node directly to avoid unnecessary wrapping
+  private def singleIdentity[A](in: INode[A]): INode[A] = in
 
   private final class BindNode[A1, A2](in: INode[A1], f: A1 => INode[A2]) extends INode[A2]:
     protected def dependsOn: Seq[INode[?]] = in :: Nil


### PR DESCRIPTION
## Summary

This PR optimizes the `KeyedInitialize` case in the `transform` function to avoid creating an unnecessary `MixedNode` wrapper when the transform is identity.

## Changes

- Added a `singleIdentity` helper function that returns the input node directly
- Updated `KeyedInitialize` case to use `singleIdentity` instead of `single(..., identity)`
- This addresses the TODO comment on line 44

## Rationale

When `KeyedInitialize` uses an identity transform, we can return the node directly instead of wrapping it in a `MixedNode`. This optimization:

- Reduces unnecessary object allocation
- Eliminates indirection in the evaluation graph
- Improves performance by avoiding the overhead of a transform that does nothing

## Testing

This change maintains backward compatibility - the behavior is identical, just more efficient. The optimization only affects the internal structure of the evaluation graph, not the results.