### PR TITLE
[2.x] fix: Use new constructor for CantDownloadModule

### DIFF
--- a/lm-coursier/src/test/scala/lmcoursier/internal/ResolutionRunSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/internal/ResolutionRunSpec.scala
@@ -2,6 +2,7 @@ package lmcoursier.internal
 
 import coursier.core.{ Module, ModuleName, Organization, Resolution }
 import coursier.error.ResolutionError.CantDownloadModule
+import coursier.version.VersionConstraint
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -11,7 +12,7 @@ class ResolutionRunSpec extends AnyFunSuite with Matchers:
     new CantDownloadModule(
       Resolution(),
       Module(Organization("org"), ModuleName("mod"), Map.empty),
-      "1.0",
+      VersionConstraint("1.0"),
       errors.toSeq
     )
 


### PR DESCRIPTION
This pr fixes the develop build that fails due to a warning in: https://github.com/sbt/sbt/actions/runs/23082287765/job/67053531187#step:18:204 

```
[warn] -- Deprecation Warning: /home/runner/work/sbt/sbt/lm-coursier/src/test/scala/lmcoursier/internal/ResolutionRunSpec.scala:11:8 
[warn] 11 |    new CantDownloadModule(
[warn]    |        ^^^^^^^^^^^^^^^^^^
[warn]    |constructor CantDownloadModule in class CantDownloadModule is deprecated since 2.1.25: Use the override accepting a VersionConstraint instead
```

Issue introduced in https://github.com/sbt/sbt/pull/8903