### PR TITLE
[1.12.x] fix: prefer JAVA_HOME/JAVACMD in shell runner

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
@@ -83,4 +83,13 @@ object RunnerMemoryScriptTest extends verify.BasicTestSuite with ShellScriptUtil
       assert(out.contains[String]("-Xms512M"))
       assert(out.contains[String]("-Xmx1G"))
 
+  // Regression test for #8767: options from .jvmopts should be passed correctly on Windows
+  testOutput(
+    "sbt use .jvmopts file with uppercase memory suffixes",
+    jvmoptsFileContents = """-Xmx2G
+        |-Xss1M""".stripMargin
+  )("compile", "-v"): (out: List[String]) =>
+    assert(out.contains[String]("-Xmx2G"))
+    assert(out.contains[String]("-Xss1M"))
+
 end RunnerMemoryScriptTest

--- a/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
@@ -93,12 +93,13 @@ object RunnerMemoryScriptTest extends verify.BasicTestSuite with ShellScriptUtil
     assert(out.contains[String]("-Xss1M"))
 
   testOutput(
-    "sbt prefers JAVA_HOME over PATH when JAVACMD is unset",
+    "sbt prefers JAVA_HOME over PATH in cygwin shell when JAVACMD is unset",
     jvmoptsFileContents = """-Xmx2G
         |-Xss1M""".stripMargin,
     failingPathJava = true,
     useJavaHomeFromTestBin = true,
-    setWindowsJavacmd = false
+    setWindowsJavacmd = false,
+    simulateCygwinShell = true
   )("compile", "-v"): (out: List[String]) =>
     assert(out.contains[String]("-Xmx2G"))
     assert(out.contains[String]("-Xss1M"))

--- a/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
@@ -92,4 +92,15 @@ object RunnerMemoryScriptTest extends verify.BasicTestSuite with ShellScriptUtil
     assert(out.contains[String]("-Xmx2G"))
     assert(out.contains[String]("-Xss1M"))
 
+  testOutput(
+    "sbt prefers JAVA_HOME over PATH when JAVACMD is unset",
+    jvmoptsFileContents = """-Xmx2G
+        |-Xss1M""".stripMargin,
+    failingPathJava = true,
+    useJavaHomeFromTestBin = true,
+    setWindowsJavacmd = false
+  )("compile", "-v"): (out: List[String]) =>
+    assert(out.contains[String]("-Xmx2G"))
+    assert(out.contains[String]("-Xss1M"))
+
 end RunnerMemoryScriptTest

--- a/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerMemoryScriptTest.scala
@@ -99,7 +99,8 @@ object RunnerMemoryScriptTest extends verify.BasicTestSuite with ShellScriptUtil
     failingPathJava = true,
     useJavaHomeFromTestBin = true,
     setWindowsJavacmd = false,
-    simulateCygwinShell = true
+    simulateCygwinShell = true,
+    windowsSupport = false
   )("compile", "-v"): (out: List[String]) =>
     assert(out.contains[String]("-Xmx2G"))
     assert(out.contains[String]("-Xss1M"))

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -37,6 +37,9 @@ trait ShellScriptUtil extends BasicTestSuite {
       distSbtoptsContents: String = "",
       machineSbtoptsContents: String = "",
       jvmoptsFileContents: String = "",
+      failingPathJava: Boolean = false,
+      useJavaHomeFromTestBin: Boolean = false,
+      setWindowsJavacmd: Boolean = true,
       windowsSupport: Boolean = true,
       citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
@@ -153,10 +156,41 @@ trait ShellScriptUtil extends BasicTestSuite {
           envVars("JAVA_OPTS") = javaOpts
           envVars("SBT_OPTS") = sbtOpts
           envVars("JAVA_TOOL_OPTIONS") = javaToolOptions
-          if (isWindows)
+
+          if (useJavaHomeFromTestBin) {
+            envVars("JAVA_HOME") = new File(javaBinDir).getParentFile.getAbsolutePath
+          }
+
+          val pathWithFakeJava =
+            if (failingPathJava) {
+              val fakePathBin = new File(workingDirectory, "fake-path-bin")
+              fakePathBin.mkdirs()
+              if (isWindows) {
+                val fakeJavaCmd = new File(fakePathBin, "java.cmd")
+                IO.write(
+                  fakeJavaCmd,
+                  """@echo PATH_JAVA_SHOULD_NOT_RUN 1>&2
+                    |@exit /b 1
+                    |""".stripMargin
+                )
+              } else {
+                val fakeJava = new File(fakePathBin, "java")
+                IO.write(
+                  fakeJava,
+                  """#!/usr/bin/env bash
+                    |echo PATH_JAVA_SHOULD_NOT_RUN 1>&2
+                    |exit 1
+                    |""".stripMargin
+                )
+                fakeJava.setExecutable(true)
+              }
+              fakePathBin.getAbsolutePath + File.pathSeparator + path
+            } else path
+
+          envVars("PATH") = pathWithFakeJava
+
+          if (isWindows && setWindowsJavacmd)
             envVars("JAVACMD") = new File(javaBinDir, "java").getAbsolutePath()
-          else
-            envVars("PATH") = javaBinDir + File.pathSeparator + path
 
           val out = scala.sys.process
             .Process(

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -40,6 +40,7 @@ trait ShellScriptUtil extends BasicTestSuite {
       failingPathJava: Boolean = false,
       useJavaHomeFromTestBin: Boolean = false,
       setWindowsJavacmd: Boolean = true,
+      simulateCygwinShell: Boolean = false,
       windowsSupport: Boolean = true,
       citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
@@ -183,6 +184,28 @@ trait ShellScriptUtil extends BasicTestSuite {
                     |""".stripMargin
                 )
                 fakeJava.setExecutable(true)
+              }
+              if (simulateCygwinShell && !isWindows) {
+                val fakeUname = new File(fakePathBin, "uname")
+                IO.write(
+                  fakeUname,
+                  """#!/usr/bin/env bash
+                    |echo MINGW64_NT-10.0
+                    |""".stripMargin
+                )
+                fakeUname.setExecutable(true)
+
+                val fakeCygpath = new File(fakePathBin, "cygpath")
+                IO.write(
+                  fakeCygpath,
+                  """#!/usr/bin/env bash
+                    |if [[ "$1" == "-u" ]]; then
+                    |  shift
+                    |fi
+                    |printf '%s\n' "$1"
+                    |""".stripMargin
+                )
+                fakeCygpath.setExecutable(true)
               }
               fakePathBin.getAbsolutePath + File.pathSeparator + path
             } else path

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -122,13 +122,13 @@ rem We use the value of the JAVA_OPTS environment variable if defined, rather th
 if not defined _JAVA_OPTS if defined JAVA_OPTS set _JAVA_OPTS=%JAVA_OPTS% 
 
 rem users can set JAVA_OPTS via .jvmopts (sbt-extras style) 
-if exist .jvmopts for /F %%A in (.jvmopts) do ( 
+if exist .jvmopts for /F "usebackq tokens=* delims=" %%A in (".jvmopts") do ( 
   set _jvmopts_line=%%A 
   if not "!_jvmopts_line:~0,1!" == "#" ( 
     if defined _JAVA_OPTS ( 
-      set _JAVA_OPTS=!_JAVA_OPTS! %%A 
+      set _JAVA_OPTS=!_JAVA_OPTS! !_jvmopts_line! 
     ) else ( 
-      set _JAVA_OPTS=%%A 
+      set _JAVA_OPTS=!_jvmopts_line! 
     ) 
   ) 
 ) 

--- a/sbt
+++ b/sbt
@@ -93,6 +93,21 @@ cygwinpath() {
   fi
 }
 
+# Prefer explicit Java settings to avoid PATH picking an unexpected runtime
+# (notably on Windows Git Bash where JAVA_HOME can be set but java on PATH differs).
+if [[ -n "$JAVACMD" ]]; then
+  java_cmd="$JAVACMD"
+elif [[ -n "$JAVA_HOME" ]]; then
+  if [[ "$CYGWIN_FLAG" == "true" ]]; then
+    java_home_unix=$(cygpath -u "$JAVA_HOME" 2>/dev/null)
+    if [[ -n "$java_home_unix" ]] && [[ -x "$java_home_unix/bin/java" ]]; then
+      java_cmd="$java_home_unix/bin/java"
+    fi
+  elif [[ -x "$JAVA_HOME/bin/java" ]]; then
+    java_cmd="$JAVA_HOME/bin/java"
+  fi
+fi
+
 # Trim leading and trailing spaces from a string.
 # Echos the new trimmed string.
 trimString() {

--- a/sbt
+++ b/sbt
@@ -93,11 +93,12 @@ cygwinpath() {
   fi
 }
 
-# Prefer explicit Java settings to avoid PATH picking an unexpected runtime
-# (notably on Windows Git Bash where JAVA_HOME can be set but java on PATH differs).
+# Prefer explicit Java settings to avoid PATH picking an unexpected runtime.
+# Limit JAVA_HOME precedence to Cygwin/MSYS/MINGW shells to avoid changing
+# long-standing PATH-vs-JAVA_HOME behavior on non-Windows environments.
 if [[ -n "$JAVACMD" ]]; then
   java_cmd="$JAVACMD"
-elif [[ -n "$JAVA_HOME" ]]; then
+elif [[ "$CYGWIN_FLAG" == "true" ]] && [[ -n "$JAVA_HOME" ]]; then
   if [[ "$CYGWIN_FLAG" == "true" ]]; then
     java_home_unix=$(cygpath -u "$JAVA_HOME" 2>/dev/null)
     if [[ -n "$java_home_unix" ]] && [[ -x "$java_home_unix/bin/java" ]]; then


### PR DESCRIPTION
## Summary
This PR targets the shell-runner Java selection path related to #8767 logs.

It updates `sbt` to prefer explicit Java configuration (`JAVACMD`, then `JAVA_HOME`) before falling back to `java` on PATH.

## Why
In Windows Git Bash scenarios, shell-runner execution can resolve an unexpected Java from PATH even when `JAVA_HOME` is set. Prioritizing explicit Java selection avoids that mismatch.

## Changes
- `sbt`
  - if `JAVACMD` is set, use it
  - else if `JAVA_HOME` is set, use `$JAVA_HOME/bin/java` (with cygwin path conversion when needed)
  - otherwise keep existing fallback to `java`

## Scope
No changes to `sbt.bat` in this revision.