### PR TITLE
[2.x] fix: Prefer direct key selection over aggregate-only fallback

### DIFF
--- a/main/src/main/scala/sbt/internal/Act.scala
+++ b/main/src/main/scala/sbt/internal/Act.scala
@@ -216,7 +216,9 @@ object Act {
         case None    => noValidKeys
         case Some(x) => success(x)
       val validFilter = structure.fold(isValid(data))(isValidForAggregate(data, _))
-      selectFromValid(ss filter validFilter, default)
+      val valid = ss filter validFilter
+      val directlyDefined = valid filter isValid(data)
+      selectFromValid(if directlyDefined.nonEmpty then directlyDefined else valid, default)
     }
 
   private def isValidForAggregate(

--- a/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/build.sbt
+++ b/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/build.sbt
@@ -1,0 +1,11 @@
+ThisBuild / scalaVersion := "2.13.18"
+
+lazy val a = project
+
+lazy val b = project
+  .in(file("."))
+  .settings(
+    libraryDependencies += "org.scalatest" %% "scalatest-funsuite" % "3.2.19" % Test
+  )
+  .dependsOn(a)
+  .aggregate(a)

--- a/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/src/test/scala/Test1.scala
+++ b/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/src/test/scala/Test1.scala
@@ -1,0 +1,7 @@
+package example
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class Test1 extends AnyFunSuite {
+  fail("This test should fail")
+}

--- a/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/test
+++ b/sbt-app/src/sbt-test/tests/i8772-root-project-testfull/test
@@ -1,0 +1,1 @@
+-> testFull


### PR DESCRIPTION
## Problem

In `2.0.0-RC9`, `testFull` can resolve to an aggregate-only candidate before a directly defined key.  
For a root project, this can run only aggregated child tests and skip root tests, so failing root tests may pass unexpectedly.

## Solution

Update `Act.select` to prefer directly defined keys in settings data and only use aggregate-only candidates as a fallback.  
Add a scripted regression test at `tests/i8772-root-project-testfull`, while preserving aggregate fallback behavior covered by `project/extra-projects-key-aggregate`.

## Verification

- Reproduced the regression on `2.0.0-RC9` and confirmed expected behavior on `2.0.0-RC8`.
- Ran: `./sbt "scripted tests/i8772-root-project-testfull"`  
  - fails without the fix, passes with the fix.
- Ran: `./sbt "scripted project/extra-projects-key-aggregate"`  
  - passes (no regression for #8690 path).

I manually reviewed all changes and verified behavior locally.

Closes #8772
