### PR TITLE
[2.x] fix: Fix spelling and link in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Compiling with sbt
 sbt compile
 ```
 
-Pull reuqest guideline
+Pull request guideline
 ----------------------
 
 - Follow the PR guidance in [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -43,7 +43,7 @@ For changes that require coordination with file changes and tasks, use scripted 
 Tech stack
 ----------
 
-- [contributing-docs/07_tech_stack.md](contribution-docs/07_tech_stach.md)
+- [contributing-docs/07_tech_stack.md](contributing-docs/07_tech_stack.md)
 
 Binary compatibility
 --------------------


### PR DESCRIPTION
### Problem
`AGENTS.md` has:
- a spelling typo in a section heading (`reuqest`)
- a broken tech stack link target (`contribution-docs/07_tech_stach.md`)

### Solution
- Corrected heading text to `Pull request guideline`
- Updated the link target to `contributing-docs/07_tech_stack.md`
