### PR TITLE
[2.x] Bump `sbt-launch` to 1.6.1 for programmatic launcher exit handling

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 
-  val launcherVersion = "1.6.0"
+  val launcherVersion = "1.6.1"
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % launcherVersion
   val rawLauncher = "org.scala-sbt" % "launcher" % launcherVersion
   val testInterface = "org.scala-sbt" % "test-interface" % "1.0"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/7540

### Summary
This PR upgrades the launcher dependency to `sbt-launch` **1.6.1**, incorporating a launcher-side fix related to [issue #7540](https://github.com/sbt/sbt/issues/7540) (programmatic usage without terminating the host JVM).  

This change is scoped strictly to **version alignment**—there are no additional behavior changes in the sbt core.

### Test
-  Run the launcher test suite.
- Confirm `sbt-launch` resolves to **1.6.1** in the dependency graph.
- Test passed: 
./sbt "reload; update; launcherPackage/test"
./sbt test- 
