### PR TITLE
[2.x] fix: handle --script-version sbt 2.x project dirs

### DIFF
--- a/launcher-package/citest2/Hello.scala
+++ b/launcher-package/citest2/Hello.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Hello {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
+}

--- a/launcher-package/citest2/build.sbt
+++ b/launcher-package/citest2/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "3.8.1",
+    name := "Hello",
+  )

--- a/launcher-package/citest2/project/build.properties
+++ b/launcher-package/citest2/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0-RC8

--- a/launcher-package/citest2/src/test/scala/HelloTest.scala
+++ b/launcher-package/citest2/src/test/scala/HelloTest.scala
@@ -1,0 +1,7 @@
+import verify._
+
+object HelloTest extends BasicTestSuite {
+  test("addition") {
+    assert(2 == 1 + 1)
+  }
+}

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -113,11 +113,21 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
       if (isWindows) cancel("Test not supported on windows")
       else assert(out.contains[String]("-Dsbt.ivy.home=/ivy/dir"))
 
-  testOutput("sbt --script-version should print sbtVersion")("--script-version"):
-    (out: List[String]) =>
-      val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-      assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
-      ()
+  testOutput(
+    "sbt --script-version should print sbtVersion (sbt 1.x project)",
+    citestVariant = "citest",
+  )("--script-version"): (out: List[String]) =>
+    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
+    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    ()
+
+  testOutput(
+    "sbt --script-version should print sbtVersion (sbt 2.x project)",
+    citestVariant = "citest2",
+  )("--script-version"): (out: List[String]) =>
+    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
+    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    ()
 
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.global.localcache=./cachePath"))

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -39,6 +39,7 @@ trait ShellScriptUtil extends BasicTestSuite {
       machineSbtoptsContents: String = "",
       jvmoptsFileContents: String = "",
       windowsSupport: Boolean = true,
+      citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
     if !windowsSupport && isWindows then
       test(name):
@@ -46,7 +47,7 @@ trait ShellScriptUtil extends BasicTestSuite {
     else
       test(name) {
         val workingDirectory = Files.createTempDirectory("sbt-launcher-package-test").toFile
-        val citestDir = new File("launcher-package/citest")
+        val citestDir = new File("launcher-package", citestVariant)
         // Clean target directory if it exists to avoid copying temporary files that may be deleted during copy
         val targetDir = new File(citestDir, "target")
         if (targetDir.exists()) {

--- a/sbt
+++ b/sbt
@@ -570,8 +570,6 @@ run() {
   detect_working_directory
   if [[ $print_sbt_version ]]; then
     execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
-  elif [[ $print_sbt_script_version ]]; then
-    echo "$init_sbt_version"
   elif [[ $print_version ]]; then
     if [[ -n "$is_this_dir_sbt" ]]; then
       execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'

--- a/sbt
+++ b/sbt
@@ -905,6 +905,12 @@ args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}"
 process_args "${args1[@]}"
 vlog "[sbt_options] $(declare -p sbt_options)"
 
+# Handle --script-version before native client so it works on sbt 2.x project dirs (#8711)
+if [[ $print_sbt_script_version ]]; then
+  echo "$init_sbt_version"
+  exit 0
+fi
+
 if [[ "$(isRunNativeClient)" == "true" ]]; then
   set -- "${residual_args[@]}"
   argumentCount=$#


### PR DESCRIPTION
## What
Fixes #8711: `sbt --script-version` now works when run from an sbt 2.x project directory.

## Problem
From a project with `project/build.properties` set to sbt 2.x (e.g. `sbt.version=2.0.0-RC8`), the script defaults to the native client (sbtn). The `--script-version` flag was only handled inside `run()` (the JVM launcher path), so when the script took the native client path it never checked `--script-version` and instead ran sbtn with that flag. sbtn doesn’t implement it, so the user saw "failed to connect to server" instead of the script version.

## Solution
Handle `--script-version` right after `process_args` and before the `isRunNativeClient` branch. If `print_sbt_script_version` is set, print `$init_sbt_version` and exit, so we never delegate to sbtn for this case.

## Testing
- From repo root (sbt 1.x): `./sbt --script-version` → prints `_to_be_replaced`
- From sbt 2.x project dir: `sbt --script-version` → prints `_to_be_replaced` (no sbtn run)