### PR TITLE
[2.x] fix: Fix spelling typos in contributing docs

### DIFF
--- a/contributing-docs/03_coding_style.md
+++ b/contributing-docs/03_coding_style.md
@@ -58,7 +58,7 @@ end O1
 ### Comments
 
 - Use ScalaDoc to provide API documentation. In general, however, document the intent and background behind the code, rather than transcribing code to English.
-- Avoid exessive inline comments, especially the ones that repeats the same information as the code.
+- Avoid excessive inline comments, especially the ones that repeats the same information as the code.
 
 ### Returns
 

--- a/contributing-docs/04_unit_tests.md
+++ b/contributing-docs/04_unit_tests.md
@@ -12,7 +12,7 @@ project.
 Property-based testing with HedgeHog
 ------------------------------------
 
-sbt contains various testing frameworks, but our prefered unit testing framework is HedgeHog.
+sbt contains various testing frameworks, but our preferred unit testing framework is HedgeHog.
 
 See [main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala](../main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala) for an example.
 

--- a/contributing-docs/07_tech_stack.md
+++ b/contributing-docs/07_tech_stack.md
@@ -76,7 +76,7 @@ Gigahorse for HTTP
 ------------------
 
 [Gigahorse][gigahorse] is a backend-independent HTTP library sbt uses for some features.
-As the concete backend we use Apache HttpClient 5.x.
+As the concrete backend we use Apache HttpClient 5.x.
 
 ```scala
 private val http = {


### PR DESCRIPTION
### Problem
The contributing docs contain spelling typos in multiple pages:
- `prefered` in `contributing-docs/04_unit_tests.md`
- `exessive` in `contributing-docs/03_coding_style.md`
- `concete` in `contributing-docs/07_tech_stack.md`

### Solution
Corrected the typos:
- `prefered` -> `preferred`
- `exessive` -> `excessive`
- `concete` -> `concrete`

