### PR TITLE
[2.x] fix: Preserve user-specified scope axes in  command instead of silently discarding them

### DIFF
--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -55,12 +55,33 @@ private[sbt] object SettingCompletions {
     def resolve(s: Setting[?]): Seq[Setting[?]] =
       Load.transformSettings(projectScope, currentRef.build, rootProject, s :: Nil)
 
+    def thisToZero[T](axis: ScopeAxis[T]): ScopeAxis[T] =
+      axis match
+        case This => Zero
+        case a    => a
+
+    def axisMatches[T](user: ScopeAxis[T], existing: ScopeAxis[T]): Boolean =
+      user match
+        case Zero | This => true
+        case Select(_)   => user == existing
+
     def rescope[T](setting: Setting[T]): Seq[Setting[?]] = {
       val akey = setting.key.key
-      val global = ScopedKey(Global, akey)
+      val userScope = setting.key.scope
+      val baseScope = Scope(
+        Zero,
+        thisToZero(userScope.config),
+        thisToZero(userScope.task),
+        thisToZero(userScope.extra),
+      )
+      val global = ScopedKey(baseScope, akey)
       val globalSetting = resolve(Def.setting(global, setting.init, setting.pos))
       globalSetting ++ allDefs.flatMap { d =>
-        if d.key == akey then Seq((d.scope / SettingKey(akey)) := global.value)
+        if d.key == akey
+          && axisMatches(userScope.config, d.scope.config)
+          && axisMatches(userScope.task, d.scope.task)
+          && axisMatches(userScope.extra, d.scope.extra)
+        then Seq((d.scope / SettingKey(akey)) := global.value)
         else Nil
       }
     }

--- a/main/src/main/scala/sbt/internal/SettingCompletions.scala
+++ b/main/src/main/scala/sbt/internal/SettingCompletions.scala
@@ -55,11 +55,6 @@ private[sbt] object SettingCompletions {
     def resolve(s: Setting[?]): Seq[Setting[?]] =
       Load.transformSettings(projectScope, currentRef.build, rootProject, s :: Nil)
 
-    def thisToZero[T](axis: ScopeAxis[T]): ScopeAxis[T] =
-      axis match
-        case This => Zero
-        case a    => a
-
     def axisMatches[T](user: ScopeAxis[T], existing: ScopeAxis[T]): Boolean =
       user match
         case Zero | This => true
@@ -70,9 +65,9 @@ private[sbt] object SettingCompletions {
       val userScope = setting.key.scope
       val baseScope = Scope(
         Zero,
-        thisToZero(userScope.config),
-        thisToZero(userScope.task),
-        thisToZero(userScope.extra),
+        Scope.subThis(Zero, userScope.config),
+        Scope.subThis(Zero, userScope.task),
+        Scope.subThis(Zero, userScope.extra),
       )
       val global = ScopedKey(baseScope, akey)
       val globalSetting = resolve(Def.setting(global, setting.init, setting.pos))

--- a/sbt-app/src/sbt-test/tests/set-every-scoped/a/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/tests/set-every-scoped/a/src/main/scala/A.scala
@@ -1,0 +1,1 @@
+object A

--- a/sbt-app/src/sbt-test/tests/set-every-scoped/b/src/main/scala/B.scala
+++ b/sbt-app/src/sbt-test/tests/set-every-scoped/b/src/main/scala/B.scala
@@ -1,0 +1,1 @@
+object B

--- a/sbt-app/src/sbt-test/tests/set-every-scoped/build.sbt
+++ b/sbt-app/src/sbt-test/tests/set-every-scoped/build.sbt
@@ -1,0 +1,18 @@
+val a = project
+val b = project
+
+val checkCompileSourcesNonEmpty = taskKey[Unit]("Verify Compile / sources is still non-empty")
+
+checkCompileSourcesNonEmpty := {
+  val srcs = (Compile / sources).value
+  if (srcs.isEmpty)
+    sys.error("Compile / sources should not be empty, but it was.")
+}
+
+val checkTestSourcesEmpty = taskKey[Unit]("Verify Test / sources is empty")
+
+checkTestSourcesEmpty := {
+  val srcs = (Test / sources).value
+  if (srcs.nonEmpty)
+    sys.error(s"Test / sources should be empty, but had: ${srcs}")
+}

--- a/sbt-app/src/sbt-test/tests/set-every-scoped/test
+++ b/sbt-app/src/sbt-test/tests/set-every-scoped/test
@@ -1,0 +1,10 @@
+# set every with a scoped key should only affect that scope across all projects
+> set every Test / sources := Nil
+
+# Compile / sources should still be non-empty for all projects
+> a/checkCompileSourcesNonEmpty
+> b/checkCompileSourcesNonEmpty
+
+# Test / sources should be empty for all projects
+> a/checkTestSourcesEmpty
+> b/checkTestSourcesEmpty


### PR DESCRIPTION
### Problem

`set every` silently discards scope axes the user provides. Running:

```
set every Test / sources := Nil
```

empties `sources` in **all** scopes including `Compile`, not just `Test`. This happens because `rescope` in `SettingCompletions.setAll` strips the scope and forces `Global`.

Fixes #1124

### Solution

Changed `rescope` to keep the user's config/task/extra axes and only wildcard the project axis. When no scope is given, behavior is unchanged - all axes match everything as before.

### Test

- `scripted tests/set-every` (existing) - passed, backward compatible
- `scripted tests/set-every-scoped` (new) - runs `set every Test / sources := Nil` on a multi-project build, checks `Compile / sources` stays intact while `Test / sources` is emptied

Generated-by: Claude Opus 4.6