### PR TITLE
[1.x] Respect `scalaOrganization` in compiler bridge resolution (#8732)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -922,6 +922,7 @@ lazy val zincLmIntegrationProj = (project in file("zinc-lm-integration"))
       exclude[IncompatibleMethTypeProblem]("sbt.internal.inc.ZincComponentCompiler*"),
       exclude[IncompatibleSignatureProblem]("sbt.internal.inc.ZincComponentCompiler*"),
       exclude[IncompatibleSignatureProblem]("sbt.internal.inc.ZincLMHelper.update"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.inc.ZincLmUtil.*"),
     ),
     libraryDependencies += launcherInterface,
   )

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -747,13 +747,15 @@ object Defaults extends BuildCommon {
           fetchBridgeBinaryJarTask(sv)
         else Def.task[Option[File]](None)
       }.value,
-      scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion.value),
+      scalaCompilerBridgeSource := ZincLmUtil
+        .getDefaultBridgeSourceModule(scalaOrganization.value, scalaVersion.value),
       auxiliaryClassFiles ++= {
         if (ScalaArtifacts.isScala3(scalaVersion.value)) List(TastyFiles.instance)
         else Nil
       },
       consoleProject / scalaCompilerBridgeBinaryJar := None,
       consoleProject / scalaCompilerBridgeSource := ZincLmUtil.getDefaultBridgeSourceModule(
+        ScalaArtifacts.Organization,
         appConfiguration.value.provider.scalaProvider.version
       ),
       classpathOptions := ClasspathOptionsUtil.noboot(scalaVersion.value),
@@ -842,6 +844,7 @@ object Defaults extends BuildCommon {
   private def fetchBridgeBinaryJarTask(scalaVersion: String): Initialize[Task[Option[File]]] =
     Def.task {
       val bridgeJar = ZincLmUtil.fetchDefaultBridgeModule(
+        scalaOrganization.value,
         scalaVersion,
         dependencyResolution.value,
         updateConfiguration.value,

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -25,7 +25,7 @@ import sbt.internal.util.Types.const
 import sbt.internal.util.{ Attributed, Settings, ~> }
 import sbt.io.{ GlobFilter, IO, Path }
 import sbt.librarymanagement.ivy.{ InlineIvyConfiguration, IvyDependencyResolution, IvyPaths }
-import sbt.librarymanagement.{ Configuration, Configurations, Resolver }
+import sbt.librarymanagement.{ Configuration, Configurations, Resolver, ScalaArtifacts }
 import sbt.nio.Settings
 import sbt.util.{ Logger, Show }
 import xsbti.compile.{ ClasspathOptionsUtil, Compilers }
@@ -87,7 +87,8 @@ private[sbt] object Load {
       componentProvider = app.provider.components,
       secondaryCacheDir = Option(zincDir),
       dependencyResolution = dependencyResolution,
-      compilerBridgeSource = ZincLmUtil.getDefaultBridgeSourceModule(scalaProvider.version),
+      compilerBridgeSource =
+        ZincLmUtil.getDefaultBridgeSourceModule(ScalaArtifacts.Organization, scalaProvider.version),
       scalaJarsTarget = zincDir,
       state.get(BasicKeys.classLoaderCache),
       log = log

--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/A.scala
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/A.scala
@@ -1,0 +1,1 @@
+object A

--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/build.sbt
@@ -1,0 +1,4 @@
+ThisBuild / scalaOrganization := "io.github.scala-wasm"
+ThisBuild / scalaVersion := "3.8.3-RC1-wasm-bin-SNAPSHOT"
+
+ThisBuild / resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"

--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/test
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/test
@@ -1,0 +1,1 @@
+> compile

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincComponentCompiler.scala
@@ -71,7 +71,12 @@ private[sbt] object ZincComponentCompiler {
     override def fetchCompiledBridge(scalaInstance: XScalaInstance, logger: Logger): File = {
       val scalaVersion = scalaInstance.actualVersion()
       val bridgeSources = userProvidedBridgeSources
-        .getOrElse(ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion))
+        .getOrElse(
+          ZincLmUtil.getDefaultBridgeSourceModule(
+            sbt.librarymanagement.ScalaArtifacts.Organization,
+            scalaVersion
+          )
+        )
       compiledBridge(bridgeSources, scalaInstance, logger)
     }
 

--- a/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
+++ b/zinc-lm-integration/src/main/scala/sbt/internal/inc/ZincLmUtil.scala
@@ -62,13 +62,14 @@ object ZincLmUtil {
   }
 
   def fetchDefaultBridgeModule(
+      scalaOrganization: String,
       scalaVersion: String,
       dependencyResolution: DependencyResolution,
       updateConfiguration: UpdateConfiguration,
       warningConfig: UnresolvedWarningConfiguration,
       logger: Logger
   ): File = {
-    val bridgeModule = getDefaultBridgeModule(scalaVersion)
+    val bridgeModule = getDefaultBridgeModule(scalaOrganization, scalaVersion)
     val descriptor = dependencyResolution.wrapDependencyInModule(bridgeModule)
     dependencyResolution
       .update(descriptor, updateConfiguration, warningConfig, logger)
@@ -86,14 +87,14 @@ object ZincLmUtil {
       .getOrElse(throw new MessageOnlyException(s"Missing $bridgeModule"))
   }
 
-  def getDefaultBridgeModule(scalaVersion: String): ModuleID = {
+  def getDefaultBridgeModule(scalaOrganization: String, scalaVersion: String): ModuleID = {
     if (ScalaArtifacts.isScala3(scalaVersion)) {
-      ModuleID(ScalaArtifacts.Organization, "scala3-sbt-bridge", scalaVersion)
+      ModuleID(scalaOrganization, "scala3-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
     } else if (VersionNumber(scalaVersion).matchesSemVer(
                  SemanticSelector(s"=2.13 >=$scala2SbtBridgeStart")
                )) {
-      ModuleID(ScalaArtifacts.Organization, "scala2-sbt-bridge", scalaVersion)
+      ModuleID(scalaOrganization, "scala2-sbt-bridge", scalaVersion)
         .withConfigurations(Some(Compile.name))
     } else {
       val compilerBridgeId = scalaVersion match {
@@ -108,6 +109,6 @@ object ZincLmUtil {
     }
   }
 
-  def getDefaultBridgeSourceModule(scalaVersion: String): ModuleID =
-    getDefaultBridgeModule(scalaVersion).sources()
+  def getDefaultBridgeSourceModule(scalaOrganization: String, scalaVersion: String): ModuleID =
+    getDefaultBridgeModule(scalaOrganization, scalaVersion).sources()
 }

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/IvyBridgeProviderSpecification.scala
@@ -64,7 +64,7 @@ abstract class IvyBridgeProviderSpecification
       case Some(v: String) => v
       case _               => throw new IllegalStateException("No zinc version specified")
     }
-    val bridge0 = ZincLmUtil.getDefaultBridgeSourceModule(scalaVersion)
+    val bridge0 = ZincLmUtil.getDefaultBridgeSourceModule(ScalaArtifacts.Organization, scalaVersion)
     // redefine the compiler bridge version
     // using the version of zinc used during testing
     // this way when building with zinc as a source dependency


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8732

**Problem**
`scalaOrganization` was ignored during compiler bridge resolution because `ZincLmUtil.getDefaultBridgeModule` hard-coded `ScalaArtifacts.Organization` (`org.scala-lang`).

**Solution**
Add a `scalaOrganization` parameter to `ZincLmUtil` methods, and passing `scalaOrganization` value to those methods.

Generated-by: Claude Opus 4.6