### PR TITLE
[1.x] bport: handle --script-version sbt 2.x project dirs (#8715)

### DIFF
--- a/launcher-package/citest2/Hello.scala
+++ b/launcher-package/citest2/Hello.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Hello {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
+}

--- a/launcher-package/citest2/build.sbt
+++ b/launcher-package/citest2/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "3.8.1",
+    name := "Hello",
+  )

--- a/launcher-package/citest2/project/build.properties
+++ b/launcher-package/citest2/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0-RC8

--- a/launcher-package/citest2/src/test/scala/HelloTest.scala
+++ b/launcher-package/citest2/src/test/scala/HelloTest.scala
@@ -1,0 +1,7 @@
+import verify._
+
+object HelloTest extends BasicTestSuite {
+  test("addition") {
+    assert(2 == 1 + 1)
+  }
+}

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -113,11 +113,21 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
       if (isWindows) cancel("Test not supported on windows")
       else assert(out.contains[String]("-Dsbt.ivy.home=/ivy/dir"))
 
-  testOutput("sbt --script-version should print sbtVersion")("--script-version"):
-    (out: List[String]) =>
-      val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-      assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
-      ()
+  testOutput(
+    "sbt --script-version should print sbtVersion (sbt 1.x project)",
+    citestVariant = "citest",
+  )("--script-version"): (out: List[String]) =>
+    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
+    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    ()
+
+  testOutput(
+    "sbt --script-version should print sbtVersion (sbt 2.x project)",
+    citestVariant = "citest2",
+  )("--script-version"): (out: List[String]) =>
+    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
+    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    ()
 
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.global.localcache=./cachePath"))

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -38,6 +38,7 @@ trait ShellScriptUtil extends BasicTestSuite {
       machineSbtoptsContents: String = "",
       jvmoptsFileContents: String = "",
       windowsSupport: Boolean = true,
+      citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
     if !windowsSupport && isWindows then
       test(name):
@@ -45,7 +46,34 @@ trait ShellScriptUtil extends BasicTestSuite {
     else
       test(name) {
         val workingDirectory = Files.createTempDirectory("sbt-launcher-package-test").toFile
-        retry(() => IO.copyDirectory(new File("launcher-package/citest"), workingDirectory))
+        val citestDir = new File("launcher-package", citestVariant)
+        // Clean target directory if it exists to avoid copying temporary files that may be deleted during copy
+        val targetDir = new File(citestDir, "target")
+        if (targetDir.exists()) {
+          try {
+            IO.delete(targetDir)
+          } catch {
+            case _: Exception => // Ignore deletion errors, will retry copy
+          }
+        }
+        // Retry copy operation to handle race conditions with temporary files
+        retry(() => {
+          try {
+            IO.copyDirectory(citestDir, workingDirectory)
+          } catch {
+            case e: java.io.IOException if e.getMessage.contains("does not exist") =>
+              // If a file doesn't exist during copy, clean target and retry
+              val targetInCitest = new File(citestDir, "target")
+              if (targetInCitest.exists()) {
+                try {
+                  IO.delete(targetInCitest)
+                } catch {
+                  case _: Exception => // Ignore
+                }
+              }
+              throw e // Re-throw to trigger retry
+          }
+        })
 
         var sbtHome: Option[File] = None
         var configHome: Option[File] = None

--- a/sbt
+++ b/sbt
@@ -567,8 +567,6 @@ run() {
   detect_working_directory
   if [[ $print_sbt_version ]]; then
     execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
-  elif [[ $print_sbt_script_version ]]; then
-    echo "$init_sbt_version"
   elif [[ $print_version ]]; then
     if [[ -n "$is_this_dir_sbt" ]]; then
       execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
@@ -901,6 +899,12 @@ args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}"
 # process the combined args, then reset "$@" to the residuals
 process_args "${args1[@]}"
 vlog "[sbt_options] $(declare -p sbt_options)"
+
+# Handle --script-version before native client so it works on sbt 2.x project dirs (#8711)
+if [[ $print_sbt_script_version ]]; then
+  echo "$init_sbt_version"
+  exit 0
+fi
 
 if [[ "$(isRunNativeClient)" == "true" ]]; then
   set -- "${residual_args[@]}"


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8715

When in an sbt 2.x project directory, the script used to delegate to sbtn before checking --script-version, so 'sbt --script-version' ran sbtn and failed. Now we print the script version and exit before the native client branch.