### PR TITLE
[2.x] fix: Fix typo in CONTRIBUTING.md ("guideslins" -> "guidelines")

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ There are lots of ways to contribute to sbt ecosystem depending on your interest
 - Review pull requests.
 - Documentation fixes and contributions are as much welcome as to patching the core. Visit [sbt/website][documentation] to learn about how to contribute.
 
-For the issue reporting guideslins, jump to [issues](#issues).
+For the issue reporting guidelines, jump to [issues](#issues).
 
 Ideas and proposals
 -------------------


### PR DESCRIPTION
### Problem
`CONTRIBUTING.md` contains a spelling typo: `guideslins`.

### Solution
Replaced it with `guidelines`.

### Verification
Manually checked the rendered markdown and file content.
