### PR TITLE
[2.x] fix: Fixes sbt 2.x metabuild resolution

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -4371,6 +4371,7 @@ object Classpaths {
   val sbtMavenSnapshots: MavenRepository =
     MavenRepository("sbt-maven-snapshot", Resolver.SbtRepositoryRoot + "/" + "maven-snapshots/")
 
+  @deprecated("no longer true for sbt 2.x", "2.0.0")
   def modifyForPlugin(plugin: Boolean, dep: ModuleID): ModuleID =
     if (plugin) dep.withConfigurations(Some(Provided.name)) else dep
 
@@ -4380,11 +4381,10 @@ object Classpaths {
       org: String,
       version: String
   ): Seq[ModuleID] =
-    if (auto)
-      modifyForPlugin(plugin, ScalaArtifacts.libraryDependency(org, version))
-        .platform(Platform.jvm) :: Nil
-    else
-      Nil
+    if auto then
+      if ScalaArtifacts.isScala3(version) then ScalaArtifacts.libraryDependency(org, version) :: Nil
+      else (modifyForPlugin(plugin, ScalaArtifacts.libraryDependency(org, version)): @nowarn) :: Nil
+    else Nil
 
   def addUnmanagedLibrary: Seq[Setting[?]] =
     Seq((Compile / unmanagedJars) ++= unmanagedScalaLibrary.value)

--- a/sbt-app/src/sbt-test/plugins/pgp/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/pgp/build.sbt
@@ -1,1 +1,2 @@
 scalaVersion := "3.8.1"
+publishLocal := {}

--- a/sbt-app/src/sbt-test/plugins/pgp/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/plugins/pgp/project/plugins.sbt
@@ -1,2 +1,1 @@
-// addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
-libraryDependencies += Defaults.sbtPluginExtra("com.github.sbt" % "sbt-pgp" % "2.3.1", "2", "3.8.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8710

## Problem
Adopting Scala 3.8 on sbt 2.x has created confusing errors with scala-library mismatch, popping up as undefined summon.

## Solution
Removing the Provided scope seems to work.
