### PR TITLE
[2.x] fix: Exclude transitive org.scala-lang artifacts when scalaOrganization differs

### DIFF
--- a/main-command/src/main/scala/sbt/Command.scala
+++ b/main-command/src/main/scala/sbt/Command.scala
@@ -173,10 +173,9 @@ object Command {
   ): State => Parser[() => State] =
     state =>
       token(OpOrID.examples(commandMap.keys.toSet)).flatMap: id =>
-        (commandMap get id) match {
+        commandMap.get(id) match
           case None    => failure(invalidValue("command", commandMap.keys)(id))
           case Some(c) => c(state)
-        }
 
   // overload instead of default parameter to keep binary compatibility
   @deprecated("Use overload that takes the onParseError callback", since = "1.9.4")

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3180,7 +3180,14 @@ object Classpaths {
     allDependencies := Def.uncached {
       projectDependencies.value ++ libraryDependencies.value
     },
-    allExcludeDependencies := excludeDependencies.value,
+    allExcludeDependencies := {
+      val excludes = excludeDependencies.value
+      excludes ++ scalaOrgExclusions(
+        scalaOrganization.value,
+        scalaVersion.value,
+        scalaArtifacts.value,
+      )
+    },
     scalaModuleInfo := (scalaModuleInfo or (
       Def.setting {
         // Resolve dynamic Scala version for scalaModuleInfo
@@ -3496,8 +3503,13 @@ object Classpaths {
         o %% "util-position",
         o %% "io"
       )
-      if (isMeta && !force) excludes.toVector ++ sbtModulesExcludes
-      else excludes
+      val scalaExcludes = scalaOrgExclusions(
+        scalaOrganization.value,
+        scalaVersion.value,
+        scalaArtifacts.value,
+      )
+      if (isMeta && !force) excludes.toVector ++ sbtModulesExcludes ++ scalaExcludes
+      else excludes ++ scalaExcludes
     },
     dependencyOverrides ++= {
       val isPlugin = sbtPlugin.value
@@ -3630,6 +3642,14 @@ object Classpaths {
           scalaBinaryVersion := binaryScalaVersion(scalaVersion.value),
           scalaEarlyVersion := CrossVersion.earlyScalaVersion(scalaVersion.value),
           scalaOrganization := ScalaArtifacts.Organization,
+          allExcludeDependencies := {
+            val excludes = excludeDependencies.value
+            excludes ++ scalaOrgExclusions(
+              scalaOrganization.value,
+              scalaVersion.value,
+              scalaArtifacts.value,
+            )
+          },
           scalaModuleInfo := {
             Some(
               ScalaModuleInfo(
@@ -4190,6 +4210,30 @@ object Classpaths {
     (outputPath / "[artifact]-[revision](-[classifier]).[ext]").absolutePath
 
   private[sbt] def isScala213(sv: String) = sv.startsWith("2.13.")
+
+  private[sbt] def scalaOrgExclusions(
+      scalaOrg: String,
+      sv: String,
+      scalaArtifactNames: Seq[String],
+  ): Vector[InclExclRule] =
+    if scalaOrg == ScalaArtifacts.Organization then Vector.empty
+    else
+      val defaultOrg = ScalaArtifacts.Organization
+      val scala2Excludes = scalaArtifactNames.toVector.map(a => InclExclRule(defaultOrg, a))
+      val scala3Excludes =
+        if ScalaArtifacts.isScala3(sv) then
+          Vector(
+            ScalaArtifacts.Scala3LibraryID,
+            ScalaArtifacts.Scala3CompilerID,
+            ScalaArtifacts.TastyCoreID,
+            ScalaArtifacts.ScaladocID,
+            ScalaArtifacts.Scala3DocID,
+            ScalaArtifacts.Scala3TastyInspectorID,
+            ScalaArtifacts.Scala3ReplID,
+          ).map(a => InclExclRule(defaultOrg, a, "*", Vector.empty, CrossVersion.binary))
+            :+ InclExclRule(defaultOrg, ScalaArtifacts.Scala3InterfacesID)
+        else Vector.empty
+      scala2Excludes ++ scala3Excludes
 
   def projectDependenciesTask: Initialize[Task[Seq[ModuleID]]] =
     Def.task {


### PR DESCRIPTION
Closes: #8821 

### **Problem**
When scalaOrganization is set to a custom value (e.g. ch.epfl.lara), transitive dependencies on org.scala-lang Scala artifacts are not excluded
or rewritten. This results in both org.scala-lang:scala3-library_3 and ch.epfl.lara:scala3-library_3 ending up on the classpath simultaneously.
The old Ivy backend handled this via OverrideScalaMediator (introduced in sbt/sbt#2634), which rewrote transitive org.scala-lang dependencies to use the configured scalaOrganization. When sbt switched to Coursier as the default resolver (sbt 1.3+), this substitution behavior was lost.

### **Solution**
Add a scalaOrgExclusions helper to Defaults that generates InclExclRule entries for all managed Scala artifacts under org.scala-lang when the configured scalaOrganization differs. These exclusions are appended to allExcludeDependencies in both the project and meta-build scopes.

For Scala 3, cross-versioned artifact names (scala3-library, scala3-compiler, tasty-core, etc.) are excluded with CrossVersion.binary, while scala3-interfaces uses a plain exclusion since it is a Java artifact.