### PR TITLE
[2.x] feat: Pretty-print dependency lock file

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
@@ -3,7 +3,7 @@ package lmcoursier.internal
 import java.io.File
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
-import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser }
+import sjsonnew.support.scalajson.unsafe.{ Converter, Parser, PrettyPrinter }
 import scala.util.{ Try, Success, Failure }
 
 object LockFile {
@@ -29,7 +29,7 @@ object LockFile {
   def write(lockFile: File, data: LockFileData): Either[String, Unit] = {
     Try {
       val json = Converter.toJson(data).get
-      val content = CompactPrinter(json)
+      val content = PrettyPrinter(json)
       lockFile.getParentFile.mkdirs()
       Files.write(lockFile.toPath, content.getBytes(StandardCharsets.UTF_8))
     } match {

--- a/lm-coursier/src/test/scala/lmcoursier/LockFileSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/LockFileSpec.scala
@@ -104,6 +104,27 @@ class LockFileSpec extends AnyFunSuite {
     }
   }
 
+  test("LockFile.write outputs pretty JSON") {
+    val lockData = LockFileData(
+      version = "1.0",
+      buildClock = "pretty-test",
+      configurations = Vector.empty,
+      metadata = LockFileMetadata(
+        sbtVersion = "2.0.0",
+        scalaVersion = Some("3.8.1")
+      )
+    )
+
+    IO.withTemporaryDirectory { dir =>
+      val lockFile = new File(dir, "pretty.lock")
+      val writeResult = LockFile.write(lockFile, lockData)
+      assert(writeResult.isRight, s"Write failed: ${writeResult.left.getOrElse("")}")
+
+      val content = IO.read(lockFile)
+      assert(content.contains("\n"), "Expected pretty-printed JSON with multiple lines")
+    }
+  }
+
   test("cacheFileToOriginalUrl converts cache file URL to HTTP URL") {
     IO.withTemporaryDirectory { cacheDir =>
       val fileUrl =


### PR DESCRIPTION
Fixes #8770

## Problem

The `dependencyLock` task writes `deps.lock` as a single line of JSON, which is difficult to review and diff (see #8770).

## Solution

Use `PrettyPrinter` instead of `CompactPrinter` in `LockFile.write` so the lock file is written as pretty-printed, multi-line JSON. Schema and semantics are unchanged; only formatting changes. Both the manual `dependencyLock` task and the lock file written during resolution use this path.

## Testing

- Reproduced the issue: ran `dependencyLock` on sbt 2.0.0-RC9 and confirmed one-line output before the change.
- Added unit test in `LockFileSpec`: "LockFile.write outputs pretty JSON" (asserts written content contains newlines).
- Existing lock round-trip and `dependencyLockCheck` behavior unchanged; parser accepts both compact and pretty JSON.

## Checklist

- [x] Reproduced the problem before changing code.
- [x] Change compiles and fixes the problem.
- [x] Unit test added.
- [x] Small, focused change (formatting only).