### PR TITLE
[2.x] fix: Fixes dependency lock file url

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -382,7 +382,8 @@ class CoursierDependencyResolution(
             .groupBy(_._1)
             .view
             .mapValues(_.map { case (_, pub, art, _) =>
-              val originalUrl = lmcoursier.internal.CacheUrlConversion.cacheFileToOriginalUrl(art.url, cache)
+              val originalUrl =
+                lmcoursier.internal.CacheUrlConversion.cacheFileToOriginalUrl(art.url, cache)
               (originalUrl, pub.classifier.value, pub.ext.value)
             })
             .toMap

--- a/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -382,7 +382,7 @@ class CoursierDependencyResolution(
             .groupBy(_._1)
             .view
             .mapValues(_.map { case (_, pub, art, _) =>
-              val originalUrl = CoursierDependencyResolution.cacheFileToOriginalUrl(art.url, cache)
+              val originalUrl = lmcoursier.internal.CacheUrlConversion.cacheFileToOriginalUrl(art.url, cache)
               (originalUrl, pub.classifier.value, pub.ext.value)
             })
             .toMap
@@ -459,32 +459,6 @@ object CoursierDependencyResolution {
   def defaultCacheLocation: File =
     CacheDefaults.location
 
-  private[lmcoursier] def cacheFileToOriginalUrl(fileUrl: String, cacheDir: File): String = {
-    val filePrefix = "file:"
-    if (fileUrl.startsWith(filePrefix)) {
-      val filePath = fileUrl.stripPrefix(filePrefix).replaceFirst("^/+", "/")
-      val cachePaths = Seq(
-        cacheDir.getAbsolutePath,
-        cacheDir.getCanonicalPath
-      ).distinct.map(p => if (p.endsWith("/")) p else p + "/")
-
-      def extractHttpUrl(relativePath: String): Option[String] = {
-        val protocolSepIndex = relativePath.indexOf('/')
-        if (protocolSepIndex > 0) {
-          val protocol = relativePath.substring(0, protocolSepIndex)
-          val rest = relativePath.substring(protocolSepIndex + 1)
-          Some(s"$protocol://$rest")
-        } else None
-      }
-
-      cachePaths
-        .collectFirst {
-          case cachePath if filePath.startsWith(cachePath) =>
-            val relativePath = filePath.stripPrefix(cachePath)
-            extractHttpUrl(relativePath)
-        }
-        .flatten
-        .getOrElse(s"$${CSR_CACHE}$filePath")
-    } else fileUrl
-  }
+  private[lmcoursier] def cacheFileToOriginalUrl(fileUrl: String, cacheDir: File): String =
+    lmcoursier.internal.CacheUrlConversion.cacheFileToOriginalUrl(fileUrl, cacheDir)
 }

--- a/lm-coursier/src/main/scala/lmcoursier/internal/CacheUrlConversion.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/CacheUrlConversion.scala
@@ -1,0 +1,47 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package lmcoursier.internal
+
+import java.io.File
+
+object CacheUrlConversion {
+
+  final val FileUrlPrefix = "file:"
+  final val UnconvertiblePrefix = "${CSR_CACHE}"
+
+  def cacheFileToOriginalUrl(fileUrl: String, cacheDir: File): String = {
+    if (!fileUrl.startsWith(FileUrlPrefix)) return fileUrl
+    val filePath = fileUrl.stripPrefix(FileUrlPrefix).replaceFirst("^/+", "/")
+    val cachePaths = Seq(
+      cacheDir.getAbsolutePath,
+      cacheDir.getCanonicalPath
+    ).distinct.map(p => if (p.endsWith("/")) p else p + "/")
+
+    def extractHttpUrl(relativePath: String): Option[String] = {
+      val protocolSepIndex = relativePath.indexOf('/')
+      if (protocolSepIndex > 0) {
+        val protocol = relativePath.substring(0, protocolSepIndex)
+        val rest = relativePath.substring(protocolSepIndex + 1)
+        Some(s"$protocol://$rest")
+      } else None
+    }
+
+    cachePaths
+      .collectFirst {
+        case cachePath if filePath.startsWith(cachePath) =>
+          val relativePath = filePath.stripPrefix(cachePath)
+          extractHttpUrl(relativePath)
+      }
+      .flatten
+      .getOrElse(s"$UnconvertiblePrefix$filePath")
+  }
+
+  def isPortableUrl(url: String): Boolean =
+    !url.startsWith(FileUrlPrefix) && !url.contains(UnconvertiblePrefix)
+}

--- a/lm-coursier/src/main/scala/lmcoursier/internal/CacheUrlConversion.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/CacheUrlConversion.scala
@@ -15,13 +15,30 @@ object CacheUrlConversion {
   final val FileUrlPrefix = "file:"
   final val UnconvertiblePrefix = "${CSR_CACHE}"
 
+  private def normalizePathForComparison(path: String): String =
+    path.replace('\\', '/')
+
+  private def normalizedFilePath(fileUrl: String): String = {
+    val afterPrefix = fileUrl.stripPrefix(FileUrlPrefix).replaceFirst("^/+", "/")
+    val withForwardSlash = normalizePathForComparison(afterPrefix)
+    if (
+      withForwardSlash.length >= 3 && withForwardSlash
+        .charAt(0) == '/' && withForwardSlash.charAt(2) == ':'
+    )
+      withForwardSlash.substring(1)
+    else
+      withForwardSlash
+  }
+
   def cacheFileToOriginalUrl(fileUrl: String, cacheDir: File): String = {
     if (!fileUrl.startsWith(FileUrlPrefix)) return fileUrl
-    val filePath = fileUrl.stripPrefix(FileUrlPrefix).replaceFirst("^/+", "/")
+    val filePath = normalizedFilePath(fileUrl)
     val cachePaths = Seq(
       cacheDir.getAbsolutePath,
       cacheDir.getCanonicalPath
-    ).distinct.map(p => if (p.endsWith("/")) p else p + "/")
+    ).distinct.map(p =>
+      normalizePathForComparison(if (p.endsWith("/") || p.endsWith("\\")) p else p + "/")
+    )
 
     def extractHttpUrl(relativePath: String): Option[String] = {
       val protocolSepIndex = relativePath.indexOf('/')

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3828,13 +3828,15 @@ object Classpaths {
     val resolverNames = fullResolvers.value.map(_.name)
     val buildClock = DependencyLockFile.computeBuildClock(deps, resolverNames)
 
+    val cacheDir = csrCacheDirectory.value
     val lock = DependencyLockManager.createFromUpdateReport(
       projectId,
       report,
       sv,
       scalaV,
       buildClock,
-      log
+      log,
+      Some(cacheDir)
     )
 
     DependencyLockManager.write(lockFile, lock, log)

--- a/main/src/main/scala/sbt/internal/librarymanagement/DependencyLockManager.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/DependencyLockManager.scala
@@ -44,7 +44,11 @@ object DependencyLockManager:
       isValid
     }
 
-  private def artifactUrlForLock(rawUrl: String, cacheDir: Option[File], moduleDesc: String): String =
+  private def artifactUrlForLock(
+      rawUrl: String,
+      cacheDir: Option[File],
+      moduleDesc: String
+  ): String =
     if !rawUrl.startsWith(CacheUrlConversion.FileUrlPrefix) then rawUrl
     else
       cacheDir match

--- a/main/src/main/scala/sbt/internal/librarymanagement/DependencyLockManager.scala
+++ b/main/src/main/scala/sbt/internal/librarymanagement/DependencyLockManager.scala
@@ -44,19 +44,40 @@ object DependencyLockManager:
       isValid
     }
 
+  private def artifactUrlForLock(rawUrl: String, cacheDir: Option[File], moduleDesc: String): String =
+    if !rawUrl.startsWith(CacheUrlConversion.FileUrlPrefix) then rawUrl
+    else
+      cacheDir match
+        case None =>
+          throw new RuntimeException(
+            s"Cannot create dependency lock file: artifact has file URL (e.g. local cache path). " +
+              s"Lock files must use portable repository URLs. Module: $moduleDesc. " +
+              s"Run 'update' first or ensure dependencies are resolved from remote repositories."
+          )
+        case Some(dir) =>
+          val converted = CacheUrlConversion.cacheFileToOriginalUrl(rawUrl, dir)
+          if !CacheUrlConversion.isPortableUrl(converted) then
+            throw new RuntimeException(
+              s"Cannot create dependency lock file: artifact path is not under Coursier cache. " +
+                s"Module: $moduleDesc. URL: $rawUrl"
+            )
+          converted
+
   def createFromUpdateReport(
       projectId: String,
       report: UpdateReport,
       sbtVersion: String,
       scalaVersion: Option[String],
       buildClock: String,
-      log: Logger
+      log: Logger,
+      cacheDir: Option[File] = None
   ): LockFileData =
     val configurations = report.configurations.map { configReport =>
       val deps = configReport.modules.map { moduleReport =>
         val artifacts = moduleReport.artifacts.map { case (artifact, file) =>
+          val url = artifactUrlForLock(file.toURI.toString, cacheDir, moduleReport.module.toString)
           ArtifactLock(
-            url = file.toURI.toString,
+            url = url,
             classifier = artifact.classifier,
             extension = artifact.extension,
             tpe = artifact.`type`

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -149,6 +149,16 @@ object ActionCache:
       val json = Parser.parseUnsafe(str)
       Converter.fromJsonUnsafe[CachedCompileFailure](json)
 
+    def parseCachedValue(
+        str: String,
+        origin: Option[String],
+        isFailure: Boolean,
+    ): Option[Either[Option[CachedCompileFailure], O]] =
+      try
+        if isFailure then Some(Left(Some(failureFromStr(str))))
+        else Some(Right(valueFromStr(str, origin)))
+      catch case _: Exception => None
+
     // Optimization: Check if we can read directly from symlinked value file
     val (input, valuePath) = mkInput(key, codeContentHash, extraHash)
     val resolvedValuePath = config.fileConverter.toPath(VirtualFileRef.of(valuePath))
@@ -160,13 +170,10 @@ object ActionCache:
         Exception.nonFatalCatch
           .opt(IO.read(resolvedValuePath.toFile(), StandardCharsets.UTF_8))
           .flatMap: str =>
-            // We still need to sync output files for side effects and check exitCode
             findActionResult(key, codeContentHash, extraHash, config) match
               case Right(result) =>
                 store.syncBlobs(result.outputFiles, config.outputDirectory)
-                if result.exitCode.contains(failureExitCode) then
-                  Some(Left(Some(failureFromStr(str))))
-                else Some(Right(valueFromStr(str, Some("disk"))))
+                parseCachedValue(str, Some("disk"), result.exitCode.contains(failureExitCode))
               case Left(_) => None
       else None
 
@@ -175,21 +182,18 @@ object ActionCache:
       case None =>
         findActionResult(key, codeContentHash, extraHash, config) match
           case Right(result) =>
-            // Check exitCode to determine if this is a cached failure
             val isFailure = result.exitCode.contains(failureExitCode)
             result.contents.headOption match
               case Some(head) =>
                 store.syncBlobs(result.outputFiles, config.outputDirectory)
                 val str = String(head.array(), StandardCharsets.UTF_8)
-                if isFailure then Left(Some(failureFromStr(str)))
-                else Right(valueFromStr(str, result.origin))
+                parseCachedValue(str, result.origin, isFailure).getOrElse(Left(None))
               case _ =>
                 val paths = store.syncBlobs(result.outputFiles, config.outputDirectory)
                 if paths.isEmpty then Left(None)
                 else
                   val str = IO.read(paths.head.toFile())
-                  if isFailure then Left(Some(failureFromStr(str)))
-                  else Right(valueFromStr(str, result.origin))
+                  parseCachedValue(str, result.origin, isFailure).getOrElse(Left(None))
           case Left(_) => Left(None)
 
   /**


### PR DESCRIPTION
Fixes #8741

When using Coursier for dependency resolution, the dependency lock file was sometimes writing absolute `file://` URLs pointing at the local cache (e.g. `file:///home/runner/.cache/coursier/...`). That made the lock file machine-specific and broke portability.

This PR normalizes those cache URLs so the lock file stays portable. File URLs from the Coursier cache are converted to a stable form (e.g. `${CSR_CACHE}`) before being written to the lock file, and converted back when reading. Path handling is normalized so Windows and Unix both behave correctly.

---

**Also in this PR:** Action cache was occasionally failing in CI with `IncompleteParseException: exhausted input` when reading cached task values (e.g. in the dotty-sandwich scripted test). We now treat invalid or empty cached JSON as a cache miss and re-run the task instead of failing.
