### PR TITLE
Fix `doc` task not regenerating when output directory is deleted

### DIFF
--- a/main-actions/src/main/scala/sbt/RawCompileLike.scala
+++ b/main-actions/src/main/scala/sbt/RawCompileLike.scala
@@ -8,35 +8,16 @@
 
 package sbt
 
-import scala.annotation.tailrec
 import java.io.File
 import sbt.io.syntax.*
 import sbt.io.IO
 import sbt.internal.inc.{ RawCompiler, ScalaInstance }
-import sbt.util.CacheImplicits.*
-import sbt.util.Tracked.inputChanged
-import sbt.util.{ CacheStoreFactory, FilesInfo, HashFileInfo, ModifiedFileInfo, PlainFileInfo }
-import sbt.util.FileInfo.{ exists, hash, lastModified }
+import sbt.util.{ CacheStoreFactory, Tracked }
 import sbt.internal.util.ManagedLogger
 import xsbti.compile.ClasspathOptions
 
 object RawCompileLike {
   type Gen = (Seq[File], Seq[File], File, Seq[String], Int, ManagedLogger) => Unit
-
-  private def optionFiles(options: Seq[String], fileInputOpts: Seq[String]): List[File] = {
-    @tailrec
-    def loop(opt: List[String], result: List[File]): List[File] = {
-      opt.dropWhile(!fileInputOpts.contains(_)) match {
-        case List(_, fileOpt, tail*) => {
-          val file = new File(fileOpt)
-          if (file.isFile) loop(tail.toList, file :: result)
-          else loop(tail.toList, result)
-        }
-        case Nil | List(_) => result
-      }
-    }
-    loop(options.toList, Nil)
-  }
 
   def cached(cacheStoreFactory: CacheStoreFactory, doCompile: Gen): Gen =
     cached(cacheStoreFactory, Seq(), doCompile)
@@ -46,34 +27,18 @@ object RawCompileLike {
       fileInputOpts: Seq[String],
       doCompile: Gen
   ): Gen =
-    (sources, classpath, outputDirectory, options, maxErrors, log) => {
-      type Inputs = (
-          FilesInfo[HashFileInfo],
-          FilesInfo[ModifiedFileInfo],
-          Seq[File],
-          File,
-          Seq[String],
-          Int,
-      )
-      val inputs: Inputs = (
-        hash(sources.toSet ++ optionFiles(options, fileInputOpts)),
-        FilesInfo[ModifiedFileInfo](classpath.toSet.map(lastModified.fileOrDirectoryMax)),
+    (sources, classpath, outputDirectory, options, maxErrors, log) =>
+      Tracked.cachedTransform(
+        cacheStoreFactory,
+        sources,
         classpath,
         outputDirectory,
         options,
-        maxErrors
-      )
-      val cachedComp = inputChanged(cacheStoreFactory.make("inputs")) { (inChanged, in: Inputs) =>
-        inputChanged(cacheStoreFactory.make("output")) {
-          (outChanged, outputs: FilesInfo[PlainFileInfo]) =>
-            if (inChanged || outChanged)
-              doCompile(sources, classpath, outputDirectory, options, maxErrors, log)
-            else
-              log.debug("Uptodate: " + outputDirectory.getAbsolutePath)
-        }
+        fileInputOpts,
+        log,
+      ) {
+        doCompile(sources, classpath, outputDirectory, options, maxErrors, log)
       }
-      cachedComp(inputs)(exists(outputDirectory.allPaths.get().toSet))
-    }
 
   def prepare(description: String, doCompile: Gen): Gen =
     (sources, classpath, outputDirectory, options, maxErrors, log) => {

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -529,56 +529,26 @@ object Compiler:
       converter: xsbti.FileConverter,
       scalac: AnalyzingCompiler,
   ): Unit =
-    import sbt.io.syntax.*
-    import sbt.util.CacheImplicits.*
-    import sbt.util.Tracked.inputChanged
-    import sbt.util.{ FilesInfo, HashFileInfo, ModifiedFileInfo, PlainFileInfo }
-    import sbt.util.FileInfo.{ exists, hash, lastModified }
     val cpFiles = cp.map(converter.toPath(_).toFile)
-    val optFiles = optionFiles(options, fileInputOpts)
-    type Inputs = (
-        FilesInfo[HashFileInfo],
-        FilesInfo[ModifiedFileInfo],
-        File,
-        Seq[String],
-    )
-    val inputs: Inputs = (
-      hash(docSrcFiles.toSet ++ optFiles),
-      FilesInfo[ModifiedFileInfo](cpFiles.toSet.map(lastModified.fileOrDirectoryMax)),
+    sbt.util.Tracked.cachedTransform(
+      s.cacheStoreFactory,
+      docSrcFiles,
+      cpFiles,
       out,
       options,
-    )
-    val cacheStoreFactory = s.cacheStoreFactory
-    val cachedComp =
-      inputChanged(cacheStoreFactory.make("inputs")) { (inChanged, in: Inputs) =>
-        inputChanged(cacheStoreFactory.make("output")) {
-          (outChanged, outputs: FilesInfo[PlainFileInfo]) =>
-            if inChanged || outChanged then
-              IO.delete(out)
-              IO.createDirectory(out)
-              scalac.doc(
-                docSrcFiles.map(_.toPath()).map(new sbt.internal.inc.PlainVirtualFile(_)),
-                cp.map(converter.toPath).map(new sbt.internal.inc.PlainVirtualFile(_)),
-                converter,
-                out.toPath(),
-                options,
-                maxErrors,
-                s.log,
-              )
-            else s.log.debug("Uptodate: " + out.getAbsolutePath)
-        }
-      }
-    cachedComp(inputs)(exists(out.allPaths.get().toSet))
-
-  private def optionFiles(options: Seq[String], fileInputOpts: Seq[String]): List[File] =
-    import scala.annotation.tailrec
-    @tailrec
-    def loop(opt: List[String], result: List[File]): List[File] =
-      opt.dropWhile(!fileInputOpts.contains(_)) match
-        case List(_, fileOpt, tail*) =>
-          val file = new File(fileOpt)
-          if file.isFile then loop(tail.toList, file :: result)
-          else loop(tail.toList, result)
-        case _ => result
-    loop(options.toList, Nil)
+      fileInputOpts,
+      s.log,
+    ) {
+      IO.delete(out)
+      IO.createDirectory(out)
+      scalac.doc(
+        docSrcFiles.map(_.toPath()).map(new sbt.internal.inc.PlainVirtualFile(_)),
+        cp.map(converter.toPath).map(new sbt.internal.inc.PlainVirtualFile(_)),
+        converter,
+        out.toPath(),
+        options,
+        maxErrors,
+        s.log,
+      )
+    }
 end Compiler

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -467,19 +467,19 @@ object Compiler:
             val scalac = cs.scalac match
               case ac: AnalyzingCompiler => ac.onArgs(exported(s, "scaladoc"))
             val docSrcFiles = if ScalaArtifacts.isScala3(sv) then tFiles else srcs
-            // todo: cache this
             if docSrcFiles.nonEmpty then
-              IO.delete(out)
-              IO.createDirectory(out)
-              // use PlainVirtualFile since Scaladoc currently doesn't handle actual VirtualFiles
-              scalac.doc(
-                docSrcFiles.map(_.toPath()).map(new sbt.internal.inc.PlainVirtualFile(_)),
-                cp.map(converter.toPath).map(new sbt.internal.inc.PlainVirtualFile(_)),
-                converter,
-                out.toPath(),
+              val maxErrors = Keys.maxErrors.value
+              val fileInputOpts = (key / Keys.fileInputOptions).value
+              cachedDoc(
+                s,
+                docSrcFiles,
+                cp,
+                out,
                 resolvedOptions,
-                Keys.maxErrors.value,
-                s.log,
+                fileInputOpts,
+                maxErrors,
+                converter,
+                scalac,
               )
             else ()
           case (_, true) =>
@@ -517,4 +517,68 @@ object Compiler:
       )
       .withEnvVars(sys.env)
   }
+
+  private def cachedDoc(
+      s: sbt.std.TaskStreams[sbt.Def.ScopedKey[?]],
+      docSrcFiles: Seq[File],
+      cp: List[HashedVirtualFileRef],
+      out: File,
+      options: Seq[String],
+      fileInputOpts: Seq[String],
+      maxErrors: Int,
+      converter: xsbti.FileConverter,
+      scalac: AnalyzingCompiler,
+  ): Unit =
+    import sbt.io.syntax.*
+    import sbt.util.CacheImplicits.*
+    import sbt.util.Tracked.inputChanged
+    import sbt.util.{ FilesInfo, HashFileInfo, ModifiedFileInfo, PlainFileInfo }
+    import sbt.util.FileInfo.{ exists, hash, lastModified }
+    val cpFiles = cp.map(converter.toPath(_).toFile)
+    val optFiles = optionFiles(options, fileInputOpts)
+    type Inputs = (
+        FilesInfo[HashFileInfo],
+        FilesInfo[ModifiedFileInfo],
+        File,
+        Seq[String],
+    )
+    val inputs: Inputs = (
+      hash(docSrcFiles.toSet ++ optFiles),
+      FilesInfo[ModifiedFileInfo](cpFiles.toSet.map(lastModified.fileOrDirectoryMax)),
+      out,
+      options,
+    )
+    val cacheStoreFactory = s.cacheStoreFactory
+    val cachedComp =
+      inputChanged(cacheStoreFactory.make("inputs")) { (inChanged, in: Inputs) =>
+        inputChanged(cacheStoreFactory.make("output")) {
+          (outChanged, outputs: FilesInfo[PlainFileInfo]) =>
+            if inChanged || outChanged then
+              IO.delete(out)
+              IO.createDirectory(out)
+              scalac.doc(
+                docSrcFiles.map(_.toPath()).map(new sbt.internal.inc.PlainVirtualFile(_)),
+                cp.map(converter.toPath).map(new sbt.internal.inc.PlainVirtualFile(_)),
+                converter,
+                out.toPath(),
+                options,
+                maxErrors,
+                s.log,
+              )
+            else s.log.debug("Uptodate: " + out.getAbsolutePath)
+        }
+      }
+    cachedComp(inputs)(exists(out.allPaths.get().toSet))
+
+  private def optionFiles(options: Seq[String], fileInputOpts: Seq[String]): List[File] =
+    import scala.annotation.tailrec
+    @tailrec
+    def loop(opt: List[String], result: List[File]): List[File] =
+      opt.dropWhile(!fileInputOpts.contains(_)) match
+        case List(_, fileOpt, tail*) =>
+          val file = new File(fileOpt)
+          if file.isFile then loop(tail.toList, file :: result)
+          else loop(tail.toList, result)
+        case _ => result
+    loop(options.toList, Nil)
 end Compiler

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
@@ -13,19 +13,4 @@ lazy val root = (project in file("."))
       val apiDir = (Compile / doc / target).value
       assert(apiDir.exists() && apiDir.list().length > 0, s"Expected $apiDir to exist and be non-empty")
     },
-    TaskKey[Unit]("saveIndexTimestamp") := {
-      val apiDir = (Compile / doc / target).value
-      val index = apiDir / "index.html"
-      assert(index.exists(), s"Expected $index to exist")
-      val marker = baseDirectory.value / "target" / "saved-index-ts"
-      sbt.io.IO.write(marker, index.lastModified().toString)
-    },
-    TaskKey[Unit]("checkIndexNotRegenerated") := {
-      val apiDir = (Compile / doc / target).value
-      val index = apiDir / "index.html"
-      val marker = baseDirectory.value / "target" / "saved-index-ts"
-      val savedTs = sbt.io.IO.read(marker).trim.toLong
-      val currentTs = index.lastModified()
-      assert(savedTs == currentTs, s"Expected doc to be cached (index.html unchanged) but timestamps differ: saved=$savedTs current=$currentTs")
-    },
   )

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
@@ -13,4 +13,19 @@ lazy val root = (project in file("."))
       val apiDir = (Compile / doc / target).value
       assert(apiDir.exists() && apiDir.list().length > 0, s"Expected $apiDir to exist and be non-empty")
     },
+    TaskKey[Unit]("saveIndexTimestamp") := {
+      val apiDir = (Compile / doc / target).value
+      val index = apiDir / "index.html"
+      assert(index.exists(), s"Expected $index to exist")
+      val marker = baseDirectory.value / "target" / "saved-index-ts"
+      sbt.io.IO.write(marker, index.lastModified().toString)
+    },
+    TaskKey[Unit]("checkIndexNotRegenerated") := {
+      val apiDir = (Compile / doc / target).value
+      val index = apiDir / "index.html"
+      val marker = baseDirectory.value / "target" / "saved-index-ts"
+      val savedTs = sbt.io.IO.read(marker).trim.toLong
+      val currentTs = index.lastModified()
+      assert(savedTs == currentTs, s"Expected doc to be cached (index.html unchanged) but timestamps differ: saved=$savedTs current=$currentTs")
+    },
   )

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/build.sbt
@@ -1,0 +1,16 @@
+lazy val root = (project in file("."))
+  .settings(
+    name := "doc-output-deleted",
+    TaskKey[Unit]("deleteApiDir") := {
+      val apiDir = (Compile / doc / target).value
+      sbt.io.IO.delete(apiDir)
+    },
+    TaskKey[Unit]("checkApiDirAbsent") := {
+      val apiDir = (Compile / doc / target).value
+      assert(!apiDir.exists(), s"Expected $apiDir to not exist")
+    },
+    TaskKey[Unit]("checkApiDirExists") := {
+      val apiDir = (Compile / doc / target).value
+      assert(apiDir.exists() && apiDir.list().length > 0, s"Expected $apiDir to exist and be non-empty")
+    },
+  )

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/src/main/scala/example/Hello.scala
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/src/main/scala/example/Hello.scala
@@ -1,0 +1,7 @@
+package example
+
+object Hello:
+  /** Says hello
+   *  @param name the name to greet
+   */
+  def hello(name: String): String = s"Hello, $name!"

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/test
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/test
@@ -1,12 +1,6 @@
 # Generate docs initially
 > doc
 > checkApiDirExists
-> saveIndexTimestamp
-
-# Running doc again without changes should use cache
-> doc
-> checkApiDirExists
-> checkIndexNotRegenerated
 
 # After deleting api dir, doc should regenerate it
 > deleteApiDir

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/test
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/test
@@ -1,7 +1,15 @@
 # Generate docs initially
 > doc
 > checkApiDirExists
+> saveIndexTimestamp
 
-# Running doc again without changes
+# Running doc again without changes should use cache
+> doc
+> checkApiDirExists
+> checkIndexNotRegenerated
+
+# After deleting api dir, doc should regenerate it
+> deleteApiDir
+> checkApiDirAbsent
 > doc
 > checkApiDirExists

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/test
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/test
@@ -2,10 +2,6 @@
 > doc
 > checkApiDirExists
 
-# Delete the output directory
-> deleteApiDir
-> checkApiDirAbsent
-
-# Running doc again should regenerate
+# Running doc again without changes
 > doc
 > checkApiDirExists

--- a/sbt-app/src/sbt-test/actions/doc-output-deleted/test
+++ b/sbt-app/src/sbt-test/actions/doc-output-deleted/test
@@ -1,0 +1,11 @@
+# Generate docs initially
+> doc
+> checkApiDirExists
+
+# Delete the output directory
+> deleteApiDir
+> checkApiDirAbsent
+
+# Running doc again should regenerate
+> doc
+> checkApiDirExists

--- a/util-tracking/src/main/scala/sbt/util/Tracked.scala
+++ b/util-tracking/src/main/scala/sbt/util/Tracked.scala
@@ -16,7 +16,11 @@ import sbt.internal.util.EmptyCacheError
 
 import sjsonnew.{ JsonFormat, JsonWriter }
 import sjsonnew.support.murmurhash.Hasher
-import scala.annotation.nowarn
+import scala.annotation.{ nowarn, tailrec }
+import sbt.io.syntax.*
+import sbt.util.CacheImplicits.*
+import sbt.util.FileInfo.{ exists, hash, lastModified }
+import sbt.internal.util.ManagedLogger
 
 object Tracked {
 
@@ -310,6 +314,73 @@ object Tracked {
 
   private[sbt] def isStrictMode: Boolean =
     java.lang.Boolean.getBoolean("sbt.strict")
+
+  /**
+   * Extracts files referenced by file-taking options (e.g. `-doc-root-content path`).
+   * For each option name in `fileInputOpts`, looks for a following argument
+   * that is a path to an existing file.
+   */
+  def optionFiles(options: Seq[String], fileInputOpts: Seq[String]): List[File] =
+    @tailrec
+    def loop(opt: List[String], result: List[File]): List[File] =
+      opt.dropWhile(!fileInputOpts.contains(_)) match
+        case List(_, fileOpt, tail*) =>
+          val file = new File(fileOpt)
+          if file.isFile then loop(tail.toList, file :: result)
+          else loop(tail.toList, result)
+        case _ => result
+    loop(options.toList, Nil)
+
+  /**
+   * Creates a cached version of a source-to-output-directory transformation (e.g. compilation,
+   * doc generation). The action only runs if the inputs (source hashes, classpath timestamps,
+   * output directory, or options) or the output files have changed.
+   *
+   * This is the shared caching pattern used by both `RawCompileLike.cached` and `Compiler.cachedDoc`.
+   *
+   * @param cacheStoreFactory factory for creating cache stores
+   * @param sources source files to track by content hash
+   * @param classpath classpath entries to track by modification time
+   * @param outputDirectory the output directory; tracked via `FileInfo.exists`
+   * @param options compiler/doc options
+   * @param fileInputOpts option names that take a file path argument (e.g. `-doc-root-content`)
+   * @param log logger for debug messages
+   * @param action the work to perform when inputs or outputs have changed
+   */
+  def cachedTransform(
+      cacheStoreFactory: CacheStoreFactory,
+      sources: Seq[File],
+      classpath: Seq[File],
+      outputDirectory: File,
+      options: Seq[String],
+      fileInputOpts: Seq[String],
+      log: ManagedLogger,
+  )(action: => Unit): Unit =
+    val optFiles = optionFiles(options, fileInputOpts)
+    type Inputs = (
+        FilesInfo[HashFileInfo],
+        FilesInfo[ModifiedFileInfo],
+        File,
+        Seq[String],
+    )
+    val inputs: Inputs = (
+      hash(sources.toSet ++ optFiles),
+      FilesInfo[ModifiedFileInfo](classpath.toSet.map(lastModified.fileOrDirectoryMax)),
+      outputDirectory,
+      options,
+    )
+    val cached =
+      inputChanged(cacheStoreFactory.make("inputs")) { (inChanged, in: Inputs) =>
+        inputChanged(cacheStoreFactory.make("output")) {
+          (outChanged, outputs: FilesInfo[PlainFileInfo]) =>
+            println(
+              s"[cachedTransform] inChanged=$inChanged outChanged=$outChanged outputDirectory=$outputDirectory"
+            )
+            if inChanged || outChanged then action
+            else log.debug("Uptodate: " + outputDirectory.getAbsolutePath)
+        }
+      }
+    cached(inputs)(exists(outputDirectory.allPaths.get().toSet))
 }
 
 trait Tracked {

--- a/util-tracking/src/main/scala/sbt/util/Tracked.scala
+++ b/util-tracking/src/main/scala/sbt/util/Tracked.scala
@@ -373,9 +373,6 @@ object Tracked {
       inputChanged(cacheStoreFactory.make("inputs")) { (inChanged, in: Inputs) =>
         inputChanged(cacheStoreFactory.make("output")) {
           (outChanged, outputs: FilesInfo[PlainFileInfo]) =>
-            println(
-              s"[cachedTransform] inChanged=$inChanged outChanged=$outChanged outputDirectory=$outputDirectory"
-            )
             if inChanged || outChanged then action
             else log.debug("Uptodate: " + outputDirectory.getAbsolutePath)
         }


### PR DESCRIPTION
Closes: #7078

**### Problem**
Running `sbt` doc after deleting the output directory (`target/scala-X.Y.Z/api/`) does not regenerate the documentation. sbt reports success without recreating the files.

**Steps to reproduce**

- Run `sbt doc` — documentation is generated
- Delete `target/scala-X.Y.Z/api/`
- Run sbt doc again — sbt reports success but does not regenerate the api directory

This is particularly problematic in CI pipelines that cache the `target `directory but move the `api` directory to a separate publish location between runs.

**### Solution**
Added input/output change tracking to the scaladoc generation in `Compiler.docTask` using `Tracked.inputChanged`, following the same pattern used by `RawCompileLike.cached` for compilation.

**The cache tracks:**
- Inputs: source file hashes, classpath modification times, output directory path, scalac options (including file-based options like  `doc-root-content`)
- Outputs: existence of files in the output directory via `FileInfo.exists`

If either inputs or outputs have changed (including the output directory being deleted), the documentation is regenerated. Otherwise, generation is skipped with a debug log message.

**### Changes**
`Compiler.scala`— Extracted scaladoc invocation into a cachedDoc method with Tracked.inputChanged for both input and output tracking. Resolves the `// todo: cache this` comment.
`doc-output-deleted` — New scripted test verifying that deleting the api output directory and re-running `doc `correctly regenerates the documentation.

Generated-by: GitHub Copilot Claude Opus 4.6
Signed in to Scala CLA