### PR TITLE
[2.x] fix: handle NoSuchFileException during cache storage

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -10,7 +10,7 @@ package sbt.util
 
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Path, Paths, StandardCopyOption }
+import java.nio.file.{ Files, NoSuchFileException, Path, Paths, StandardCopyOption }
 import sbt.internal.util.{ ActionCacheEvent, CacheEventLog, StringVirtualFile1 }
 import sbt.io.syntax.*
 import sbt.io.IO
@@ -81,34 +81,40 @@ object ActionCache:
           case e: Exception =>
             cacheEventLog.append(ActionCacheEvent.Error)
             throw e
-      val json = Converter.toJsonUnsafe(result)
-      val normalizedOutputDir = outputDirectory.toAbsolutePath.normalize()
-      val uncacheableOutputs =
-        outputs.filter(f =>
-          f match
-            case vf if vf.id.endsWith(ActionCache.dirZipExt) =>
-              false
-            case _ =>
-              val outputPath = fileConverter.toPath(f).toAbsolutePath.normalize()
-              !outputPath.startsWith(normalizedOutputDir)
-        )
-      if uncacheableOutputs.nonEmpty then
-        cacheEventLog.append(ActionCacheEvent.Error)
-        logger.error(
-          s"Cannot cache task because its output files are outside the output directory: \n" +
-            uncacheableOutputs.mkString("  - ", "\n  - ", "")
-        )
-        result
-      else
-        cacheEventLog.append(ActionCacheEvent.OnsiteTask)
-        val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
-        val valueFile = StringVirtualFile1(valuePath, CompactPrinter(json))
-        val newOutputs = Vector(valueFile) ++ outputs.toVector
-        store.put(UpdateActionResultRequest(input, newOutputs, exitCode = 0)) match
-          case Right(cachedResult) =>
-            store.syncBlobs(cachedResult.outputFiles, outputDirectory)
-            result
-          case Left(e) => throw e
+      try
+        val json = Converter.toJsonUnsafe(result)
+        val normalizedOutputDir = outputDirectory.toAbsolutePath.normalize()
+        val uncacheableOutputs =
+          outputs.filter(f =>
+            f match
+              case vf if vf.id.endsWith(ActionCache.dirZipExt) =>
+                false
+              case _ =>
+                val outputPath = fileConverter.toPath(f).toAbsolutePath.normalize()
+                !outputPath.startsWith(normalizedOutputDir)
+          )
+        if uncacheableOutputs.nonEmpty then
+          cacheEventLog.append(ActionCacheEvent.Error)
+          logger.error(
+            s"Cannot cache task because its output files are outside the output directory: \n" +
+              uncacheableOutputs.mkString("  - ", "\n  - ", "")
+          )
+          result
+        else
+          cacheEventLog.append(ActionCacheEvent.OnsiteTask)
+          val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
+          val valueFile = StringVirtualFile1(valuePath, CompactPrinter(json))
+          val newOutputs = Vector(valueFile) ++ outputs.toVector
+          store.put(UpdateActionResultRequest(input, newOutputs, exitCode = 0)) match
+            case Right(cachedResult) =>
+              store.syncBlobs(cachedResult.outputFiles, outputDirectory)
+              result
+            case Left(e) => throw e
+      catch
+        case e: NoSuchFileException =>
+          logger.debug(s"Skipping cache storage due to missing file: ${e.getMessage}")
+          cacheEventLog.append(ActionCacheEvent.Error)
+          result
 
     // Single cache lookup - use exitCode to distinguish success from failure
     getWithFailure(key, codeContentHash, extraHash, tags, config) match

--- a/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
+++ b/util-cache/src/main/scala/sbt/util/CacheImplicits.scala
@@ -74,6 +74,6 @@ trait CacheImplicits extends BasicCacheImplicits with BasicJsonProtocol:
               val lastModified = attrs.lastModifiedTime().toMillis()
               val sizeBytes = attrs.size()
               getOrElseUpdate(ref, lastModified, sizeBytes)(fallback)
-          catch case _: NoSuchFileException => fallback
+          catch case e: NoSuchFileException => throw e
         case _ => fallback
 end CacheImplicits


### PR DESCRIPTION
## Problem

When a file referenced during cache serialization is deleted between task execution and cache storage, sbt crashes with an uncaught `NoSuchFileException`. This is intermittent and happens during
concurrent builds (e.g. scripted tests).

The root cause is a double-fault in `CacheImplicits.hashedVirtualFileRefToStr`:

1. `Files.readAttributes(path, ...)` throws `NoSuchFileException` (file was deleted)
2. The catch block calls `fallback` → `super.hashedVirtualFileRefToStr(ref)`
3. That calls `ref.contentHashStr()` which reads the file again → second `NoSuchFileException`, uncaught

Fixes #8687

## Solution

Two changes:

1. **`CacheImplicits.hashedVirtualFileRefToStr`**: Re-throw `NoSuchFileException` instead of calling `fallback` (which will also throw). This propagates the error state cleanly instead of
double-faulting.

2. **`ActionCache.organicTask`**: Wrap the cache storage portion (after the action completes successfully) in a try-catch for `NoSuchFileException`. When caught, log a debug message, record an error
event, and return the task result without caching.

This is safe because:
- The task itself already completed successfully — only cache storage fails.
- No false cache entries are created.
- Next run will re-execute the task (cache miss), which is the correct behavior.

## Testing

- `sbt utilCache/test` — all 35 tests pass, no regressions.