### PR TITLE
[2.x] Print warning about scala-reflect not found

### DIFF
--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -172,6 +172,11 @@ private[sbt] object LibraryManagement {
             .apply(updateInputs)
           if isCached then markAsCached(report) else report
         catch
+          case r: ResolveException
+              if r.failed.exists(isMissingScalaLib) &&
+                module.scalaModuleInfo.exists(_.scalaBinaryVersion == "2.13") =>
+            informSandwich()
+            throw r
           case t: (NullPointerException | OutOfMemoryError) =>
             val resolvedAgain = resolve
             val culprit = t.getClass.getSimpleName
@@ -184,6 +189,26 @@ private[sbt] object LibraryManagement {
       import LibraryManagementCodec.given
       Tracked.inputChanged(cacheStoreFactory.make("inputs"))(doCachedResolve)
     }
+
+    def informSandwich(): Unit =
+      log.warn("[sbt-8728] Smorrebrod - the end of Scala 2.13-3.x sandwich")
+      log.warn("")
+      log.warn("Scala 3.8+ cannot be used in a Scala 2.13 subproject.")
+      log.warn(
+        "Dependency resolution failed because scala-reflect or -compiler 3.x does not exist."
+      )
+      log.warn(
+        "This happens when a Scala 2.13 subproject depends on Scala 3.8+ directly or transitively."
+      )
+      log.warn("To fix this, either")
+      log.warn("  - Keep Scala 3 subproject or transitive dependency to 3.7 or below, or")
+      log.warn("  - Migrate the Scala 2.13 subproject to Scala 3.x")
+      log.warn("See https://github.com/sbt/sbt/discussions/8728")
+
+    def isMissingScalaLib(m: ModuleID): Boolean =
+      m.organization == "org.scala-lang" &&
+        (m.name == "scala-compiler" || m.name == "scala-reflect") &&
+        (m.revision.startsWith("3."))
 
     // Get the handler to use and feed it in the inputs
     // This is lm-engine specific input hashed into Long


### PR DESCRIPTION
## Problem
scala-reflect not found issue is confusing.

## Solution
Print out a specialized warning message. I'm going to use <https://github.com/sbt/sbt/discussions/8728> as a placeholder until we have some more official page from the Scala team.

## Test

```
sbt:smorrebrod-root> compile
[info] Updating projectc_2.13
[info] Resolved projectc_2.13 dependencies
[warn]
[warn] 	Note: Unresolved dependencies path:
[warn] [sbt-8728] Smorrebrod - the end of Scala 2.13-3.x sandwich
[warn] Scala 3.8+ cannot be used in a Scala 2.13 subproject.
[warn] Dependency resolution failed because scala-reflect or -compiler 3.x does not exist.
[warn] This happens when a Scala 2.13 subproject depends on Scala 3.8+ directly or transitively.
[warn] To fix this, either
[warn]   - Keep Scala 3 subproject or transitive dependency to 3.7 or below, or
[warn]   - Migrate the Scala 2.13 subproject to Scala 3.x
[warn] See https://github.com/sbt/sbt/discussions/8728
[error] stack trace is suppressed; run last projectC / update for the full output
[error] (projectC / update) sbt.librarymanagement.ResolveException: Error downloading org.scala-lang:scala-reflect:3.8.1
[error]   Not found
[error]   Not found
[error]   not found: /Users/xxx/.ivy2/local/org.scala-lang/scala-reflect/3.8.1/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/3.8.1/scala-reflect-3.8.1.pom
[error] elapsed time: 1 s, cache 100%, 26 disk cache hits
```