### PR TITLE
[2.x] fix: Fixes script mode using Scala 3.x

### DIFF
--- a/lm-coursier/src/test/scala/lmcoursier/internal/ResolutionRunSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/internal/ResolutionRunSpec.scala
@@ -2,6 +2,7 @@ package lmcoursier.internal
 
 import coursier.core.{ Module, ModuleName, Organization, Resolution }
 import coursier.error.ResolutionError.CantDownloadModule
+import coursier.version.VersionConstraint
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -11,7 +12,7 @@ class ResolutionRunSpec extends AnyFunSuite with Matchers:
     new CantDownloadModule(
       Resolution(),
       Module(Organization("org"), ModuleName("mod"), Map.empty),
-      "1.0",
+      VersionConstraint("1.0"),
       errors.toSeq
     )
 

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -184,6 +184,7 @@ final class ScriptMain extends xsbti.AppMain {
 private[sbt] object ScriptMain {
   private[sbt] def run(configuration: xsbti.AppConfiguration): xsbti.MainResult = {
     import BasicCommandStrings.runEarly
+    Plugins.defaultRequires = sbt.plugins.JvmPlugin
     val state = StandardMain.initialState(
       xMain.dealiasBaseDirectory(configuration),
       BuiltinCommands.ScriptCommands,

--- a/main/src/main/scala/sbt/internal/Script.scala
+++ b/main/src/main/scala/sbt/internal/Script.scala
@@ -9,7 +9,7 @@
 package sbt
 package internal
 
-import sbt.librarymanagement.Configurations
+import sbt.librarymanagement.{ Configurations, ScalaArtifacts }
 
 import sbt.util.Level
 
@@ -26,6 +26,37 @@ import scala.annotation.tailrec
 
 object Script {
   final val Name = "script"
+  // When shebang is stripped, compiler error line numbers may be off by one for the original file;
+  // position mapping could be added in a future improvement (see sbt/sbt#6274).
+  /** If the first line is a shebang (#!), drop it so the compiler never sees it. */
+  private[internal] def stripShebang(lines: Seq[String]): Seq[String] =
+    if (lines.nonEmpty && lines.head.startsWith("#!")) lines.drop(1) else lines
+
+  /** Lines that are not inside any /*** ... */ block (i.e. the executable script body). */
+  private[internal] def scriptBodyLines(file: File): Seq[String] = {
+    val lines = IO.readLines(file).toIndexedSeq
+    // Block(offset, lines): offset = index of /*** line, lines = content between /*** and */ (excl. both).
+    // Exclude /*** (off), content (off+1..off+ls.size), and */ (off+1+ls.size).
+    val blockSet = blocks(file).flatMap {
+      case Block(off, ls) => (off until off + 2 + ls.size)
+    }.toSet
+    lines.indices.filterNot(blockSet).map(lines)
+  }
+
+  /** Write a Scala 3 compilable file that wraps the script body in object Main { def main(...) = { ... } }. */
+  private def writeWrappedScript(body: Seq[String], out: File): Unit = {
+    val indent = "  "
+    val inner = body.map(line => indent + line).mkString("\n")
+    val content =
+      s"""object Main {
+         |  def main(args: Array[String]): Unit = {
+         |$inner
+         |  }
+         |}
+         |""".stripMargin
+    IO.write(out, content)
+  }
+
   lazy val command =
     Command.command(Name) { state =>
       val scriptArg = state.remainingCommands.headOption map { _.commandLine } getOrElse sys.error(
@@ -44,7 +75,11 @@ object Script {
         else scriptArg.substring(0, dotIndex) + ".scala"
       }
       val script = new File(src, scalaFile)
-      IO.copyFile(scriptFile, script)
+      val linesWithoutShebang = stripShebang(IO.readLines(scriptFile))
+      IO.write(script, linesWithoutShebang.mkString("", "\n", "\n"))
+
+      val scriptMain = new File(src, "Main.scala")
+      writeWrappedScript(scriptBodyLines(script), scriptMain)
 
       val (eval, structure) = Load.defaultLoad(state, base, state.log)
       val session = Load.initialSession(structure, eval)
@@ -55,12 +90,23 @@ object Script {
       val embeddedSettings = blocks(script).flatMap { block =>
         evaluate(eval(), vf, block.lines, currentUnit.imports, block.offset + 1)(currentLoader)
       }
-      val scriptAsSource = (Compile / sources) := Def.uncached(script :: Nil)
-      val asScript =
-        scalacOptions ++= Def.uncached(Seq("-Xscript", script.getName.stripSuffix(".scala")))
+      val scriptBaseName = script.getName.stripSuffix(".scala")
+      val scriptAsSource = (Compile / sources) := Def.uncached {
+        if (ScalaArtifacts.isScala3(scalaVersion.value)) scriptMain :: Nil else script :: Nil
+      }
+      val asScript = scalacOptions := Def.uncached {
+        val extra =
+          if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
+          else Seq("-Xscript", scriptBaseName)
+        scalacOptions.value ++ extra
+      }
+      val scriptMainClass = (run / mainClass) := Def.uncached {
+        if (ScalaArtifacts.isScala3(scalaVersion.value)) Some("Main") else Some(scriptBaseName)
+      }
       val scriptSettings = Seq(
         asScript,
         scriptAsSource,
+        scriptMainClass,
         (Global / logLevel) := Level.Warn,
         (Global / showSuccess) := false
       )

--- a/main/src/test/scala/sbt/internal/ScriptTest.scala
+++ b/main/src/test/scala/sbt/internal/ScriptTest.scala
@@ -1,0 +1,115 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.io.File
+import verify.BasicTestSuite
+import sbt.io.IO
+
+object ScriptTest extends BasicTestSuite {
+
+  test("stripShebang returns same lines when first line does not start with #!") {
+    val lines = Seq("println(1)", "val x = 2")
+    val result = Script.stripShebang(lines)
+    assert(result == lines)
+  }
+
+  test("stripShebang drops first line when it is a shebang") {
+    val lines = Seq("#!/usr/bin/env sbt -Dsbt.main.class=sbt.ScriptMain", "println(1)")
+    val result = Script.stripShebang(lines)
+    assert(result == Seq("println(1)"))
+  }
+
+  test("stripShebang leaves empty list unchanged") {
+    val result = Script.stripShebang(Seq.empty)
+    assert(result.isEmpty)
+  }
+
+  test("stripShebang leaves single non-shebang line unchanged") {
+    val lines = Seq("println(42)")
+    val result = Script.stripShebang(lines)
+    assert(result == lines)
+  }
+
+  test("stripShebang drops only first line when it is #!") {
+    val lines = Seq("#!", "*/", "println(1)")
+    val result = Script.stripShebang(lines)
+    assert(result == Seq("*/", "println(1)"))
+  }
+
+  test("scriptBodyLines returns all lines when file has no blocks") {
+    val f = File.createTempFile("script", ".scala")
+    try {
+      IO.write(f, "println(1)\nval x = 2\n")
+      val result = Script.scriptBodyLines(f)
+      assert(result.contains("println(1)"))
+      assert(result.contains("val x = 2"))
+      assert(!result.exists(_.startsWith("/***")))
+    } finally f.delete()
+  }
+
+  test("scriptBodyLines excludes lines inside /*** */ block") {
+    val f = File.createTempFile("script", ".scala")
+    try {
+      IO.write(
+        f,
+        """println("before")
+          |/***
+          |scalaVersion := "3.0.0"
+          |*/
+          |println("after")
+          |""".stripMargin
+      )
+      val result = Script.scriptBodyLines(f)
+      assert(result.contains("println(\"before\")"))
+      assert(result.contains("println(\"after\")"))
+      assert(!result.contains("scalaVersion := \"3.0.0\""))
+      assert(
+        !result.contains("*/"),
+        "closing */ must not appear in script body (would break wrapped Main.scala)"
+      )
+    } finally f.delete()
+  }
+
+  test("scriptBodyLines excludes block content when file has only a block") {
+    val f = File.createTempFile("script", ".scala")
+    try {
+      IO.write(
+        f,
+        """/***
+          |scalaVersion := "3.0.0"
+          |*/
+          |""".stripMargin
+      )
+      val result = Script.scriptBodyLines(f)
+      assert(
+        !result.contains("scalaVersion := \"3.0.0\""),
+        s"block content must be excluded, got $result"
+      )
+    } finally f.delete()
+  }
+
+  test("blocks parses block containing settings") {
+    val f = File.createTempFile("script", ".scala")
+    try {
+      IO.write(
+        f,
+        """line0
+          |/***
+          |scalaVersion := "3.0.0"
+          |*/
+          |line3
+          |""".stripMargin
+      )
+      val result = Script.blocks(f)
+      val settingBlock = result.find(_.lines.contains("scalaVersion := \"3.0.0\""))
+      assert(settingBlock.isDefined, s"expected a block with scalaVersion, got $result")
+    } finally f.delete()
+  }
+}

--- a/sbtw/src/main/scala/sbtw/ArgParser.scala
+++ b/sbtw/src/main/scala/sbtw/ArgParser.scala
@@ -53,5 +53,6 @@ object ArgParser:
       .parse(parser, args, LauncherOptions())
       .map: opts =>
         val sbtNew = opts.residual.contains("new") || opts.residual.contains("init")
-        opts.copy(sbtNew = sbtNew)
+        val isScript = opts.residual.exists(_.startsWith("-Dsbt.main.class=sbt.ScriptMain"))
+        opts.copy(sbtNew = sbtNew, allowEmpty = opts.allowEmpty || isScript)
 end ArgParser


### PR DESCRIPTION
## Problem

Scripts run via `sbt -Dsbt.main.class=sbt.ScriptMain` (or a shebang) that set `scalaVersion := "3.x"` in a `/*** ... */` block fail with:
1. `[warn] bad option '-Xscript' was ignored` — Scala 3 does not support the `-Xscript` compiler option.
2. `[error] Expected a toplevel definition` at line 1 — the hash-bang line is copied into the compiled source, and Scala 3 does not strip it in this path.

Reproduction: create a `.scala` file with shebang, `/*** scalaVersion := "3.0.0-M3" */`, and `println("hello")`, then run it with ScriptMain.

## Root Cause

In `main/src/main/scala/sbt/internal/Script.scala`:
- The script file was copied verbatim (L46), so the shebang remained and the compiler saw it as line 1.
- `scalacOptions` always added `-Xscript` (L59–60) regardless of Scala version; Scala 3 ignores this option and does not wrap top-level statements in a main class.

## Solution

1. **Strip shebang when copying** — Read the script file, drop the first line if it starts with `#!`, and write the rest. The compiler never sees the shebang. A short comment documents that error line numbers may be off by one for the original file (position mapping can be added later).

2. **Scala 3–specific handling** — Scala 3 does not support `-Xscript`. We:
   - Compute the script body (lines not inside any `/*** ... */` block) and write a second file `Main.scala` that wraps it in `object Main { def main(args: Array[String]): Unit = { ... } }`.
   - Use `ScalaArtifacts.isScala3(scalaVersion.value)` (evaluated via `Def.uncached`) to choose: for Scala 3, use `Main.scala` as the only compile source, do not add `-Xscript`, and set `(run / mainClass) := Some("Main")`; for Scala 2, keep the existing behavior (single script source + `-Xscript` + script base name as main class).

3. **Fix scriptBodyLines block indices** — Blocks store the index of the `/***` line; the content lines follow. Excluded indices are `offset` through `offset + 1 + lines.size` so both the delimiter and the block content are excluded from the script body.

Alternatives considered: relying on the Scala 3 compiler to strip shebang (that support is in the script runner, not when compiling a copied file); or dropping the feature (issue is still open and labeled help wanted, so fixing in sbt is in scope).

## Testing

- **Unit tests** (`main/src/test/scala/sbt/internal/ScriptTest.scala`):
  - `stripShebang` — no shebang, shebang on first line, empty, single line, only first line dropped.
  - `scriptBodyLines` — no blocks (all lines), one block (block content excluded), only block (block content excluded).
  - `blocks` — parses a block containing `scalaVersion`.
- **Verify:** `./sbt "mainProj/Test/testOnly sbt.internal.ScriptTest"` → PASS.
- **Manual:** Run a script with shebang and `scalaVersion := "3.3.1"` via `sbt -Dsbt.main.class=sbt.ScriptMain script.scala` (or after `publishLocalBin` with the built sbt).

## Before / After

- **Before:** Script with shebang and `scalaVersion := "3.0.0-M3"` fails with `-Xscript` warning and syntax error on the shebang line.
- **After:** Shebang is stripped from the copied file; for Scala 3 the script body is compiled as `Main.scala` with `object Main { def main(...) = { ... } }`, no `-Xscript`, and `run` uses main class `Main`. Script compiles and runs.

## Edge Cases Handled

- Script with shebang + Scala 2: shebang stripped, `-Xscript` and script base name used (unchanged behavior).
- Script with shebang + Scala 3: shebang stripped, wrapped `Main.scala`, no `-Xscript`, main class `Main`.
- Script without shebang: same logic; Scala 3 still uses wrapped file.
- Script with only `/*** */` (no code): wrapped body is empty; valid.
- Empty script file: wrapped body empty; valid.
- Embedded `scalaVersion` (e.g. 3.x) in `/*** */`: settings applied before our `Def.uncached` blocks run, so the correct branch is chosen.
- Backward compatibility: Scala 2 behavior unchanged.
- Error line numbers when shebang is stripped: documented as known limitation; position mapping can be added later.

Closes #6274
