### PR TITLE
[2.x] fix: Disk cache label

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -166,7 +166,7 @@ object ActionCache:
                 store.syncBlobs(result.outputFiles, config.outputDirectory)
                 if result.exitCode.contains(failureExitCode) then
                   Some(Left(Some(failureFromStr(str))))
-                else Some(Right(valueFromStr(str, Some("symlink"))))
+                else Some(Right(valueFromStr(str, Some("disk"))))
               case Left(_) => None
       else None
 


### PR DESCRIPTION
## Problem
Currently symlink hit is reported separately from the disk cache, which is not necessary.

## Solution
Rename the symlink label to disk.