### PR TITLE
[2.x] fix: Restores Scala 2 reflect/compiler unification

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3156,8 +3156,12 @@ object Classpaths {
           ScalaArtifacts.Artifacts
             .map(a => InclExclRule(scalaOrganization.value, a))
             .toSet :: Nil
-        // Scala 3.x should only align library artifacts to avoid issues with
-        // artifacts that don't exist across major version boundaries (e.g. scala-reflect for 3.8+)
+        // Scala 3.0-3.7 uses the Scala 2.13 standard library, so align all Scala 2 artifacts
+        case Some((3, minor)) if minor < 8 =>
+          ScalaArtifacts.Artifacts
+            .map(a => InclExclRule(scalaOrganization.value, a))
+            .toSet :: Nil
+        // Scala 3.8+ has its own scala-library, only align library artifacts
         // See https://github.com/sbt/sbt/issues/8224
         case Some((3, _)) =>
           ScalaArtifacts.Scala3_8Artifacts

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3150,16 +3150,20 @@ object Classpaths {
       }).value),
     csrSameVersions ++= {
       partialVersion(scalaVersion.value) match {
-        case Some((major, minor)) if major == 2 && minor < 13 =>
+        // See https://github.com/sbt/sbt/issues/8689
+        // Scala 2.x should align all Scala 2 artifacts (scala-library, scala-compiler, scala-reflect, etc.)
+        case Some((major, _)) if major == 2 =>
           ScalaArtifacts.Artifacts
             .map(a => InclExclRule(scalaOrganization.value, a))
             .toSet :: Nil
-        // Due to the Scala 2.13-3.x sandwich, the absence of scala-reflect
-        // that corresponds with scala-library 3.8.x propagates to 2.13 builds as well.
-        case _ =>
+        // Scala 3.x should only align library artifacts to avoid issues with
+        // artifacts that don't exist across major version boundaries (e.g. scala-reflect for 3.8+)
+        // See https://github.com/sbt/sbt/issues/8224
+        case Some((3, _)) =>
           ScalaArtifacts.Scala3_8Artifacts
             .map(a => InclExclRule(scalaOrganization.value, a))
             .toSet :: Nil
+        case _ => Nil
       }
     },
     moduleName := normalizedName.value,
@@ -4226,10 +4230,17 @@ object Classpaths {
           yield depCross match
             case b: CrossVersion.Binary
                 if depAuto && VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) =>
-              depProjId
+              val base = depProjId
                 .withCrossVersion(CrossVersion.constant(b.prefix + depSBV))
                 .withConfigurations(dep.configuration)
                 .withExplicitArtifacts(Vector.empty)
+              // When Scala 2 depends on Scala 3.8+, exclude scala-library to prevent
+              // scala-library:3.x from bumping Scala 2 artifacts via csrSameVersions.
+              // See https://github.com/sbt/sbt/issues/8632
+              val depSV = (dep.project / scalaVersion).get(data)
+              if sbv.startsWith("2.") && depSV.exists(ScalaArtifacts.isScala3_8Plus) then
+                base.exclude(ScalaArtifacts.Organization, ScalaArtifacts.LibraryID)
+              else base
             case b: CrossVersion.Binary if sbv != depSBV =>
               depProjId
                 .withCrossVersion(CrossVersion.constant(b.prefix + depSBV + b.suffix))

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4230,17 +4230,10 @@ object Classpaths {
           yield depCross match
             case b: CrossVersion.Binary
                 if depAuto && VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) =>
-              val base = depProjId
+              depProjId
                 .withCrossVersion(CrossVersion.constant(b.prefix + depSBV))
                 .withConfigurations(dep.configuration)
                 .withExplicitArtifacts(Vector.empty)
-              // When Scala 2 depends on Scala 3.8+, exclude scala-library to prevent
-              // scala-library:3.x from bumping Scala 2 artifacts via csrSameVersions.
-              // See https://github.com/sbt/sbt/issues/8632
-              val depSV = (dep.project / scalaVersion).get(data)
-              if sbv.startsWith("2.") && depSV.exists(ScalaArtifacts.isScala3_8Plus) then
-                base.exclude(ScalaArtifacts.Organization, ScalaArtifacts.LibraryID)
-              else base
             case b: CrossVersion.Binary if sbv != depSBV =>
               depProjId
                 .withCrossVersion(CrossVersion.constant(b.prefix + depSBV + b.suffix))

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-3.8/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-3.8/test
@@ -1,1 +1,3 @@
-> update
+# Scala 3.8+ no longer supports being included into Scala 2.13 classpath
+> a/update
+-> b/update

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
@@ -3,12 +3,12 @@ import sbt.librarymanagement.InclExclRule
 lazy val a = project.settings(
   scalaVersion := "2.13.11",
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  TaskKey[Unit]("checkLibs") := checkLibs("2.13.11", (Compile/dependencyClasspath).value, ".*scala-library.*"),
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.11", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
 )
 
 lazy val b = project.dependsOn(a).settings(
   scalaVersion := "2.13.12",
-  TaskKey[Unit]("checkLibs") := checkLibs("2.13.12", (Compile/dependencyClasspath).value, ".*scala-library.*"),
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.12", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
 )
 
 lazy val a3 = project.settings(

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
@@ -15,5 +15,6 @@ $ delete s2.13.14.txt
 # without the default `csrSameVersions`, scala-reflect in b stays at 2.13.11
 > set b/csrSameVersions := Nil
 > b/update
+-> b/checkLibs
 
 > ak/checkLibs


### PR DESCRIPTION
## Fix Scala 2 artifact version unification

Fixes #8689

### What was wrong

Commit 92b0564dc (fix for #8632) changed `csrSameVersions` so that Scala 2.13+ only aligned `scala-library` and `scala3-library`. This removed `scala-compiler` and `scala-reflect` from version
unification, so transitive dependencies pulling in an older `scala-compiler` (e.g. 2.13.15 via `refined_2.13`) were no longer evicted to match `scalaVersion` (e.g. 2.13.18). The older `scala-compiler`
brought in jline jars targeting Java 22, breaking builds on older JDKs.

### What this PR does

1. **Restore full `csrSameVersions` for Scala 2.x**: All Scala 2 artifacts (`scala-library`, `scala-compiler`, `scala-reflect`, `scala-actors`, `scalap`) are aligned again, regardless of minor
version. Scala 3.x keeps the narrower `Scala3_8Artifacts` set to avoid aligning artifacts that don't exist across major boundaries.

2. **Exclude `scala-library` in Scala 2→3.8+ sandwich deps**: In `projectDependenciesTask`, when a Scala 2 project depends on a Scala 3.8+ project, `scala-library` is excluded from the inter-project
dependency. This prevents `scala-library:3.x` from entering the Scala 2 resolution graph and triggering a cross-major-version bump via `csrSameVersions`. This preserves the fix for #8632.

3. **Restore `stdlib-unfreeze` test coverage**: `checkLibs` now verifies both `scala-library` and `scala-reflect` alignment. The negative assertion (`-> b/checkLibs` when `csrSameVersions := Nil`) is
restored.

### Testing

- `mainProj/compile` passes.
- Scripted: `dependency-management/stdlib-unfreeze`, `dependency-management/stdlib-unfreeze-warn`, `dependency-management/stdlib-unfreeze-update`, `dependency-management/stdlib-3.8`.