### PR TITLE
[2.x] feat: client-side run env inheritance

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -765,7 +765,7 @@ class NetworkClient(
         workingDirectory = info.workingDirectory.map(new File(_)),
         runJVMOptions = Vector.empty,
         connectInput = info.connectInput,
-        envVars = info.environmentVariables,
+        envVars = RunHandler.mergedEnvVars(info.environmentVariables),
       )
       val command = info.cmd :: info.args.toList
       val jpb = new JProcessBuilder(command*)

--- a/main-command/src/main/scala/sbt/internal/util/RunHandler.scala
+++ b/main-command/src/main/scala/sbt/internal/util/RunHandler.scala
@@ -18,6 +18,11 @@ import scala.util.Try
 
 // Process runinfos
 object RunHandler:
+  private[internal] def mergedEnvVars(
+      environmentVariables: Map[String, String]
+  ): Map[String, String] =
+    sys.env.toMap ++ environmentVariables
+
   def jvmRun(info: JvmRunInfo, log: Logger): Try[Unit] =
     val option = ForkOptions(
       javaHome = info.javaHome.map(File(_)),
@@ -26,7 +31,7 @@ object RunHandler:
       workingDirectory = info.workingDirectory.map(File(_)),
       runJVMOptions = info.jvmOptions,
       connectInput = info.connectInput,
-      envVars = info.environmentVariables,
+      envVars = mergedEnvVars(info.environmentVariables),
     )
     // ForkRun handles exit code handling and cancellation
     val runner = new ForkRun(option)

--- a/main-command/src/test/scala/sbt/internal/util/RunHandlerTest.scala
+++ b/main-command/src/test/scala/sbt/internal/util/RunHandlerTest.scala
@@ -1,0 +1,22 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+
+import verify.BasicTestSuite
+
+object RunHandlerTest extends BasicTestSuite:
+  test("mergedEnvVars includes current process environment and applies explicit overrides"):
+    val overrides = Map("PATH" -> "__override__", "SBT_RUNUTIL_TEST_VAR" -> "value")
+    val result = RunHandler.mergedEnvVars(overrides)
+
+    assert(result.get("SBT_RUNUTIL_TEST_VAR").contains("value"))
+    assert(result.get("PATH").contains("__override__"))
+    assert(result.contains("HOME"))
+
+end RunHandlerTest


### PR DESCRIPTION
Fixes #7012.

When `sbtn run` is executed through client jobs, the run env currently only uses explicit task env vars. This can keep stale process-level values around across invocations.

This change merges the current client process environment (`sys.env`) with explicit overrides, so each invocation reflects the shell env it was started with.

Changes:
- merge `sys.env` with job env overrides in `RunHandler.jvmRun`
- apply the same merge for native client-side runs in `NetworkClient`
- add a focused unit test for env merge behavior and override precedence