### PR TITLE
[1.x] deps: Update lm-coursier-shaded 2.1.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,7 @@ object Dependencies {
   def addSbtZincCompile = addSbtModule(sbtZincPath, "zincCompile", zincCompile)
   def addSbtZincCompileCore = addSbtModule(sbtZincPath, "zincCompileCore", zincCompileCore)
 
-  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.1.10"
+  val lmCoursierShaded = "io.get-coursier" %% "lm-coursier-shaded" % "2.1.12"
 
   def sjsonNew(n: String) =
     Def.setting("com.eed3si9n" %% n % "0.10.1") // contrabandSjsonNewVersion.value

--- a/sbt-app/src/sbt-test/dependency-management/scala-version-check-exempt/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/scala-version-check-exempt/build.sbt
@@ -4,6 +4,16 @@ ThisBuild / scalaVersion := "2.11.12"
 libraryDependencies += "org.scala-lang" %% "scala-actors-migration" % "1.1.0"
 libraryDependencies += "org.scala-lang" %% "scala-pickling" % "0.9.1"
 
+// This is a workaround for https://github.com/coursier/coursier/issues/3525, ported backported from https://github.com/sbt/sbt/pull/8381/changes#diff-bb1add3538eec3272df81b1f5bef249d096aa240d5408a4ceff8917557f5142fR15
+// [info] [error] lmcoursier.internal.shaded.coursier.params.rule.SameVersion$CantForceSameVersion:
+// Can't force version 2.11.12 for modules org.scala-lang:scala-compiler, org.scala-lang:scala-reflect, org.scala-lang:scala-library
+// ....
+// [info] [error] Caused by: lmcoursier.internal.shaded.coursier.params.rule.SameVersion$SameVersionConflict:
+// Unsatisfied rule SameVersion(HashSet(ModuleMatcher(org.scala-lang:scala-compiler), ModuleMatcher(org.scala-lang:scalap),
+// ModuleMatcher(org.scala-lang:scala-actors), ModuleMatcher(org.scala-lang:scala-reflect), ModuleMatcher(org.scala-lang:scala-library))):
+// Found versions 2.11.0, 2.11.12 for org.scala-lang:scala-actors, org.scala-lang:scala-compiler, org.scala-lang:scala-library, org.scala-lang:scala-reflect
+libraryDependencies += "org.scala-lang" % "scala-actors" % "2.11.12"
+
 lazy val check = taskKey[Unit]("Runs the check")
 
 check := {


### PR DESCRIPTION
2.1.12 introduces retries for 5xx http errors per https://github.com/coursier/sbt-coursier/pull/601