### PR TITLE
[2.x] fix: Fixes sbt runner script' sbtn detection

### DIFF
--- a/sbt
+++ b/sbt
@@ -797,7 +797,7 @@ detectNativeClient() {
     arch=$(uname -m)
     [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
+    [[ -f "${sbt_bin_dir}/sbtn-universal-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-universal-apple-darwin"
   elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
     [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe"
   elif [[ "$OSTYPE" == "freebsd"* ]]; then


### PR DESCRIPTION
`sbtn-x86_64-apple-darwin` doesn't exist anymore.

While the existing solution does work, it seemed worth tidying up while I had it in mind.

I tested this fix on 1.10.1 and 1.12.3, and it prevents entering the _acquire_sbtn_ function when _detectNativeBinary_ detects the binary already exists.