### PR TITLE
[2.x] fix: Add null check for resource URL

### DIFF
--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ResourceLoader.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ResourceLoader.scala
@@ -14,7 +14,11 @@ import java.util.Properties
 private[inc] object ResourceLoader {
   def getPropertiesFor(resource: String): Properties = {
     val properties = new Properties
-    val propertiesStream = getClass.getResource(resource).openStream
+    val resourceUrl = getClass.getResource(resource)
+    if (resourceUrl eq null) {
+      throw new java.io.FileNotFoundException(s"Resource not found: $resource")
+    }
+    val propertiesStream = resourceUrl.openStream
     try {
       properties.load(propertiesStream)
     } finally propertiesStream.close()


### PR DESCRIPTION
**Problem**
getPropertiesFor method calls getResource().openStream() without checking if getResource returns null. When a resource doesn't exist, this causes a NullPointerException with no context about which resource was missing.

**Solution**
Added null check before calling openStream() and throw a descriptive FileNotFoundException with the resource name if the resource is not found. This prevents NullPointerException and provides better error messages.
