### PR TITLE
[1.x] bport: Runner should fail on JDK < 17 for sbt 2.x

### DIFF
--- a/launcher-package/integration-test/bin/java
+++ b/launcher-package/integration-test/bin/java
@@ -1,9 +1,28 @@
 #!/usr/bin/env python3
 
+import os
 import sys
+import tempfile
 
 if '--version' in sys.argv or '-version' in sys.argv:
-    print('openjdk version "1.8.0_212"')
+    print('openjdk version "17.0.12" 2024-07-16')
+elif '--rt-ext-dir' in sys.argv:
+    # Simulate JDK 9+ rt.jar ext dir: output a directory path containing
+    # "java9-rt-ext-" that the launcher scripts look for via grep/findstr.
+    ext_dir = os.path.join(tempfile.gettempdir(), 'java9-rt-ext-fake')
+    os.makedirs(ext_dir, exist_ok=True)
+    # Create a dummy rt.jar so the launcher won't try to --export-rt
+    rt_jar = os.path.join(ext_dir, 'rt.jar')
+    if not os.path.exists(rt_jar):
+        open(rt_jar, 'w').close()
+    print(ext_dir)
+elif '--export-rt' in sys.argv:
+    # Simulate rt.jar export: create the file at the specified path
+    idx = sys.argv.index('--export-rt')
+    if idx + 1 < len(sys.argv):
+        rt_path = sys.argv[idx + 1]
+        os.makedirs(os.path.dirname(rt_path), exist_ok=True)
+        open(rt_path, 'w').close()
 else:
     for arg in sys.argv[1:]:
         print(repr(arg)[1:-1])

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -617,12 +617,12 @@ if !sbt_args_print_sbt_script_version! equ 1 (
   goto :eof
 )
 
+call :checkjava
+
 if !run_native_client! equ 1 if not defined sbt_args_print_version (
   goto :runnative !SBT_ARGS!
   goto :eof
 )
-
-call :checkjava
 
 if defined sbt_args_sbt_jar (
   set "sbt_jar=!sbt_args_sbt_jar!"
@@ -1006,8 +1006,23 @@ exit /B 0
 
 :checkjava
 set /a required_version=8
+rem sbt 2.x requires JDK 17+
+set "_sbt_check_ver=!build_props_sbt_version!"
+if not defined _sbt_check_ver set "_sbt_check_ver=!init_sbt_version!"
+if defined _sbt_check_ver (
+  for /F "delims=.-_ tokens=1" %%m in ("!_sbt_check_ver!") do (
+    if %%m GEQ 2 set /a required_version=17
+  )
+)
+set "_sbt_check_ver="
 if /I !JAVA_VERSION! GEQ !required_version! (
   exit /B 0
+)
+if !required_version! GEQ 17 (
+  >&2 echo.
+  >&2 echo [error] sbt 2.x requires JDK 17 or above, but you have JDK !JAVA_VERSION!
+  >&2 echo.
+  exit /B 1
 )
 >&2 echo.
 >&2 echo The Java Development Kit ^(JDK^) installation you have is not up to date.

--- a/sbt
+++ b/sbt
@@ -500,6 +500,18 @@ checkJava() {
   fi
 }
 
+# sbt 2.x requires JDK 17+
+checkJava17ForSbt2() {
+  local sbtV="$build_props_sbt_version"
+  [[ "$sbtV" == "" ]] && sbtV="$init_sbt_version"
+  [[ "$sbtV" == "" ]] && return
+  local sbtMajor=$(echo "$sbtV" | sed 's/^\([0-9]*\).*/\1/')
+  if (( sbtMajor >= 2 )) && [[ "$java_version" != "no_java" ]] && (( java_version < 17 )); then
+    echoerr "[error] sbt 2.x requires JDK 17 or above, but you have JDK $java_version"
+    exit 1
+  fi
+}
+
 copyRt() {
   local at_least_9="$(expr $java_version ">=" 9)"
   if [[ "$at_least_9" == "1" ]]; then
@@ -906,13 +918,15 @@ if [[ $print_sbt_script_version ]]; then
   exit 0
 fi
 
+java_version="$(jdk_version)"
+vlog "[process_args] java_version = '$java_version'"
+checkJava17ForSbt2
+
 if [[ "$(isRunNativeClient)" == "true" ]] && [[ -z "$print_version" ]]; then
   set -- "${residual_args[@]}"
   argumentCount=$#
   runNativeClient
 else
-  java_version="$(jdk_version)"
-  vlog "[process_args] java_version = '$java_version'"
   addDefaultMemory
   addSbtScriptProperty
   addJdkWorkaround


### PR DESCRIPTION
This is a backport of #8825

## Problem
Running sbt 2.x with JDK 8 produces a confusing "server was not detected" error because the JDK version check only required JDK 8+ and only ran in the non-native-client path.

## Solution
Move java_version detection before the native client decision and add checkJava17ForSbt2 that requires JDK 17+ when sbt major version >= 2.

Fixes #8813