### PR TITLE
Fix/7487 scaladoc project flag warning

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2029,14 +2029,18 @@ object Defaults extends BuildCommon {
           else Map.empty[HashedVirtualFileRef, URI]
         },
         fileInputOptions := Seq("-doc-root-content", "-diagrams-dot-path"),
-        scalacOptions ++= {
+        scalacOptions := {
           val sv = scalaVersion.value
           val config = configuration.value
           val projectName = name.value
+          val base = scalacOptions.value
           if (ScalaArtifacts.isScala3(sv)) {
-            val project = if (config == Compile) projectName else s"$projectName-$config"
-            Seq("-project", project)
-          } else Seq.empty
+            // Only add -project flag if it's not already present to avoid "Flag -project set repeatedly" warning
+            if (!base.contains("-project")) {
+              val project = if (config == Compile) projectName else s"$projectName-$config"
+              base ++ Seq("-project", project)
+            } else base
+          } else base
         },
         (TaskZero / key) := Def.uncached {
           val s = streams.value

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2034,9 +2034,12 @@ object Defaults extends BuildCommon {
           val config = configuration.value
           val projectName = name.value
           val base = scalacOptions.value
+          // Check both task-scoped and configuration-scoped scalacOptions for -project flag
+          val configScalacOptions = (config / scalacOptions).value
+          val hasProjectFlag = base.contains("-project") || configScalacOptions.contains("-project")
           if (ScalaArtifacts.isScala3(sv)) {
             // Only add -project flag if it's not already present to avoid "Flag -project set repeatedly" warning
-            if (!base.contains("-project")) {
+            if (!hasProjectFlag) {
               val project = if (config == Compile) projectName else s"$projectName-$config"
               base ++ Seq("-project", project)
             } else base

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2034,12 +2034,12 @@ object Defaults extends BuildCommon {
           val config = configuration.value
           val projectName = name.value
           val base = scalacOptions.value
-          // Check both task-scoped and configuration-scoped scalacOptions for -project flag
-          val configScalacOptions = (config / scalacOptions).value
-          val hasProjectFlag = base.contains("-project") || configScalacOptions.contains("-project")
+          // In sbt, task-scoped settings inherit from configuration-scoped settings.
+          // So base should already include values from (config / scalacOptions).
+          // We check if -project is already present in the inherited value.
           if (ScalaArtifacts.isScala3(sv)) {
             // Only add -project flag if it's not already present to avoid "Flag -project set repeatedly" warning
-            if (!hasProjectFlag) {
+            if (!base.contains("-project")) {
               val project = if (config == Compile) projectName else s"$projectName-$config"
               base ++ Seq("-project", project)
             } else base

--- a/sbt-app/src/sbt-test/project/scaladoc-project-flag/build.sbt
+++ b/sbt-app/src/sbt-test/project/scaladoc-project-flag/build.sbt
@@ -1,0 +1,22 @@
+// Test for issue #7487: scaladoc should not warn "Flag -project set repeatedly"
+scalaVersion := "3.3.1"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "scaladoc-project-flag",
+    // Add -project flag manually to test that it's not added again
+    Compile / scalacOptions += "-project",
+    Compile / scalacOptions += "test-project",
+    TaskKey[Unit]("check") := {
+      val opts = (Compile / doc / scalacOptions).value
+      val projectFlags = opts.zipWithIndex.filter(_._1 == "-project")
+      // Should have at most one -project flag (the one we added manually)
+      // If the fix works, sbt won't add another one
+      assert(
+        projectFlags.length <= 1,
+        s"Expected at most one -project flag, but found ${projectFlags.length} at indices: ${projectFlags.map(_._2).mkString(", ")}. Options: ${opts.mkString(", ")}"
+      )
+      streams.value.log.info("✓ No duplicate -project flags found")
+    }
+  )
+

--- a/sbt-app/src/sbt-test/project/scaladoc-project-flag/build.sbt
+++ b/sbt-app/src/sbt-test/project/scaladoc-project-flag/build.sbt
@@ -20,3 +20,4 @@ lazy val root = (project in file("."))
     }
   )
 
+

--- a/sbt-app/src/sbt-test/project/scaladoc-project-flag/test
+++ b/sbt-app/src/sbt-test/project/scaladoc-project-flag/test
@@ -1,0 +1,6 @@
+# Test that scaladoc doesn't warn about "Flag -project set repeatedly"
+# This test verifies the fix for issue #7487
+
+# Check that -project flag is not duplicated
+> check
+

--- a/sbt-app/src/sbt-test/project/scaladoc-project-flag/test
+++ b/sbt-app/src/sbt-test/project/scaladoc-project-flag/test
@@ -4,3 +4,4 @@
 # Check that -project flag is not duplicated
 > check
 
+


### PR DESCRIPTION
## Reproduction

1. Create a Scala 3 project (any version except 3.0.0) and manually add the `-project` flag:
   ```scala
   // build.sbt
   scalaVersion := "3.3.1"
   Compile / scalacOptions += "-project"
   Compile / scalacOptions += "my-project-name"
   ```

2. Run `sbt doc`

3. **Before the fix**: You'll see the warning `Flag -project set repeatedly` because sbt automatically adds `-project` for Scala 3 projects, causing a duplicate when it's already manually added.

4. **After the fix**: No warning appears, and `-project` is only present once.

You can verify with:
```bash
sbt "show Compile / doc / scalacOptions"
```

## Solution

Modified `docTaskSettings` in `main/src/main/scala/sbt/Defaults.scala` to check if the `-project` flag is already present in `scalacOptions` before adding it. This prevents duplicate flags and eliminates the warning.

### Changes

- Added a check: `if (!base.contains("-project"))` before adding the flag
- Only adds `-project` flag if it's not already present
- Leverages sbt's inheritance model where task-scoped settings inherit from configuration-scoped settings

## Testing

### Scripted Test

Added a scripted test at `sbt-app/src/sbt-test/project/scaladoc-project-flag/` that:
- Sets up a Scala 3.3.1 project
- Manually adds `-project` flag to `scalacOptions`
- Verifies that the flag is not duplicated when running `doc` task

### Manual Testing

1. Create a Scala 3 project with `-project` flag manually added:
   ```scala
   scalaVersion := "3.3.1"
   Compile / scalacOptions += "-project"
   Compile / scalacOptions += "my-project"
   ```

2. Run `sbt doc` - should NOT show "Flag -project set repeatedly" warning

3. Verify with `sbt "show Compile / doc / scalacOptions"` - should show `-project` only once

## Files Changed

- `main/src/main/scala/sbt/Defaults.scala` - Fixed duplicate flag logic
- `sbt-app/src/sbt-test/project/scaladoc-project-flag/build.sbt` - Added test
- `sbt-app/src/sbt-test/project/scaladoc-project-flag/test` - Added test script

## Related Issue

Fixes #7487