### PR TITLE
[2.x] fix: Restore bincompat for ScriptedRun methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -724,14 +724,8 @@ lazy val mainProj = (project in file("main"))
     mimaBinaryIssueFilters ++= Vector(
       exclude[DirectMissingMethodProblem]("sbt.internal.ConsoleProject.*"),
       exclude[DirectMissingMethodProblem]("sbt.coursierint.LMCoursier.coursierConfiguration"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun.run"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun.invoke"),
-      exclude[ReversedMissingMethodProblem]("sbt.ScriptedRun.invoke"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun#RunInParallelV1.invoke"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun#RunInParallelV2.invoke"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun#RunV1.invoke"),
-      exclude[DirectMissingMethodProblem]("sbt.ScriptedRun#RunV2.invoke"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.Compiler.scalaInstanceTask"),
+      exclude[ReversedMissingMethodProblem]("sbt.ScriptedRun.invoke"),
     ),
   )
   .dependsOn(lmCore, lmIvy, lmCoursierShadedPublishing)

--- a/main/src/main/scala/sbt/ScriptedRun.scala
+++ b/main/src/main/scala/sbt/ScriptedRun.scala
@@ -10,9 +10,31 @@ package sbt
 
 import java.io.File
 import java.lang.reflect.Method
-import scala.annotation.unused
 
 sealed trait ScriptedRun {
+  final def run(
+      resourceBaseDirectory: File,
+      bufferLog: Boolean,
+      tests: Seq[String],
+      launcherJar: File,
+      javaCommand: String,
+      launchOpts: Seq[String],
+      prescripted: java.util.List[File],
+      instances: Int,
+  ): Unit = {
+    run(
+      resourceBaseDirectory,
+      bufferLog,
+      tests,
+      launcherJar,
+      javaCommand,
+      launchOpts,
+      prescripted,
+      instances,
+      keepTempDirectory = false,
+    )
+  }
+
   final def run(
       resourceBaseDirectory: File,
       bufferLog: Boolean,
@@ -38,6 +60,29 @@ sealed trait ScriptedRun {
       )
       ()
     } catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
+  }
+
+  protected def invoke(
+      resourceBaseDirectory: File,
+      bufferLog: java.lang.Boolean,
+      tests: Array[String],
+      launcherJar: File,
+      javaCommand: String,
+      launchOpts: Array[String],
+      prescripted: java.util.List[File],
+      instances: java.lang.Integer,
+  ): AnyRef = {
+    invoke(
+      resourceBaseDirectory,
+      bufferLog,
+      tests,
+      launcherJar,
+      javaCommand,
+      launchOpts,
+      prescripted,
+      instances,
+      keepTempDirectory = false,
+    )
   }
 
   protected def invoke(
@@ -115,11 +160,11 @@ object ScriptedRun {
         bufferLog: java.lang.Boolean,
         tests: Array[String],
         launcherJar: File,
-        @unused javaCommand: String,
+        javaCommand: String,
         launchOpts: Array[String],
         prescripted: java.util.List[File],
-        @unused instances: java.lang.Integer,
-        @unused keepTempDirectory: java.lang.Boolean,
+        instances: java.lang.Integer,
+        keepTempDirectory: java.lang.Boolean,
     ): AnyRef =
       run.invoke(
         scriptedTests,
@@ -138,11 +183,11 @@ object ScriptedRun {
         bufferLog: java.lang.Boolean,
         tests: Array[String],
         launcherJar: File,
-        @unused javaCommand: String,
+        javaCommand: String,
         launchOpts: Array[String],
         prescripted: java.util.List[File],
         instances: Integer,
-        @unused keepTempDirectory: java.lang.Boolean,
+        keepTempDirectory: java.lang.Boolean,
     ): AnyRef =
       runInParallel.invoke(
         scriptedTests,
@@ -165,8 +210,8 @@ object ScriptedRun {
         javaCommand: String,
         launchOpts: Array[String],
         prescripted: java.util.List[File],
-        @unused instances: java.lang.Integer,
-        @unused keepTempDirectory: java.lang.Boolean,
+        instances: java.lang.Integer,
+        keepTempDirectory: java.lang.Boolean,
     ): AnyRef =
       run.invoke(
         scriptedTests,
@@ -190,7 +235,7 @@ object ScriptedRun {
         launchOpts: Array[String],
         prescripted: java.util.List[File],
         instances: Integer,
-        @unused keepTempDirectory: java.lang.Boolean,
+        keepTempDirectory: java.lang.Boolean,
     ): AnyRef =
       runInParallel.invoke(
         scriptedTests,
@@ -214,7 +259,7 @@ object ScriptedRun {
         javaCommand: String,
         launchOpts: Array[String],
         prescripted: java.util.List[File],
-        @unused instances: java.lang.Integer,
+        instances: java.lang.Integer,
         keepTempDirectory: java.lang.Boolean,
     ): AnyRef =
       run.invoke(


### PR DESCRIPTION
Fixes #8653

## Problem

In PR #8621, I added a new `keepTempDirectory` parameter to `ScriptedRun.run()` and `invoke()` methods. To suppress MiMa warnings, I added `mimaBinaryIssueFilters` for:
- `DirectMissingMethodProblem("sbt.ScriptedRun.run")`
- `DirectMissingMethodProblem("sbt.ScriptedRun.invoke")`
- `DirectMissingMethodProblem` for various internal `RunV1`, `RunV2`, `RunInParallelV1`, `RunInParallelV2` classes

However, this broke binary compatibility, which prevents sbt 1.x from calling sbt 2.x for cross-building (building sbt 2.x plugins using sbt 1.x).

## Solution

Instead of using MiMa filters to suppress the warnings, this PR restores binary compatibility by:

1. **Adding backward-compatible overloaded methods**: Created overloaded `run()` and `invoke()` methods without the `keepTempDirectory` parameter that delegate to the new methods with `keepTempDirectory=false`

2. **Removing problematic MiMa filters**: Removed all `DirectMissingMethodProblem` filters for `ScriptedRun` methods

3. **Keeping acceptable filter**: Retained only `ReversedMissingMethodProblem("sbt.ScriptedRun.invoke")` filter, which is acceptable since the old method signatures are preserved

4. **Code cleanup**: Removed unused `@unused` import

## Changes

### `main/src/main/scala/sbt/ScriptedRun.scala`
- Added overloaded `run()` method without `keepTempDirectory` parameter (delegates to new method with `false`)
- Added overloaded `invoke()` method without `keepTempDirectory` parameter (delegates to new method with `false`)
- Removed `@unused` import (no longer needed)
- Removed `@unused` annotations from internal class methods

### `build.sbt`
- Removed MiMa filters for `DirectMissingMethodProblem` on `ScriptedRun` methods
- Kept `ReversedMissingMethodProblem("sbt.ScriptedRun.invoke")` filter

## Testing

- ✅ Compiles successfully
- ✅ `mainProj/mimaReportBinaryIssues` passes
- ✅ Binary compatibility maintained for cross-building

## Checklist

- [x] Compiles successfully
- [x] Binary compatibility verified with MiMa
- [x] Backward-compatible method signatures preserved
- [x] New functionality still works with `keepTempDirectory` parameter
