### PR TITLE
[2.x] refactor: Use `enum` instead of `scala.Enumeration` in sbt.Execute.State

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -473,6 +473,12 @@ lazy val taskProj = (project in file("tasks"))
     name := "Tasks",
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[MissingTypesProblem]("sbt.Execute$State$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sbt.Execute#State.this"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sbt.Execute#State.Pending"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sbt.Execute#State.Running"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sbt.Execute#State.Calling"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sbt.Execute#State.Done"),
     )
   )
 

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -75,9 +75,8 @@ private[sbt] final class Execute(
       view.inline1(a) match
         case Some(v) => Result.Value(v())
         case None    => results(a)
-  private type State = State.Value
-  private object State extends Enumeration {
-    val Pending, Running, Calling, Done = Value
+  private enum State {
+    case Pending, Running, Calling, Done
   }
   import State.{ Pending, Running, Calling, Done }
 


### PR DESCRIPTION
I think this is a binary compatible change because `State` is `private`.