### PR TITLE
Fix CancellationException thrown on compile error with usePipelining

### DIFF
--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/A/src/main/scala/main.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/A/src/main/scala/main.scala
@@ -1,0 +1,4 @@
+@main
+def main(): Unit =
+  println("Hello from A!")
+

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/B/src/main/scala/main.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/B/src/main/scala/main.scala
@@ -1,0 +1,6 @@
+@main
+def main(): Unit =
+  println("Hello from B!")
+  // This will cause a compile error - undefined symbol
+  undefinedSymbol
+

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/build.sbt
@@ -1,0 +1,48 @@
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+ThisBuild / scalaVersion := "3.3.4"
+
+ThisBuild / usePipelining := true
+
+lazy val A = (project in file("A"))
+  .settings(
+    name := "A"
+  )
+
+lazy val B = (project in file("B"))
+  .settings(
+    name := "B"
+  ).dependsOn(A)
+
+// Custom task to verify that compilation fails gracefully without CancellationException
+lazy val root = (project in file("."))
+  .aggregate(A, B)
+  .settings(
+    TaskKey[Unit]("verifyNoCancellationException") := {
+      val s = streams.value
+      try {
+        (B / Compile / compile).value
+        sys.error("Expected compilation to fail")
+      } catch {
+        case e: sbt.Incomplete =>
+          // Check that the cause is not a CancellationException
+          val allCauses = sbt.Incomplete.allExceptions(e)
+          val hasCancellationException = allCauses.exists {
+            case ce: java.util.concurrent.CancellationException => true
+            case _ => false
+          }
+          if (hasCancellationException) {
+            sys.error("CancellationException was thrown and not handled properly")
+          }
+          // Compilation failed as expected, and no CancellationException was thrown
+          s.log.info("Compilation failed gracefully without CancellationException")
+        case e: Throwable =>
+          // Check if it's a CancellationException
+          if (e.isInstanceOf[java.util.concurrent.CancellationException]) {
+            sys.error("CancellationException was thrown and not handled properly")
+          }
+          throw e
+      }
+    }
+  )
+

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/test
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-cancellation-exception/test
@@ -1,0 +1,8 @@
+# Test for issue #7973: CancellationException thrown on compile error with usePipelining
+# This test verifies that when a compile error occurs with usePipelining enabled,
+# no CancellationException stack trace is displayed.
+
+# Compile should fail due to compile error, but should not show CancellationException
+# The verifyNoCancellationException task will check that compilation fails gracefully
+> verifyNoCancellationException
+

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -318,8 +318,8 @@ object ConcurrentRestrictions {
           case _: CancellationException =>
             // Handle cancellation gracefully - return a Completed that throws Incomplete
             // This prevents the CancellationException from propagating and showing a stack trace
-            new Completed {
-              def process(): Unit = throw Incomplete(None, message = Some("cancelled"))
+            Execute.completed {
+              throw Incomplete(None, message = Some("cancelled"))
             }
         }
       }

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import sbt.internal.util.AttributeKey
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{ Future as JFuture, RejectedExecutionException }
+import java.util.concurrent.{ CancellationException, Future as JFuture, RejectedExecutionException }
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
@@ -312,7 +312,16 @@ object ConcurrentRestrictions {
           throw new RejectedExecutionException(
             "Tried to get values for a closed completion service"
           )
-        jservice.take().get()
+        try {
+          jservice.take().get()
+        } catch {
+          case _: CancellationException =>
+            // Handle cancellation gracefully - return a Completed that throws Incomplete
+            // This prevents the CancellationException from propagating and showing a stack trace
+            new Completed {
+              def process(): Unit = throw Incomplete(None, message = Some("cancelled"))
+            }
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #7973

When tasks are cancelled (e.g., during compile errors with usePipelining),
the CancellationException from jservice.take().get() was propagating
and showing a stack trace. This fix catches CancellationException and
returns a Completed that throws Incomplete, which is handled gracefully
by the execution engine without showing a stack trace.

## Changes
- Added import for CancellationException
- Modified ConcurrentRestrictions.take() to catch CancellationException
- Returns a Completed that throws Incomplete instead of letting CancellationException propagate

## Testing
This should resolve the issue where compile errors with usePipelining cause
CancellationException stack traces to be displayed.