### PR TITLE
[2.x] fix: Skip Conflict when dependency relocations form a cycle

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
@@ -6,12 +6,13 @@ import coursier.{ Dependency, Resolution }
 
 import scala.annotation.tailrec
 
-/** Detects cyclic Maven / Gradle relocation chains that make
-  * `coursier.graph.DependencyTree` loop forever (see sbt#8917, coursier#3578).
-  *
-  * Mirrors one step of `coursier.graph.DependencyTree.Node.relocation` so we
-  * only skip `Conflict` when Coursier would spin on the same graph.
-  */
+/**
+ * Detects cyclic Maven / Gradle relocation chains that make
+ * `coursier.graph.DependencyTree` loop forever (see sbt#8917, coursier#3578).
+ *
+ * Mirrors one step of `coursier.graph.DependencyTree.Node.relocation` so we
+ * only skip `Conflict` when Coursier would spin on the same graph.
+ */
 private[internal] object RelocationCycleDetector {
 
   type Mvc = CoreResolution.ModuleVersionConstraint

--- a/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
@@ -13,68 +13,58 @@ import scala.annotation.tailrec
  * Mirrors one step of `coursier.graph.DependencyTree.Node.relocation` so we
  * only skip `Conflict` when Coursier would spin on the same graph.
  */
-private[internal] object RelocationCycleDetector {
+private[internal] object RelocationCycleDetector:
 
   type Mvc = CoreResolution.ModuleVersionConstraint
 
-  private def oneRelocationStep(resolution: Resolution, dep: Dependency): Option[Mvc] = {
-    val reconciledVersion =
-      resolution.reconciledVersions.get(dep.module) match {
-        case Some(v) => v
-        case None    => return None
-      }
-    val dep0 =
-      if (dep.versionConstraint == reconciledVersion) dep
-      else dep.withVersionConstraint(reconciledVersion)
-    val (_, proj) =
-      resolution.projectCache0.get(dep0.moduleVersionConstraint) match {
-        case Some(v) => v
-        case None    => return None
-      }
-    val mavenRelocatedOpt =
-      if (proj.relocated && proj.dependencies0.lengthCompare(1) == 0)
-        Some(proj.dependencies0.head._2)
-      else None
-    def gradleModuleRelocatedOpt =
-      dep0.variantSelector match {
-        case attr: VariantSelector.AttributesBased =>
-          if (proj.variants.isEmpty) None
-          else
-            proj.variantFor(attr) match {
-              case Left(_)        => None
-              case Right(variant) => proj.isRelocatedVariant(variant)
-            }
-        case _: VariantSelector.ConfigurationBased => None
-      }
-    mavenRelocatedOpt.orElse(gradleModuleRelocatedOpt) match {
-      case Some(relocatedTo) =>
-        val relocatedTo0 =
-          if (relocatedTo.variantSelector.isEmpty)
-            relocatedTo.withVariantSelector(dep0.variantSelector)
-          else relocatedTo
-        Some(relocatedTo0.moduleVersionConstraint)
-      case None => None
-    }
-  }
+  private def oneRelocationStep(resolution: Resolution, dep: Dependency): Option[Mvc] =
+    resolution.reconciledVersions
+      .get(dep.module)
+      .flatMap: recon =>
+        val dep0 =
+          if dep.versionConstraint == recon then dep
+          else dep.withVersionConstraint(recon)
+        resolution.projectCache0
+          .get(dep0.moduleVersionConstraint)
+          .flatMap:
+            case (_, proj) =>
+              val mavenRelocatedOpt =
+                if proj.relocated && proj.dependencies0.lengthCompare(1) == 0 then
+                  Some(proj.dependencies0.head._2)
+                else None
+              def gradleRelocated: Option[Dependency] =
+                dep0.variantSelector match
+                  case attr: VariantSelector.AttributesBased =>
+                    if proj.variants.isEmpty then None
+                    else
+                      proj.variantFor(attr) match
+                        case Left(_)        => None
+                        case Right(variant) => proj.isRelocatedVariant(variant)
+                  case _: VariantSelector.ConfigurationBased => None
+              mavenRelocatedOpt
+                .orElse(gradleRelocated)
+                .map: relocatedTo =>
+                  val relocatedTo0 =
+                    if relocatedTo.variantSelector.isEmpty then
+                      relocatedTo.withVariantSelector(dep0.variantSelector)
+                    else relocatedTo
+                  relocatedTo0.moduleVersionConstraint
 
   /** When true, `coursier.graph.Conflict(resolution)` can run indefinitely. */
-  def hasRelocationCycle(resolution: Resolution): Boolean = {
-    if (!resolution.isDone || resolution.conflicts.nonEmpty || resolution.errors0.nonEmpty)
-      return false
-    val keys = resolution.projectCache0.keySet
-    keys.exists { start =>
-      @tailrec
-      def walk(visited: Set[Mvc], cur: Option[Mvc]): Boolean =
-        cur match {
-          case None => false
-          case Some(mvc) =>
-            if (visited.contains(mvc)) true
-            else {
-              val dep = Dependency(module = mvc._1, version = mvc._2)
-              walk(visited + mvc, oneRelocationStep(resolution, dep))
-            }
-        }
-      walk(Set.empty, Some(start))
+  def hasRelocationCycle(resolution: Resolution): Boolean =
+    resolution.isDone && resolution.conflicts.isEmpty && resolution.errors0.isEmpty && {
+      val keys = resolution.projectCache0.keySet
+      keys.exists: start =>
+        @tailrec
+        def walk(visited: Set[Mvc], cur: Option[Mvc]): Boolean =
+          cur match
+            case None => false
+            case Some(mvc) =>
+              if visited.contains(mvc) then true
+              else
+                val dep = Dependency(module = mvc._1, version = mvc._2)
+                walk(visited + mvc, oneRelocationStep(resolution, dep))
+        walk(Set.empty, Some(start))
     }
-  }
-}
+
+end RelocationCycleDetector

--- a/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/RelocationCycleDetector.scala
@@ -1,0 +1,79 @@
+package lmcoursier.internal
+
+import coursier.core.*
+import coursier.core.Resolution as CoreResolution
+import coursier.{ Dependency, Resolution }
+
+import scala.annotation.tailrec
+
+/** Detects cyclic Maven / Gradle relocation chains that make
+  * `coursier.graph.DependencyTree` loop forever (see sbt#8917, coursier#3578).
+  *
+  * Mirrors one step of `coursier.graph.DependencyTree.Node.relocation` so we
+  * only skip `Conflict` when Coursier would spin on the same graph.
+  */
+private[internal] object RelocationCycleDetector {
+
+  type Mvc = CoreResolution.ModuleVersionConstraint
+
+  private def oneRelocationStep(resolution: Resolution, dep: Dependency): Option[Mvc] = {
+    val reconciledVersion =
+      resolution.reconciledVersions.get(dep.module) match {
+        case Some(v) => v
+        case None    => return None
+      }
+    val dep0 =
+      if (dep.versionConstraint == reconciledVersion) dep
+      else dep.withVersionConstraint(reconciledVersion)
+    val (_, proj) =
+      resolution.projectCache0.get(dep0.moduleVersionConstraint) match {
+        case Some(v) => v
+        case None    => return None
+      }
+    val mavenRelocatedOpt =
+      if (proj.relocated && proj.dependencies0.lengthCompare(1) == 0)
+        Some(proj.dependencies0.head._2)
+      else None
+    def gradleModuleRelocatedOpt =
+      dep0.variantSelector match {
+        case attr: VariantSelector.AttributesBased =>
+          if (proj.variants.isEmpty) None
+          else
+            proj.variantFor(attr) match {
+              case Left(_)        => None
+              case Right(variant) => proj.isRelocatedVariant(variant)
+            }
+        case _: VariantSelector.ConfigurationBased => None
+      }
+    mavenRelocatedOpt.orElse(gradleModuleRelocatedOpt) match {
+      case Some(relocatedTo) =>
+        val relocatedTo0 =
+          if (relocatedTo.variantSelector.isEmpty)
+            relocatedTo.withVariantSelector(dep0.variantSelector)
+          else relocatedTo
+        Some(relocatedTo0.moduleVersionConstraint)
+      case None => None
+    }
+  }
+
+  /** When true, `coursier.graph.Conflict(resolution)` can run indefinitely. */
+  def hasRelocationCycle(resolution: Resolution): Boolean = {
+    if (!resolution.isDone || resolution.conflicts.nonEmpty || resolution.errors0.nonEmpty)
+      return false
+    val keys = resolution.projectCache0.keySet
+    keys.exists { start =>
+      @tailrec
+      def walk(visited: Set[Mvc], cur: Option[Mvc]): Boolean =
+        cur match {
+          case None => false
+          case Some(mvc) =>
+            if (visited.contains(mvc)) true
+            else {
+              val dep = Dependency(module = mvc._1, version = mvc._2)
+              walk(visited + mvc, oneRelocationStep(resolution, dep))
+            }
+        }
+      walk(Set.empty, Some(start))
+    }
+  }
+}

--- a/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
@@ -361,6 +361,22 @@ private[internal] object SbtUpdateReport {
       classLoaders: Seq[ClassLoader],
   ): UpdateReport = {
 
+    val skipConflictDetail: Map[Configuration, Boolean] =
+      resolutions.map { case (cfg, subRes) =>
+        cfg -> RelocationCycleDetector.hasRelocationCycle(subRes)
+      }.toMap
+    val configsWithRelocationCycle =
+      skipConflictDetail.collect { case (cfg, true) => cfg.value }.toSeq.sorted
+    if (configsWithRelocationCycle.nonEmpty) {
+      log.warn(
+        "Skipping dependency conflict detail for configuration(s) " +
+          configsWithRelocationCycle.mkString(", ") +
+          ": cyclic Maven or Gradle relocations in the resolved graph. " +
+          "Resolution succeeded; eviction detail may be incomplete. " +
+          "See https://github.com/sbt/sbt/issues/8917"
+      )
+    }
+
     val configReports = resolutions.map { (config, subRes) =>
       val reports = moduleReports(
         thisModule,
@@ -396,7 +412,9 @@ private[internal] object SbtUpdateReport {
       }
 
       def conflicts: Seq[coursier.graph.Conflict] =
-        try coursier.graph.Conflict(subRes)
+        try
+          if (skipConflictDetail.getOrElse(config, false)) Nil
+          else coursier.graph.Conflict(subRes)
         catch case e: Throwable if missingOk => Nil
       val evicted = for {
         c <- conflicts

--- a/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
@@ -296,6 +296,19 @@ final class ResolutionSpec extends AnyPropSpec with Matchers {
     assert(resolution.isRight)
   }
 
+  property("resolve sbt-site 1.4.1 (sbt #8917)") {
+    val pluginAttributes = Map("scalaVersion" -> "2.12", "sbtVersion" -> "1.0")
+    val dependencies =
+      Vector(("com.typesafe.sbt" % "sbt-site" % "1.4.1").withExtraAttributes(pluginAttributes))
+    val coursierModule = module(lmEngine, stubModule, dependencies, Some("2.12.4"))
+    val resolution =
+      lmEngine.update(coursierModule, UpdateConfiguration(), UnresolvedWarningConfiguration(), log)
+    assert(resolution.isRight)
+    val compileConfig =
+      resolution.toOption.get.configurations.find(_.configuration == Compile.toConfigRef).get
+    compileConfig.modules.map(_.module.name) should not be empty
+  }
+
   property("resolve licenses from parent poms") {
     val dependencies =
       Vector(("org.apache.commons" % "commons-compress" % "1.26.2"))

--- a/lm-coursier/src/test/scala/lmcoursier/internal/RelocationCycleDetectorSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/internal/RelocationCycleDetectorSpec.scala
@@ -1,0 +1,10 @@
+package lmcoursier.internal
+
+import coursier.Resolution
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class RelocationCycleDetectorSpec extends AnyFunSuite with Matchers:
+
+  test("incomplete resolution is not treated as having a relocation cycle"):
+    RelocationCycleDetector.hasRelocationCycle(Resolution()) shouldBe false


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8924

## Problem

sbt 1.12.6+ (and sbt 2.x with Coursier 2.1.25-M24) hangs indefinitely on `update` for projects using `addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")`. The JVM stays in a tight loop; Ctrl+C often does not stop it (see [#8917](https://github.com/sbt/sbt/issues/8917)).

## Root Cause

After resolution succeeds, `SbtUpdateReport` calls `coursier.graph.Conflict(resolution)`, which builds `DependencyTree` nodes. Each node’s `relocation` helper follows Maven/Gradle relocation metadata with tail recursion but **no cycle detection**. For sbt-site’s graph, relocation chains revisit the same coordinates, so `relocation` never terminates ([coursier#3578](https://github.com/coursier/coursier/issues/3578)).

## Solution

Add `RelocationCycleDetector`, which performs **the same single relocation step** as Coursier’s `DependencyTree.Node.relocation` and walks the implied graph. If any relocation chain would revisit a node, we **skip** `coursier.graph.Conflict` for affected configurations (resolution and artifacts are unchanged). One warning per update lists affected configuration names.

Alternatives considered: (1) bump Coursier to an unreleased fixed version — not available on Maven Central; (2) timeout around `Conflict` — nondeterministic and hides real errors; (3) vendor patched `DependencyTree` — would not affect `Conflict` in the coursier JAR (same-artifact linkage).

## Testing

- `RelocationCycleDetectorSpec`: incomplete resolution is not flagged as cyclic.
- `ResolutionSpec` property **resolve sbt-site 1.4.1 (sbt #8917)**: same resolution path as the reported bug; completes in bounded time with a non-empty classpath.

Verify:

```bash
./sbt "lmCoursier/testOnly lmcoursier.ResolutionSpec -- -z \"sbt-site\""
./sbt lmCoursier/test
```

## Before / After

- **Before**: `update` on sbt-site never finishes (infinite relocation expansion inside `Conflict`).
- **After**: Update completes; classpath is correct; users may see one warning and slightly less eviction detail for configs with cyclic relocations.

## Edge Cases Handled

- **Gradle + Maven relocation**: same branches as Coursier’s `relocation`.
- **Only when resolution is done and clean**: same guard as Coursier before applying relocations in `DependencyTree`.
- **Per-configuration**: only configs whose graph contains a relocation cycle skip conflict extraction.
- **`missingOk`**: existing `try`/`catch` unchanged.
