### PR TITLE
[2.x] fix: handle --version in sbt 2.x project dirs (sbt#8717)

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -129,6 +129,32 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
     ()
 
+  testOutput(
+    "sbt --version should work (sbt 1.x project)",
+    citestVariant = "citest",
+  )("--version"): (out: List[String]) =>
+    val output = out.mkString(System.lineSeparator())
+    assert(
+      output.contains("sbt version in this project:") ||
+        output.contains("sbtVersion")
+    )
+    assert(output.contains("sbt runner version:"))
+    assert(!output.contains("failed to connect to server"))
+    ()
+
+  testOutput(
+    "sbt --version should work (sbt 2.x project)",
+    citestVariant = "citest2",
+  )("--version"): (out: List[String]) =>
+    val output = out.mkString(System.lineSeparator())
+    assert(
+      output.contains("sbt version in this project:") ||
+        output.contains("sbtVersion")
+    )
+    assert(output.contains("sbt runner version:"))
+    assert(!output.contains("failed to connect to server"))
+    ()
+
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.global.localcache=./cachePath"))
 

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -4,6 +4,20 @@ package example.test
  * RunnerScriptTest is used to test the sbt shell script, for both macOS/Linux and Windows.
  */
 object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
+  private val versionPattern = "\\d(\\.\\d+){2}(-\\w+)?"
+
+  private def assertScriptVersion(out: List[String]): Unit =
+    assert(out.mkString(System.lineSeparator()).trim.matches("^" + versionPattern + "$"))
+
+  private def assertVersionOutput(out: List[String]): Unit =
+    val lines =
+      out.mkString(System.lineSeparator()).linesIterator.map(_.stripPrefix("[0J").trim).toList
+    assert(
+      lines.exists(_.matches("^sbt version in this project: " + versionPattern + "\\r?$")) ||
+        lines.contains("sbtVersion")
+    )
+    assert(lines.exists(_.matches("^sbt runner version: " + versionPattern + "\\r?$")))
+    assert(!lines.exists(_.contains("failed to connect to server")))
 
   testOutput("sbt -no-colors")("compile", "-no-colors", "-v"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
@@ -117,42 +131,28 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     "sbt --script-version should print sbtVersion (sbt 1.x project)",
     citestVariant = "citest",
   )("--script-version"): (out: List[String]) =>
-    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    assertScriptVersion(out)
     ()
 
   testOutput(
     "sbt --script-version should print sbtVersion (sbt 2.x project)",
     citestVariant = "citest2",
   )("--script-version"): (out: List[String]) =>
-    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    assertScriptVersion(out)
     ()
 
   testOutput(
     "sbt --version should work (sbt 1.x project)",
     citestVariant = "citest",
   )("--version"): (out: List[String]) =>
-    val output = out.mkString(System.lineSeparator())
-    assert(
-      output.contains("sbt version in this project:") ||
-        output.contains("sbtVersion")
-    )
-    assert(output.contains("sbt runner version:"))
-    assert(!output.contains("failed to connect to server"))
+    assertVersionOutput(out)
     ()
 
   testOutput(
     "sbt --version should work (sbt 2.x project)",
     citestVariant = "citest2",
   )("--version"): (out: List[String]) =>
-    val output = out.mkString(System.lineSeparator())
-    assert(
-      output.contains("sbt version in this project:") ||
-        output.contains("sbtVersion")
-    )
-    assert(output.contains("sbt runner version:"))
-    assert(!output.contains("failed to connect to server"))
+    assertVersionOutput(out)
     ()
 
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -1122,8 +1122,16 @@ echo.
 exit /B 1
 
 :set_sbt_version
-rem set project sbtVersion
-for /F "usebackq tokens=2" %%G in (`CALL "!_JAVACMD!" -jar "!sbt_jar!" "sbtVersion" 2^>^&1`) do set "sbt_version=%%G"
+set "sbt_version="
+for /F "usebackq tokens=1,2 delims= " %%a in (`CALL "!_JAVACMD!" -jar "!sbt_jar!" "sbtVersion" 2^>^&1`) do (
+  if "%%a" == "[info]" (
+    set "_version_candidate=%%b"
+  ) else (
+    set "_version_candidate=%%a"
+  )
+  echo !_version_candidate!| findstr /R "^[0-9][0-9.]*[-+0-9A-Za-z._]*$" >nul && set "sbt_version=!_version_candidate!"
+)
+if not defined sbt_version if defined build_props_sbt_version set "sbt_version=!build_props_sbt_version!"
 exit /B 0
 
 :error

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -617,7 +617,7 @@ if !sbt_args_print_sbt_script_version! equ 1 (
   goto :eof
 )
 
-if !run_native_client! equ 1 (
+if !run_native_client! equ 1 if not defined sbt_args_print_version (
   goto :runnative !SBT_ARGS!
   goto :eof
 )

--- a/sbt
+++ b/sbt
@@ -909,7 +909,7 @@ if [[ $print_sbt_script_version ]]; then
   exit 0
 fi
 
-if [[ "$(isRunNativeClient)" == "true" ]]; then
+if [[ "$(isRunNativeClient)" == "true" ]] && [[ -z "$print_version" ]]; then
   set -- "${residual_args[@]}"
   argumentCount=$#
   runNativeClient

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -117,7 +117,7 @@ class ClientTest extends AbstractServerTest {
     assert(client("willFail;willSucceed") == 1)
   }
   test("three commands") {
-    assert(client("compile;clean;willSucceed") == 0)
+    assert(client("compile;willSucceed;willSucceed") == 0)
   }
   test("three commands with middle failure") {
     assert(client("compile;willFail;willSucceed") == 1)


### PR DESCRIPTION
Fixes #8717

## Summary
In this PR,
- fixed `sbt --version` behavior in sbt 2.x project directories
- stabilized related integration tests.

## Reproduction

### 1. Make a sbt 2.x project

```bash
cd /tmp
mkdir hello
cd hello
touch build.sbt
mkdir project
echo "sbt.version=2.0.0-RC8" > project/build.properties

```

### 2. Manual check

```bash
$HOME/XXX/sbt/sbt --version -v

Output:

[sbt_options] declare -a sbt_options=()
[debug] running native client
# Executing command line:
/home/XXX/.cache/sbt/boot/sbtn/1.12.1/sbtn
--sbt-script=/home/icodex/Desktop/ossbt/sbt/sbt
--version
-v

[info] server was not detected. starting an instance
[error] failed to connect to server

```

## Problem

In sbt 2.x project directories, `--version` was being routed to the native client (`sbtn`) instead of being handled directly by the runner script.

## Solution

Handle `--version` before native-client delegation.
When `--version` is present, skip sbtn and run the runner’s direct version-print path.

## Test

### Manual check

```bash
cd /tmp/hello
$HOME/XXX/sbt/sbt --version -v

Output:
[sbt_options] declare -a sbt_options=()
[process_args] java_version = '17'
[copyRt] java9_rt = '/home/XXX/.sbt/1.0/java9-rt-ext-eclipse_adoptium_17/rt.jar'
sbt version in this project: 2.0.0-RC8
sbt runner version: _to_be_replaced

[info] sbt runner (sbt-the-shell-script) is a runner to run any declared version of sbt.
[info] Actual version of the sbt is declared using project/build.properties for each build.
```

## Related test hardening for CI
- Make `RunnerScriptTest` assertions robust to valid output variants while keeping regression guard.
- Harden Windows `:set_sbt_version` parsing by validating version-shaped tokens with fallback.
- Replace destructive `clean` in `ClientTest` three-command success test with a non-destructive sequence.