### PR TITLE
[1.x] bport: require coreutils for RPM (#8712)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ Global / excludeLint += nativeImageVersion
 usePgpKeyHex("642AC823")
 // usePgpKeyHex("2BE67AC00D699E04E840B7FE29967E804D85663F")
 
-def commonBaseSettings: Seq[Setting[_]] = Def.settings(
+def commonBaseSettings: Seq[Setting[?]] = Def.settings(
   headerLicense := Some(
     HeaderLicense.Custom(
       """|sbt

--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -301,11 +301,11 @@ val launcherPackage = (project in file(".")).
     rpmVendor := "scalacenter",
     rpmUrl := Some("http://github.com/sbt/sbt-launcher-package"),
     rpmLicense := Some("Apache-2.0"),
-    // This is intentionally empty. java-devel could bring in JDK 9-ea on Fedora,
+    // This is intentionally does not list Java. java-devel could bring in JDK 9-ea on Fedora,
     // and java-1.8.0-devel doesn't work on CentOS 6 and 7.
     // https://github.com/sbt/sbt-launcher-package/issues/151
     // https://github.com/elastic/logstash/issues/6275#issuecomment-261359933
-    rpmRequirements := Seq(),
+    rpmRequirements := Seq("coreutils"),
     rpmProvides := Seq("sbt"),
 
     // WINDOWS SPECIFIC


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8712

## Problem
Apparently sbt can fail when it doesn't have rm,
which can happen "when building relocatable RPM's and building an OS image in a chroot."

## Solution
It was suggested that we require coreutils.