### PR TITLE
[1.x] bport: Update semanticdbVersion in SemanticdbPlugin.scala

### DIFF
--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -27,7 +27,7 @@ object SemanticdbPlugin extends AutoPlugin {
     semanticdbEnabled := SysProp.semanticdb,
     semanticdbIncludeInJar := false,
     semanticdbOptions := List(),
-    semanticdbVersion := "4.14.2"
+    semanticdbVersion := "4.15.2"
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
This is a backport of https://github.com/sbt/sbt/pull/8885