### PR TITLE
[2.x] fix: Handle NoSuchFileException in hashedVirtualFileRefToStr

### DIFF
--- a/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
+++ b/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
@@ -61,7 +61,12 @@ trait CacheImplicits extends BasicCacheImplicits with BasicJsonProtocol:
    * A string representation of HashedVirtualFileRef, delimited by `>`.
    */
   override def hashedVirtualFileRefToStr(ref: HashedVirtualFileRef): String =
-    def fallback: String = super.hashedVirtualFileRefToStr(ref)
+    def fallback: String =
+      try super.hashedVirtualFileRefToStr(ref)
+      catch
+        case _: NoSuchFileException =>
+          import Digest.*
+          s"${ref.id}>${Digest.zero.contentHashStr}/0"
     if ref.id().endsWith(".scala") || ref.id().endsWith(".java") then fallback
     else
       ref match

--- a/util-cache/src/test/scala/sbt/util/CacheImplicitsTest.scala
+++ b/util-cache/src/test/scala/sbt/util/CacheImplicitsTest.scala
@@ -1,0 +1,30 @@
+package sbt.util
+
+import java.io.InputStream
+import java.nio.file.{ NoSuchFileException, Path, Paths }
+import verify.BasicTestSuite
+import xsbti.{ BasicVirtualFileRef, PathBasedFile }
+
+object CacheImplicitsTest extends BasicTestSuite:
+  test("hashedVirtualFileRefToStr handles non-existent PathBasedFile"):
+    val nonExistentPath = Paths.get("/tmp/does-not-exist-8687.jar")
+    val ref = TestPathBasedFile(nonExistentPath)
+    val result = CacheImplicits.hashedVirtualFileRefToStr(ref)
+    assert(result.contains(">"))
+    assert(result.contains("/"))
+    val parsed = CacheImplicits.strToHashedVirtualFileRef(result)
+    assert(parsed.id == ref.id)
+    assert(parsed.sizeBytes == 0L)
+end CacheImplicitsTest
+
+class TestPathBasedFile(p: Path) extends BasicVirtualFileRef(p.toString) with PathBasedFile:
+  override def toPath: Path = p
+  override def input: InputStream =
+    throw NoSuchFileException(p.toString)
+  override def contentHash: Long =
+    throw NoSuchFileException(p.toString)
+  override def contentHashStr: String =
+    throw NoSuchFileException(p.toString)
+  override def sizeBytes: Long =
+    throw NoSuchFileException(p.toString)
+end TestPathBasedFile


### PR DESCRIPTION
# Handle NoSuchFileException during caching (issue #8687)

## Summary

Fixes an intermittent `NoSuchFileException` that occurs when a file referenced during caching is deleted before its content hash can be computed.

## Changes

- **`CacheImplicits.hashedVirtualFileRefToStr`**: Wrapped the `fallback` function in a try-catch for `NoSuchFileException`. Previously, the catch clause on `Files.readAttributes` would call `fallback`, which in turn called `ref.contentHashStr()` — triggering the same exception again, this time uncaught. The fallback now returns a valid zero-hash string instead of crashing.
- **New test `CacheImplicitsTest`**: Verifies that `hashedVirtualFileRefToStr` handles a `PathBasedFile` pointing to a non-existent file gracefully and produces a round-trippable string.

## How to verify

Run the unit test:

```bash
sbt "utilCache/testOnly sbt.util.CacheImplicitsTest"
