### PR TITLE
[2.x] fix: Filter semanticdb options from scaladoc invocations

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -94,7 +94,7 @@ object SemanticdbPlugin extends AutoPlugin {
         val sdbOpts = semanticdbOptions.value.toSet
         (doc / scalacOptions).value.filterNot { opt =>
           sdbOpts.contains(opt) ||
-            (opt.startsWith("-Xplugin:") && opt.contains("semanticdb"))
+          (opt.startsWith("-Xplugin:") && opt.contains("semanticdb"))
         }
       } else (doc / scalacOptions).value
     },

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -89,6 +89,15 @@ object SemanticdbPlugin extends AutoPlugin {
           orig
         }
     }).value,
+    doc / scalacOptions := {
+      if (semanticdbEnabled.value) {
+        val sdbOpts = semanticdbOptions.value.toSet
+        (doc / scalacOptions).value.filterNot { opt =>
+          sdbOpts.contains(opt) ||
+            (opt.startsWith("-Xplugin:") && opt.contains("semanticdb"))
+        }
+      } else (doc / scalacOptions).value
+    },
   )
 
   def targetRootOptions(scalaVersion: String, targetRoot: File): Seq[String] = {

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/build.sbt
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/build.sbt
@@ -1,0 +1,10 @@
+semanticdbEnabled := true
+
+val matrix = projectMatrix
+  .defaultAxes(VirtualAxis.jvm)
+  .jvmPlatform(scalaVersions =
+    Seq(
+      "2.12.21",
+      "3.6.4"
+    )
+  )

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/matrix/src/main/scala/foo/A.scala
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/matrix/src/main/scala/foo/A.scala
@@ -1,0 +1,7 @@
+package foo
+
+object A {
+  def main(args: Array[String]): Unit = {
+    println("hello world")
+  }
+}

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/test
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/test
@@ -1,0 +1,13 @@
+# Verify that scaladoc works when semanticdbEnabled is true
+# This tests the fix for issue #8740
+
+# Scala 2.x: doc should succeed without semanticdb options leaking
+> matrix2_12/doc
+
+# Scala 3.x: doc should succeed without semanticdb options leaking
+> matrix3/doc
+
+# Verify that compile still generates semanticdb files
+> compile
+$ exists target/**/scala-2.12*/**/meta/META-INF/semanticdb/matrix/src/main/scala/foo/A.scala.semanticdb
+$ exists target/**/scala-3*/**/meta/META-INF/semanticdb/matrix/src/main/scala/foo/A.scala.semanticdb


### PR DESCRIPTION
## Problem

When `semanticdbEnabled := true` is set on Scala 2.x projects, the `doc` task fails because semanticdb-related compiler options (`-Xplugin:...semanticdb...`, `-P:semanticdb:targetroot:*`, `-Yrangepos`) leak into `doc / scalacOptions`. Scaladoc does not support these options, causing:

```
[error] bad option: -P:semanticdb:targetroot:/path/to/target/meta
[error] (Compile / doc) Scaladoc generation failed
```

Fixes #8740.

## Solution

Added a `doc / scalacOptions` setting in `SemanticdbPlugin.configurationSettings` that, when `semanticdbEnabled` is true, filters out:

1. All options from `semanticdbOptions` (`-Yrangepos`, `-P:semanticdb:targetroot:*` for Scala 2.x; `-Xsemanticdb`, `-semanticdb-target` for Scala 3.x)
2. Any `-Xplugin:` flag containing `semanticdb` (the compiler plugin JAR)

This is placed in `SemanticdbPlugin` because it introduces these options, so it should be responsible for scoping them away from `doc`.

## Tests

New scripted test `project/semanticdb-doc` that:
- Runs `doc` on both Scala 2.12 and Scala 3.6 with `semanticdbEnabled := true`
- Verifies that `compile` still generates `.semanticdb` files

## AI Disclosure

This PR was created with assistance from Claude Opus 4.6 (AI). All code changes have been reviewed and verified for correctness.

Generated-by: Claude Opus 4.6