### PR TITLE
[2.x] fix: auto-exclude org.scala-lang artifacts for custom scalaOrganization

### DIFF
--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -108,6 +108,16 @@ object LMCoursier {
         (o.value, n.value)
       }
       .sorted
+    // When scalaOrganization differs from default, automatically exclude
+    // org.scala-lang Scala artifacts to prevent classpath conflicts (#8821)
+    val scalaOrgExclusions: Vector[(String, String)] =
+      if (scalaOrg != ScalaArtifacts.Organization) {
+        Vector(
+          "scala-library", "scala-compiler", "scala-reflect",
+          "scala3-library_3", "scala3-compiler_3", "scala3-interfaces",
+          "tasty-core_3"
+        ).map(n => (ScalaArtifacts.Organization, n))
+      } else Vector.empty
     val autoScala = autoScalaLib && scalaModInfo.forall(
       _.overrideScalaVersion
     )
@@ -127,7 +137,7 @@ object LMCoursier {
       .withInterProjectDependencies(interProjectDependencies.toVector)
       .withExtraProjects(extraProjects.toVector)
       .withFallbackDependencies(fallbackDeps.toVector)
-      .withExcludeDependencies(coursierExcludeDeps)
+      .withExcludeDependencies(coursierExcludeDeps ++ scalaOrgExclusions)
       .withAutoScalaLibrary(autoScala)
       .withSbtScalaJars(sbtBootJars.toVector)
       .withSbtScalaVersion(sbtScalaVersion)


### PR DESCRIPTION
## Summary
- Fixes #8821
- Automatically adds exclusion rules for `org.scala-lang` Scala artifacts when `scalaOrganization` is set to a non-default value
- Prevents duplicate Scala libraries on the classpath when using custom Scala forks

## Problem
When `scalaOrganization` is set to a custom value (e.g. `ch.epfl.lara` or `io.github.scala-wasm`), Coursier's resolver doesn't rewrite transitive `org.scala-lang` dependencies. Both the custom org's Scala library and the default `org.scala-lang` version appear on the classpath, causing conflicts like "package scala contains object and package with same name: caps."

## Changes
- `main/src/main/scala/sbt/coursierint/LMCoursier.scala`: When `scalaOrg != ScalaArtifacts.Organization`, automatically exclude `org.scala-lang` artifacts (`scala-library`, `scala-compiler`, `scala-reflect`, `scala3-library_3`, `scala3-compiler_3`, `scala3-interfaces`, `tasty-core_3`)

This replicates the behavior of the old Ivy backend's `OverrideScalaMediator` as an sbt-side workaround until Coursier adds native support for arbitrary `scalaOrganization` substitution (coursier/coursier#3562).

## Test plan
- [ ] Set `scalaOrganization := "ch.epfl.lara"` with a library dependency, verify no duplicate `org.scala-lang` jars on classpath
- [ ] Verify default `scalaOrganization` projects are unaffected