### PR TITLE
[2.x] Fix: sbt.bat build.properties lookup on Windows

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -94,7 +94,7 @@ if defined JAVA_HOMES (
 )
 
 if exist "project\build.properties" (
-  for /F "eol=# delims== tokens=1*" %%a in (project\build.properties) do (
+  for /F "usebackq eol=# delims== tokens=1*" %%a in ("project\build.properties") do (
     if "%%a" == "sbt.version" if not "%%b" == "" (
       set build_props_sbt_version=%%b
     )


### PR DESCRIPTION
Closes #6959

## Problem
On Windows, the original batch logic could fail while trying to read `project\build.properties`, which led to errors

> The system cannot find the file project\build.properties.

especially with options like `--mem 4096`

## Fix
Changed a line in the /src/universal/bin/sbt.bat from
`for /F "eol=# delims== tokens=1*" %%a in (project\build.properties) do (`
to
`for /F "usebackq eol=# delims== tokens=1*" %%a in ("project\build.properties") do (`

# How does it fix the issue?

- Quotes the filename `project\build.properties`
  - so the file operand is passed as a single literal path
- Adds `usebackq`
   - which tells for `for /F` that a double-quoted item is a filename
   
# Test on windows
`--mem 4096 --script-version`
- ran success as expected and didn't emit : `The system cannot find the file project\build.properties`.

`--version`
- correctly print sbt version