### PR TITLE
[2.x] fix: Handle JVM parameters with spaces in dot files

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -253,6 +253,30 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
         s"sbtopts options should appear before CLI memory settings. g1Index=$g1Index, xmxCliIndex=$xmxCliIndex"
       )
 
+  // Test for issue #7333: JVM parameters with spaces in .sbtopts
+  testOutput(
+    "sbt with -J--add-modules jdk.incubator.concurrent in .sbtopts (args with spaces)",
+    sbtOptsFileContents = "-J--add-modules jdk.incubator.concurrent",
+    windowsSupport = false,
+  )("-v"): (out: List[String]) =>
+    assert(out.contains[String]("--add-modules"))
+    assert(out.contains[String]("jdk.incubator.concurrent"))
+
+  // Test for issue #7333: -D with spaces in .jvmopts
+  testOutput(
+    "sbt with -Dkey=\"value with spaces\" in .jvmopts",
+    jvmoptsFileContents = """-Dtest.7333="value with spaces"""",
+    windowsSupport = false,
+  )("-v"): (out: List[String]) =>
+    assert(
+      out.exists(_.contains("test.7333")),
+      s"Expected -Dtest.7333= in output, got: ${out.filter(_.contains("test.7333")).mkString(", ")}"
+    )
+    assert(
+      out.exists(_.contains("value with spaces")),
+      "Expected 'value with spaces' in -D value"
+    )
+
   // Test for issue #7289: Special characters in .jvmopts should not cause shell expansion
   testOutput(
     "sbt with special characters in .jvmopts (pipes, wildcards, ampersands)",

--- a/sbt
+++ b/sbt
@@ -766,6 +766,61 @@ process_args () {
   }
 }
 
+# Parse a line into words respecting double and single quotes.
+# Outputs one word per line. Used for .sbtopts and .jvmopts to handle args with spaces (#7333).
+parseLineIntoWords() {
+  local line="$1"
+  local word=""
+  local i=0
+  local len=${#line}
+  local in_dq=0 in_sq=0
+  while (( i < len )); do
+    local c="${line:$i:1}"
+    if (( in_dq )); then
+      word+="$c"
+      [[ "$c" == '"' ]] && in_dq=0
+    elif (( in_sq )); then
+      word+="$c"
+      [[ "$c" == "'" ]] && in_sq=0
+    else
+      case "$c" in
+        '"')  in_dq=1; word+="$c" ;;
+        "'")  in_sq=1; word+="$c" ;;
+        ' '|$'\t')
+          [[ -n "$word" ]] && printf '%s\n' "$word"
+          word=""
+          ;;
+        *)    word+="$c" ;;
+      esac
+    fi
+    ((i++))
+  done
+  [[ -n "$word" ]] && printf '%s\n' "$word"
+}
+
+# Load config file into array, parsing each line and respecting quotes.
+# For -J lines: split the remainder and prepend -J to each token (so -J--add-modules jdk.incubator.concurrent
+# becomes -J--add-modules and -Jjdk.incubator.concurrent). Fixes #7333.
+loadConfigFileIntoArray() {
+  local -n arr=$1
+  local file="$2"
+  [[ ! -f "$file" ]] && return
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=$(printf '%s' "$line" | sed $'/^\#/d;s/\r$//')
+    [[ -z "$line" ]] && continue
+    if [[ "$line" == -J* ]]; then
+      local rest="${line#-J}"
+      while IFS= read -r token; do
+        [[ -n "$token" ]] && arr+=("-J$token")
+      done < <(parseLineIntoWords "$rest")
+    else
+      while IFS= read -r token; do
+        [[ -n "$token" ]] && arr+=("$token")
+      done < <(parseLineIntoWords "$line")
+    fi
+  done < <(cat "$file")
+}
+
 loadConfigFile() {
   # Make sure the last line is read even if it doesn't have a terminating \n
   # Output lines literally without shell expansion to handle special characters safely
@@ -861,14 +916,14 @@ sbt_file_opts=()
 
 # Pull in the machine-wide settings configuration.
 if [[ -f "$machine_sbt_opts_file" ]]; then
-  sbt_file_opts+=($(loadConfigFile "$machine_sbt_opts_file"))
+  loadConfigFileIntoArray sbt_file_opts "$machine_sbt_opts_file"
 else
   # Otherwise pull in the default settings configuration.
-  [[ -f "$dist_sbt_opts_file" ]] && sbt_file_opts+=($(loadConfigFile "$dist_sbt_opts_file"))
+  [[ -f "$dist_sbt_opts_file" ]] && loadConfigFileIntoArray sbt_file_opts "$dist_sbt_opts_file"
 fi
 
 # Pull in the project-level config file, if it exists (highest priority, overrides machine/dist).
-[[ -f "$sbt_opts_file" ]] && sbt_file_opts+=($(loadConfigFile "$sbt_opts_file"))
+[[ -f "$sbt_opts_file" ]] && loadConfigFileIntoArray sbt_file_opts "$sbt_opts_file"
 
 # Prepend sbtopts so command line args appear last and win for duplicate properties.
 if (( ${#sbt_file_opts[@]} > 0 )); then
@@ -876,14 +931,15 @@ if (( ${#sbt_file_opts[@]} > 0 )); then
 fi
 
 # Pull in the project-level java config, if it exists.
-[[ -f ".jvmopts" ]] && export JAVA_OPTS="$JAVA_OPTS $(loadConfigFile .jvmopts)"
+jvmopts_args=()
+[[ -f ".jvmopts" ]] && loadConfigFileIntoArray jvmopts_args ".jvmopts"
 
 # Pull in default JAVA_OPTS
 [[ -z "${JAVA_OPTS// }" ]] && export JAVA_OPTS="$default_java_opts"
 
 [[ -f "$build_props_file" ]] && loadPropFile "$build_props_file"
 
-java_args=($JAVA_OPTS)
+java_args=($JAVA_OPTS "${jvmopts_args[@]}")
 sbt_options0=(${SBT_OPTS:-$default_sbt_opts})
 java_tool_options=($JAVA_TOOL_OPTIONS)
 jdk_java_options=($JDK_JAVA_OPTIONS)

--- a/sbt
+++ b/sbt
@@ -801,8 +801,9 @@ parseLineIntoWords() {
 # Load config file into array, parsing each line and respecting quotes.
 # For -J lines: split the remainder and prepend -J to each token (so -J--add-modules jdk.incubator.concurrent
 # becomes -J--add-modules and -Jjdk.incubator.concurrent). Fixes #7333.
+# Uses eval+printf %q instead of local -n for Bash 3.x compatibility (macOS default).
 loadConfigFileIntoArray() {
-  local -n arr=$1
+  local arr_name="$1"
   local file="$2"
   [[ ! -f "$file" ]] && return
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -811,11 +812,11 @@ loadConfigFileIntoArray() {
     if [[ "$line" == -J* ]]; then
       local rest="${line#-J}"
       while IFS= read -r token; do
-        [[ -n "$token" ]] && arr+=("-J$token")
+        [[ -n "$token" ]] && eval "$arr_name+=($(printf '%q' "-J$token"))"
       done < <(parseLineIntoWords "$rest")
     else
       while IFS= read -r token; do
-        [[ -n "$token" ]] && arr+=("$token")
+        [[ -n "$token" ]] && eval "$arr_name+=($(printf '%q' "$token"))"
       done < <(parseLineIntoWords "$line")
     fi
   done < <(cat "$file")

--- a/sbt
+++ b/sbt
@@ -798,13 +798,11 @@ parseLineIntoWords() {
   [[ -n "$word" ]] && printf '%s\n' "$word"
 }
 
-# Load config file into array, parsing each line and respecting quotes.
-# For -J lines: split the remainder and prepend -J to each token (so -J--add-modules jdk.incubator.concurrent
-# becomes -J--add-modules and -Jjdk.incubator.concurrent). Fixes #7333.
-# Uses eval+printf %q instead of local -n for Bash 3.x compatibility (macOS default).
-loadConfigFileIntoArray() {
-  local arr_name="$1"
-  local file="$2"
+# Output config file tokens one per line. For -J lines, each token is prefixed with -J.
+# No eval; caller appends via: while IFS= read -r t; do [[ -n "$t" ]] && arr+=("$t"); done < <(outputConfigFileTokens "$file")
+# Fixes #7333; Bash 3.x compatible.
+outputConfigFileTokens() {
+  local file="$1"
   [[ ! -f "$file" ]] && return
   while IFS= read -r line || [[ -n "$line" ]]; do
     line=$(printf '%s' "$line" | sed $'/^\#/d;s/\r$//')
@@ -812,11 +810,11 @@ loadConfigFileIntoArray() {
     if [[ "$line" == -J* ]]; then
       local rest="${line#-J}"
       while IFS= read -r token; do
-        [[ -n "$token" ]] && eval "$arr_name+=($(printf '%q' "-J$token"))"
+        [[ -n "$token" ]] && printf '%s\n' "-J$token"
       done < <(parseLineIntoWords "$rest")
     else
       while IFS= read -r token; do
-        [[ -n "$token" ]] && eval "$arr_name+=($(printf '%q' "$token"))"
+        [[ -n "$token" ]] && printf '%s\n' "$token"
       done < <(parseLineIntoWords "$line")
     fi
   done < <(cat "$file")
@@ -917,14 +915,14 @@ sbt_file_opts=()
 
 # Pull in the machine-wide settings configuration.
 if [[ -f "$machine_sbt_opts_file" ]]; then
-  loadConfigFileIntoArray sbt_file_opts "$machine_sbt_opts_file"
+  while IFS= read -r t; do [[ -n "$t" ]] && sbt_file_opts+=("$t"); done < <(outputConfigFileTokens "$machine_sbt_opts_file")
 else
   # Otherwise pull in the default settings configuration.
-  [[ -f "$dist_sbt_opts_file" ]] && loadConfigFileIntoArray sbt_file_opts "$dist_sbt_opts_file"
+  [[ -f "$dist_sbt_opts_file" ]] && while IFS= read -r t; do [[ -n "$t" ]] && sbt_file_opts+=("$t"); done < <(outputConfigFileTokens "$dist_sbt_opts_file")
 fi
 
 # Pull in the project-level config file, if it exists (highest priority, overrides machine/dist).
-[[ -f "$sbt_opts_file" ]] && loadConfigFileIntoArray sbt_file_opts "$sbt_opts_file"
+[[ -f "$sbt_opts_file" ]] && while IFS= read -r t; do [[ -n "$t" ]] && sbt_file_opts+=("$t"); done < <(outputConfigFileTokens "$sbt_opts_file")
 
 # Prepend sbtopts so command line args appear last and win for duplicate properties.
 if (( ${#sbt_file_opts[@]} > 0 )); then
@@ -933,7 +931,7 @@ fi
 
 # Pull in the project-level java config, if it exists.
 jvmopts_args=()
-[[ -f ".jvmopts" ]] && loadConfigFileIntoArray jvmopts_args ".jvmopts"
+[[ -f ".jvmopts" ]] && while IFS= read -r t; do [[ -n "$t" ]] && jvmopts_args+=("$t"); done < <(outputConfigFileTokens ".jvmopts")
 
 # Pull in default JAVA_OPTS
 [[ -z "${JAVA_OPTS// }" ]] && export JAVA_OPTS="$default_java_opts"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7333

### Problem

The sbt launcher script used naive word splitting when parsing `.sbtopts` and `.jvmopts`, so arguments with spaces were split incorrectly. For example, `-J--add-modules jdk.incubator.concurrent` in `.sbtopts` and `-Dtest.key="value with spaces"` in `.jvmopts` were not passed to the JVM as intended.

### Solution

Parsing was updated to be quote-aware. A new `parseLineIntoWords()` helper splits lines while respecting single and double quotes. `loadConfigFileIntoArray()` loads config files into bash arrays: for `-J` lines it splits the remainder and prepends `-J` to each token (e.g. `-J--add-modules jdk.incubator.concurrent` → `-J--add-modules` and `-Jjdk.incubator.concurrent`); for other lines it uses quote-aware splitting. `.sbtopts` now uses `loadConfigFileIntoArray` instead of `loadConfigFile`; `.jvmopts` uses `loadConfigFileIntoArray` and merges the result into `java_args` instead of appending via `JAVA_OPTS` string concatenation.

### Testing

Two integration tests were added in `RunnerScriptTest.scala`: one for `-J--add-modules jdk.incubator.concurrent` in `.sbtopts`, and one for `-Dtest.7333="value with spaces"` in `.jvmopts`, both verifying that the full values are passed correctly to the JVM.