### PR TITLE
[2.x] Fix lazy val name handling in Eval

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -19,6 +19,7 @@ import java.nio.file.{ Files, Path, Paths, StandardOpenOption }
 import java.security.MessageDigest
 import scala.jdk.CollectionConverters.*
 import scala.quoted.*
+import scala.reflect.NameTransformer
 import sbt.io.{ Hash, IO }
 
 /**
@@ -429,8 +430,9 @@ object Eval:
           vals ::= name.mangledString
         case tpd.ValDef(name, tpt, _) if name.is(NameKinds.LazyLocalName) =>
           val str = name.mangledString
-          val methodName = str.take(str.indexOf("$lzy"))
-          val m = tree.symbol.owner.requiredMethod(methodName.replace("$minus", "-"))
+          val methodName = str.take(str.indexOf(NameTransformer.LAZY_LOCAL_SUFFIX_STRING))
+          val decodedName = NameTransformer.decode(methodName)
+          val m = tree.symbol.owner.requiredMethod(decodedName)
           if isAcceptableType(m.info) then vals ::= methodName
         case t: tpd.Template   => this((), t.body)
         case t: tpd.PackageDef => this((), t.stats)

--- a/sbt-app/src/sbt-test/project-load/lazy-val-name/build.sbt
+++ b/sbt-app/src/sbt-test/project-load/lazy-val-name/build.sbt
@@ -1,0 +1,13 @@
+lazy val `a + b` = "2.13.18"
+
+// https://github.com/scala/scala3/blob/3.8.2/library/src/scala/reflect/NameTransformer.scala#L47-L64
+lazy val ~=<>!#%^&|*/+-:\\?@ = "my-name"
+
+scalaVersion := `a + b`
+
+name := ~=<>!#%^&|*/+-:\\?@
+
+InputKey[Unit]("check") := {
+  assert(scalaVersion.value == "2.13.18")
+  assert(name.value == "my-name")
+}

--- a/sbt-app/src/sbt-test/project-load/lazy-val-name/test
+++ b/sbt-app/src/sbt-test/project-load/lazy-val-name/test
@@ -1,0 +1,2 @@
+> compile
+> check


### PR DESCRIPTION
in sbt 2.0.0-RC9

```
[error] dotty.tools.dotc.core.TypeError$$anon$1: object $Wrapb6d74462cf does not have a member method $tilde$eq$less$greater$bang$hash$percent$up$amp$bar$times$div$plus-$colon$bslash$bslash$qmark$at
[error] Use 'last' for the full log.
```