### PR TITLE
[1.x] bport: handle --version in sbt 2.x project dirs

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -4,6 +4,20 @@ package example.test
  * RunnerScriptTest is used to test the sbt shell script, for both macOS/Linux and Windows.
  */
 object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
+  private val versionPattern = "\\d(\\.\\d+){2}(-\\w+)?"
+
+  private def assertScriptVersion(out: List[String]): Unit =
+    assert(out.mkString(System.lineSeparator()).trim.matches("^" + versionPattern + "$"))
+
+  private def assertVersionOutput(out: List[String]): Unit =
+    val lines =
+      out.mkString(System.lineSeparator()).linesIterator.map(_.stripPrefix("[0J").trim).toList
+    assert(
+      lines.exists(_.matches("^sbt version in this project: " + versionPattern + "\\r?$")) ||
+        lines.contains("sbtVersion")
+    )
+    assert(lines.exists(_.matches("^sbt runner version: " + versionPattern + "\\r?$")))
+    assert(!lines.exists(_.contains("failed to connect to server")))
 
   testOutput("sbt -no-colors")("compile", "-no-colors", "-v"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.log.noformat=true"))
@@ -117,16 +131,28 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     "sbt --script-version should print sbtVersion (sbt 1.x project)",
     citestVariant = "citest",
   )("--script-version"): (out: List[String]) =>
-    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    assertScriptVersion(out)
     ()
 
   testOutput(
     "sbt --script-version should print sbtVersion (sbt 2.x project)",
     citestVariant = "citest2",
   )("--script-version"): (out: List[String]) =>
-    val expectedVersion = "^" + ExtendedRunnerTest.versionRegEx + "$"
-    assert(out.mkString(System.lineSeparator()).trim.matches(expectedVersion))
+    assertScriptVersion(out)
+    ()
+
+  testOutput(
+    "sbt --version should work (sbt 1.x project)",
+    citestVariant = "citest",
+  )("--version"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput(
+    "sbt --version should work (sbt 2.x project)",
+    citestVariant = "citest2",
+  )("--version"): (out: List[String]) =>
+    assertVersionOutput(out)
     ()
 
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -617,7 +617,7 @@ if !sbt_args_print_sbt_script_version! equ 1 (
   goto :eof
 )
 
-if !run_native_client! equ 1 (
+if !run_native_client! equ 1 if not defined sbt_args_print_version (
   goto :runnative !SBT_ARGS!
   goto :eof
 )
@@ -1120,8 +1120,16 @@ echo.
 exit /B 1
 
 :set_sbt_version
-rem set project sbtVersion
-for /F "usebackq tokens=2" %%G in (`CALL "!_JAVACMD!" -jar "!sbt_jar!" "sbtVersion" 2^>^&1`) do set "sbt_version=%%G"
+set "sbt_version="
+for /F "usebackq tokens=1,2 delims= " %%a in (`CALL "!_JAVACMD!" -jar "!sbt_jar!" "sbtVersion" 2^>^&1`) do (
+  if "%%a" == "[info]" (
+    set "_version_candidate=%%b"
+  ) else (
+    set "_version_candidate=%%a"
+  )
+  echo !_version_candidate!| findstr /R "^[0-9][0-9.]*[-+0-9A-Za-z._]*$" >nul && set "sbt_version=!_version_candidate!"
+)
+if not defined sbt_version if defined build_props_sbt_version set "sbt_version=!build_props_sbt_version!"
 exit /B 0
 
 :error

--- a/sbt
+++ b/sbt
@@ -906,7 +906,7 @@ if [[ $print_sbt_script_version ]]; then
   exit 0
 fi
 
-if [[ "$(isRunNativeClient)" == "true" ]]; then
+if [[ "$(isRunNativeClient)" == "true" ]] && [[ -z "$print_version" ]]; then
   set -- "${residual_args[@]}"
   argumentCount=$#
   runNativeClient

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -115,7 +115,7 @@ object ClientTest extends AbstractServerTest {
     assert(client("willFail;willSucceed") == 1)
   }
   test("three commands") { _ =>
-    assert(client("compile;clean;willSucceed") == 0)
+    assert(client("compile;willSucceed;willSucceed") == 0)
   }
   test("three commands with middle failure") { _ =>
     assert(client("compile;willFail;willSucceed") == 1)


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8735

## Problem
`sbt --version` in sbt 2.x project directories was delegated to the native client, which could try to start/connect to a server instead of printing version info.

## Solution
Skip native-client delegation when `--version` is requested, and add runner-script tests for sbt 1.x and 2.x project variants.