### PR TITLE
[1.x] bport: Restore Scala 2 artifact version unification

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3097,16 +3097,24 @@ object Classpaths {
       }).value,
     csrSameVersions ++= {
       partialVersion(scalaVersion.value) match {
-        case Some((major, minor)) if major == 2 && minor < 13 =>
+        // See https://github.com/sbt/sbt/issues/8689
+        // Scala 2.x should align all Scala 2 artifacts (scala-library, scala-compiler, scala-reflect, etc.)
+        case Some((major, _)) if major == 2 =>
           ScalaArtifacts.Artifacts
             .map(a => InclExclRule(scalaOrganization.value, a))
             .toSet :: Nil
-        // Due to the Scala 2.13-3.x sandwich, the absence of scala-reflect
-        // that corresponds with scala-library 3.8.x propagates to 2.13 builds as well.
-        case _ =>
+        // Scala 3.0-3.7 uses the Scala 2.13 standard library, so align all Scala 2 artifacts
+        case Some((3, minor)) if minor < 8 =>
+          ScalaArtifacts.Artifacts
+            .map(a => InclExclRule(scalaOrganization.value, a))
+            .toSet :: Nil
+        // Scala 3.8+ has its own scala-library, only align library artifacts
+        // See https://github.com/sbt/sbt/issues/8224
+        case Some((3, _)) =>
           ScalaArtifacts.Scala3_8Artifacts
             .map(a => InclExclRule(scalaOrganization.value, a))
             .toSet :: Nil
+        case _ => Nil
       }
     },
     moduleName := normalizedName.value,

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-3.8/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-3.8/test
@@ -1,1 +1,3 @@
-> update
+# Scala 3.8+ no longer supports being included into Scala 2.13 classpath
+> a/update
+-> b/update

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
@@ -3,12 +3,12 @@ import sbt.librarymanagement.InclExclRule
 lazy val a = project.settings(
   scalaVersion := "2.13.11",
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  TaskKey[Unit]("checkLibs") := checkLibs("2.13.11", (Compile/dependencyClasspath).value, ".*scala-library.*"),
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.11", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
 )
 
 lazy val b = project.dependsOn(a).settings(
   scalaVersion := "2.13.12",
-  TaskKey[Unit]("checkLibs") := checkLibs("2.13.12", (Compile/dependencyClasspath).value, ".*scala-library.*"),
+  TaskKey[Unit]("checkLibs") := checkLibs("2.13.12", (Compile/dependencyClasspath).value, ".*scala-(library|reflect).*"),
 )
 
 lazy val a3 = project.settings(

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/test
@@ -15,5 +15,6 @@ $ delete s2.13.14.txt
 # without the default `csrSameVersions`, scala-reflect in b stays at 2.13.11
 > set b/csrSameVersions := Nil
 > b/update
+-> b/checkLibs
 
 > ak/checkLibs


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8700

Commit 92b0564dc (fix for #8632) changed `csrSameVersions` so that Scala 2.13+ only aligned `scala-library` and `scala3-library`. This removed `scala-compiler` and `scala-reflect` from version unification, so transitive dependencies pulling in an older `scala-compiler` (e.g. 2.13.15 via `refined_2.13`) were no longer evicted to match `scalaVersion` (e.g. 2.13.18).