### PR TITLE
[2.x] Fallback to $HOME/.config/sbt

### DIFF
--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -207,11 +207,12 @@ object SysProp:
   /**
    * Default directory for global sbt config (plugins, settings). Respects XDG Base Directory
    * and platform conventions: SBT_CONFIG_HOME, then XDG_CONFIG_HOME/sbt (Unix), then
-   * LOCALAPPDATA/sbt (Windows), else user.home/.sbt.
+   * LOCALAPPDATA/sbt (Windows), else user.home/.config/sbt.
    */
   def defaultGlobalBaseDirectory: File =
     def fromEnv(name: String): Option[File] =
       sys.env.get(name).filter(_.nonEmpty).map(p => file(p.trim))
+    def fallbackDir: File = home / ".config" / "sbt"
     val propBase =
       sys.props.get(BuildPaths.GlobalBaseProperty).filter(_.nonEmpty).map(p => file(p.trim))
     propBase
@@ -220,7 +221,7 @@ object SysProp:
         if Util.isWindows then fromEnv("LOCALAPPDATA").map(_ / "sbt")
         else fromEnv("XDG_CONFIG_HOME").map(_ / "sbt")
       )
-      .getOrElse(home / BuildPaths.ConfigDirectoryName)
+      .getOrElse(fallbackDir)
       .getAbsoluteFile
 
   /**

--- a/sbt
+++ b/sbt
@@ -645,7 +645,7 @@ Usage: `basename "$0"` [options]
   --jvm-client        run JVM client
   --timings           display task timings report on shutdown
   --allow-empty       start sbt even if current directory contains no sbt project
-  --sbt-dir   <path>  path to global settings/plugins directory (default: \$XDG_CONFIG_HOME/sbt or ~/.sbt)
+  --sbt-dir   <path>  path to global settings/plugins directory (default: \$XDG_CONFIG_HOME/sbt or ~/.config/sbt)
   --sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
   --sbt-cache <path>  path to global cache directory (default: operating system specific)
   --ivy       <path>  path to local Ivy repository (default: ~/.ivy2)


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/3681

## Problem/Solution
When XDG_CONFIG_HOME is not defined, we should fallback to `$HOME/.config/sbt`.
