### PR TITLE
[2.x] fix: Update help text for ++

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -153,7 +153,7 @@ shift
 if "%~0" == "" goto args_end
 set g=%~0
 
-rem make sure the sbt_args_debug gets set first incase any argument parsing uses :dlog
+rem make sure the sbt_args_debug gets set first in case any argument parsing uses :dlog
 if "%~0" == "-d" set _debug_arg=true
 if "%~0" == "--debug" set _debug_arg=true
 

--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -497,7 +497,7 @@ private[sbt] object Continuous {
              * are other changes detected in the burst. As soon as no changes are detected
              * during the polling window, we return all of the detected events. The polling
              * period is by default 5 milliseconds which is short enough to detect bursts
-             * induced by commands like git rebase but fast enough to not lead to a noticable
+             * induced by commands like git rebase but fast enough to not lead to a noticeable
              * increase in latency.
              */
             @tailrec def aggregate(res: Seq[Event]): Seq[Event] =


### PR DESCRIPTION
Closes #6988 

## Problem
The help text still mentions filtering projects by **Scala binary compatibility** even the behavior was removed previously.

## Solution
Update the `++` command detailed help text to reflect current behavior.

## Changes
- the help text in the `main/src/main/scala/sbt/internal/CommandStrings.scala`

## Test
- sbt compile
- sbt mainProj/text
- sbt scalafmtCheck
- sbt mimaReportBinaryIssues

## Notes
As this PR only updates text, it doesn't change ++ behavior.