### PR TITLE
[2.x] fix: support Java 9+ platform module classes in console classloader

### DIFF
--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -334,7 +334,7 @@ object Compiler:
       val cpFiles = cp.map(converter.toPath).map(_.toFile())
       val fullcp = (cpFiles ++ si.allJars).distinct
       val tempDir = IO.createUniqueDirectory((task / Keys.taskTemporaryDirectory).value).toPath
-      val loader = ClasspathUtil.makeLoader(fullcp.map(_.toPath), si, tempDir)
+      val loader = ClasspathUtil.makeLoader(fullcp.map(_.toPath), si.loaderLibraryOnly, si, tempDir)
       val compiler =
         (task / Keys.compilers).value.scalac match
           case ac: AnalyzingCompiler => ac.onArgs(exported(s, "scala"))

--- a/main/src/main/scala/sbt/internal/ConsoleProject.scala
+++ b/main/src/main/scala/sbt/internal/ConsoleProject.scala
@@ -89,7 +89,7 @@ object ConsoleProject:
     val imports = BuildUtil.getImports(unit.unit) ++ BuildUtil.importAll(bindings.map(_._1))
     val importString = imports.mkString("", ";\n", ";\n\n")
     val initCommands = importString + extra
-    val loader = ClasspathUtil.makeLoader(unit.classpath, si, tempDir)
+    val loader = ClasspathUtil.makeLoader(unit.classpath, si.loaderLibraryOnly, si, tempDir)
     val terminal = Terminal.get
     // TODO - Hook up dsl classpath correctly...
     (new Console(compiler))(


### PR DESCRIPTION
## Summary
- Fixes #8664
- Switches `ClasspathUtil.makeLoader` from 3-arg to 4-arg overload in `Compiler.scala` and `ConsoleProject.scala`
- Uses `si.loaderLibraryOnly` as parent classloader, preserving standard parent-first delegation to the platform classloader on Java 9+

## Problem
When running `console` in sbt with Scala 3 on Java 9+, accessing classes from non-`java.base` modules (like `javax.sql.DataSource` from `java.sql`) throws `NoClassDefFoundError`. The 3-arg `makeLoader` wraps the classloader in `ClasspathFilter`, which blocks delegation to the platform classloader.

## Changes
- `main/src/main/scala/sbt/internal/Compiler.scala`: Use 4-arg `makeLoader` with `si.loaderLibraryOnly` parent
- `main/src/main/scala/sbt/internal/ConsoleProject.scala`: Same change

## Test plan
- [ ] Run `sbt console` on Java 17+ with Scala 3, verify `classOf[javax.sql.DataSource]` works
- [ ] Verify existing console functionality is not regressed