### PR TITLE
[1.x] bport: Comments in dot files

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -285,4 +285,49 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
       s"Should not have shell expansion errors, but found: ${errorMessages.mkString(", ")}"
     )
 
+  // Test for issue #8755: Inline comments should be supported in .jvmopts
+  testOutput(
+    "sbt with inline comments in .jvmopts",
+    jvmoptsFileContents = """--add-opens=java.base/java.util=ALL-UNNAMED # This is an inline comment
+        |-Dtest.key=value # Another comment
+        |-Dtest.key2=file:/log4j2#prod.xml""".stripMargin,
+    windowsSupport = false,
+  )("-v"): (out: List[String]) =>
+    // Verify that options are present (comments should be stripped)
+    assert(
+      !out.contains[String]("#"),
+      "Comments are stripped out"
+    )
+    assert(
+      out.contains[String]("--add-opens=java.base/java.util=ALL-UNNAMED"),
+      "Option with inline comment should be parsed correctly"
+    )
+    assert(
+      out.contains[String]("-Dtest.key=value"),
+      "System property with inline comment should be parsed correctly"
+    )
+    assert(
+      out.contains[String]("-Dtest.key2=file:/log4j2#prod.xml"),
+      "System property with inline comment should be parsed correctly"
+    )
+    // Verify comments themselves are NOT present as separate arguments
+    assert(
+      !out.exists(_.contains("This is an inline comment")),
+      "Inline comment should not appear in command line"
+    )
+    assert(
+      !out.exists(_.contains("Another comment")),
+      "Inline comment should not appear in command line"
+    )
+    // Verify no "command not found" errors for '#' character
+    val errorMessages = out.filter(line =>
+      line.contains("Could not find or load main class #") ||
+        line.contains("command not found") ||
+        line.contains("was unexpected")
+    )
+    assert(
+      errorMessages.isEmpty,
+      s"Should not have errors from comment character, but found: ${errorMessages.mkString(", ")}"
+    )
+
 end RunnerScriptTest

--- a/sbt
+++ b/sbt
@@ -766,7 +766,7 @@ process_args () {
 loadConfigFile() {
   # Make sure the last line is read even if it doesn't have a terminating \n
   # Output lines literally without shell expansion to handle special characters safely
-  cat "$1" | sed $'/^\#/d;s/\r$//' | while read -r line || [[ -n "$line" ]]; do
+  cat "$1" | sed $'/^\#/d;s/[[:space:]]\{1,\}#.*//;s/\r$//' | while read -r line || [[ -n "$line" ]]; do
     # Use printf with properly quoted variable to prevent shell expansion
     # This safely handles special characters like |, *, &, etc.
     printf '%s\n' "$line"


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8841

## Problem
Hash comments doesn't work in dot files.

## Solution
This reapplies the comment removal sed,
with improved inline comment handling.