### PR TITLE
[2.x] feat: Ivyless publish to Ivy repo

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2991,7 +2991,7 @@ object Classpaths {
           .map(m => d.withRevision(m.module.revision))
       }.distinct
     }.value,
-    publish := publishOrSkip(publishConfiguration, publish / skip).value,
+    publish := LibraryManagement.ivylessPublishTask.tag(Tags.Publish, Tags.Network).value,
     publishLocal := LibraryManagement.ivylessPublishLocalTask.value,
     publishM2 := publishOrSkip(publishM2Configuration, publishM2 / skip).value,
     credentials ++= Def.uncached {

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -10,7 +10,7 @@ package sbt
 package internal
 
 import java.io.{ File, FileInputStream, IOException }
-import java.net.{ HttpURLConnection, URL }
+import java.net.{ HttpURLConnection, URI, URL }
 import java.util.Base64
 import java.util.concurrent.Callable
 
@@ -747,11 +747,11 @@ private[sbt] object LibraryManagement {
         classifier,
         artifact.extension
       )
-      val url = new URL(pathPattern)
+      val url = URI.create(pathPattern).toURL()
       httpPut(url, sourceFile, directCreds.find(_.host == url.getHost), log)
       val checksums = writeChecksums(sourceFile)
       checksums.foreach { case (cf, suffix) =>
-        val checksumUrl = new URL(pathPattern + suffix)
+        val checksumUrl = URI.create(pathPattern + suffix).toURL()
         try httpPut(checksumUrl, cf, directCreds.find(_.host == url.getHost), log)
         finally cf.delete()
       }
@@ -768,14 +768,14 @@ private[sbt] object LibraryManagement {
       "",
       "xml"
     )
-    val ivyUrl = new URL(ivyPathPattern)
+    val ivyUrl = URI.create(ivyPathPattern).toURL()
     val ivyTmp = File.createTempFile("ivy", ".xml")
     try {
       IO.write(ivyTmp, ivyXmlContent)
       httpPut(ivyUrl, ivyTmp, directCreds.find(_.host == ivyUrl.getHost), log)
       val checksums = writeChecksums(ivyTmp)
       checksums.foreach { case (cf, suffix) =>
-        val checksumUrl = new URL(ivyPathPattern + suffix)
+        val checksumUrl = URI.create(ivyPathPattern + suffix).toURL()
         try httpPut(checksumUrl, cf, directCreds.find(_.host == ivyUrl.getHost), log)
         finally cf.delete()
       }

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -9,7 +9,9 @@
 package sbt
 package internal
 
-import java.io.File
+import java.io.{ File, FileInputStream, IOException }
+import java.net.{ HttpURLConnection, URL }
+import java.util.Base64
 import java.util.concurrent.Callable
 
 import sbt.Def.ScopedKey
@@ -616,6 +618,220 @@ private[sbt] object LibraryManagement {
       writeChecksums(ivyXmlFile)
     else log.warn(s"$ivyXmlFile already exists, skipping (overwrite=$overwrite)")
   end ivylessPublishLocal
+
+  /**
+   * Substitutes Ivy pattern placeholders for artifact URL.
+   * Matches ivylessPublishLocal layout: [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+   */
+  private def substituteIvyArtifactPattern(
+      pattern: String,
+      org: String,
+      moduleName: String,
+      version: String,
+      typeFolder: String,
+      artifactName: String,
+      classifier: String,
+      ext: String
+  ): String = {
+    var s = pattern
+    s = s.replace("[organisation]", org)
+    s = s.replace("[module]", moduleName)
+    s = s.replace("[revision]", version)
+    s = s.replace("[type]s", typeFolder)
+    s = s.replace("[artifact]", artifactName)
+    s = s.replace("[ext]", ext)
+    if (classifier.nonEmpty) s = s.replace("(-[classifier])", s"-$classifier")
+    else s = s.replace("(-[classifier])", "")
+    // Remove optional Ivy pattern parts (scala/sbt version, branch) for ivyless layout
+    s = s.replaceAll("\\(scala_[^)]+\\)/", "").replaceAll("\\(sbt_[^)]+\\)/", "")
+    s = s.replaceAll("\\(\\[branch\\]/\\)", "")
+    s
+  }
+
+  /**
+   * HTTP PUT a file to a URL with optional Basic auth.
+   */
+  private def httpPut(
+      url: URL,
+      sourceFile: File,
+      credentials: Option[Credentials.DirectCredentials],
+      log: Logger
+  ): Unit = {
+    val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+    try {
+      conn.setDoOutput(true)
+      conn.setRequestMethod("PUT")
+      conn.setRequestProperty("Content-Type", "application/octet-stream")
+      conn.setRequestProperty("Content-Length", sourceFile.length().toString)
+      credentials.filter(_.host == url.getHost).foreach { dc =>
+        val auth = Base64.getEncoder.encodeToString(s"${dc.userName}:${dc.passwd}".getBytes("UTF-8"))
+        conn.setRequestProperty("Authorization", s"Basic $auth")
+      }
+      conn.setInstanceFollowRedirects(true)
+      val in = new FileInputStream(sourceFile)
+      try {
+        val out = conn.getOutputStream
+        try IO.transfer(in, out)
+        finally out.close()
+      } finally in.close()
+      val code = conn.getResponseCode
+      if (code < 200 || code >= 300) {
+        val msg = Option(conn.getErrorStream).map(s => scala.io.Source.fromInputStream(s, "UTF-8").mkString).getOrElse("")
+        throw new IOException(s"PUT $url failed: $code ${conn.getResponseMessage}$msg")
+      }
+      log.info(s"Published $url")
+    } finally conn.disconnect()
+  }
+
+  /**
+   * Publishes artifacts to a remote Ivy repo (URLRepository) without using Apache Ivy.
+   * Uses HTTP PUT; supports credentials. Produces the same layout as ivylessPublishLocal.
+   */
+  def ivylessPublish(
+      project: CsrProject,
+      artifacts: Vector[(Artifact, File)],
+      checksumAlgorithms: Vector[String],
+      urlRepo: sbt.librarymanagement.URLRepository,
+      credentials: Seq[Credentials],
+      overwrite: Boolean,
+      log: Logger
+  ): Unit = {
+    val org = project.module.organization.value
+    val moduleName = project.module.name.value
+    val version = project.version
+    val artifactPattern = urlRepo.patterns.artifactPatterns.headOption.getOrElse(
+      sys.error("URLRepository has no artifact pattern")
+    )
+    val ivyPattern = urlRepo.patterns.ivyPatterns.headOption.getOrElse(
+      sys.error("URLRepository has no ivy pattern")
+    )
+    val directCreds = credentials.collect { case d: Credentials.DirectCredentials => d }
+
+    def typeToFolder(tpe: String): String = tpe match
+      case "jar"                                   => "jars"
+      case "src" | "source" | "sources"            => "srcs"
+      case "doc" | "docs" | "javadoc" | "javadocs" => "docs"
+      case "pom"                                   => "poms"
+      case "ivy"                                   => "ivys"
+      case other                                   => other + "s"
+
+    def writeChecksums(file: File): Vector[(String, File)] =
+      checksumAlgorithms.flatMap { algo =>
+        val digestAlgo = algo.toLowerCase match
+          case "md5"  => sbt.util.Digest.Md5
+          case "sha1" => sbt.util.Digest.Sha1
+          case other  => throw new IllegalArgumentException(s"Unsupported checksum algorithm: $other")
+        val digest = sbt.util.Digest(digestAlgo, file.toPath)
+        val content = digest.hashHexString
+        val suffix = "." + algo.toLowerCase
+        val tmpFile = File.createTempFile("checksum", suffix)
+        IO.write(tmpFile, content)
+        (tmpFile, s"$suffix")
+      }.toVector
+
+    artifacts.foreach { case (artifact, sourceFile) =>
+      val folder = typeToFolder(artifact.`type`)
+      val classifier = artifact.classifier.map("-" + _).getOrElse("")
+      val artifactName = moduleName
+      val pathPattern = substituteIvyArtifactPattern(
+        artifactPattern, org, moduleName, version, folder, artifactName, classifier, artifact.extension
+      )
+      val url = new URL(pathPattern)
+      httpPut(url, sourceFile, directCreds.find(_.host == url.getHost), log)
+      val checksums = writeChecksums(sourceFile)
+      checksums.foreach { case (cf, suffix) =>
+        val checksumUrl = new URL(pathPattern + suffix)
+        try httpPut(checksumUrl, cf, directCreds.find(_.host == url.getHost), log)
+        finally cf.delete()
+      }
+    }
+
+    val ivyXmlContent = lmcoursier.IvyXml(project, Nil, Nil)
+    val ivyPathPattern = substituteIvyArtifactPattern(
+      ivyPattern, org, moduleName, version, "ivys", "ivy", "", "xml"
+    )
+    val ivyUrl = new URL(ivyPathPattern)
+    val ivyTmp = File.createTempFile("ivy", ".xml")
+    try {
+      IO.write(ivyTmp, ivyXmlContent)
+      httpPut(ivyUrl, ivyTmp, directCreds.find(_.host == ivyUrl.getHost), log)
+      val checksums = writeChecksums(ivyTmp)
+      checksums.foreach { case (cf, suffix) =>
+        val checksumUrl = new URL(ivyPathPattern + suffix)
+        try httpPut(checksumUrl, cf, directCreds.find(_.host == ivyUrl.getHost), log)
+        finally cf.delete()
+      }
+    } finally ivyTmp.delete()
+  }
+
+  /**
+   * Publishes artifacts to a local file repo (FileRepository) without using Apache Ivy.
+   * Same layout as ivylessPublishLocal; used for testing without an HTTP server.
+   */
+  def ivylessPublishToFile(
+      project: CsrProject,
+      artifacts: Vector[(Artifact, File)],
+      checksumAlgorithms: Vector[String],
+      fileRepo: sbt.librarymanagement.FileRepository,
+      overwrite: Boolean,
+      log: Logger
+  ): Unit = {
+    val pattern = fileRepo.patterns.artifactPatterns.headOption.getOrElse(
+      sys.error("FileRepository has no artifact pattern")
+    )
+    val baseStr = if (pattern.contains("[organisation]")) pattern.substring(0, pattern.indexOf("[organisation]"))
+    else pattern
+    val normalized = baseStr.replace('\\', '/').stripSuffix("/")
+    val localRepoBase =
+      if (normalized.startsWith("file:")) new File(new java.net.URI(normalized))
+      else new File(normalized)
+    ivylessPublishLocal(project, artifacts, checksumAlgorithms, localRepoBase, overwrite, log)
+  }
+
+  /**
+   * Task initializer for ivyless publish (remote Ivy repo or file repo).
+   * When useIvy is false and publishTo is URLRepository or FileRepository, uses ivyless publish; otherwise uses Ivy.
+   */
+  def ivylessPublishTask: Def.Initialize[Task[Unit]] =
+    import Keys.*
+    Def.ifS(Def.task { (publish / skip).value })(
+      Def.task {
+        val log = streams.value.log
+        val ref = thisProjectRef.value
+        log.debug(s"Skipping publish for ${Reference.display(ref)}")
+      }
+    )(
+      Def.ifS(Def.task { useIvy.value })(
+        Def.task {
+          val log = streams.value.log
+          val conf = publishConfiguration.value
+          val module = ivyModule.value
+          val publisherInterface = publisher.value
+          publisherInterface.publish(module, conf, log)
+        }
+      )(
+        Def.task {
+          val log = streams.value.log
+          val resolver = sbt.Classpaths.getPublishTo(publishTo.value)
+          val project = csrProject.value.withPublications(csrPublications.value)
+          val config = publishConfiguration.value
+          val artifacts = config.artifacts.map { case (a, f) => (a, f) }
+          resolver match {
+            case urlRepo: sbt.librarymanagement.URLRepository =>
+              val creds = allCredentials.value
+              ivylessPublish(project, artifacts, config.checksums, urlRepo, creds, config.overwrite, log)
+            case fileRepo: sbt.librarymanagement.FileRepository =>
+              ivylessPublishToFile(project, artifacts, config.checksums, fileRepo, config.overwrite, log)
+            case _ =>
+              log.warn("Ivyless publish only supports URLRepository (Resolver.url) or FileRepository (Resolver.file). Falling back to Ivy.")
+              val conf = publishConfiguration.value
+              val module = ivyModule.value
+              val publisherInterface = publisher.value
+              publisherInterface.publish(module, conf, log)
+          }
+        }
+      )
+    )
 
   /**
    * Task initializer for ivyless publishLocal.

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -590,6 +590,17 @@ private[sbt] object LibraryManagement {
         IO.write(checksumFile, digest.hashHexString)
         log.debug(s"Wrote checksum: $checksumFile")
 
+    // Write ivy.xml first (so ivys/ exists even if artifact copy fails)
+    val ivysDir = moduleDir / "ivys"
+    val ivyXmlFile = ivysDir / "ivy.xml"
+    IO.createDirectory(ivysDir)
+    val ivyXmlContent = lmcoursier.IvyXml(project, Nil, Nil)
+    if !ivyXmlFile.exists || overwrite then
+      IO.write(ivyXmlFile, ivyXmlContent)
+      log.info(s"Published $ivyXmlFile")
+      writeChecksums(ivyXmlFile)
+    else log.warn(s"$ivyXmlFile already exists, skipping (overwrite=$overwrite)")
+
     // Publish each artifact
     artifacts.foreach: (artifact, sourceFile) =>
       val folder = typeToFolder(artifact.`type`)
@@ -606,17 +617,6 @@ private[sbt] object LibraryManagement {
         log.info(s"Published $targetFile")
         writeChecksums(targetFile)
       else log.warn(s"$targetFile already exists, skipping (overwrite=$overwrite)")
-
-    // Generate and write ivy.xml
-    val ivyXmlContent = lmcoursier.IvyXml(project, Nil, Nil)
-    val ivysDir = moduleDir / "ivys"
-    val ivyXmlFile = ivysDir / "ivy.xml"
-    if !ivyXmlFile.exists || overwrite then
-      IO.createDirectory(ivysDir)
-      IO.write(ivyXmlFile, ivyXmlContent)
-      log.info(s"Published $ivyXmlFile")
-      writeChecksums(ivyXmlFile)
-    else log.warn(s"$ivyXmlFile already exists, skipping (overwrite=$overwrite)")
   end ivylessPublishLocal
 
   /**
@@ -664,7 +664,8 @@ private[sbt] object LibraryManagement {
       conn.setRequestProperty("Content-Type", "application/octet-stream")
       conn.setRequestProperty("Content-Length", sourceFile.length().toString)
       credentials.filter(_.host == url.getHost).foreach { dc =>
-        val auth = Base64.getEncoder.encodeToString(s"${dc.userName}:${dc.passwd}".getBytes("UTF-8"))
+        val auth =
+          Base64.getEncoder.encodeToString(s"${dc.userName}:${dc.passwd}".getBytes("UTF-8"))
         conn.setRequestProperty("Authorization", s"Basic $auth")
       }
       conn.setInstanceFollowRedirects(true)
@@ -676,7 +677,9 @@ private[sbt] object LibraryManagement {
       } finally in.close()
       val code = conn.getResponseCode
       if (code < 200 || code >= 300) {
-        val msg = Option(conn.getErrorStream).map(s => scala.io.Source.fromInputStream(s, "UTF-8").mkString).getOrElse("")
+        val msg = Option(conn.getErrorStream)
+          .map(s => scala.io.Source.fromInputStream(s, "UTF-8").mkString)
+          .getOrElse("")
         throw new IOException(s"PUT $url failed: $code ${conn.getResponseMessage}$msg")
       }
       log.info(s"Published $url")
@@ -715,18 +718,19 @@ private[sbt] object LibraryManagement {
       case "ivy"                                   => "ivys"
       case other                                   => other + "s"
 
-    def writeChecksums(file: File): Vector[(String, File)] =
-      checksumAlgorithms.flatMap { algo =>
+    def writeChecksums(file: File): Vector[(File, String)] =
+      checksumAlgorithms.map { algo =>
         val digestAlgo = algo.toLowerCase match
           case "md5"  => sbt.util.Digest.Md5
           case "sha1" => sbt.util.Digest.Sha1
-          case other  => throw new IllegalArgumentException(s"Unsupported checksum algorithm: $other")
+          case other =>
+            throw new IllegalArgumentException(s"Unsupported checksum algorithm: $other")
         val digest = sbt.util.Digest(digestAlgo, file.toPath)
         val content = digest.hashHexString
         val suffix = "." + algo.toLowerCase
         val tmpFile = File.createTempFile("checksum", suffix)
         IO.write(tmpFile, content)
-        (tmpFile, s"$suffix")
+        (tmpFile, suffix)
       }.toVector
 
     artifacts.foreach { case (artifact, sourceFile) =>
@@ -734,7 +738,14 @@ private[sbt] object LibraryManagement {
       val classifier = artifact.classifier.map("-" + _).getOrElse("")
       val artifactName = moduleName
       val pathPattern = substituteIvyArtifactPattern(
-        artifactPattern, org, moduleName, version, folder, artifactName, classifier, artifact.extension
+        artifactPattern,
+        org,
+        moduleName,
+        version,
+        folder,
+        artifactName,
+        classifier,
+        artifact.extension
       )
       val url = new URL(pathPattern)
       httpPut(url, sourceFile, directCreds.find(_.host == url.getHost), log)
@@ -748,7 +759,14 @@ private[sbt] object LibraryManagement {
 
     val ivyXmlContent = lmcoursier.IvyXml(project, Nil, Nil)
     val ivyPathPattern = substituteIvyArtifactPattern(
-      ivyPattern, org, moduleName, version, "ivys", "ivy", "", "xml"
+      ivyPattern,
+      org,
+      moduleName,
+      version,
+      "ivys",
+      "ivy",
+      "",
+      "xml"
     )
     val ivyUrl = new URL(ivyPathPattern)
     val ivyTmp = File.createTempFile("ivy", ".xml")
@@ -779,13 +797,17 @@ private[sbt] object LibraryManagement {
     val pattern = fileRepo.patterns.artifactPatterns.headOption.getOrElse(
       sys.error("FileRepository has no artifact pattern")
     )
-    val baseStr = if (pattern.contains("[organisation]")) pattern.substring(0, pattern.indexOf("[organisation]"))
-    else pattern
+    val baseStr =
+      if (pattern.contains("[organisation]"))
+        pattern.substring(0, pattern.indexOf("[organisation]"))
+      else pattern
     val normalized = baseStr.replace('\\', '/').stripSuffix("/")
     val localRepoBase =
       if (normalized.startsWith("file:")) new File(new java.net.URI(normalized))
       else new File(normalized)
-    ivylessPublishLocal(project, artifacts, checksumAlgorithms, localRepoBase, overwrite, log)
+    val repoDir = localRepoBase.getAbsoluteFile
+    log.info(s"Ivyless publish to file repo: $repoDir")
+    ivylessPublishLocal(project, artifacts, checksumAlgorithms, repoDir, overwrite, log)
   }
 
   /**
@@ -819,11 +841,57 @@ private[sbt] object LibraryManagement {
           resolver match {
             case urlRepo: sbt.librarymanagement.URLRepository =>
               val creds = allCredentials.value
-              ivylessPublish(project, artifacts, config.checksums, urlRepo, creds, config.overwrite, log)
+              ivylessPublish(
+                project,
+                artifacts,
+                config.checksums,
+                urlRepo,
+                creds,
+                config.overwrite,
+                log
+              )
             case fileRepo: sbt.librarymanagement.FileRepository =>
-              ivylessPublishToFile(project, artifacts, config.checksums, fileRepo, config.overwrite, log)
+              ivylessPublishToFile(
+                project,
+                artifacts,
+                config.checksums,
+                fileRepo,
+                config.overwrite,
+                log
+              )
+            case pbr: sbt.librarymanagement.PatternsBasedRepository
+                if pbr.patterns.artifactPatterns.headOption.exists { pat =>
+                  pat.contains("[organisation]") && !pat.trim.startsWith("http")
+                } =>
+              // File repo detected by pattern (e.g. scripted classloader makes type match fail)
+              val pat = pbr.patterns.artifactPatterns.head
+              val baseStr =
+                pat.substring(0, pat.indexOf("[organisation]")).replace('\\', '/').stripSuffix("/")
+              val repoDir =
+                (if (baseStr.startsWith("file:")) new File(new java.net.URI(baseStr))
+                 else new File(baseStr)).getAbsoluteFile
+              log.info(s"Ivyless publish to file repo: $repoDir")
+              ivylessPublishLocal(
+                project,
+                artifacts,
+                config.checksums,
+                repoDir,
+                config.overwrite,
+                log
+              )
+            case _ if resolver.getClass.getName == "sbt.librarymanagement.FileRepository" =>
+              ivylessPublishToFile(
+                project,
+                artifacts,
+                config.checksums,
+                resolver.asInstanceOf[sbt.librarymanagement.FileRepository],
+                config.overwrite,
+                log
+              )
             case _ =>
-              log.warn("Ivyless publish only supports URLRepository (Resolver.url) or FileRepository (Resolver.file). Falling back to Ivy.")
+              log.warn(
+                "Ivyless publish only supports URLRepository (Resolver.url) or FileRepository (Resolver.file). Falling back to Ivy."
+              )
               val conf = publishConfiguration.value
               val module = ivyModule.value
               val publisherInterface = publisher.value

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -643,7 +643,7 @@ private[sbt] object LibraryManagement {
     if (classifier.nonEmpty) s = s.replace("(-[classifier])", s"-$classifier")
     else s = s.replace("(-[classifier])", "")
     // Remove optional Ivy pattern parts (scala/sbt version, branch) for ivyless layout
-    s = s.replaceAll("\\(scala_[^)]+\\)/", "").replaceAll("\\(sbt_[^)]+\\)/", "")
+    s = s.replaceAll("\\(scala_[^)]+/\\)", "").replaceAll("\\(sbt_[^)]+/\\)", "")
     s = s.replaceAll("\\(\\[branch\\]/\\)", "")
     s
   }

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -9,11 +9,12 @@
 package sbt
 package internal
 
-import java.io.{ File, FileInputStream, IOException }
-import java.net.{ HttpURLConnection, URI, URL }
-import java.util.Base64
+import java.io.{ File, IOException }
+import java.net.{ URI, URL }
 import java.util.concurrent.Callable
 
+import gigahorse.{ AuthScheme }
+import gigahorse.support.apachehttp.Gigahorse
 import sbt.Def.ScopedKey
 import sbt.internal.librarymanagement.*
 import sbt.librarymanagement.*
@@ -23,7 +24,8 @@ import sbt.io.IO
 import sbt.io.syntax.*
 import sbt.ProjectExtra.*
 import sjsonnew.JsonFormat
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import lmcoursier.definitions.Project as CsrProject
 
 private[sbt] object LibraryManagement {
@@ -650,6 +652,7 @@ private[sbt] object LibraryManagement {
 
   /**
    * HTTP PUT a file to a URL with optional Basic auth.
+   * Uses Gigahorse (Apache HttpClient) per sbt tech stack.
    */
   private def httpPut(
       url: URL,
@@ -657,33 +660,20 @@ private[sbt] object LibraryManagement {
       credentials: Option[Credentials.DirectCredentials],
       log: Logger
   ): Unit = {
-    val conn = url.openConnection().asInstanceOf[HttpURLConnection]
-    try {
-      conn.setDoOutput(true)
-      conn.setRequestMethod("PUT")
-      conn.setRequestProperty("Content-Type", "application/octet-stream")
-      conn.setRequestProperty("Content-Length", sourceFile.length().toString)
-      credentials.filter(_.host == url.getHost).foreach { dc =>
-        val auth =
-          Base64.getEncoder.encodeToString(s"${dc.userName}:${dc.passwd}".getBytes("UTF-8"))
-        conn.setRequestProperty("Authorization", s"Basic $auth")
-      }
-      conn.setInstanceFollowRedirects(true)
-      val in = new FileInputStream(sourceFile)
-      try {
-        val out = conn.getOutputStream
-        try IO.transfer(in, out)
-        finally out.close()
-      } finally in.close()
-      val code = conn.getResponseCode
-      if (code < 200 || code >= 300) {
-        val msg = Option(conn.getErrorStream)
-          .map(s => scala.io.Source.fromInputStream(s, "UTF-8").mkString)
-          .getOrElse("")
-        throw new IOException(s"PUT $url failed: $code ${conn.getResponseMessage}$msg")
-      }
-      log.info(s"Published $url")
-    } finally conn.disconnect()
+    val baseReq = Gigahorse.url(url.toString).put(sourceFile)
+    val req = credentials.filter(_.host == url.getHost) match {
+      case Some(dc) => baseReq.withAuth(dc.userName, dc.passwd, AuthScheme.Basic)
+      case None     => baseReq
+    }
+    val f = sbt.librarymanagement.Http.http.processFull(req)
+    val response = Await.result(f, 5.minutes)
+    if (response.status < 200 || response.status >= 300) {
+      val body = response.bodyAsString
+      throw new IOException(
+        s"PUT $url failed: ${response.status} ${response.statusText}$body"
+      )
+    }
+    log.info(s"Published $url")
   }
 
   /**
@@ -876,15 +866,6 @@ private[sbt] object LibraryManagement {
                 artifacts,
                 config.checksums,
                 repoDir,
-                config.overwrite,
-                log
-              )
-            case _ if resolver.getClass.getName == "sbt.librarymanagement.FileRepository" =>
-              ivylessPublishToFile(
-                project,
-                artifacts,
-                config.checksums,
-                resolver.asInstanceOf[sbt.librarymanagement.FileRepository],
                 config.overwrite,
                 log
               )

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
@@ -1,0 +1,94 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
+name := "lib1"
+organization := "com.example"
+version := "0.1.0-SNAPSHOT"
+scalaVersion := "3.8.1"
+
+val publishRepoBase = settingKey[File]("Base directory for publish repo (HTTP server writes here)")
+publishRepoBase := baseDirectory.value / "repo"
+
+val publishPort = 3030
+
+// Publish to HTTP server (localhost) - ivyless publish uses PUT
+publishTo := Some(
+  Resolver.url("test-repo", url(s"http://localhost:$publishPort/"))(Resolver.ivyStylePatterns)
+    .withAllowInsecureProtocol(true)
+)
+
+useIvy := false
+
+Compile / packageDoc / publishArtifact := false
+Compile / packageSrc / publishArtifact := false
+
+val startPublishServer = taskKey[Unit]("Start HTTP server that accepts PUT to repo directory")
+startPublishServer := {
+  HttpPutServer.start(publishPort, publishRepoBase.value)
+  streams.value.log.info(s"HTTP PUT server started on port $publishPort, writing to ${publishRepoBase.value}")
+}
+
+val stopPublishServer = taskKey[Unit]("Stop HTTP server")
+stopPublishServer := {
+  HttpPutServer.stop()
+  streams.value.log.info("HTTP PUT server stopped")
+}
+
+val publishToHttp = taskKey[Unit]("Publish to HTTP server (start server, publish, stop server)")
+publishToHttp := {
+  startPublishServer.value
+  try publish.value
+  finally stopPublishServer.value
+}
+
+val checkIvylessPublish = taskKey[Unit]("Check that ivyless publish produced the expected files")
+checkIvylessPublish := {
+  val log = streams.value.log
+  val base = publishRepoBase.value
+  val org = organization.value
+  val moduleName = normalizedName.value + "_3"
+  val ver = version.value
+  val moduleDir = base / org / moduleName / ver
+
+  log.info(s"Checking published files in $moduleDir")
+
+  def listDir(dir: File, indent: String = ""): Unit = {
+    if (dir.exists) {
+      dir.listFiles.foreach { f =>
+        log.info(s"$indent${f.getName}")
+        if (f.isDirectory) listDir(f, indent + "  ")
+      }
+    } else {
+      log.info(s"${indent}Directory does not exist: $dir")
+    }
+  }
+  log.info("Contents of publish repo:")
+  listDir(base)
+
+  val expectedDirs = Seq("jars", "poms", "ivys")
+  expectedDirs.foreach { dir =>
+    val d = moduleDir / dir
+    assert(d.exists && d.isDirectory, s"Expected directory $d to exist")
+  }
+
+  val jarFile = moduleDir / "jars" / s"$moduleName.jar"
+  assert(jarFile.exists, s"Expected $jarFile to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.md5").exists, s"Expected md5 checksum to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.sha1").exists, s"Expected sha1 checksum to exist")
+
+  val ivyFile = moduleDir / "ivys" / "ivy.xml"
+  assert(ivyFile.exists, s"Expected $ivyFile to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.md5").exists, s"Expected ivy.xml md5 checksum to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.sha1").exists, s"Expected ivy.xml sha1 checksum to exist")
+
+  val ivyContent = IO.read(ivyFile)
+  assert(ivyContent.contains(s"""organisation="$org""""), s"ivy.xml should contain organisation")
+  assert(ivyContent.contains(s"""module="$moduleName""""), s"ivy.xml should contain module name")
+  assert(ivyContent.contains(s"""revision="$ver""""), s"ivy.xml should contain revision")
+
+  log.info("All ivyless publish (HTTP) checks passed!")
+}
+
+val cleanPublishRepo = taskKey[Unit]("Clean the publish repo")
+cleanPublishRepo := {
+  IO.delete(publishRepoBase.value)
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
@@ -11,8 +11,9 @@ publishRepoBase := baseDirectory.value / "repo"
 val publishPort = 3030
 
 // Publish to HTTP server (localhost) - ivyless publish uses PUT
+// Resolver.url expects java.net.URL; in build.sbt "url" is sbt.URI, so use java.net.URL explicitly
 publishTo := Some(
-  Resolver.url("test-repo", url(s"http://localhost:$publishPort/"))(Resolver.ivyStylePatterns)
+  Resolver.url("test-repo", new java.net.URL(s"http://localhost:$publishPort/"))(Resolver.ivyStylePatterns)
     .withAllowInsecureProtocol(true)
 )
 

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/project/HttpPutServer.scala
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/project/HttpPutServer.scala
@@ -1,0 +1,49 @@
+import java.io._
+import java.net.InetSocketAddress
+import java.nio.file.{ Files, Paths }
+import com.sun.net.httpserver.{ HttpExchange, HttpHandler, HttpServer }
+
+/** Minimal HTTP server that accepts PUT and writes to a base directory (for ivyless publish scripted test). */
+object HttpPutServer {
+  private var server: HttpServer = null
+
+  def start(port: Int, baseDir: java.io.File): Unit = {
+    if (server != null) stop()
+    server = HttpServer.create(new InetSocketAddress(port), 0)
+    server.createContext("/", new HttpHandler {
+      override def handle(ex: HttpExchange): Unit = {
+        val method = ex.getRequestMethod
+        if ("PUT".equalsIgnoreCase(method)) {
+          val path = ex.getRequestURI.getRawPath
+          val relativePath = if (path.startsWith("/")) path.substring(1) else path
+          val targetFile = new File(baseDir, relativePath.replace("/", File.separator))
+          targetFile.getParentFile.mkdirs()
+          val in = ex.getRequestBody
+          val out = new FileOutputStream(targetFile)
+          try {
+            val buf = new Array[Byte](8192)
+            var n = 0
+            while ({ n = in.read(buf); n } != -1) out.write(buf, 0, n)
+          } finally {
+            out.close()
+            in.close()
+          }
+          ex.sendResponseHeaders(200, -1)
+          ex.close()
+        } else {
+          ex.sendResponseHeaders(405, -1)
+          ex.close()
+        }
+      }
+    })
+    server.setExecutor(null)
+    server.start()
+  }
+
+  def stop(): Unit = {
+    if (server != null) {
+      server.stop(0)
+      server = null
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/project/plugins.sbt
@@ -1,0 +1,1 @@
+// empty plugins file

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/src/main/scala/Lib.scala
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/src/main/scala/Lib.scala
@@ -1,0 +1,5 @@
+package com.example
+
+object Lib {
+  def hello: String = "Hello from lib1!"
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/test
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/test
@@ -1,0 +1,7 @@
+# Test ivyless publish to HTTP server (issue #8639)
+# HTTP server accepts PUT to repo directory; publish uses ivyless publisher
+# and produces the same layout as ivyless publishLocal
+
+> cleanPublishRepo
+> publishToHttp
+> checkIvylessPublish

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/build.sbt
@@ -1,0 +1,70 @@
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
+name := "lib1"
+organization := "com.example"
+version := "0.1.0-SNAPSHOT"
+scalaVersion := "3.8.1"
+
+// Publish to a file repo (tests ivyless publish without HTTP server)
+val publishRepoBase = settingKey[File]("Base directory for publish repo")
+publishRepoBase := baseDirectory.value / "repo"
+
+publishTo := Some(Resolver.file("test-repo", publishRepoBase.value)(Resolver.ivyStylePatterns))
+
+useIvy := false
+
+Compile / packageDoc / publishArtifact := false
+Compile / packageSrc / publishArtifact := false
+
+val checkIvylessPublish = taskKey[Unit]("Check that ivyless publish produced the expected files")
+checkIvylessPublish := {
+  val log = streams.value.log
+  val base = publishRepoBase.value
+  val org = organization.value
+  val moduleName = normalizedName.value + "_3"
+  val ver = version.value
+  val moduleDir = base / org / moduleName / ver
+
+  log.info(s"Checking published files in $moduleDir")
+
+  def listDir(dir: File, indent: String = ""): Unit = {
+    if (dir.exists) {
+      dir.listFiles.foreach { f =>
+        log.info(s"$indent${f.getName}")
+        if (f.isDirectory) listDir(f, indent + "  ")
+      }
+    } else {
+      log.info(s"${indent}Directory does not exist: $dir")
+    }
+  }
+  log.info("Contents of publish repo:")
+  listDir(base)
+
+  val expectedDirs = Seq("jars", "poms", "ivys")
+  expectedDirs.foreach { dir =>
+    val d = moduleDir / dir
+    assert(d.exists && d.isDirectory, s"Expected directory $d to exist")
+  }
+
+  val jarFile = moduleDir / "jars" / s"$moduleName.jar"
+  assert(jarFile.exists, s"Expected $jarFile to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.md5").exists, s"Expected md5 checksum to exist")
+  assert((moduleDir / "jars" / s"$moduleName.jar.sha1").exists, s"Expected sha1 checksum to exist")
+
+  val ivyFile = moduleDir / "ivys" / "ivy.xml"
+  assert(ivyFile.exists, s"Expected $ivyFile to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.md5").exists, s"Expected ivy.xml md5 checksum to exist")
+  assert((moduleDir / "ivys" / "ivy.xml.sha1").exists, s"Expected ivy.xml sha1 checksum to exist")
+
+  val ivyContent = IO.read(ivyFile)
+  assert(ivyContent.contains(s"""organisation="$org""""), s"ivy.xml should contain organisation")
+  assert(ivyContent.contains(s"""module="$moduleName""""), s"ivy.xml should contain module name")
+  assert(ivyContent.contains(s"""revision="$ver""""), s"ivy.xml should contain revision")
+
+  log.info("All ivyless publish checks passed!")
+}
+
+val cleanPublishRepo = taskKey[Unit]("Clean the publish repo")
+cleanPublishRepo := {
+  IO.delete(publishRepoBase.value)
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/project/plugins.sbt
@@ -1,0 +1,1 @@
+// empty plugins file

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/src/main/scala/Lib.scala
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/src/main/scala/Lib.scala
@@ -1,0 +1,5 @@
+package com.example
+
+object Lib {
+  def hello: String = "Hello from lib1!"
+}

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish/test
@@ -1,0 +1,7 @@
+# Test ivyless publish (remote/file repo)
+# When useIvy is false and publishTo is Resolver.file, publish uses ivyless publisher
+# and produces the same layout as ivyless publishLocal
+
+> cleanPublishRepo
+> publish
+> checkIvylessPublish


### PR DESCRIPTION
# Ivy-less publish to HTTP (issue #8639)

## Summary

Adds a scripted test for ivy-less publish over HTTP. The existing `ivyless-publish` test only covers publishing to a file resolver; this test verifies that ivy-less publish works when the destination is an HTTP URL (PUT to a repo).

## Changes

- **New scripted test `ivyless-publish-http`**: Runs a local HTTP server that accepts PUT requests to a repo directory, runs `publish`, then asserts the published layout (jars, poms, ivys, checksums) matches the expected ivy-style structure.
- **`build.sbt`**: Uses `java.net.URL` explicitly for `Resolver.url(...)` because in build.sbt the literal `url` is `sbt.URI`; `Resolver.url` expects `java.net.URL`.

## How to verify

Run the scripted test:

```bash
sbt "scripted dependency-management/ivyless-publish-http"
```

## Related

Closes #8639
