### PR TITLE
[2.x] fix: Remove -Dsbt.global.base in runner script

### DIFF
--- a/launcher-package/integration-test/src/test/scala/IntegrationTestPaths.scala
+++ b/launcher-package/integration-test/src/test/scala/IntegrationTestPaths.scala
@@ -18,7 +18,9 @@ object IntegrationTestPaths {
         val name = if (isWindows) "sbt.bat" else "sbt"
         new File(b.getParentFile, s"target/universal/stage/bin/$name").getAbsoluteFile
       case None =>
-        val rel = if (isWindows) "../target/universal/stage/bin/sbt.bat" else "../target/universal/stage/bin/sbt"
+        val rel =
+          if (isWindows) "../target/universal/stage/bin/sbt.bat"
+          else "../target/universal/stage/bin/sbt"
         new File(rel).getAbsoluteFile
     }
 

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -122,14 +122,6 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     assert(out.contains[String]("-Dsbt.boot.directory=project/.boot"))
     assert(out.contains[String]("-Dsbt.ivy.home=project/.ivy"))
 
-  testOutput(
-    "sbt with XDG_CONFIG_HOME set uses it for sbt.global.base (Closes #3681)",
-    machineSbtoptsContents = "-v",
-    windowsSupport = false,
-  )("compile", "-v"): (out: List[String]) =>
-    val hasGlobalBase = out.exists(s => s.contains("-Dsbt.global.base=") && s.contains("/sbt"))
-    assert(hasGlobalBase, s"Expected -Dsbt.global.base=.../sbt in output (XDG): ${out.mkString(System.lineSeparator())}")
-
   testOutput("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("-v"):
     (out: List[String]) =>
       if (isWindows) cancel("Test not supported on windows")

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -4,6 +4,8 @@ import java.io.File
 import java.io.PrintWriter
 import java.nio.file.Files
 import sbt.io.IO
+import scala.collection.mutable
+import scala.sys.process.{ BasicIO, Process, ProcessIO }
 import verify.BasicTestSuite
 
 trait ShellScriptUtil extends BasicTestSuite {
@@ -158,16 +160,22 @@ trait ShellScriptUtil extends BasicTestSuite {
             envVars("PATH") = javaBinDir + File.pathSeparator + path
 
           val cmd = LauncherTestHelper.launcherCommand(testSbtScript.getAbsolutePath) ++ args
-          val out = scala.sys.process
-            .Process(
-              cmd,
-              workingDirectory,
-              envVars.toSeq*
+          val lines = mutable.ListBuffer.empty[String]
+          def processLine(line: String): Unit =
+            Console.err.println(line)
+            lines.append(line)
+          val p = Process(cmd, workingDirectory, envVars.toSeq*)
+            .run(
+              new ProcessIO(
+                _.close(),
+                BasicIO.processFully(processLine),
+                BasicIO.processFully(processLine)
+              )
             )
-            .!!
-            .linesIterator
-            .toList
-          f(out)
+          if p.exitValue != 0 then
+            lines.foreach(l => Console.err.println(l))
+            sys.error(s"process exit with ${p.exitValue}")
+          f(lines.toList)
           ()
         finally
           IO.delete(workingDirectory)

--- a/sbt
+++ b/sbt
@@ -976,13 +976,6 @@ else
   vlog "[process_args] java_version = '$java_version'"
   addDefaultMemory
   addSbtScriptProperty
-  if ! printf '%s\n' "${sbt_options[@]}" | grep -q '^-Dsbt\.global\.base='; then
-    if [[ -n "${SBT_CONFIG_HOME}" ]]; then
-      addSbt "-Dsbt.global.base=$SBT_CONFIG_HOME"
-    elif [[ -n "${XDG_CONFIG_HOME}" ]]; then
-      addSbt "-Dsbt.global.base=${XDG_CONFIG_HOME}/sbt"
-    fi
-  fi
   addJdkWorkaround
   set -- "${residual_args[@]}"
   argumentCount=$#


### PR DESCRIPTION
## Problem
1. It's difficult to find out when Process fails.
2. global.base setting isn't needed in sbt runner script.

## Solution
1. Forward to stderr as it happens.
2. Remove global.base setting in the runner script.