### PR TITLE
[2.x] Improve -help/--help and fix launcher test harness

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -154,6 +154,16 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
     assertVersionOutput(out)
     ()
 
+  // Test for issue #4189: Improve -help and help commands
+  testOutput(
+    "sbt --help should show getting-started hints",
+    citestVariant = "citest",
+  )("--help"): (out: List[String]) =>
+    val helpText = out.mkString(System.lineSeparator())
+    assert(helpText.contains("Getting started with sbt"))
+    assert(helpText.contains("sbt new scala/scala3.g8"))
+    assert(helpText.contains("help <command>"))
+
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>
     assert(out.contains[String]("-Dsbt.global.localcache=./cachePath"))
 

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -161,7 +161,7 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
   )("--help"): (out: List[String]) =>
     val helpText = out.mkString(System.lineSeparator())
     assert(helpText.contains("Getting started with sbt"))
-    assert(helpText.contains("sbt new scala/scala3.g8"))
+    assert(helpText.contains("sbt init"))
     assert(helpText.contains("help <command>"))
 
   testOutput("--sbt-cache")("--sbt-cache", "./cachePath"): (out: List[String]) =>

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -154,7 +154,7 @@ trait ShellScriptUtil extends BasicTestSuite {
             envVars("XDG_CONFIG_HOME") = configHomeDir.getAbsolutePath
           }
 
-          val path = sys.env.getOrElse("PATH", sys.env("Path"))
+          val path = sys.env.getOrElse("PATH", sys.env.getOrElse("Path", ""))
           val javaHomeEnv = sys.env.getOrElse("JAVA_HOME", System.getProperty("java.home"))
           envVars("JAVA_OPTS") = javaOpts
           envVars("SBT_OPTS") = sbtOpts

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -155,15 +155,16 @@ trait ShellScriptUtil extends BasicTestSuite {
           }
 
           val path = sys.env.getOrElse("PATH", sys.env("Path"))
+          val javaHomeEnv = sys.env.getOrElse("JAVA_HOME", System.getProperty("java.home"))
           envVars("JAVA_OPTS") = javaOpts
           envVars("SBT_OPTS") = sbtOpts
           envVars("JAVA_TOOL_OPTIONS") = javaToolOptions
           if isWindows then
             envVars("JAVACMD") = new File(javaBinDir, "java").getAbsolutePath()
-            envVars("JAVA_HOME") = sys.env("JAVA_HOME")
+            envVars("JAVA_HOME") = javaHomeEnv
           else
             envVars("PATH") = javaBinDir + File.pathSeparator + path
-            envVars("JAVA_HOME") = sys.env("JAVA_HOME")
+            envVars("JAVA_HOME") = javaHomeEnv
           val cmd =
             LauncherTestHelper.launcherCommand(testSbtScript.getAbsolutePath, isGitBashTest) ++ args
           val lines = mutable.ListBuffer.empty[String]

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -1140,10 +1140,7 @@ echo shows precedence: JAVA_OPTS lowest, command line options highest.
 echo.
 echo Getting started with sbt:
 echo.
-echo   - To create a new project:
-echo       sbt new scala/scala3.g8
-echo     or, for Scala 2:
-echo       sbt new scala/scala-seed.g8
+echo   - To create a new project run: sbt init
 echo.
 echo   - Once in the sbt shell, type:
 echo       help

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -1138,9 +1138,21 @@ echo.
 echo In the case of duplicated or conflicting options, the order above
 echo shows precedence: JAVA_OPTS lowest, command line options highest.
 echo.
+echo Getting started with sbt:
+echo.
+echo   - To create a new project:
+echo       sbt new scala/scala3.g8
+echo     or, for Scala 2:
+echo       sbt new scala/scala-seed.g8
+echo.
+echo   - Once in the sbt shell, type:
+echo       help
+echo       help ^<command^>
+echo     to see available commands and detailed help.
+echo.
 
 @endlocal
-exit /B 1
+exit /B 0
 
 :set_sbt_version
 set "sbt_version="

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -586,7 +586,9 @@ class NetworkClient(
   private def getExitCode(jvalue: Option[JValue]): Integer = jvalue match {
     case Some(jv) =>
       import sbt.protocol.codec.JsonProtocol.given
-      Converter.fromJson[ExecStatusEvent](jv).toOption
+      Converter
+        .fromJson[ExecStatusEvent](jv)
+        .toOption
         .flatMap(_.exitCode)
         .fold(Integer.valueOf(1))(code => Integer.valueOf(code.toInt))
     case _ => Integer.valueOf(1)
@@ -631,7 +633,9 @@ class NetworkClient(
           val response = msg.result match {
             case Some(jvalue) =>
               import sbt.protocol.codec.JsonProtocol.given
-              Converter.fromJson[CompletionResponse](jvalue).getOrElse(CompletionResponse(Vector.empty[String]))
+              Converter
+                .fromJson[CompletionResponse](jvalue)
+                .getOrElse(CompletionResponse(Vector.empty[String]))
             case _ => CompletionResponse(Vector.empty[String])
           }
           completions(response)

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -36,7 +36,7 @@ import sbt.io.syntax.*
 import sbt.protocol.*
 import sbt.util.{ Level, Logger }
 import sjsonnew.BasicJsonProtocol.*
-import sjsonnew.shaded.scalajson.ast.unsafe.JValue
+import sjsonnew.shaded.scalajson.ast.unsafe.{ JObject, JValue }
 import sjsonnew.support.scalajson.unsafe.Converter
 
 import scala.annotation.tailrec
@@ -584,14 +584,14 @@ class NetworkClient(
   }
 
   private def getExitCode(jvalue: Option[JValue]): Integer = jvalue match {
-    case Some(jv) =>
-      import sbt.protocol.codec.JsonProtocol.given
-      Converter
-        .fromJson[ExecStatusEvent](jv)
-        .toOption
-        .flatMap(_.exitCode)
-        .fold(Integer.valueOf(1))(code => Integer.valueOf(code.toInt))
-    case _ => Integer.valueOf(1)
+    case Some(o: JObject) =>
+      o.value
+        .collectFirst {
+          case v if v.field == "exitCode" =>
+            Converter.fromJson[Integer](v.value).getOrElse(Integer.valueOf(1))
+        }
+        .getOrElse(1)
+    case _ => 1
   }
 
   private val onAttachResponse: PartialFunction[JsonRpcResponseMessage, Unit] = {
@@ -630,15 +630,28 @@ class NetworkClient(
       pendingCompletions.remove(msg.id) match {
         case null => ()
         case completions =>
-          val response = msg.result match {
-            case Some(jvalue) =>
-              import sbt.protocol.codec.JsonProtocol.given
-              Converter
-                .fromJson[CompletionResponse](jvalue)
-                .getOrElse(CompletionResponse(Vector.empty[String]))
+          completions(msg.result match {
+            case Some(o: JObject) =>
+              o.value
+                .foldLeft(CompletionResponse(Vector.empty[String])) { (resp, i) =>
+                  if (i.field == "items")
+                    resp.withItems(
+                      Converter
+                        .fromJson[Vector[String]](i.value)
+                        .getOrElse(Vector.empty[String])
+                    )
+                  else if (i.field == "cachedTestNames")
+                    resp.withCachedTestNames(
+                      Converter.fromJson[Boolean](i.value).getOrElse(true)
+                    )
+                  else if (i.field == "cachedMainClassNames")
+                    resp.withCachedMainClassNames(
+                      Converter.fromJson[Boolean](i.value).getOrElse(true)
+                    )
+                  else resp
+                }
             case _ => CompletionResponse(Vector.empty[String])
-          }
-          completions(response)
+          })
       }
   }
   // cache the composed plan

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -36,7 +36,7 @@ import sbt.io.syntax.*
 import sbt.protocol.*
 import sbt.util.{ Level, Logger }
 import sjsonnew.BasicJsonProtocol.*
-import sjsonnew.shaded.scalajson.ast.unsafe.{ JObject, JValue }
+import sjsonnew.shaded.scalajson.ast.unsafe.JValue
 import sjsonnew.support.scalajson.unsafe.Converter
 
 import scala.annotation.tailrec
@@ -584,14 +584,12 @@ class NetworkClient(
   }
 
   private def getExitCode(jvalue: Option[JValue]): Integer = jvalue match {
-    case Some(o: JObject) =>
-      o.value
-        .collectFirst {
-          case v if v.field == "exitCode" =>
-            Converter.fromJson[Integer](v.value).getOrElse(Integer.valueOf(1))
-        }
-        .getOrElse(1)
-    case _ => 1
+    case Some(jv) =>
+      import sbt.protocol.codec.JsonProtocol.given
+      Converter.fromJson[ExecStatusEvent](jv).toOption
+        .flatMap(_.exitCode)
+        .fold(Integer.valueOf(1))(code => Integer.valueOf(code.toInt))
+    case _ => Integer.valueOf(1)
   }
 
   private val onAttachResponse: PartialFunction[JsonRpcResponseMessage, Unit] = {
@@ -630,28 +628,13 @@ class NetworkClient(
       pendingCompletions.remove(msg.id) match {
         case null => ()
         case completions =>
-          completions(msg.result match {
-            case Some(o: JObject) =>
-              o.value
-                .foldLeft(CompletionResponse(Vector.empty[String])) { (resp, i) =>
-                  if (i.field == "items")
-                    resp.withItems(
-                      Converter
-                        .fromJson[Vector[String]](i.value)
-                        .getOrElse(Vector.empty[String])
-                    )
-                  else if (i.field == "cachedTestNames")
-                    resp.withCachedTestNames(
-                      Converter.fromJson[Boolean](i.value).getOrElse(true)
-                    )
-                  else if (i.field == "cachedMainClassNames")
-                    resp.withCachedMainClassNames(
-                      Converter.fromJson[Boolean](i.value).getOrElse(true)
-                    )
-                  else resp
-                }
+          val response = msg.result match {
+            case Some(jvalue) =>
+              import sbt.protocol.codec.JsonProtocol.given
+              Converter.fromJson[CompletionResponse](jvalue).getOrElse(CompletionResponse(Vector.empty[String]))
             case _ => CompletionResponse(Vector.empty[String])
-          })
+          }
+          completions(response)
       }
   }
   // cache the composed plan

--- a/sbt
+++ b/sbt
@@ -694,10 +694,7 @@ shows precedence: JAVA_OPTS lowest, command line options highest.
 
 Getting started with sbt:
 
-  - To create a new project:
-      sbt new scala/scala3.g8
-    or, for Scala 2:
-      sbt new scala/scala-seed.g8
+  - To create a new project run: sbt init
 
   - Once in the sbt shell, type:
       help

--- a/sbt
+++ b/sbt
@@ -7,6 +7,7 @@ declare -a java_args
 declare -a scalac_args
 declare -a sbt_commands
 declare -a sbt_options
+declare -a print_help
 declare -a print_version
 declare -a print_sbt_version
 declare -a print_sbt_script_version
@@ -690,6 +691,18 @@ Usage: `basename "$0"` [options]
 
 In the case of duplicated or conflicting options, the order above
 shows precedence: JAVA_OPTS lowest, command line options highest.
+
+Getting started with sbt:
+
+  - To create a new project:
+      sbt new scala/scala3.g8
+    or, for Scala 2:
+      sbt new scala/scala-seed.g8
+
+  - Once in the sbt shell, type:
+      help
+      help <command>
+    to see available commands and detailed help.
 EOM
 }
 
@@ -782,7 +795,7 @@ parseLineIntoWords() {
 process_args () {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-            -h|-help|--help) usage; exit 1 ;;
+            -h|-help|--help) print_help=1 && shift ;;
       -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
       -V|-version|--version) print_version=1 && shift ;;
           --numeric-version) print_sbt_version=1 && shift ;;
@@ -990,6 +1003,12 @@ args1=( "${cli_options[@]}" "${cli_commands[@]}" "${sbt_additional_commands[@]}"
 # process the combined args, then reset "$@" to the residuals
 process_args "${args1[@]}"
 vlog "[sbt_options] $(declare -p sbt_options)"
+
+# Handle -h/--help/-help at the script level without requiring Java or a project
+if [[ $print_help ]]; then
+  usage
+  exit 0
+fi
 
 # Handle --script-version before native client so it works on sbt 2.x project dirs (#8711)
 if [[ $print_sbt_script_version ]]; then


### PR DESCRIPTION
- sbt script: add 'Getting started' section to usage (create project, help commands)
- sbt script: handle -h/--help without starting JVM, exit 0
- RunnerScriptTest: add test for 'sbt --help should show getting-started hints'
- ShellScriptUtil: use java.home when JAVA_HOME unset so tests run in CI