### PR TITLE
[2.x] fix: Guard setParser to fix a startup crash

### DIFF
--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -704,12 +704,15 @@ object BuiltinCommands {
     (ext.structure, Select(ext.currentRef), ext.showKey)
   }
 
-  def setParser = (s: State) => {
-    val extracted = Project.extract(s)
-    import extracted.*
-    token(Space ~> flag("every" ~ Space)) ~
-      SettingCompletions.settingParser(structure.data, structure.index.keyMap, currentProject)
-  }
+  def setParser = (s: State) =>
+    Act.requireSession(
+      s, {
+        val extracted = Project.extract(s)
+        import extracted.*
+        token(Space ~> flag("every" ~ Space)) ~
+          SettingCompletions.settingParser(structure.data, structure.index.keyMap, currentProject)
+      }
+    )
 
   import Def.ScopedKey
   // type PolyStateKeysParser = [a] => State => Parser[Seq[ScopedKey[a]]]


### PR DESCRIPTION
Fixes #7092 

## Summary
It fixes a startup crash when `sbt` is launched with an early log-level command such as `--error` and `~/.sbtrc` contains a malformed alias whose body starts with `set`.
Previously, sbt could throw 
`java.lang.RuntimeException: Session not initialized.`
instead of reporting a normal parsing error.

## Root cause
For a malformed alias like `alias err = set maxErrors :=`,

It starts with 'set', this reaches `BuiltinCommands.setParser`, which calls `Project.extract(s)`.
At this point, the session may not yet be initialized, so it fails with `Session not initalized`.

## Fix
Wrap `BuiltinCommands.setParser` with `Act.requireSession(...)`.
This makes the parser fail gracefully when no session is available, matching the behavior of other session-dependent parsers.

## Validation
1. temporary `HOME` with : `alias err = set maxErrors :=`
2. then `./sbt --error exit`.
3. result: no `Session not initialized` crash.

also tested with `--error exit`, `help`, `projects`, and a `set` command, the no errors

