### PR TITLE
[2.x] fix: Escape pipe characters in sbtconfig.txt and .sbtopts on Windows

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -282,7 +282,6 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     "sbt with special characters in .jvmopts (pipes, wildcards, ampersands)",
     jvmoptsFileContents =
       "-Dtest.pipes=host1|host2|host3\n-Dtest.wildcards=path/*/pattern\n-Dtest.ampersand=value&other",
-    windowsSupport = false,
   )("-v"): (out: List[String]) =>
     // Verify that properties with special characters are handled correctly
     // The pipe characters should be treated literally, not as shell operators

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -64,9 +64,10 @@ if exist .sbtopts for /F %%A in (.sbtopts) do (
       set _sbtopts_line=!_sbtopts_line:~2,1000!
     )
     if defined _SBT_OPTS (
-      set _SBT_OPTS=!_SBT_OPTS! !_sbtopts_line!
+      rem Use quotes to prevent pipe characters (|) from being interpreted as command separators
+      set "_SBT_OPTS=!_SBT_OPTS! !_sbtopts_line!"
     ) else (
-      set _SBT_OPTS=!_sbtopts_line!
+      set "_SBT_OPTS=!_sbtopts_line!"
     )
   )
 )
@@ -81,7 +82,8 @@ if exist "!SBT_CONFIG!" (
     set DO_NOT_REUSE_ME=%%i
     rem ZOMG (Part #2) WE use !! here to delay the expansion of
     rem SBT_CFG_OPTS, otherwise it remains "" for this loop.
-    set SBT_CFG_OPTS=!SBT_CFG_OPTS! !DO_NOT_REUSE_ME!
+    rem Use quotes to prevent pipe characters (|) from being interpreted as command separators
+    set "SBT_CFG_OPTS=!SBT_CFG_OPTS! !DO_NOT_REUSE_ME!"
   )
 )
 


### PR DESCRIPTION
Fixes #5171

When parsing sbtconfig.txt and .sbtopts files on Windows, pipe characters (`|`) in JVM options were being interpreted as batch file command separators, causing "was unexpected at this time" errors.

This commonly occurred with the `-Dhttp.nonProxyHosts` option when specifying multiple hosts separated by pipes, e.g.:
```
-Dhttp.nonProxyHosts="127.0.*|localhost"
```

## Changes

The fix wraps the variable assignment in quotes to prevent the pipe from being interpreted as a command separator while still allowing the pipe to be preserved in the final Java system property value.

**Before:**
```batch
set SBT_CFG_OPTS=!SBT_CFG_OPTS! !DO_NOT_REUSE_ME!
```

**After:**
```batch
set "SBT_CFG_OPTS=!SBT_CFG_OPTS! !DO_NOT_REUSE_ME!"
```

This is the standard Windows batch file pattern for safely handling variables that may contain special characters.

## Testing

The same fix is applied to both:
- sbtconfig.txt parsing (line 84)
- .sbtopts parsing (lines 67, 69)

This ensures consistent handling of pipe characters in both configuration methods.