### PR TITLE
[2.x] fix: Fix potential division by zero in CacheEventLog.toSummary

### DIFF
--- a/util-cache/src/main/scala/sbt/internal/util/CacheEventLog.scala
+++ b/util-cache/src/main/scala/sbt/internal/util/CacheEventLog.scala
@@ -71,7 +71,7 @@ class CacheEventLog:
       val hits = events.view.collect { case (ActionCacheEvent.Found(id), v) => (id, v) }.toMap
       val hitCount = hits.values.sum
       val missCount = total - hitCount
-      val hitRate = (hitCount.toDouble / total.toDouble)
+      val hitRate = if total > 0 then (hitCount.toDouble / total.toDouble) else 0.0
       val onsiteCount = events.get(ActionCacheEvent.OnsiteTask)
       val errorCount = events.get(ActionCacheEvent.Error)
       CacheEventSummary.Data(


### PR DESCRIPTION
## Description

This PR fixes a potential division by zero issue in `CacheEventLog.toSummary` method. When calculating the hit rate, if `total` is 0, the division would result in `NaN` or `Infinity`.

## Changes

- Added a guard condition to check if `total > 0` before performing division
- If `total` is 0, `hitRate` is set to `0.0` instead

## Testing

- All existing tests pass (35 tests in utilCache)
- The fix maintains backward compatibility

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)