### PR TITLE
fix: Respect scalaOrganization when resolving compiler bridge

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -753,7 +753,8 @@ object Defaults extends BuildCommon {
             r,
             uc,
             (update / unresolvedWarningConfiguration).value,
-            s.log
+            s.log,
+            scalaOrganization.value
           )
           val out = t / "compiler-bridge" / jar.getName()
           val outVf = conv.toVirtualFile(out.toPath())
@@ -768,7 +769,7 @@ object Defaults extends BuildCommon {
         if b.nonEmpty then Def.task { b }
         else Compiler.scalaCompilerBridgeJarsTask(scalaCompilerBridgeSource, s.log)
       }).value,
-      scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),
+      scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value, scalaOrganization.value),
       auxiliaryClassFiles ++= {
         if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
         else Nil

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -769,7 +769,8 @@ object Defaults extends BuildCommon {
         if b.nonEmpty then Def.task { b }
         else Compiler.scalaCompilerBridgeJarsTask(scalaCompilerBridgeSource, s.log)
       }).value,
-      scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value, scalaOrganization.value),
+      scalaCompilerBridgeSource := ZincLmUtil
+        .getDefaultBridgeSourceModule(scalaVersion.value, scalaOrganization.value),
       auxiliaryClassFiles ++= {
         if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
         else Nil

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -88,9 +88,10 @@ object ZincLmUtil {
       dependencyResolution: DependencyResolution,
       updateConfiguration: UpdateConfiguration,
       warningConfig: UnresolvedWarningConfiguration,
-      logger: Logger
+      logger: Logger,
+      scalaOrganization: String = ScalaArtifacts.Organization
   ): File = {
-    val bridgeModule = getDefaultBridgeModule(scalaVersion)
+    val bridgeModule = getDefaultBridgeModule(scalaVersion, scalaOrganization)
     val descriptor = dependencyResolution.wrapDependencyInModule(bridgeModule)
     dependencyResolution
       .update(descriptor, updateConfiguration, warningConfig, logger)
@@ -108,12 +109,12 @@ object ZincLmUtil {
       .getOrElse(throw new MessageOnlyException(s"Missing $bridgeModule"))
   }
 
-  def getDefaultBridgeModule(scalaVersion: String): ModuleID = {
+  def getDefaultBridgeModule(scalaVersion: String, scalaOrganization: String = ScalaArtifacts.Organization): ModuleID = {
     if (ScalaArtifacts.isScala3(scalaVersion)) {
-      ModuleID(ScalaArtifacts.Organization, "scala3-sbt-bridge", scalaVersion)
+      ModuleID(scalaOrganization, "scala3-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
     } else if (hasScala2SbtBridge(scalaVersion)) {
-      ModuleID(ScalaArtifacts.Organization, "scala2-sbt-bridge", scalaVersion)
+      ModuleID(scalaOrganization, "scala2-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
     } else {
       val compilerBridgeId = scalaVersion match {
@@ -128,6 +129,6 @@ object ZincLmUtil {
     }
   }
 
-  def getDefaultBridgeSourceModule(scalaVersion: String): ModuleID =
-    getDefaultBridgeModule(scalaVersion).sources()
+  def getDefaultBridgeSourceModule(scalaVersion: String, scalaOrganization: String = ScalaArtifacts.Organization): ModuleID =
+    getDefaultBridgeModule(scalaVersion, scalaOrganization).sources()
 }

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -109,7 +109,10 @@ object ZincLmUtil {
       .getOrElse(throw new MessageOnlyException(s"Missing $bridgeModule"))
   }
 
-  def getDefaultBridgeModule(scalaVersion: String, scalaOrganization: String = ScalaArtifacts.Organization): ModuleID = {
+  def getDefaultBridgeModule(
+      scalaVersion: String,
+      scalaOrganization: String = ScalaArtifacts.Organization
+  ): ModuleID = {
     if (ScalaArtifacts.isScala3(scalaVersion)) {
       ModuleID(scalaOrganization, "scala3-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
@@ -129,6 +132,9 @@ object ZincLmUtil {
     }
   }
 
-  def getDefaultBridgeSourceModule(scalaVersion: String, scalaOrganization: String = ScalaArtifacts.Organization): ModuleID =
+  def getDefaultBridgeSourceModule(
+      scalaVersion: String,
+      scalaOrganization: String = ScalaArtifacts.Organization
+  ): ModuleID =
     getDefaultBridgeModule(scalaVersion, scalaOrganization).sources()
 }

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincLmUtilSpec.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincLmUtilSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.inc
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ZincLmUtilSpec extends AnyFlatSpec with Matchers {
+  "getDefaultBridgeSourceModule" should "use the passed scala organization for Scala 3 bridge modules" in {
+    val customOrg = "example.scala.org"
+    val module = ZincLmUtil.getDefaultBridgeSourceModule("3.3.5", customOrg)
+
+    module.organization shouldBe customOrg
+    module.name shouldBe "scala3-sbt-bridge"
+  }
+}


### PR DESCRIPTION
Fixes #8731

When using custom Scala distributions with `scalaOrganization` set (like scala-wasm), sbt was trying to fetch compiler bridges from `org.scala-lang` instead of the configured organization.

**Changes:**
- Updated `ZincLmUtil.fetchDefaultBridgeModule` to accept `scalaOrganization` parameter
- Updated `ZincLmUtil.getDefaultBridgeModule` to use provided organization for both Scala 2 and Scala 3 bridges
- Updated `ZincLmUtil.getDefaultBridgeSourceModule` to propagate the organization
- Updated call site in `Defaults.scala` to pass `scalaOrganization.value`

Now custom Scala distributions can properly resolve their compiler bridges.