### PR TITLE
[1.9.x] Fix macOS arm64 detection for sbtn

### DIFF
--- a/sbt
+++ b/sbt
@@ -721,7 +721,9 @@ detectNativeClient() {
     arch=$(uname -m)
     [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
+    arch=$(uname -m)
+    [[ "$arch" == "arm64" ]] && arch="aarch64"
+    [[ -f "${sbt_bin_dir}/sbtn-${arch}-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-apple-darwin"
   elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
     [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe"
   elif [[ "$OSTYPE" == "freebsd"* ]]; then


### PR DESCRIPTION
I wish to backport this to 1.9.x, as from 1.10.x onward y'all include _sbtn-universal-apple-darwin_ instead. 

`uname -m` on Apple silicon yields `arm64` not `aarch64` like on linux. Detect this and invoke the `aarch64` binary instead on older sbt before the universal binary.

I will [note the dead code](https://github.com/sbt/sbt/pull/8810) checking for _sbtn-x86_64-apple-darwin_ exists in develop, but the acquire_sbtn function would never fetch that file.

keywords:
```
sbt --client clean
/Users/.../sbt/1.9.9/bin/sbt: line 229: /Users/.../sbt/1.9.9/bin/sbtn-x86_64-apple-darwin: Bad CPU type in executable
```

I will note that an ls on my `sbt/1.9.9/bin` has both [`sbtn-x86_64-apple-darwin`, `sbtn-aarch64-apple-darwin`], but I cannot test what `uname -m` returns on an intel apple device without the hardware. I'll update when I find someone with an older macbook. Perhaps a [stack overflow post](https://apple.stackexchange.com/questions/368243/how-can-i-identify-the-macos-version-from-the-command-line) with `uname -a` is enough of an indicator.

Also of note, the Scala/Akka CLA is currently returning 500s when attempting to sign.