### PR TITLE
[2.x] fix: Print server stderr on startup failure

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -347,6 +347,7 @@ class NetworkClient(
       else None
     val term = Terminal.console
     term.exitRawMode()
+    var serverStderrFile: Option[File] = None
     val process = socket match {
       case None if startServer =>
         if (log) console.appendLog(Level.Info, "server was not detected. starting an instance")
@@ -393,15 +394,19 @@ class NetworkClient(
 
         // https://github.com/sbt/sbt/issues/8442
         // On Linux, if stdout/stderr are inherited and the buffer fills up (~64KB),
-        // the server process will block on writes. Discard output since the server
-        // communicates via the boot socket, not stdout/stderr.
+        // the server process will block on writes. Redirect to files instead of
+        // inheriting or piping to avoid buffer deadlocks while still capturing
+        // errors for diagnostics (https://github.com/sbt/sbt/issues/8812).
         val nullFile = new File(if (Util.isWindows) "NUL" else "/dev/null")
+        val stderrFile = Files.createTempFile("sbt-server-err", ".log").toFile
+        stderrFile.deleteOnExit()
+        serverStderrFile = Some(stderrFile)
         val processBuilder =
           new ProcessBuilder((nohup ++ cmd)*)
             .directory(arguments.baseDirectory)
             .redirectInput(Redirect.PIPE)
             .redirectOutput(nullFile)
-            .redirectError(nullFile)
+            .redirectError(stderrFile)
         processBuilder.environment.put(Terminal.TERMINAL_PROPS, props)
         Try(processBuilder.start()) match {
           case Success(process) =>
@@ -540,7 +545,22 @@ class NetworkClient(
       sbtProcess.set(null)
       Util.ignoreResult(Runtime.getRuntime.removeShutdownHook(shutdown))
     }
-    if (!portfile.exists()) throw new ServerFailedException
+    if (!portfile.exists()) {
+      // Print captured server stderr so users can see why the server failed to start
+      for (errFile <- serverStderrFile) {
+        try {
+          val bytes = Files.readAllBytes(errFile.toPath)
+          if (bytes.nonEmpty) {
+            errorStream.write(bytes)
+            errorStream.flush()
+          }
+        } catch { case _: Exception => }
+        finally errFile.delete()
+      }
+      throw new ServerFailedException
+    }
+    // Clean up stderr temp file on successful startup
+    serverStderrFile.foreach(_.delete())
     if (attached.get && !stdinBytes.isEmpty) Option(inputThread.get).foreach(_.drain())
   }
 


### PR DESCRIPTION
Fixes #8812

## Summary
When the sbt server fails to start, print the actual error instead of only showing "failed to connect to server".

## Problem
When the server process fails during auto-start (e.g. wrong JDK version producing `UnsupportedClassVersionError`), the client only prints:
```
[error] failed to connect to server
```
This hides the real cause. The `--server` flag shows the error because it uses `inheritIO()`, but the auto-start path redirects stderr to `/dev/null` (added in #8442 to prevent Linux pipe buffer deadlocks).

## Solution
Redirect server stderr to a temp file instead of `/dev/null`. If the server fails to start (portfile never appears), read and print the temp file contents before throwing `ServerFailedException`. This preserves the #8442 fix (writing to a file avoids pipe buffer deadlocks) while capturing startup errors for diagnostics.

The temp file is cleaned up eagerly on both success and failure paths, with `deleteOnExit()` as a safety net.

## Changes
- `main-command/.../NetworkClient.scala`
  - Redirect server stderr to a temp file instead of `/dev/null`
  - On startup failure, read and print the temp file before throwing `ServerFailedException`
  - Delete the temp file eagerly after use (both success and failure paths)