### PR TITLE
[2.x] feat: Add rootProject macro (fixes #4511)

### DIFF
--- a/main-settings/src/main/scala/sbt/std/KeyMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/KeyMacro.scala
@@ -43,6 +43,10 @@ private[sbt] object KeyMacro:
     val name = definingValName(errorMsg2)
     '{ Project($name, new File($name)) }
 
+  def rootProjectImpl(using Quotes): Expr[Project] =
+    val name = definingValName(errorMsgRootProject)
+    '{ Project($name, new File(".")) }
+
   private def summonRuntimeClass[A: Type](using Quotes): Expr[Class[?]] =
     val classTag = Expr
       .summon[ClassTag[A]]
@@ -57,6 +61,9 @@ private[sbt] object KeyMacro:
 
   private def errorMsg2: String =
     """project must be directly assigned to a val, such as `val x = project.in(file("core"))`."""
+
+  private def errorMsgRootProject: String =
+    """rootProject must be directly assigned to a val, such as `val root = rootProject`."""
 
   private[sbt] def definingValName(errorMsg: String)(using Quotes): Expr[String] =
     val term = enclosingTerm

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4618,6 +4618,13 @@ trait BuildExtra extends BuildCommon with DefExtra {
    * The name of the val is used as the project ID and the name of the base directory of the project.
    */
   inline def project: Project = ${ std.KeyMacro.projectImpl }
+
+  /**
+   * Creates the root project with base directory ".".
+   * This is a macro that expects to be assigned directly to a val (e.g. `val root = rootProject`).
+   * The name of the val is used as the project ID; the base is always the build root.
+   */
+  inline def rootProject: Project = ${ std.KeyMacro.rootProjectImpl }
   inline def projectMatrix: ProjectMatrix = ${ ProjectMatrix.projectMatrixImpl }
 
   /**

--- a/main/src/test/scala/ProjectMacro.scala
+++ b/main/src/test/scala/ProjectMacro.scala
@@ -11,7 +11,7 @@ package sbt
 import scala.util.control.NonFatal
 import org.scalacheck.*
 import Prop.*
-import sbt.BuildExtra.project
+import sbt.BuildExtra.{ project, rootProject }
 import java.io.File
 
 class ProjectDefs {
@@ -23,6 +23,8 @@ class ProjectDefs {
   // def y = project
 
   val z = (project in new File("dir"))
+
+  val root = rootProject
 
   val a: Project = project
 
@@ -60,6 +62,10 @@ object ProjectMacro extends Properties("ProjectMacro") {
 
   property("Directory overridable") = secure {
     check(z, "z", "dir")
+  }
+
+  property("rootProject has base .") = secure {
+    check(root, "root", ".")
   }
 
   def check(p: Project, id: String, dir: String): Prop = {


### PR DESCRIPTION
Adds a `rootProject` macro so the root project can be defined as:
`val root = rootProject`
instead of:
`val root = (project in file(".")).`
- KeyMacro.scala: `rootProjectImpl` macro implementation
- Defaults.scala: `inline def rootProject` in `BuildExtra`
- ProjectMacro.scala: unit test for `rootProject`

Fixes #4511