### PR TITLE
[2.x] test: Add nested-testquick scripted test

### DIFF
--- a/sbt-app/src/sbt-test/tests/nested-testquick/build.sbt
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/build.sbt
@@ -1,0 +1,11 @@
+Global / cacheStores := Seq.empty
+
+ThisBuild / scalaVersion := "2.12.21"
+
+lazy val root = (project in file("."))
+  .settings(
+    crossPaths := false,
+    autoScalaLibrary := false,
+    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.2" % Test,
+    Test / parallelExecution := false,
+  )

--- a/sbt-app/src/sbt-test/tests/nested-testquick/changed/BadCalcTest.java
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/changed/BadCalcTest.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class BadCalcTest {
+  @Test
+  public void testBadAdd() {
+    assertEquals(99, Calc.add(1, 2));
+  }
+
+  public static class Nested {
+    @Test
+    public void testBadAddNegative() {
+      assertEquals(99, Calc.add(1, -2));
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/nested-testquick/changed/Calc.java
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/changed/Calc.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Calc {
+  public static int add(int a, int b) {
+    return a * b;
+  }
+}

--- a/sbt-app/src/sbt-test/tests/nested-testquick/src/main/java/com/example/Calc.java
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/src/main/java/com/example/Calc.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Calc {
+  public static int add(int a, int b) {
+    return a + b;
+  }
+}

--- a/sbt-app/src/sbt-test/tests/nested-testquick/src/test/java/com/example/CalcTest.java
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/src/test/java/com/example/CalcTest.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class CalcTest {
+  @Test
+  public void testAdd() {
+    assertEquals(3, Calc.add(1, 2));
+  }
+
+  public static class Nested {
+    @Test
+    public void testAddNegative() {
+      assertEquals(-1, Calc.add(1, -2));
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/nested-testquick/src/test/java/com/example/GoodCalcTest.java
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/src/test/java/com/example/GoodCalcTest.java
@@ -3,17 +3,16 @@ package com.example;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
-public class CalcTest {
+public class GoodCalcTest {
   @Test
-  public void testAdd() {
+  public void testAddPositive() {
     assertEquals(3, Calc.add(1, 2));
   }
 
   public static class Nested {
     @Test
-    public void testAddNegative() {
-      assertEquals(-1, Calc.add(1, -2));
+    public void testAddZero() {
+      assertEquals(0, Calc.add(0, 0));
     }
   }
-
 }

--- a/sbt-app/src/sbt-test/tests/nested-testquick/test
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/test
@@ -3,10 +3,18 @@
 # and we need to verify that testQuick properly tracks them.
 
 # Run all tests -- should pass.
-> test
+> testOnly com.example.CalcTest com.example.GoodCalcTest
 
 # testQuick should be a no-op since all tests passed.
 > testQuick
+
+# Verify testOnly picks up a good test.
+> testOnly com.example.GoodCalcTest
+
+# Copy in BadCalcTest and verify it fails.
+$ copy-file changed/BadCalcTest.java src/test/java/com/example/BadCalcTest.java
+> compile
+-> testOnly com.example.BadCalcTest
 
 # Introduce a bug in Calc.java (add -> multiply).
 $ copy-file changed/Calc.java src/main/java/com/example/Calc.java

--- a/sbt-app/src/sbt-test/tests/nested-testquick/test
+++ b/sbt-app/src/sbt-test/tests/nested-testquick/test
@@ -1,0 +1,16 @@
+# Verify that testQuick works with nested test classes.
+# Nested test classes use $ encoding (e.g. CalcTest$Nested)
+# and we need to verify that testQuick properly tracks them.
+
+# Run all tests -- should pass.
+> test
+
+# testQuick should be a no-op since all tests passed.
+> testQuick
+
+# Introduce a bug in Calc.java (add -> multiply).
+$ copy-file changed/Calc.java src/main/java/com/example/Calc.java
+> compile
+
+# testQuick should re-run and fail because the source changed.
+-> testQuick


### PR DESCRIPTION
Closes: #7650
### Problem
The `tests/nested-testquick` scripted test only verified `test` and `testQuick` but did not exercise `testOnly` against individual test
classes, nor did it verify that a failing nested test class is detected.

### Solution
- Added `GoodCalcTest.java` (with a `Nested` inner class) as a passing test.
- Added `changed/BadCalcTest.java` (with a `Nested` inner class) as a deliberately failing test, staged in `changed/` so it does not interfere with initial test runs.
- Updated the scripted `test` script to use `testOnly` for targeted execution:
  - `> testOnly com.example.GoodCalcTest` (passes)
  - `-> testOnly com.example.BadCalcTest` (expected failure)

### Result
`scripted tests/nested-testquick` passes.

### AI usage disclosure
This PR was created with AI assistance (GitHub Copilot). All changes have been reviewed and verified by running `scripted tests/nested-testquick` locally. 

Generated-by: GitHub Copilot Claude Opus 4.6
Signed in to Scala CLA