### PR TITLE
[2.x] feat: Eviction error for downgrade of Scala 3.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -826,6 +826,7 @@ lazy val serverTestProj = (project in file("server-test"))
   .dependsOn(sbtProj % "compile->test", scriptedSbtProj % "compile->test")
   .settings(
     testedBaseSettings,
+    allowUnsafeScalaLibUpgrade := true, // demote Scala 3 eviction to warn if deps bring newer scala3-library_3
     Utils.noPublish,
     // make server tests serial
     Test / watchTriggers += baseDirectory.value.toGlob / "src" / "server-test" / **,

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -215,6 +215,39 @@ object Compiler:
           if err then sys.error(msg)
           else s.log.warn(msg)
         else ()
+    else if ScalaArtifacts.isScala3(sv) then
+      val scala3LibOpt = for
+        compileReport <- fullReport.configuration(Configurations.Compile)
+        lib <- compileReport.modules.find(
+          _.module.name.startsWith(ScalaArtifacts.Scala3LibraryPrefix)
+        )
+      yield lib
+      for lib <- scala3LibOpt do
+        val libVer = lib.module.revision
+        val libName = lib.module.name
+        val proj =
+          Def.displayBuildRelative(Keys.thisProjectRef.value.build, Keys.thisProjectRef.value)
+        if VersionNumber(sv).matchesSemVer(SemanticSelector(s"<$libVer")) then
+          val err = !Keys.allowUnsafeScalaLibUpgrade.value
+          val fix =
+            if err then
+              """Upgrade the `scalaVersion` to fix the build. If upgrading the Scala compiler version is
+                |not possible (for example due to a regression in the compiler or a missing dependency),
+                |this error can be demoted by setting `allowUnsafeScalaLibUpgrade := true`.""".stripMargin
+            else s"""Note that the dependency classpath and the runtime classpath of your project
+                 |contain the newer $libName $libVer, even if the scalaVersion is $sv.
+                 |Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.""".stripMargin
+          val msg =
+            s"""Expected `$proj scalaVersion` to be $libVer or later, but found $sv.
+               |To maintain the compile-time alignment, the Scala compiler cannot be older than $libName on the dependency classpath.
+               |
+               |$fix
+               |
+               |See `$proj evicted` to know why $libName was upgraded from $sv to $libVer.
+               |""".stripMargin
+          if err then sys.error(msg)
+          else s.log.warn(msg)
+        else ()
     else ()
     def file(id: String): Option[File] =
       for

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -158,6 +158,34 @@ object Compiler:
     val fullReport = Keys.update.value
     val s = Keys.streams.value
 
+    def reportScalaLibEviction(
+        proj: String,
+        sv: String,
+        libVer: String,
+        libName: String,
+        err: Boolean,
+        alignmentLine: String,
+        evictedLine: String
+    ): Unit =
+      val fix =
+        if err then
+          """Upgrade the `scalaVersion` to fix the build. If upgrading the Scala compiler version is
+            |not possible (for example due to a regression in the compiler or a missing dependency),
+            |this error can be demoted by setting `allowUnsafeScalaLibUpgrade := true`.""".stripMargin
+        else s"""Note that the dependency classpath and the runtime classpath of your project
+             |contain the newer $libName $libVer, even if the scalaVersion is $sv.
+             |Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.""".stripMargin
+      val msg =
+        s"""Expected `$proj scalaVersion` to be $libVer or later, but found $sv.
+           |$alignmentLine
+           |
+           |$fix
+           |
+           |$evictedLine
+           |""".stripMargin
+      if err then sys.error(msg)
+      else s.log.warn(msg)
+
     // For Scala 3, update scala-library.jar in `scala-tool` and `scala-doc-tool` in case a newer version
     // is present in the `compile` configuration. This is needed once forwards binary compatibility is dropped
     // to avoid NoSuchMethod exceptions when expanding macros.
@@ -194,26 +222,16 @@ object Compiler:
         val proj =
           Def.displayBuildRelative(Keys.thisProjectRef.value.build, Keys.thisProjectRef.value)
         if VersionNumber(sv).matchesSemVer(SemanticSelector(s"<$libVer")) then
-          val err = !Keys.allowUnsafeScalaLibUpgrade.value
-          val fix =
-            if err then
-              """Upgrade the `scalaVersion` to fix the build. If upgrading the Scala compiler version is
-                |not possible (for example due to a regression in the compiler or a missing dependency),
-                |this error can be demoted by setting `allowUnsafeScalaLibUpgrade := true`.""".stripMargin
-            else s"""Note that the dependency classpath and the runtime classpath of your project
-                 |contain the newer $libName $libVer, even if the scalaVersion is $sv.
-                 |Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.""".stripMargin
-          val msg =
-            s"""Expected `$proj scalaVersion` to be $libVer or later, but found $sv.
-               |To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
-               |should not be older than $libName on the dependency classpath.
-               |
-               |$fix
-               |
-               |See `$proj evicted` to know why $libName $libVer is getting pulled in.
-               |""".stripMargin
-          if err then sys.error(msg)
-          else s.log.warn(msg)
+          reportScalaLibEviction(
+            proj,
+            sv,
+            libVer,
+            libName,
+            !Keys.allowUnsafeScalaLibUpgrade.value,
+            s"""To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
+              |should not be older than $libName on the dependency classpath.""".stripMargin,
+            s"See `$proj evicted` to know why $libName $libVer is getting pulled in."
+          )
         else ()
     else if ScalaArtifacts.isScala3(sv) then
       val scala3LibOpt = for
@@ -228,25 +246,15 @@ object Compiler:
         val proj =
           Def.displayBuildRelative(Keys.thisProjectRef.value.build, Keys.thisProjectRef.value)
         if VersionNumber(sv).matchesSemVer(SemanticSelector(s"<$libVer")) then
-          val err = !Keys.allowUnsafeScalaLibUpgrade.value
-          val fix =
-            if err then
-              """Upgrade the `scalaVersion` to fix the build. If upgrading the Scala compiler version is
-                |not possible (for example due to a regression in the compiler or a missing dependency),
-                |this error can be demoted by setting `allowUnsafeScalaLibUpgrade := true`.""".stripMargin
-            else s"""Note that the dependency classpath and the runtime classpath of your project
-                 |contain the newer $libName $libVer, even if the scalaVersion is $sv.
-                 |Compilation (macro expansion) or using the Scala REPL in sbt may fail with a LinkageError.""".stripMargin
-          val msg =
-            s"""Expected `$proj scalaVersion` to be $libVer or later, but found $sv.
-               |To maintain the compile-time alignment, the Scala compiler cannot be older than $libName on the dependency classpath.
-               |
-               |$fix
-               |
-               |See `$proj evicted` to know why $libName was upgraded from $sv to $libVer.
-               |""".stripMargin
-          if err then sys.error(msg)
-          else s.log.warn(msg)
+          reportScalaLibEviction(
+            proj,
+            sv,
+            libVer,
+            libName,
+            !Keys.allowUnsafeScalaLibUpgrade.value,
+            s"To maintain the compile-time alignment, the Scala compiler cannot be older than $libName on the dependency classpath.",
+            s"See `$proj evicted` to know why $libName was upgraded from $sv to $libVer."
+          )
         else ()
     else ()
     def file(id: String): Option[File] =

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/build.sbt
@@ -1,0 +1,12 @@
+// Regression test for #6694: Scala 3 eviction error when scalaVersion < scala3-library_3 on classpath.
+// low has scalaVersion 3.3.2 and depends on high (3.3.4), so resolved scala3-library_3 is 3.3.4.
+// Without allowUnsafeScalaLibUpgrade, compile must fail with the eviction error.
+
+lazy val high = project.settings(
+  scalaVersion := "3.3.4",
+)
+
+lazy val low = project.dependsOn(high).settings(
+  scalaVersion := "3.3.2",
+  // do NOT set allowUnsafeScalaLibUpgrade — we expect the build to fail
+)

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/high/H.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/high/H.scala
@@ -1,0 +1,1 @@
+object H { def id[A](a: A): A = a }

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/low/L.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/low/L.scala
@@ -1,0 +1,1 @@
+object L { def main(args: Array[String]): Unit = println(H.id(1)) }

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-eviction/test
@@ -1,0 +1,2 @@
+# Expect compile to fail: scalaVersion 3.3.2 < scala3-library_3 3.3.4 from high
+-> low/compile

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/build.sbt
@@ -1,0 +1,11 @@
+// Same as stdlib-unfreeze-scala3-eviction but with allowUnsafeScalaLibUpgrade := true on low.
+// low has scalaVersion 3.3.2 and depends on high (3.3.4); we demote the eviction to a warning so compile succeeds.
+
+lazy val high = project.settings(
+  scalaVersion := "3.3.4",
+)
+
+lazy val low = project.dependsOn(high).settings(
+  allowUnsafeScalaLibUpgrade := true,
+  scalaVersion := "3.3.2",
+)

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/high/H.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/high/H.scala
@@ -1,0 +1,1 @@
+object H { def id[A](a: A): A = a }

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/low/L.scala
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/low/L.scala
@@ -1,0 +1,1 @@
+object L { def main(args: Array[String]): Unit = println(H.id(1)) }

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/test
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze-scala3-warn/test
@@ -1,0 +1,3 @@
+# With allowUnsafeScalaLibUpgrade := true, compile and run succeed (eviction is a warning only)
+> low/compile
+> low/run

--- a/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/stdlib-unfreeze/build.sbt
@@ -16,6 +16,7 @@ lazy val a3 = project.settings(
 )
 
 lazy val b3 = project.dependsOn(a3).settings(
+  allowUnsafeScalaLibUpgrade := true, // b3 has 3.3.2, a3 brings 3.3.4; demote to warn so b3/run still passes
   scalaVersion := "3.3.2", // 2.13.12 library
   TaskKey[Unit]("checkScala") := {
     val i = scalaInstance.value

--- a/sbt-app/src/sbt-test/project/scala-dyn-version/build.sbt
+++ b/sbt-app/src/sbt-test/project/scala-dyn-version/build.sbt
@@ -1,4 +1,5 @@
 ThisBuild / scalaVersion := "3-latest.candidate"
+ThisBuild / allowUnsafeScalaLibUpgrade := true  // dynamic scalaVersion (3-latest.candidate) vs resolved scala3-library_3; demote to warn
 
 lazy val checkDynVersion = taskKey[Unit]("Check that scalaDynVersion resolves correctly")
 


### PR DESCRIPTION
Closes #6694

## Opting out of the eviction error

Similar to Scala 2.13, `allowUnsafeScalaLibUpgrade := true` can be used to opt out of the eviction error:

```scala
lazy val high = project.settings(
  scalaVersion := "3.3.4",
)

lazy val low = project.dependsOn(high).settings(
  allowUnsafeScalaLibUpgrade := true,
  scalaVersion := "3.3.2",
)
```

## Problem

When `scalaVersion` is set to a Scala 3.x version (e.g. 3.0.0) and a dependency brings a **newer** `scala3-library_3` (e.g. 3.1.0), sbt resolves and uses the older compiler with the newer standard library on the classpath. That violates compile-time alignment and can cause TASTy/bytecode errors (e.g. [scala/scala3#25406](https://github.com/scala/scala3/issues/25406)). There was no eviction error or warning for this downgrade scenario.

**Reproduction:** Set `ThisBuild / scalaVersion := "3.0.0"`, add a library that depends on Scala 3.1.0; run `compile`. Build succeeds without any warning even though the compiler is older than the library on the classpath.

## Root Cause

In `main/src/main/scala/sbt/internal/Compiler.scala`, `scalaInstanceConfigFromUpdate` only checks **Scala 2.13**: when `Classpaths.isScala213(sv)` it compares `scalaVersion` to the Scala library on the Compile report and fails or warns via `allowUnsafeScalaLibUpgrade`. There was no analogous branch for Scala 3, so the `scala3-library_*` version on the classpath was never compared to `scalaVersion`.

## Solution

1. **Scala 3 eviction check** — After the existing 2.13 block in `scalaInstanceConfigFromUpdate`, add an `else if ScalaArtifacts.isScala3(sv)` branch that:
   - Finds the `scala3-library_*` module (using `ScalaArtifacts.Scala3LibraryPrefix`) in the Compile configuration’s update report.
   - If `scalaVersion` is strictly less than that module’s revision, fail the build with a clear message (or warn if `allowUnsafeScalaLibUpgrade := true`), reusing the same pattern and setting as 2.13 (PR 7480 / SIP-51).
   - Message follows the maintainer’s spec: compile-time alignment, “See `$proj evicted` to know why $libName was upgraded from $sv to $libVer.”

2. **stdlib-unfreeze** — Add `allowUnsafeScalaLibUpgrade := true` to project **b3** so that after the new check, existing steps `b3/run` and `b3/checkScala` still pass (they now log a warning).

3. **Scripted tests** — Add two tests:
   - **stdlib-unfreeze-scala3-eviction**: Project `low` (3.3.2) depends on `high` (3.3.4); no `allowUnsafeScalaLibUpgrade`. Expect `-> low/compile` (build fails with the new error).
   - **stdlib-unfreeze-scala3-warn**: Same setup with `allowUnsafeScalaLibUpgrade := true` on `low`; expect `low/compile` and `low/run` to succeed (warning only).

No new setting; no change to resolution or to `updateLibraryToCompileConfiguration`. Scala 2.13 behavior is unchanged.

## Testing

- **Regression:** `scripted dependency-management/stdlib-unfreeze-scala3-eviction` — fails without the fix (no error), passes with the fix (`low/compile` fails with the eviction message).
- **Demotion:** `scripted dependency-management/stdlib-unfreeze-scala3-warn` — with `allowUnsafeScalaLibUpgrade := true`, `low/compile` and `low/run` succeed and the warning is logged.
- **Existing:** `scripted dependency-management/stdlib-unfreeze` — still passes (b3 has `allowUnsafeScalaLibUpgrade := true`).
- **Verify:** `./sbt "mainProj/compile"` and `./sbt "scripted dependency-management/stdlib-unfreeze dependency-management/stdlib-unfreeze-scala3-eviction dependency-management/stdlib-unfreeze-scala3-warn"` → PASS.

## Before / After

- **Before:** Project with `scalaVersion := "3.3.2"` and a dependency bringing `scala3-library_3` 3.3.4 compiles and runs with no warning; compiler is older than the library on the classpath.
- **After:** Same project fails at build time with: `Expected \`low / scalaVersion\` to be 3.3.4 or later, but found 3.3.2. To maintain the compile-time alignment... See \`low / evicted\` to know why scala3-library_3 was upgraded from 3.3.2 to 3.3.4.` With `allowUnsafeScalaLibUpgrade := true`, the build succeeds and the same text is logged as a warning.

## Edge Cases Handled

- No `scala3-library_*` on Compile classpath (e.g. Java-only): no check run.
- `allowUnsafeScalaLibUpgrade := true`: warn only, no `sys.error`.
- Multiple `scala3-library_*` modules: resolution produces one winner; we use the first match (single module in practice).
- Scala 3.0–3.7 vs 3.8+: only `scala3-library_*` is checked (not `scala-library` for 3.8+ in this branch).
- Backward compatibility: only adds failure/warning when a previously silent misalignment exists; no change when versions align or when not Scala 3.
- Project display name and message wording follow the maintainer’s spec and 2.13 style.
