### PR TITLE
[2.x] Extend 2.x universe to BinCompatV, like 2.0.0-RC9-bin-SNAPSHOT

### DIFF
--- a/lm-core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
+++ b/lm-core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala
@@ -42,8 +42,9 @@ object CrossVersionUtil {
    * Compatible versions include 0.12.0-1 and 0.12.0-RC1 for Some(0, 12).
    */
   private[sbt] def sbtApiVersion(v: String): Option[(Long, Long)] = v match {
-    case ReleaseV(x, y, _, _)   => Some(sbtApiVersion(x.toLong, y.toLong))
-    case CandidateV(x, y, _, _) => Some(sbtApiVersion(x.toLong, y.toLong))
+    case ReleaseV(x, y, _, _)      => Some(sbtApiVersion(x.toLong, y.toLong))
+    case CandidateV(x, y, _, _)    => Some(sbtApiVersion(x.toLong, y.toLong))
+    case BinCompatV(x, y, _, _, _) => Some(sbtApiVersion(x.toLong, y.toLong))
     case NonReleaseV_n(x, y, z, _) if x.toLong == 0 && z.toLong > 0 =>
       Some(sbtApiVersion(x.toLong, y.toLong))
     case NonReleaseV_n(x, y, z, _) if x.toLong > 0 && (y.toLong > 0 || z.toLong > 0) =>

--- a/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -111,6 +111,9 @@ class CrossVersionTest extends UnitSpec {
   it should "for 2.0.0-RC1 return 2" in {
     binarySbtVersion("2.0.0-RC1") shouldBe "2"
   }
+  it should "for 2.0.0-RC9-bin-SNAPSHOT return 2" in {
+    binarySbtVersion("2.0.0-RC9-bin-SNAPSHOT") shouldBe "2"
+  }
   it should "for 2 return 2" in {
     binarySbtVersion("2") shouldBe "2"
   }

--- a/server-test/src/test/scala/testpkg/BuildServerTest.scala
+++ b/server-test/src/test/scala/testpkg/BuildServerTest.scala
@@ -101,7 +101,7 @@ class BuildServerTest extends AbstractServerTest {
       "project/A.scala",
       "project/src/main/java",
       "project/src/main/scala-3",
-      s"project/src/main/scala-sbt-${TestProperties.version}",
+      "project/src/main/scala-sbt-2",
       "project/src/main/scala/",
       s"target/out/jvm/scala-${TestProperties.scalaVersion}/buildserver-build/src_managed/main"
     ).map(rel => new File(svr.baseDirectory.getAbsoluteFile, rel).toURI).sorted


### PR DESCRIPTION
## Problem
Some scripted tests are failing due to the fact that -bin-SNAPSHOT isn't being recognized.

## Solution
This fixes sbtApiVersion to recognize BinCompatV.