### PR TITLE
[2.x] fix: Support inline comments in .jvmopts and .sbtopts files

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -309,4 +309,40 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
       s"Should not have shell expansion errors, but found: ${errorMessages.mkString(", ")}"
     )
 
+  // Test for issue #8755: Inline comments should be supported in .jvmopts
+  testOutput(
+    "sbt with inline comments in .jvmopts",
+    jvmoptsFileContents =
+      "--add-opens=java.base/java.util=ALL-UNNAMED # This is an inline comment\n-Dtest.key=value # Another comment",
+    windowsSupport = false,
+  )("-v"): (out: List[String]) =>
+    // Verify that options are present (comments should be stripped)
+    assert(
+      out.contains[String]("--add-opens=java.base/java.util=ALL-UNNAMED"),
+      "Option with inline comment should be parsed correctly"
+    )
+    assert(
+      out.contains[String]("-Dtest.key=value"),
+      "System property with inline comment should be parsed correctly"
+    )
+    // Verify comments themselves are NOT present as separate arguments
+    assert(
+      !out.exists(_.contains("This is an inline comment")),
+      "Inline comment should not appear in command line"
+    )
+    assert(
+      !out.exists(_.contains("Another comment")),
+      "Inline comment should not appear in command line"
+    )
+    // Verify no "command not found" errors for '#' character
+    val errorMessages = out.filter(line =>
+      line.contains("Could not find or load main class #") ||
+        line.contains("command not found") ||
+        line.contains("was unexpected")
+    )
+    assert(
+      errorMessages.isEmpty,
+      s"Should not have errors from comment character, but found: ${errorMessages.mkString(", ")}"
+    )
+
 end RunnerScriptTest

--- a/sbt
+++ b/sbt
@@ -805,7 +805,7 @@ outputConfigFileTokens() {
   local file="$1"
   [[ ! -f "$file" ]] && return
   while IFS= read -r line || [[ -n "$line" ]]; do
-    line=$(printf '%s' "$line" | sed $'/^\#/d;s/\r$//')
+    line=$(printf '%s' "$line" | sed $'/^\#/d;s/\s*\#.*//;s/\r$//')
     [[ -z "$line" ]] && continue
     if [[ "$line" == -J* ]]; then
       local rest="${line#-J}"


### PR DESCRIPTION
fixes #8755

### Problem
After PR #8730 (commit 921efce), inline comments in `.jvmopts` and `.sbtopts` files cause errors.
For example, `--add-opens=java.base/java.util=ALL-UNNAMED # comment` results in:
```
Error: Could not find or load main class #
```

The `#` and everything after it is now parsed as separate arguments instead of being stripped as a comment.

### Solution
Update the sed command in `outputConfigFileTokens()` to strip inline comments (everything from `#` to end of line) before parsing tokens:

```diff
-    line=$(printf '%s' "$line" | sed $'/^\#/d;s/\r$//')
+    line=$(printf '%s' "$line" | sed $'/^\#/d;s/\s*\#.*//;s/\r$//')
```

The new `s/\s*\#.*//` pattern:
- `\s*` - matches optional whitespace before `#`
- `\#` - matches the `#` character
- `.*` - matches everything to end of line

This means `--add-opens=java.base/java.util=ALL-UNNAMED # comment` becomes `--add-opens=java.base/java.util=ALL-UNNAMED` before token parsing.

### Testing
- Added integration test verifying inline comments are stripped from `.jvmopts`
- Manually tested with `.jvmopts` containing inline comments - no errors
- Full line comments (starting with `#`) still work correctly

**Manual test output:**
```bash
# Input .jvmopts:
--add-opens=java.base/java.util=ALL-UNNAMED # This is a comment
-Xmx2g # Memory setting
-Dtest.key=value # inline comment here too

# Parsed tokens (comments stripped):
--add-opens=java.base/java.util=ALL-UNNAMED
-Xmx2g
-Dtest.key=value
```

### AI Disclosure
Generated-by: Claude Sonnet 4.5

All code has been manually reviewed, tested, and verified to solve issue #8755.