### PR TITLE
[2.x] fix: Relax non-delegation for settings on shell

### DIFF
--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -600,14 +600,21 @@ object Act {
     keys.flatMap(key => getValue(structure.data, key).map(KeyValue(key, _)))
 
   /**
-   * Starting sbt 2.0.0, we will not delegate when a non-existent scoping
-   * such as Compile / update is required.
+   * Resolves a key from settings data. Starting sbt 2.0.0 we do not delegate for
+   * tasks when the user specified an explicit scope (config or task axis), so that
+   * non-existent scopes like `Compile / update` fail. Settings may still delegate
+   * so that e.g. `Compile/console/fork` resolves when `console/fork` is defined
+   * in a delegated scope (see #8757).
    */
   private def getValue[T](data: Def.Settings, key: ScopedKey[T]): Option[T] =
-    if key.scope.config.isSelect ||
-      key.scope.task.isSelect
-    then data.getDirect(key)
-    else data.get(key)
+    val scopeExplicit = key.scope.config.isSelect || key.scope.task.isSelect
+    if !scopeExplicit then data.get(key)
+    else
+      data
+        .getDirect(key)
+        .orElse:
+          if key.key.tag.isSetting then data.get(key)
+          else None
 
   def requireSession[T](s: State, p: => Parser[T]): Parser[T] =
     if s.get(sessionSettings).isEmpty then failure("No project loaded") else p

--- a/sbt-app/src/sbt-test/project/settings-delegate/build.sbt
+++ b/sbt-app/src/sbt-test/project/settings-delegate/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "3.8.1"

--- a/sbt-app/src/sbt-test/project/settings-delegate/test
+++ b/sbt-app/src/sbt-test/project/settings-delegate/test
@@ -1,0 +1,6 @@
+# Fix #8757: settings may delegate when scope is explicit (tasks still must not).
+# console/fork is defined in default scope; Compile/console/fork should resolve via delegation.
+> compile
+
+# Setting with explicit config scope delegates (e.g. Compile/console/fork -> console/fork)
+> show Compile/console/fork


### PR DESCRIPTION
Fixes #8757 

## Problem

After the change in #8539, the shell stopped delegating for any scoped key. So when you run something like `Compile/console/fork`, you get "No such setting/task" even when `console/fork` is defined in a delegated scope (e.g. the default config). That’s annoying for settings, where delegation is usually what you want.

## Solution

We keep the current behaviour for **tasks**: if you type a task with an explicit scope and it isn’t defined in that exact scope, it still fails (so typos like `Compile/update` don’t silently run something else). For **settings** we allow delegation again: if the key isn’t found in the requested scope, we follow the normal scope delegation and use the value from a delegate scope. So `Compile/console/fork` works when `console/fork` is defined in a more general scope.

The change is in `Act.getValue`: when the user has specified an explicit config or task scope we still try a direct lookup first; if that returns nothing and the key is a setting (via `key.key.tag.isSetting`), we fall back to `data.get(key)` so delegation applies. Task keys never use that fallback.

