### PR TITLE
[1.x] bport: Fixes double quotes handling in fork mode (#8765)

### DIFF
--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -161,7 +161,7 @@ object Fork {
 
   /**
    * Create an arguments file from a sequence of command line arguments
-   * by quoting each argument to a line with escaped backslashes
+   * by quoting each argument to a line with escaped backslashes and double quotes
    *
    * @param options command line options to write to the args file
    * @return
@@ -173,7 +173,7 @@ object Fork {
     val pw = new PrintWriter(file)
     options.foreach { option =>
       pw.write("\"")
-      pw.write(option.replace("\\", "\\\\"))
+      pw.write(option.replace("\\", "\\\\").replace("\"", "\\\""))
       pw.write("\"")
       pw.write(System.lineSeparator())
     }

--- a/run/src/test/scala/sbt/ForkTest.scala
+++ b/run/src/test/scala/sbt/ForkTest.scala
@@ -63,7 +63,26 @@ object ForkTest extends Properties("Fork") {
         }
     }
 
-  private[this] def trimClasspath(cp: String): String =
+  property("Arguments with double quotes preserved in arguments file mode.") = {
+    val baos = new java.io.ByteArrayOutputStream()
+    val jsonArg = """{"a":1}"""
+    // Pad JVM options to exceed MaxConcatenatedOptionLength (5000) and trigger argsfile mode
+    val padding = "-Dproperty=" + ("X" * 5000)
+    val absClasspath = Path.makeString(requiredEntries)
+    val args = List("-cp", absClasspath, padding, "sbt.echoArgs", jsonArg)
+    val config = ForkOptions()
+      .withOutputStrategy(CustomOutput(baos))
+      .withCanUseArgumentsFile(true)
+    val exitCode =
+      try Fork.java(config, args)
+      catch { case e: Exception => e.printStackTrace(); 1 }
+    val output = baos.toString("UTF-8").trim
+    s"exitCode: $exitCode" |:
+      s"output: '$output', expected: '$jsonArg'" |:
+      (exitCode == 0) && (output == jsonArg)
+  }
+
+  private def trimClasspath(cp: String): String =
     if (cp.length > MaximumClasspathLength) {
       val lastEntryI = cp.lastIndexOf(File.pathSeparatorChar.toInt, MaximumClasspathLength)
       if (lastEntryI > 0)
@@ -78,5 +97,12 @@ object ForkTest extends Properties("Fork") {
 object exit {
   def main(args: Array[String]): Unit = {
     System.exit(java.lang.Integer.parseInt(args(0)))
+  }
+}
+
+// Echoes each argument on its own line, used to verify argument passing
+object echoArgs {
+  def main(args: Array[String]): Unit = {
+    args.foreach(println)
   }
 }

--- a/sbt-app/src/sbt-test/run/fork-argsfile-quotes/build.sbt
+++ b/sbt-app/src/sbt-test/run/fork-argsfile-quotes/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "3.6.4"
+run / fork := true
+// Force arguments file mode by exceeding MaxConcatenatedOptionLength (5000)
+run / javaOptions += ("-Dsome.long.property=" + ("X" * 5000))
+// Pass JSON with double quotes as a system property — this goes through the argsfile
+run / javaOptions += """-Djson={"a":1}"""

--- a/sbt-app/src/sbt-test/run/fork-argsfile-quotes/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/run/fork-argsfile-quotes/src/main/scala/Main.scala
@@ -1,0 +1,6 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    val json = System.getProperty("json")
+    assert(json == """{"a":1}""", s"""Expected '{"a":1}' but got '$json'""")
+  }
+}

--- a/sbt-app/src/sbt-test/run/fork-argsfile-quotes/test
+++ b/sbt-app/src/sbt-test/run/fork-argsfile-quotes/test
@@ -1,0 +1,2 @@
+# Verify that double quotes in JVM options survive the argsfile round-trip (sbt/sbt#7129)
+> run


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8765

When using the arguments file (`@argsfile`) mechanism for forked runs, double quotes inside arguments were not escaped, causing the JVM's argument file parser to strip them. For example, passing `{"a":1}` as an argument would result in `{a:1}`.

Escape `"` as `\"` in `createArgumentsFile`, matching the existing backslash escaping, so the JVM correctly round-trips quoted arguments.

Fixes sbt/sbt#7129