### PR TITLE
[2.x] feat: case-insensitive tab completion

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -107,7 +107,12 @@ object LineReader {
     new LineReader {
       override def readLine(prompt: String, mask: Option[Char]): Option[String] = {
         val term = JLine3(terminal)
-        val reader = LineReaderBuilder.builder().terminal(term).completer(completer(parser)).build()
+        val reader = LineReaderBuilder
+          .builder()
+          .terminal(term)
+          .completer(completer(parser))
+          .option(JLineReader.Option.CASE_INSENSITIVE, true)
+          .build()
         try {
           inputrcFileContents.foreach { bytes =>
             InputRC.configure(

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -142,30 +142,28 @@ object JLineCompletion {
       beforeCursor: String,
       completions: String => (Seq[String], Seq[String]),
       reader: ConsoleReader
-  ): Boolean = {
-    try {
+  ): Boolean =
+    try
       val token = tokenBeforeCursor(beforeCursor)
-      if (token.isEmpty) return false
-
-      val prefix = beforeCursor.dropRight(token.length)
-      val (fallbackInsert, _) = completions(prefix)
-      val candidates = filterCaseInsensitive(token, fallbackInsert)
-
-      if (candidates.isEmpty) false
-      else if (candidates.size == 1) {
-        replaceCurrentToken(beforeCursor, candidates.head, reader)
-        true
-      } else {
-        val common = commonPrefixIgnoreCase(candidates)
-        replaceCurrentToken(beforeCursor, common, reader)
-        if (common.length <= token.length)
-          showCompletions(candidates.sorted, reader)
-        true
-      }
-    } catch {
+      if token.isEmpty then false
+      else
+        val prefix = beforeCursor.dropRight(token.length)
+        val (fallbackInsert, _) = completions(prefix)
+        val candidates = filterCaseInsensitive(token, fallbackInsert)
+        candidates match
+          case Seq() =>
+            false
+          case Seq(single) =>
+            replaceCurrentToken(beforeCursor, single, reader)
+            true
+          case many =>
+            val common = commonPrefixIgnoreCase(many)
+            replaceCurrentToken(beforeCursor, common, reader)
+            if common.length <= token.length then
+              showCompletions(many.sorted, reader)
+            true
+    catch
       case _: Exception => false
-    }
-  }
 
   private[complete] def filterCaseInsensitive(
       token: String,
@@ -182,13 +180,12 @@ object JLineCompletion {
       beforeCursor: String,
       replacement: String,
       reader: ConsoleReader
-  ): Unit = {
+  ): Unit =
     val tokenLength = tokenBeforeCursor(beforeCursor).length
     var remaining = tokenLength
-    while (remaining > 0 && reader.backspace()) remaining -= 1
+    while remaining > 0 && reader.backspace() do remaining -= 1
     reader.putString(replacement)
     reader.redrawLine()
-  }
 
   private[complete] def commonPrefixIgnoreCase(values: Seq[String]): String =
     if (values.isEmpty) ""

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -159,11 +159,9 @@ object JLineCompletion {
           case many =>
             val common = commonPrefixIgnoreCase(many)
             replaceCurrentToken(beforeCursor, common, reader)
-            if common.length <= token.length then
-              showCompletions(many.sorted, reader)
+            if common.length <= token.length then showCompletions(many.sorted, reader)
             true
-    catch
-      case _: Exception => false
+    catch case _: Exception => false
 
   private[complete] def filterCaseInsensitive(
       token: String,

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -110,6 +110,7 @@ object JLineCompletion {
     b.buffer.substring(0, b.cursor)
   }
 
+  // returns false if there was nothing to insert and nothing to display
   def complete(
       beforeCursor: String,
       completions: String => (Seq[String], Seq[String]),
@@ -117,90 +118,21 @@ object JLineCompletion {
   ): Boolean = {
     val (insert, display) = completions(beforeCursor)
     val common = commonPrefix(insert)
-    if (common.nonEmpty) {
+    if (common.isEmpty)
+      if (display.isEmpty)
+        ()
+      else
+        showCompletions(display, reader)
+    else
       appendCompletion(common, reader)
-      true
-    } else if (insert.nonEmpty) {
-      showCompletions(display, reader)
-      true
-    } else if (caseInsensitiveFallback(beforeCursor, completions, reader)) {
-      true
-    } else if (display.nonEmpty) {
-      showCompletions(display, reader)
-      true
-    } else {
-      false
-    }
+
+    !(common.isEmpty && display.isEmpty)
   }
 
   def appendCompletion(common: String, reader: ConsoleReader): Unit = {
     reader.getCursorBuffer.write(common)
     reader.redrawLine()
   }
-
-  private def caseInsensitiveFallback(
-      beforeCursor: String,
-      completions: String => (Seq[String], Seq[String]),
-      reader: ConsoleReader
-  ): Boolean =
-    try
-      val token = tokenBeforeCursor(beforeCursor)
-      if token.isEmpty then false
-      else
-        val prefix = beforeCursor.dropRight(token.length)
-        val (fallbackInsert, _) = completions(prefix)
-        val candidates = filterCaseInsensitive(token, fallbackInsert)
-        candidates match
-          case Seq() =>
-            false
-          case Seq(single) =>
-            replaceCurrentToken(beforeCursor, single, reader)
-            true
-          case many =>
-            val common = commonPrefixIgnoreCase(many)
-            replaceCurrentToken(beforeCursor, common, reader)
-            if common.length <= token.length then showCompletions(many.sorted, reader)
-            true
-    catch case _: Exception => false
-
-  private[complete] def filterCaseInsensitive(
-      token: String,
-      candidates: Seq[String]
-  ): Seq[String] =
-    candidates.filter(startsWithIgnoreCase(_, token))
-
-  private[complete] def tokenBeforeCursor(beforeCursor: String): String = {
-    val tokenStart = beforeCursor.lastIndexWhere(_.isWhitespace) + 1
-    beforeCursor.substring(tokenStart)
-  }
-
-  private def replaceCurrentToken(
-      beforeCursor: String,
-      replacement: String,
-      reader: ConsoleReader
-  ): Unit =
-    val tokenLength = tokenBeforeCursor(beforeCursor).length
-    var remaining = tokenLength
-    while remaining > 0 && reader.backspace() do remaining -= 1
-    reader.putString(replacement)
-    reader.redrawLine()
-
-  private[complete] def commonPrefixIgnoreCase(values: Seq[String]): String =
-    if (values.isEmpty) ""
-    else values.reduceLeft(commonPrefixIgnoreCase)
-
-  private[complete] def commonPrefixIgnoreCase(a: String, b: String): String = {
-    val len = scala.math.min(a.length, b.length)
-    @tailrec def loop(i: Int): Int =
-      if (i >= len) i
-      else if (a.charAt(i).toLower == b.charAt(i).toLower) loop(i + 1)
-      else i
-    a.substring(0, loop(0))
-  }
-
-  private[complete] def startsWithIgnoreCase(value: String, prefix: String): Boolean =
-    value.length >= prefix.length &&
-      value.regionMatches(true, 0, prefix, 0, prefix.length)
 
   /**
    * `display` is assumed to be the exact strings requested to be displayed. In particular,

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/JLineCompletion.scala
@@ -110,7 +110,6 @@ object JLineCompletion {
     b.buffer.substring(0, b.cursor)
   }
 
-  // returns false if there was nothing to insert and nothing to display
   def complete(
       beforeCursor: String,
       completions: String => (Seq[String], Seq[String]),
@@ -118,21 +117,95 @@ object JLineCompletion {
   ): Boolean = {
     val (insert, display) = completions(beforeCursor)
     val common = commonPrefix(insert)
-    if (common.isEmpty)
-      if (display.isEmpty)
-        ()
-      else
-        showCompletions(display, reader)
-    else
+    if (common.nonEmpty) {
       appendCompletion(common, reader)
-
-    !(common.isEmpty && display.isEmpty)
+      true
+    } else if (insert.nonEmpty) {
+      showCompletions(display, reader)
+      true
+    } else if (caseInsensitiveFallback(beforeCursor, completions, reader)) {
+      true
+    } else if (display.nonEmpty) {
+      showCompletions(display, reader)
+      true
+    } else {
+      false
+    }
   }
 
   def appendCompletion(common: String, reader: ConsoleReader): Unit = {
     reader.getCursorBuffer.write(common)
     reader.redrawLine()
   }
+
+  private def caseInsensitiveFallback(
+      beforeCursor: String,
+      completions: String => (Seq[String], Seq[String]),
+      reader: ConsoleReader
+  ): Boolean = {
+    try {
+      val token = tokenBeforeCursor(beforeCursor)
+      if (token.isEmpty) return false
+
+      val prefix = beforeCursor.dropRight(token.length)
+      val (fallbackInsert, _) = completions(prefix)
+      val candidates = filterCaseInsensitive(token, fallbackInsert)
+
+      if (candidates.isEmpty) false
+      else if (candidates.size == 1) {
+        replaceCurrentToken(beforeCursor, candidates.head, reader)
+        true
+      } else {
+        val common = commonPrefixIgnoreCase(candidates)
+        replaceCurrentToken(beforeCursor, common, reader)
+        if (common.length <= token.length)
+          showCompletions(candidates.sorted, reader)
+        true
+      }
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  private[complete] def filterCaseInsensitive(
+      token: String,
+      candidates: Seq[String]
+  ): Seq[String] =
+    candidates.filter(startsWithIgnoreCase(_, token))
+
+  private[complete] def tokenBeforeCursor(beforeCursor: String): String = {
+    val tokenStart = beforeCursor.lastIndexWhere(_.isWhitespace) + 1
+    beforeCursor.substring(tokenStart)
+  }
+
+  private def replaceCurrentToken(
+      beforeCursor: String,
+      replacement: String,
+      reader: ConsoleReader
+  ): Unit = {
+    val tokenLength = tokenBeforeCursor(beforeCursor).length
+    var remaining = tokenLength
+    while (remaining > 0 && reader.backspace()) remaining -= 1
+    reader.putString(replacement)
+    reader.redrawLine()
+  }
+
+  private[complete] def commonPrefixIgnoreCase(values: Seq[String]): String =
+    if (values.isEmpty) ""
+    else values.reduceLeft(commonPrefixIgnoreCase)
+
+  private[complete] def commonPrefixIgnoreCase(a: String, b: String): String = {
+    val len = scala.math.min(a.length, b.length)
+    @tailrec def loop(i: Int): Int =
+      if (i >= len) i
+      else if (a.charAt(i).toLower == b.charAt(i).toLower) loop(i + 1)
+      else i
+    a.substring(0, loop(0))
+  }
+
+  private[complete] def startsWithIgnoreCase(value: String, prefix: String): Boolean =
+    value.length >= prefix.length &&
+      value.regionMatches(true, 0, prefix, 0, prefix.length)
 
   /**
    * `display` is assumed to be the exact strings requested to be displayed. In particular,

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
@@ -11,49 +11,15 @@ package complete
 
 import org.scalacheck.*
 import org.scalacheck.Prop.*
-import org.scalacheck.Gen.*
 
 object JLineCompletionSpec extends Properties("JLineCompletion"):
-  private val alphaNumChars: Seq[Char] =
-    ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
-  private val genToken: Gen[String] = nonEmptyListOf(oneOf(alphaNumChars)).map(_.mkString)
-  private val genTail: Gen[String] = listOf(oneOf(alphaNumChars)).map(_.mkString)
 
-  private def randomCase(s: String): Gen[String] =
-    sequence[Seq[Char], Char](s.toVector.map: c =>
-      if c.isLetter then oneOf(c.toLower, c.toUpper)
-      else const(c)).map(_.mkString)
-
-  property("startsWithIgnoreCase accepts case variants of matching prefix") =
-    forAll(genToken, genTail): (prefix, tail) =>
-      forAll(randomCase(prefix)): casedPrefix =>
-        JLineCompletion.startsWithIgnoreCase(prefix + tail, casedPrefix)
-
-  property("startsWithIgnoreCase rejects longer prefixes") = forAll(genToken): token =>
-    !JLineCompletion.startsWithIgnoreCase(token, token + "x")
-
-  property("tokenBeforeCursor returns suffix after last whitespace") =
-    forAll(listOf(genToken), genToken): (parts, lastToken) =>
-      val beforeCursor = (parts :+ lastToken).mkString(" ")
-      JLineCompletion.tokenBeforeCursor(beforeCursor) == lastToken
-
-  property("filterCaseInsensitive matches a known command regardless of case") =
-    forAll(randomCase("testo")): token =>
-      val candidates = Seq("testOnly", "testQuick", "compile", "clean")
-      JLineCompletion.filterCaseInsensitive(token, candidates) == Seq("testOnly")
-
-  property("commonPrefixIgnoreCase preserves shared prefix length") = forAll(genToken): prefix =>
-    val a = prefix + "Only"
-    val b = prefix + "Quick"
-    JLineCompletion.commonPrefixIgnoreCase(Seq(a, b)).length == prefix.length
-
-  property("parser completor drops wrong-case insertions for issue scenario") =
+  property("case-insensitive completions are available at token start") =
     val commands = Set("testOnly", "testQuick", "compile", "clean")
     val parser = Parser.token(DefaultParsers.ID.examples(commands))
-    val completor = JLineCompletion.parserAsCompletor(parser)
-    val (insertWrongCase, _) = completor("testo", 1)
-    val (fallbackInsert, _) = completor("", 1)
-    (insertWrongCase.isEmpty) :| "strict parser insertion is empty" &&
-    (JLineCompletion.filterCaseInsensitive("testo", fallbackInsert) == Seq("testOnly")) :|
-      "fallback candidates recover testOnly"
+    val completions = Parser.completions(parser, "", 1).get
+    val names = completions.map(_.append)
+    (names.contains("testOnly")) :| "testOnly is in initial completions" &&
+    (names.contains("compile")) :| "compile is in initial completions"
+
 end JLineCompletionSpec

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.util
+package complete
+
+class JLineCompletionSpec extends UnitSpec:
+
+  "tokenBeforeCursor" should "return the final token when no whitespace exists" in {
+    JLineCompletion.tokenBeforeCursor("testo") shouldEqual "testo"
+  }
+
+  it should "return the token after the last whitespace" in {
+    JLineCompletion.tokenBeforeCursor("root / testo") shouldEqual "testo"
+  }
+
+  it should "return empty when cursor is right after whitespace" in {
+    JLineCompletion.tokenBeforeCursor("test ") shouldEqual ""
+  }
+
+  it should "handle empty input" in {
+    JLineCompletion.tokenBeforeCursor("") shouldEqual ""
+  }
+
+  "startsWithIgnoreCase" should "match when prefix differs only in case" in {
+    JLineCompletion.startsWithIgnoreCase("testOnly", "testo") shouldBe true
+  }
+
+  it should "match when prefix case is fully uppercase" in {
+    JLineCompletion.startsWithIgnoreCase("compile", "COMP") shouldBe true
+  }
+
+  it should "not match when prefix is entirely different" in {
+    JLineCompletion.startsWithIgnoreCase("compile", "test") shouldBe false
+  }
+
+  it should "match when prefix and value case already agree" in {
+    JLineCompletion.startsWithIgnoreCase("testOnly", "testO") shouldBe true
+  }
+
+  "filterCaseInsensitive" should "find candidates matching token regardless of case" in {
+    val candidates = Seq("testOnly", "testQuick", "compile", "clean")
+    JLineCompletion.filterCaseInsensitive("testo", candidates) shouldEqual Seq("testOnly")
+  }
+
+  it should "return multiple candidates when several match" in {
+    val candidates = Seq("testOnly", "testQuick", "compile")
+    val result = JLineCompletion.filterCaseInsensitive("test", candidates)
+    result should contain theSameElementsAs Seq("testOnly", "testQuick")
+  }
+
+  it should "return empty when nothing matches" in {
+    JLineCompletion.filterCaseInsensitive("xyz", Seq("testOnly", "compile")) shouldBe empty
+  }
+
+  "commonPrefixIgnoreCase" should "find shared prefix across case-differing candidates" in {
+    JLineCompletion.commonPrefixIgnoreCase("testOnly", "testQuick") shouldEqual "test"
+  }
+
+  it should "return full string when single candidate" in {
+    JLineCompletion.commonPrefixIgnoreCase(Seq("testOnly")) shouldEqual "testOnly"
+  }
+
+  it should "handle candidates with identical case-insensitive prefixes" in {
+    JLineCompletion.commonPrefixIgnoreCase(Seq("TestOnly", "testQuick")) shouldEqual "Test"
+  }
+
+  it should "return empty for empty input" in {
+    JLineCompletion.commonPrefixIgnoreCase(Seq.empty) shouldEqual ""
+  }
+
+  "case-insensitive completion via parser" should "produce completions for correct case" in {
+    val commands = Set("testOnly", "testQuick", "compile", "clean")
+    val parser = Parser.token(DefaultParsers.ID.examples(commands))
+    val completor = JLineCompletion.parserAsCompletor(parser)
+
+    val (insertCorrect, _) = completor("test", 1)
+    assert(insertCorrect.nonEmpty, "expected completions for correctly-cased prefix")
+
+    val (insertWrongCase, _) = completor("testo", 1)
+    assert(insertWrongCase.isEmpty, "expected no completions for wrong-cased prefix")
+  }
+
+  it should "allow fallback to find candidates from prefix completions" in {
+    val commands = Set("testOnly", "testQuick", "compile", "clean")
+    val parser = Parser.token(DefaultParsers.ID.examples(commands))
+    val completor = JLineCompletion.parserAsCompletor(parser)
+    val completions: String => (Seq[String], Seq[String]) =
+      str => completor(str, 1)
+
+    val (fallbackInsert, _) = completions("")
+    val candidates = JLineCompletion.filterCaseInsensitive("testo", fallbackInsert)
+    candidates shouldEqual Seq("testOnly")
+  }
+
+  it should "find multiple candidates when prefix matches several commands" in {
+    val commands = Set("testOnly", "testQuick", "compile", "clean")
+    val parser = Parser.token(DefaultParsers.ID.examples(commands))
+    val completor = JLineCompletion.parserAsCompletor(parser)
+    val completions: String => (Seq[String], Seq[String]) =
+      str => completor(str, 1)
+
+    val (fallbackInsert, _) = completions("")
+    val candidates = JLineCompletion.filterCaseInsensitive("TEST", fallbackInsert)
+    candidates should contain theSameElementsAs Seq("testOnly", "testQuick")
+    JLineCompletion.commonPrefixIgnoreCase(candidates) shouldEqual "test"
+  }
+
+  it should "handle scoped input by using prefix before the mistyped token" in {
+    val keys = Set("compile", "testOnly", "clean")
+    val scopeParser =
+      Parser.token(DefaultParsers.ID) ~
+        Parser.token(DefaultParsers.OptSpace ~ '/' ~ DefaultParsers.OptSpace) ~
+        Parser.token(DefaultParsers.ID.examples(keys))
+    val completor = JLineCompletion.parserAsCompletor(scopeParser)
+    val completions: String => (Seq[String], Seq[String]) =
+      str => completor(str, 1)
+
+    val (prefixInsert, _) = completions("root / ")
+    val candidates = JLineCompletion.filterCaseInsensitive("testo", prefixInsert)
+    candidates shouldEqual Seq("testOnly")
+  }
+
+end JLineCompletionSpec

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
@@ -9,121 +9,54 @@
 package sbt.internal.util
 package complete
 
-class JLineCompletionSpec extends UnitSpec:
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import org.scalacheck.Gen.*
 
-  "tokenBeforeCursor" should "return the final token when no whitespace exists" in {
-    JLineCompletion.tokenBeforeCursor("testo") shouldEqual "testo"
-  }
+object JLineCompletionSpec extends Properties("JLineCompletion"):
+  private val alphaNumChars: Seq[Char] =
+    ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+  private val genToken: Gen[String] = nonEmptyListOf(oneOf(alphaNumChars)).map(_.mkString)
+  private val genTail: Gen[String] = listOf(oneOf(alphaNumChars)).map(_.mkString)
 
-  it should "return the token after the last whitespace" in {
-    JLineCompletion.tokenBeforeCursor("root / testo") shouldEqual "testo"
-  }
+  private def randomCase(s: String): Gen[String] =
+    sequence[Seq[Char], Char](s.toVector.map: c =>
+      if c.isLetter then oneOf(c.toLower, c.toUpper)
+      else const(c)
+    ).map(_.mkString)
 
-  it should "return empty when cursor is right after whitespace" in {
-    JLineCompletion.tokenBeforeCursor("test ") shouldEqual ""
-  }
+  property("startsWithIgnoreCase accepts case variants of matching prefix") =
+    forAll(genToken, genTail): (prefix, tail) =>
+      forAll(randomCase(prefix)): casedPrefix =>
+        JLineCompletion.startsWithIgnoreCase(prefix + tail, casedPrefix)
 
-  it should "handle empty input" in {
-    JLineCompletion.tokenBeforeCursor("") shouldEqual ""
-  }
+  property("startsWithIgnoreCase rejects longer prefixes") =
+    forAll(genToken): token =>
+      !JLineCompletion.startsWithIgnoreCase(token, token + "x")
 
-  "startsWithIgnoreCase" should "match when prefix differs only in case" in {
-    JLineCompletion.startsWithIgnoreCase("testOnly", "testo") shouldBe true
-  }
+  property("tokenBeforeCursor returns suffix after last whitespace") =
+    forAll(listOf(genToken), genToken): (parts, lastToken) =>
+      val beforeCursor = (parts :+ lastToken).mkString(" ")
+      JLineCompletion.tokenBeforeCursor(beforeCursor) == lastToken
 
-  it should "match when prefix case is fully uppercase" in {
-    JLineCompletion.startsWithIgnoreCase("compile", "COMP") shouldBe true
-  }
+  property("filterCaseInsensitive matches a known command regardless of case") =
+    forAll(randomCase("testo")): token =>
+      val candidates = Seq("testOnly", "testQuick", "compile", "clean")
+      JLineCompletion.filterCaseInsensitive(token, candidates) == Seq("testOnly")
 
-  it should "not match when prefix is entirely different" in {
-    JLineCompletion.startsWithIgnoreCase("compile", "test") shouldBe false
-  }
+  property("commonPrefixIgnoreCase preserves shared prefix length") =
+    forAll(genToken): prefix =>
+      val a = prefix + "Only"
+      val b = prefix + "Quick"
+      JLineCompletion.commonPrefixIgnoreCase(Seq(a, b)).length == prefix.length
 
-  it should "match when prefix and value case already agree" in {
-    JLineCompletion.startsWithIgnoreCase("testOnly", "testO") shouldBe true
-  }
-
-  "filterCaseInsensitive" should "find candidates matching token regardless of case" in {
-    val candidates = Seq("testOnly", "testQuick", "compile", "clean")
-    JLineCompletion.filterCaseInsensitive("testo", candidates) shouldEqual Seq("testOnly")
-  }
-
-  it should "return multiple candidates when several match" in {
-    val candidates = Seq("testOnly", "testQuick", "compile")
-    val result = JLineCompletion.filterCaseInsensitive("test", candidates)
-    result should contain theSameElementsAs Seq("testOnly", "testQuick")
-  }
-
-  it should "return empty when nothing matches" in {
-    JLineCompletion.filterCaseInsensitive("xyz", Seq("testOnly", "compile")) shouldBe empty
-  }
-
-  "commonPrefixIgnoreCase" should "find shared prefix across case-differing candidates" in {
-    JLineCompletion.commonPrefixIgnoreCase("testOnly", "testQuick") shouldEqual "test"
-  }
-
-  it should "return full string when single candidate" in {
-    JLineCompletion.commonPrefixIgnoreCase(Seq("testOnly")) shouldEqual "testOnly"
-  }
-
-  it should "handle candidates with identical case-insensitive prefixes" in {
-    JLineCompletion.commonPrefixIgnoreCase(Seq("TestOnly", "testQuick")) shouldEqual "Test"
-  }
-
-  it should "return empty for empty input" in {
-    JLineCompletion.commonPrefixIgnoreCase(Seq.empty) shouldEqual ""
-  }
-
-  "case-insensitive completion via parser" should "produce completions for correct case" in {
+  property("parser completor drops wrong-case insertions for issue scenario") =
     val commands = Set("testOnly", "testQuick", "compile", "clean")
     val parser = Parser.token(DefaultParsers.ID.examples(commands))
     val completor = JLineCompletion.parserAsCompletor(parser)
-
-    val (insertCorrect, _) = completor("test", 1)
-    assert(insertCorrect.nonEmpty, "expected completions for correctly-cased prefix")
-
     val (insertWrongCase, _) = completor("testo", 1)
-    assert(insertWrongCase.isEmpty, "expected no completions for wrong-cased prefix")
-  }
-
-  it should "allow fallback to find candidates from prefix completions" in {
-    val commands = Set("testOnly", "testQuick", "compile", "clean")
-    val parser = Parser.token(DefaultParsers.ID.examples(commands))
-    val completor = JLineCompletion.parserAsCompletor(parser)
-    val completions: String => (Seq[String], Seq[String]) =
-      str => completor(str, 1)
-
-    val (fallbackInsert, _) = completions("")
-    val candidates = JLineCompletion.filterCaseInsensitive("testo", fallbackInsert)
-    candidates shouldEqual Seq("testOnly")
-  }
-
-  it should "find multiple candidates when prefix matches several commands" in {
-    val commands = Set("testOnly", "testQuick", "compile", "clean")
-    val parser = Parser.token(DefaultParsers.ID.examples(commands))
-    val completor = JLineCompletion.parserAsCompletor(parser)
-    val completions: String => (Seq[String], Seq[String]) =
-      str => completor(str, 1)
-
-    val (fallbackInsert, _) = completions("")
-    val candidates = JLineCompletion.filterCaseInsensitive("TEST", fallbackInsert)
-    candidates should contain theSameElementsAs Seq("testOnly", "testQuick")
-    JLineCompletion.commonPrefixIgnoreCase(candidates) shouldEqual "test"
-  }
-
-  it should "handle scoped input by using prefix before the mistyped token" in {
-    val keys = Set("compile", "testOnly", "clean")
-    val scopeParser =
-      Parser.token(DefaultParsers.ID) ~
-        Parser.token(DefaultParsers.OptSpace ~ '/' ~ DefaultParsers.OptSpace) ~
-        Parser.token(DefaultParsers.ID.examples(keys))
-    val completor = JLineCompletion.parserAsCompletor(scopeParser)
-    val completions: String => (Seq[String], Seq[String]) =
-      str => completor(str, 1)
-
-    val (prefixInsert, _) = completions("root / ")
-    val candidates = JLineCompletion.filterCaseInsensitive("testo", prefixInsert)
-    candidates shouldEqual Seq("testOnly")
-  }
-
+    val (fallbackInsert, _) = completor("", 1)
+    (insertWrongCase.isEmpty) :| "strict parser insertion is empty" &&
+    (JLineCompletion.filterCaseInsensitive("testo", fallbackInsert) == Seq("testOnly")) :|
+      "fallback candidates recover testOnly"
 end JLineCompletionSpec

--- a/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
+++ b/internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala
@@ -22,17 +22,15 @@ object JLineCompletionSpec extends Properties("JLineCompletion"):
   private def randomCase(s: String): Gen[String] =
     sequence[Seq[Char], Char](s.toVector.map: c =>
       if c.isLetter then oneOf(c.toLower, c.toUpper)
-      else const(c)
-    ).map(_.mkString)
+      else const(c)).map(_.mkString)
 
   property("startsWithIgnoreCase accepts case variants of matching prefix") =
     forAll(genToken, genTail): (prefix, tail) =>
       forAll(randomCase(prefix)): casedPrefix =>
         JLineCompletion.startsWithIgnoreCase(prefix + tail, casedPrefix)
 
-  property("startsWithIgnoreCase rejects longer prefixes") =
-    forAll(genToken): token =>
-      !JLineCompletion.startsWithIgnoreCase(token, token + "x")
+  property("startsWithIgnoreCase rejects longer prefixes") = forAll(genToken): token =>
+    !JLineCompletion.startsWithIgnoreCase(token, token + "x")
 
   property("tokenBeforeCursor returns suffix after last whitespace") =
     forAll(listOf(genToken), genToken): (parts, lastToken) =>
@@ -44,11 +42,10 @@ object JLineCompletionSpec extends Properties("JLineCompletion"):
       val candidates = Seq("testOnly", "testQuick", "compile", "clean")
       JLineCompletion.filterCaseInsensitive(token, candidates) == Seq("testOnly")
 
-  property("commonPrefixIgnoreCase preserves shared prefix length") =
-    forAll(genToken): prefix =>
-      val a = prefix + "Only"
-      val b = prefix + "Quick"
-      JLineCompletion.commonPrefixIgnoreCase(Seq(a, b)).length == prefix.length
+  property("commonPrefixIgnoreCase preserves shared prefix length") = forAll(genToken): prefix =>
+    val a = prefix + "Only"
+    val b = prefix + "Quick"
+    JLineCompletion.commonPrefixIgnoreCase(Seq(a, b)).length == prefix.length
 
   property("parser completor drops wrong-case insertions for issue scenario") =
     val commands = Set("testOnly", "testQuick", "compile", "clean")


### PR DESCRIPTION
## Summary

This PR adds case-insensitive tab completion fallback in the interactive JLine completion flow.

When strict parser completion returns no insert candidates (for example, typing `testo` for `testOnly`), sbt now retries completion from the current token prefix and filters candidates case-insensitively. If one match exists, it replaces the current token; if multiple matches exist, it inserts the shared prefix and shows candidates.

## Related Issues

Fixes #2251

## Testing

- [x] Added focused unit tests in `internal/util-complete/src/test/scala/sbt/internal/util/complete/JLineCompletionSpec.scala`
- [x] Ran targeted test:
  - `./sbt "completeProj/testOnly sbt.internal.util.complete.JLineCompletionSpec"`
- [x] Ran module test suite:
  - `./sbt "completeProj/test"`

## Checklist

- [x] Code follows project style
- [x] Tests added for new behavior
- [x] Existing completion tests still pass
