### PR TITLE
Ivyless Ivy repo publish 

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2991,7 +2991,7 @@ object Classpaths {
           .map(m => d.withRevision(m.module.revision))
       }.distinct
     }.value,
-    publish := publishOrSkip(publishConfiguration, publish / skip).value,
+    publish := LibraryManagement.ivylessPublishTask.value,
     publishLocal := LibraryManagement.ivylessPublishLocalTask.value,
     publishM2 := publishOrSkip(publishM2Configuration, publishM2 / skip).value,
     credentials ++= Def.uncached {

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -14,6 +14,7 @@ import java.util.concurrent.Callable
 
 import sbt.Def.ScopedKey
 import sbt.internal.librarymanagement.*
+import sbt.internal.librarymanagement.ivy.IvyCredentials
 import sbt.librarymanagement.*
 import sbt.librarymanagement.syntax.*
 import sbt.util.{ CacheStore, CacheStoreFactory, Level, Logger, Tracked }
@@ -23,6 +24,7 @@ import sbt.ProjectExtra.*
 import sjsonnew.JsonFormat
 import scala.concurrent.duration.FiniteDuration
 import lmcoursier.definitions.Project as CsrProject
+import gigahorse.InMemoryBody
 
 private[sbt] object LibraryManagement {
   given linter: sbt.dsl.LinterLevel.Ignore.type = sbt.dsl.LinterLevel.Ignore
@@ -616,6 +618,247 @@ private[sbt] object LibraryManagement {
       writeChecksums(ivyXmlFile)
     else log.warn(s"$ivyXmlFile already exists, skipping (overwrite=$overwrite)")
   end ivylessPublishLocal
+
+  /**
+   * Publishes artifacts to a remote Ivy repository without using Apache Ivy.
+   * Uses HTTP PUT requests via gigahorse to upload files.
+   *
+   * @param project Coursier project containing module info
+   * @param artifacts Vector of (Artifact, File) pairs to publish
+   * @param checksumAlgorithms Checksum algorithms to use (e.g., "md5", "sha1")
+   * @param patterns The Ivy patterns containing the base URL and path patterns
+   * @param credentials Optional credentials for authentication
+   * @param overwrite Whether to overwrite existing artifacts
+   * @param log Logger for output
+   */
+  def ivylessPublish(
+      project: CsrProject,
+      artifacts: Vector[(Artifact, File)],
+      checksumAlgorithms: Vector[String],
+      patterns: Patterns,
+      credentials: Option[DirectCredentials],
+      overwrite: Boolean,
+      log: Logger
+  ): Unit =
+    import gigahorse.*
+    import gigahorse.support.apachehttp.Gigahorse
+    import scala.concurrent.Await
+    import scala.concurrent.duration.*
+
+    val org = project.module.organization.value
+    val moduleName = project.module.name.value
+    val version = project.version
+
+    // Get the artifact pattern (first one)
+    val artifactPattern = patterns.artifactPatterns.headOption.getOrElse(
+      throw new IllegalArgumentException("No artifact pattern defined in resolver")
+    )
+
+    // Get the ivy pattern (first one, or derive from artifact pattern)
+    val ivyPattern = patterns.ivyPatterns.headOption.getOrElse(artifactPattern)
+
+    /**
+     * Substitutes Ivy pattern tokens with actual values.
+     * Tokens: [organisation], [module], [revision], [type], [artifact], [ext], [classifier]
+     */
+    def substitutePattern(
+        pattern: String,
+        artifactType: String,
+        artifactName: String,
+        extension: String,
+        classifier: Option[String]
+    ): String =
+      val substituted = pattern
+        .replace("[organisation]", org.replace('.', '/'))
+        .replace("[organization]", org.replace('.', '/'))
+        .replace("[module]", moduleName)
+        .replace("[revision]", version)
+        .replace("[type]", artifactType)
+        .replace("[artifact]", artifactName)
+        .replace("[ext]", extension)
+
+      // Handle optional classifier: (-[classifier]) should be removed if no classifier
+      val classifierPattern = """\(-\[classifier\]\)|\[classifier\]""".r
+      classifier match
+        case Some(c) =>
+          classifierPattern.replaceAllIn(substituted, "-" + c)
+        case None =>
+          classifierPattern.replaceAllIn(substituted, "")
+    end substitutePattern
+
+    /**
+     * Uploads a file to the given URL using HTTP PUT.
+     */
+    def uploadFile(url: String, file: File): Unit =
+      log.info(s"Uploading ${file.getName} to $url")
+
+      val http = sbt.librarymanagement.Http.http
+      val fileBytes = IO.readBytes(file)
+
+      val baseReq = Gigahorse
+        .url(url)
+        .withMethod("PUT")
+        .withBody(InMemoryBody(fileBytes))
+        .withHeaders(
+          "Content-Type" -> "application/octet-stream",
+          "Content-Length" -> fileBytes.length.toString
+        )
+
+      // Add authentication if credentials are provided
+      val req = credentials match
+        case Some(creds) =>
+          val auth = java.util.Base64.getEncoder.encodeToString(
+            s"${creds.userName}:${creds.passwd}".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+          )
+          baseReq.withHeaders("Authorization" -> s"Basic $auth")
+        case None => baseReq
+
+      try
+        val response = Await.result(http.run(req, Gigahorse.asString), 5.minutes)
+        log.debug(s"Upload successful: $url")
+      catch
+        case e: gigahorse.StatusError if e.status == 409 && !overwrite =>
+          log.warn(s"Artifact already exists at $url (overwrite=$overwrite)")
+        case e: Exception =>
+          throw new RuntimeException(s"Failed to upload to $url: ${e.getMessage}", e)
+    end uploadFile
+
+    /**
+     * Generates checksum and uploads it.
+     */
+    def uploadChecksums(url: String, file: File): Unit =
+      checksumAlgorithms.foreach: algo =>
+        val digestAlgo = algo.toLowerCase match
+          case "md5"  => sbt.util.Digest.Md5
+          case "sha1" => sbt.util.Digest.Sha1
+          case other =>
+            throw new IllegalArgumentException(s"Unsupported checksum algorithm: $other")
+        val digest = sbt.util.Digest(digestAlgo, file.toPath)
+        val checksumUrl = s"$url.${algo.toLowerCase}"
+
+        log.debug(s"Uploading checksum to $checksumUrl")
+
+        val http = sbt.librarymanagement.Http.http
+        val checksumBytes = digest.hashHexString.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+
+        val baseReq = Gigahorse
+          .url(checksumUrl)
+          .withMethod("PUT")
+          .withBody(InMemoryBody(checksumBytes))
+          .withHeaders("Content-Type" -> "text/plain")
+
+        val req = credentials match
+          case Some(creds) =>
+            val auth = java.util.Base64.getEncoder.encodeToString(
+              s"${creds.userName}:${creds.passwd}".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            )
+            baseReq.withHeaders("Authorization" -> s"Basic $auth")
+          case None => baseReq
+
+        try Await.result(http.run(req, Gigahorse.asString), 1.minute)
+        catch
+          case e: gigahorse.StatusError if e.status == 409 && !overwrite =>
+            log.warn(s"Checksum already exists at $checksumUrl")
+          case e: Exception =>
+            throw new RuntimeException(s"Failed to upload checksum to $checksumUrl: ${e.getMessage}", e)
+    end uploadChecksums
+
+    // Helper to map artifact type to Ivy type
+    def toIvyType(tpe: String): String = tpe match
+      case "src" | "source" | "sources" => "source"
+      case "doc" | "docs" | "javadoc"   => "doc"
+      case other                        => other
+
+    // Publish each artifact
+    artifacts.foreach: (artifact, sourceFile) =>
+      val ivyType = toIvyType(artifact.`type`)
+      val url = substitutePattern(
+        artifactPattern,
+        ivyType,
+        moduleName,
+        artifact.extension,
+        artifact.classifier
+      )
+      uploadFile(url, sourceFile)
+      uploadChecksums(url, sourceFile)
+
+    // Generate and upload ivy.xml
+    val ivyXmlContent = lmcoursier.IvyXml(project, Nil, Nil)
+    val ivyUrl = substitutePattern(ivyPattern, "ivy", "ivy", "xml", None)
+
+    // Write ivy.xml to temp file for upload
+    val tempIvyFile = java.io.File.createTempFile("ivy", ".xml")
+    try
+      IO.write(tempIvyFile, ivyXmlContent)
+      uploadFile(ivyUrl, tempIvyFile)
+      uploadChecksums(ivyUrl, tempIvyFile)
+    finally
+      tempIvyFile.delete()
+
+    log.info(s"Published $moduleName to remote Ivy repository")
+  end ivylessPublish
+
+  /**
+   * Task initializer for ivyless publish (remote).
+   * Uses Def.ifS for proper selective functor behavior.
+   */
+  def ivylessPublishTask: Def.Initialize[Task[Unit]] =
+    import Keys.*
+    Def.ifS(Def.task { (publish / skip).value })(
+      // skip = true
+      Def.task {
+        val log = streams.value.log
+        val ref = thisProjectRef.value
+        log.debug(s"Skipping publish for ${Reference.display(ref)}")
+      }
+    )(
+      // skip = false
+      Def.ifS(Def.task { useIvy.value })(
+        // useIvy = true: use Ivy-based publisher
+        Def.task {
+          val log = streams.value.log
+          val conf = publishConfiguration.value
+          val module = ivyModule.value
+          val publisherInterface = publisher.value
+          publisherInterface.publish(module, conf, log)
+        }
+      )(
+        // useIvy = false: use ivyless publisher
+        Def.task {
+          val log = streams.value.log
+          publishTo.value match
+            case Some(repo: URLRepository) =>
+              val project = csrProject.value.withPublications(csrPublications.value)
+              val config = publishConfiguration.value
+              val artifacts = config.artifacts.map { case (a, f) => (a, f) }
+              val checksumAlgos = config.checksums
+              val creds = credentials.value
+              val resolvedCreds = repo.patterns.artifactPatterns.headOption.flatMap { pattern =>
+                // Extract host from pattern URL
+                val hostPattern = """https?://([^/]+)""".r
+                hostPattern.findFirstMatchIn(pattern).map(_.group(1)).flatMap { host =>
+                  IvyCredentials.forHost(creds, host)
+                }
+              }
+              val overwriteFlag = config.overwrite
+              ivylessPublish(
+                project,
+                artifacts,
+                checksumAlgos,
+                repo.patterns,
+                resolvedCreds,
+                overwriteFlag,
+                log
+              )
+            case Some(other) =>
+              throw new MessageOnlyException(
+                s"Ivyless publish only supports URLRepository, got: ${other.getClass.getName}"
+              )
+            case None =>
+              throw new MessageOnlyException("publishTo is not set")
+        }
+      )
+    )
 
   /**
    * Task initializer for ivyless publishLocal.

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -17,6 +17,7 @@ import sbt.internal.librarymanagement.*
 import sbt.internal.librarymanagement.ivy.IvyCredentials
 import sbt.librarymanagement.*
 import sbt.librarymanagement.syntax.*
+import sbt.internal.util.MessageOnlyException
 import sbt.util.{ CacheStore, CacheStoreFactory, Level, Logger, Tracked }
 import sbt.io.IO
 import sbt.io.syntax.*

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -636,7 +636,7 @@ private[sbt] object LibraryManagement {
       artifacts: Vector[(Artifact, File)],
       checksumAlgorithms: Vector[String],
       patterns: Patterns,
-      credentials: Option[DirectCredentials],
+      credentials: Option[Credentials.DirectCredentials],
       overwrite: Boolean,
       log: Logger
   ): Unit =

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/build.sbt
@@ -1,0 +1,183 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
+name := "lib1"
+organization := "com.example"
+version := "0.1.0-SNAPSHOT"
+scalaVersion := "3.8.1"
+
+// Use ivyless publisher
+useIvy := false
+
+// Disable doc generation to speed up the test
+Compile / packageDoc / publishArtifact := false
+Compile / packageSrc / publishArtifact := false
+
+// Directory where the HTTP server will store uploaded files
+val repoDir = settingKey[File]("Repository directory for the test HTTP server")
+repoDir := baseDirectory.value / "repo"
+
+// Port for the test HTTP server
+val serverPort = settingKey[Int]("Port for the test HTTP server")
+serverPort := 18080
+
+// Configure publishTo to use the local HTTP server with Ivy-style patterns
+publishTo := Some(
+  Resolver.url(
+    "test-repo",
+    new java.net.URL(s"http://localhost:${serverPort.value}/")
+  )(Resolver.ivyStylePatterns)
+)
+
+// Task to start the HTTP server
+val startServer = taskKey[Unit]("Start the test HTTP server")
+startServer := {
+  val log = streams.value.log
+  val port = serverPort.value
+  val repo = repoDir.value
+
+  IO.delete(repo)
+  IO.createDirectory(repo)
+
+  log.info(s"Starting HTTP server on port $port, serving from $repo")
+
+  // Start server in a background thread
+  val server = com.sun.net.httpserver.HttpServer.create(
+    new java.net.InetSocketAddress(port), 0
+  )
+
+  server.createContext("/", new com.sun.net.httpserver.HttpHandler {
+    def handle(exchange: com.sun.net.httpserver.HttpExchange): Unit = {
+      val method = exchange.getRequestMethod
+      val path = exchange.getRequestURI.getPath
+      val targetFile = new File(repo, path)
+
+      log.debug(s"$method $path -> $targetFile")
+
+      method match {
+        case "PUT" =>
+          // Create parent directories
+          IO.createDirectory(targetFile.getParentFile)
+
+          // Read request body and write to file
+          val body = IO.readBytes(exchange.getRequestBody)
+          IO.write(targetFile, body)
+
+          exchange.sendResponseHeaders(201, -1)
+          exchange.close()
+          log.info(s"Uploaded: $path (${body.length} bytes)")
+
+        case "GET" =>
+          if (targetFile.exists) {
+            val bytes = IO.readBytes(targetFile)
+            exchange.sendResponseHeaders(200, bytes.length)
+            exchange.getResponseBody.write(bytes)
+            exchange.close()
+          } else {
+            exchange.sendResponseHeaders(404, -1)
+            exchange.close()
+          }
+
+        case "HEAD" =>
+          if (targetFile.exists) {
+            exchange.sendResponseHeaders(200, -1)
+          } else {
+            exchange.sendResponseHeaders(404, -1)
+          }
+          exchange.close()
+
+        case _ =>
+          exchange.sendResponseHeaders(405, -1)
+          exchange.close()
+      }
+    }
+  })
+
+  server.setExecutor(null)
+  server.start()
+
+  // Store server reference for cleanup
+  val serverRef = new java.util.concurrent.atomic.AtomicReference(server)
+  sys.props.put("test.http.server", serverRef.toString)
+
+  log.info(s"HTTP server started on http://localhost:$port/")
+}
+
+// Task to stop the HTTP server
+val stopServer = taskKey[Unit]("Stop the test HTTP server")
+stopServer := {
+  val log = streams.value.log
+  log.info("Note: Server will be stopped when sbt exits")
+}
+
+// Task to print debug info
+val printPaths = taskKey[Unit]("Print paths for debugging")
+printPaths := {
+  val log = streams.value.log
+  log.info(s"repoDir = ${repoDir.value}")
+  log.info(s"serverPort = ${serverPort.value}")
+  log.info(s"publishTo = ${publishTo.value}")
+  log.info(s"useIvy = ${useIvy.value}")
+}
+
+// Task to check that files were published correctly
+val checkPublish = taskKey[Unit]("Check that publish produced the expected files")
+checkPublish := {
+  val log = streams.value.log
+  val repo = repoDir.value
+  val org = organization.value.replace('.', '/')
+  val moduleName = normalizedName.value + "_3"
+  val ver = version.value
+
+  // Expected path based on Ivy patterns:
+  // [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  val moduleDir = repo / org / moduleName / ver
+
+  log.info(s"Checking published files in $moduleDir")
+
+  // List what's actually in the repo directory
+  def listDir(dir: File, indent: String = ""): Unit = {
+    if (dir.exists) {
+      dir.listFiles.toSeq.sorted.foreach { f =>
+        log.info(s"$indent${f.getName}")
+        if (f.isDirectory) listDir(f, indent + "  ")
+      }
+    } else {
+      log.info(s"${indent}Directory does not exist: $dir")
+    }
+  }
+  log.info("Contents of repo:")
+  listDir(repo)
+
+  // Check that the main artifacts exist
+  val expectedDirs = Seq("jars", "poms", "ivys")
+  expectedDirs.foreach { dir =>
+    val d = moduleDir / dir
+    assert(d.exists && d.isDirectory, s"Expected directory $d to exist")
+  }
+
+  // Check jar file and checksums
+  val jarFile = moduleDir / "jars" / s"$moduleName.jar"
+  assert(jarFile.exists, s"Expected $jarFile to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.md5").exists, s"Expected md5 checksum to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.sha1").exists, s"Expected sha1 checksum to exist")
+
+  // Check ivy.xml and checksums
+  val ivyFile = moduleDir / "ivys" / "ivy.xml"
+  assert(ivyFile.exists, s"Expected $ivyFile to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.md5").exists, s"Expected ivy.xml md5 checksum to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.sha1").exists, s"Expected ivy.xml sha1 checksum to exist")
+
+  // Check ivy.xml content
+  val ivyContent = IO.read(ivyFile)
+  assert(ivyContent.contains(s"""organisation="${organization.value}""""), s"ivy.xml should contain organisation")
+  assert(ivyContent.contains(s"""module="$moduleName""""), s"ivy.xml should contain module name")
+  assert(ivyContent.contains(s"""revision="$ver""""), s"ivy.xml should contain revision")
+
+  log.success("All publish checks passed!")
+}
+
+// Task to clean the repo
+val cleanRepo = taskKey[Unit]("Clean the repo directory")
+cleanRepo := {
+  IO.delete(repoDir.value)
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/project/plugins.sbt
@@ -1,0 +1,1 @@
+// No additional plugins needed

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/src/main/scala/Lib.scala
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/src/main/scala/Lib.scala
@@ -1,0 +1,5 @@
+package com.example
+
+object Lib {
+  def greeting: String = "Hello from Lib!"
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/test
@@ -1,0 +1,18 @@
+# Test ivyless publish to remote HTTP server
+# This test verifies that when useIvy is set to false,
+# publish uploads files to a remote Ivy repository via HTTP
+
+# Clean any previous test state
+> cleanRepo
+
+# Print paths for debugging
+> printPaths
+
+# Start the HTTP server
+> startServer
+
+# Run publish with ivyless publisher
+> publish
+
+# Verify the published files
+> checkPublish


### PR DESCRIPTION
This PR adds support for publishing artifacts to remote Ivy repositories via HTTP without using Apache Ivy, following the same pattern as the recently merged ivyless `publishLocal`.

Fixes #8639