### PR TITLE
Support macOS arm64 detection for 1.9.x sbt

### DIFF
--- a/sbt
+++ b/sbt
@@ -797,7 +797,9 @@ detectNativeClient() {
     arch=$(uname -m)
     [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
+    arch=$(uname -m)
+    [[ "$arch" == "arm64" ]] && arch="aarch64"
+    [[ -f "${sbt_bin_dir}/sbtn-${arch}-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-apple-darwin"
   elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
     [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe"
   elif [[ "$OSTYPE" == "freebsd"* ]]; then


### PR DESCRIPTION
I wish to backport this to 1.9.x, as from 1.10.x onward y'all include _sbtn-universal-apple-darwin_ instead. 

`uname -m` on Apple silicon yields `arm64` not `aarch64` like on linux. Detect this and invoke the `aarch64` binary instead on older sbt before the universal binary.

I will note the dead code checking for _sbtn-x86_64-apple-darwin_ exists in develop, but the acquire_sbtn function would never fetch that file.

keywords:
```
sbt --client clean
/Users/.../sbt/1.9.9/bin/sbt: line 229: /Users/.../sbt/1.9.9/bin/sbtn-x86_64-apple-darwin: Bad CPU type in executable
```

... I think I created this incorrectly, fixing one moment.

