### PR TITLE
Fix TODO/FIXME items: improve exception handling and resource copying

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4301,7 +4301,7 @@ object Classpaths {
   private[sbt] def makePickleProducts: Initialize[Task[Seq[VirtualFile]]] = Def.task {
     // This is a conditional task.
     if (earlyOutputPing.await.value) {
-      // TODO: copyResources.value
+      val _ = copyResources.value
       earlyOutput.value :: Nil
     } else {
       val c = fileConverter.value

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -11,7 +11,7 @@ package sbt
 import java.io.{ File, IOException }
 import java.net.URI
 import java.nio.channels.ClosedChannelException
-import java.nio.file.{ FileAlreadyExistsException, FileSystems, Files }
+import java.nio.file.{ FileSystems, Files }
 import java.util.Properties
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.atomic.AtomicBoolean
@@ -1230,10 +1230,11 @@ object BuiltinCommands {
   private def skipBanner: Command = Command.command(SkipBanner)(skipBanner)
   private def skipBanner(state: State): State = {
     val skipFile = skipWelcomeFile(state, sbtVersion(state))
-    try Files.createFile(skipFile)
-    catch {
-      case _: FileAlreadyExistsException =>
-      case e: IOException                => state.log.error(s"Couldn't create file $skipFile: $e")
+    if (!Files.exists(skipFile)) {
+      try Files.createFile(skipFile)
+      catch {
+        case e: IOException => state.log.error(s"Couldn't create file $skipFile: $e")
+      }
     }
     state
   }

--- a/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -241,7 +241,7 @@ object IvyXml {
       val task = m.invoke(sbt.Keys).asInstanceOf[TaskKey[PublishConfiguration]]
       List(task)
     } catch {
-      case _: Throwable => // FIXME Too wide
+      case _: NoSuchMethodException | _: IllegalAccessException | _: java.lang.reflect.InvocationTargetException | _: ClassCastException =>
         Nil
     }
 


### PR DESCRIPTION
- Fix FIXME in IvyXml.scala: Replace too-wide Throwable catch with specific exceptions (NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassCastException)

- Fix TODO in Defaults.scala: Add copyResources.value in makePickleProducts to ensure resources are copied when using early output/build pipelining

- Improve skipBanner command: Check file existence before creating to avoid unnecessary exception handling