### PR TITLE
[2.x] Fix `Aggregation.printSettings` pattern matching

### DIFF
--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -52,8 +52,8 @@ object Aggregation {
       display: Show[ScopedKey[?]]
   ): Unit =
     xs match {
-      case KeyValue(_, x: Seq[?]) :: Nil => print(x.mkString("* ", "\n* ", ""))
-      case KeyValue(_, x) :: Nil         => print(x.toString)
+      case Seq(KeyValue(_, x: Seq[?])) => print(x.mkString("* ", "\n* ", ""))
+      case Seq(KeyValue(_, x))         => print(x.toString)
       case _ =>
         xs foreach { kv =>
           print(display.show(kv.key))


### PR DESCRIPTION
`xs` is `Seq` not `List`.

I think following code is anti pattern.

```scala
val xs: Seq[A] = ???
xs match {
  case _ :: Nil => // patten match by List
  case _ =>
}
```

```
Welcome to Scala 3.8.1 (21.0.10, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> def f[A](xs: Seq[A]): String = xs match {
         case _ :: Nil => "Seq size is 1"
         case _ => "other"
       }
def f[A](xs: Seq[A]): String
                                                                                                                                            
scala> f(List("aaa"))
val res0: String = "Seq size is 1"
                                                                                                                                            
scala> f(Vector("aaa"))
val res1: String = "other"
```