### PR TITLE
[2.x] fix: Resolve virtual file refs in scaladoc options

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2064,6 +2064,13 @@ object Defaults extends BuildCommon {
                 if (ScalaArtifacts.isScala3(sv)) Opts.doc.externalAPIScala3(xapisFiles)
                 else Opts.doc.externalAPI(xapisFiles)
               val options = sOpts ++ externalApiOpts
+              def convertVfRef(value: String): String =
+                if !value.contains("$") then value
+                else converter.toPath(VirtualFileRef.of(value)).toString
+              val resolvedOptions = options.map { x =>
+                if !x.contains("$") then x
+                else x.split(":").map(_.split(",").map(convertVfRef).mkString(",")).mkString(":")
+              }
               val scalac = cs.scalac match
                 case ac: AnalyzingCompiler => ac.onArgs(Compiler.exported(s, "scaladoc"))
               val docSrcFiles = if ScalaArtifacts.isScala3(sv) then tFiles else srcs
@@ -2077,7 +2084,7 @@ object Defaults extends BuildCommon {
                   cp.map(converter.toPath).map(new sbt.internal.inc.PlainVirtualFile(_)),
                   converter,
                   out.toPath(),
-                  options,
+                  resolvedOptions,
                   maxErrors.value,
                   s.log,
                 )

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/build.sbt
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/build.sbt
@@ -1,0 +1,2 @@
+semanticdbEnabled := true
+scalaVersion := "2.12.21"

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/src/main/scala/A.scala
@@ -1,0 +1,1 @@
+object A

--- a/sbt-app/src/sbt-test/project/semanticdb-doc/test
+++ b/sbt-app/src/sbt-test/project/semanticdb-doc/test
@@ -1,0 +1,2 @@
+# scaladoc should succeed when semanticdbEnabled is true
+> doc


### PR DESCRIPTION
## Problem

Fixes #8740

When `semanticdbEnabled := true` is set on Scala 2.x projects, the `doc` task fails because `${CSR_CACHE}` placeholders in `scalacOptions` (specifically the `-Xplugin:` path for the semanticdb compiler plugin JAR) are not resolved before being passed to Scaladoc. This causes:

```
[error] bad option: -P:semanticdb:targetroot:/path/to/target/meta
[error] (Compile / doc) Scaladoc generation failed
```

The root cause is that the plugin JAR path contains an unresolved `${CSR_CACHE}` variable, so the plugin fails to load, and its associated `-P:semanticdb:*` flags are rejected as unknown options.

### Reproduction (from #8740)

```scala
// build.sbt
semanticdbEnabled := true
scalaVersion := "2.12.21"
```

```
sbt> doc
[error] bad option: -P:semanticdb:targetroot:...
```

## Solution

Resolve virtual file references (containing `$`) in `scalacOptions` before passing them to the Scaladoc bridge in `docTaskSettings`. This matches the approach already used in zinc's `MixedAnalyzingCompiler.compileScala()` (see sbt/zinc#1545), which resolves `$` variables for compilation but not for doc generation.

The resolution splits each option by `:` and `,`, then converts any part containing `$` via `VirtualFileRef.of() -> converter.toPath()`.

## Tests

- New `project/semanticdb-doc` scripted test: runs `doc` on a Scala 2.12 project with `semanticdbEnabled := true`
- Ran `project/*`, `actions/*`, `compiler-project/*` scripted test suites locally — all pass

## AI Disclosure

This PR was developed with assistance from GitHub Copilot (Claude Opus 4.6). All code changes, test design, and debugging were AI-assisted.

Generated-by: GitHub Copilot (Claude Opus 4.6)
