### PR TITLE
[1.x] bport: Refer to universal sbtn in detectNativeClient

### DIFF
--- a/sbt
+++ b/sbt
@@ -791,7 +791,7 @@ detectNativeClient() {
     arch=$(uname -m)
     [[ -f "${sbt_bin_dir}/sbtn-${arch}-pc-linux" ]] && sbtn_command="${sbt_bin_dir}/sbtn-${arch}-pc-linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    [[ -f "${sbt_bin_dir}/sbtn-x86_64-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-apple-darwin"
+    [[ -f "${sbt_bin_dir}/sbtn-universal-apple-darwin" ]] && sbtn_command="${sbt_bin_dir}/sbtn-universal-apple-darwin"
   elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
     [[ -f "${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe" ]] && sbtn_command="${sbt_bin_dir}/sbtn-x86_64-pc-win32.exe"
   elif [[ "$OSTYPE" == "freebsd"* ]]; then


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8810

## Problem
sbtn-x86_64-apple-darwin doesn't exist anymore

## Solution
point to universal binary instead