### PR TITLE
[2.x] Use JProcess for interactive forking

### DIFF
--- a/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
+++ b/internal/util-control/src/main/scala/sbt/internal/util/RunningProcesses.scala
@@ -8,6 +8,7 @@
 
 package sbt.internal.util
 
+import java.lang.{ Process as JProcess }
 import java.util.concurrent.ConcurrentHashMap
 import scala.sys.process.Process
 
@@ -17,17 +18,21 @@ import scala.sys.process.Process
  * processes when the user inputs ctrl+c.
  */
 private[sbt] object RunningProcesses {
-  val active = ConcurrentHashMap.newKeySet[Process]
-  def add(process: Process): Unit = active.synchronized {
+  val active = ConcurrentHashMap.newKeySet[AnyRef]
+  def add(process: AnyRef): Unit = active.synchronized {
     active.add(process)
     ()
   }
-  def remove(process: Process): Unit = active.synchronized {
+  def remove(process: AnyRef): Unit = active.synchronized {
     active.remove(process)
     ()
   }
   def killAll(): Unit = active.synchronized {
-    active.forEach(_.destroy())
+    active.forEach {
+      case p: Process  => p.destroy()
+      case p: JProcess => p.destroy()
+      case _           => ()
+    }
     active.clear()
   }
 }

--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -16,7 +16,7 @@ import OutputStrategy.*
 import sbt.internal.util.{ RunningProcesses, Util }
 import Util.*
 
-import java.lang.{ ProcessBuilder as JProcessBuilder }
+import java.lang.{ ProcessBuilder as JProcessBuilder, Process as JProcess }
 import java.util.Locale
 
 /**
@@ -36,7 +36,15 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
    * define the arguments passed to the forked command.
    */
   def apply(config: ForkOptions, arguments: Seq[String]): Int =
-    Fork.blockForExitCode(fork(config, arguments))
+    import config.*
+    val outStrategy = outputStrategy.getOrElse(StdoutOutput)
+    if connectInput && outStrategy == StdoutOutput then
+      Fork.blockJForExitCode(interactiveFork(config, arguments))
+    else Fork.blockForExitCode(fork(config, arguments))
+
+  private def interactiveFork(config: ForkOptions, arguments: Seq[String]): JProcess =
+    val (extraEnv, jpb) = prep(config, arguments)
+    Fork.forkInternalInteractive(config, extraEnv, jpb)
 
   /**
    * Forks the configured process and returns a `Process` that can be used to wait for completion or
@@ -45,7 +53,14 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
    * Fork instance, it is prepended to `arguments` to define the arguments passed to the forked
    * command.
    */
-  def fork(config: ForkOptions, arguments: Seq[String]): Process = {
+  def fork(config: ForkOptions, arguments: Seq[String]): Process =
+    val (extraEnv, jpb) = prep(config, arguments)
+    Fork.forkInternal(config, extraEnv, jpb)
+
+  private def prep(
+      config: ForkOptions,
+      arguments: Seq[String]
+  ): (List[(String, String)], JProcessBuilder) =
     import config.*
     val executable = Fork.javaCommand(javaHome, commandName).getAbsolutePath
     val preOptions = makeOptions(runJVMOptions, bootJars, arguments)
@@ -63,8 +78,7 @@ final class Fork(val commandName: String, val runnerClass: Option[String]) {
     val extraEnv = classpathEnv.toList.map { value =>
       Fork.ClasspathEnvKey -> value
     }
-    Fork.forkInternal(config, extraEnv, jpb)
-  }
+    (extraEnv, jpb)
 
   private def makeOptions(
       jvmOptions: Seq[String],
@@ -194,6 +208,29 @@ object Fork {
       case out: LoggedOutput      => process.run(out.logger, connectInput = false)
       case out: CustomOutput      => (process #> out.output).run(connectInput = false)
       case out: CustomInputOutput => process.run(out.processIO)
+  }
+
+  private[sbt] def forkInternalInteractive(
+      config: ForkOptions,
+      extraEnv: List[(String, String)],
+      jpb: JProcessBuilder
+  ): JProcess =
+    import config.{ envVars as env, * }
+    val environment: List[(String, String)] = env.toList ++ extraEnv
+    workingDirectory.foreach(jpb.directory(_))
+    environment.foreach { case (k, v) => jpb.environment.put(k, v) }
+    jpb.inheritIO()
+    jpb.start()
+
+  private[sbt] def blockJForExitCode(p: JProcess): Int = {
+    RunningProcesses.add(p)
+    try
+      p.waitFor()
+      p.exitValue()
+    finally {
+      if (p.isAlive()) p.destroy()
+      RunningProcesses.remove(p)
+    }
   }
 
   private[sbt] def blockForExitCode(p: Process): Int = {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8676

## Problem

For interactive apps, including Scala REPL, it's better to use the raw Java Process, rather than Scala process that attempts to grab the output stream in a thread.

## Solution
For forking that require both input and output,
use a Java process instead of the Scala process.

## Note

This was inspired by https://github.com/sbt/sbt/pull/8604.