### PR TITLE
[2.x] fix: Fixes scripted test loading build definition twice

### DIFF
--- a/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -238,19 +238,21 @@ final class ScriptedTests(
         IO.copyDirectory(originalDir, tempTestDir)
 
         val runTest = () => {
-          // Reload and initialize (to reload contents of .sbtrc files)
           def sbtHandlerError = sys error "Missing sbt handler. Scripted is misconfigured."
           val sbtHandler = handlers.getOrElse('>', sbtHandlerError)
-          val statement = Statement("reload;initialize", Nil, successExpected = true, line = -1)
 
-          // Run reload inside the hook to reuse error handling for pending tests
           val wrapHook = (file: File) => {
             preHook(file)
-            try runner.processStatement(sbtHandler, statement, states)
-            catch {
-              case t: Throwable =>
-                val newMsg = "Reload for scripted batch execution failed."
-                throw new TestException(statement, newMsg, t)
+            // Reload only when a previous sbt instance exists; a new instance already loads the project on boot
+            if (states(sbtHandler) != None) {
+              val statement =
+                Statement("reload;initialize", Nil, successExpected = true, line = -1)
+              try runner.processStatement(sbtHandler, statement, states)
+              catch {
+                case t: Throwable =>
+                  val newMsg = "Reload for scripted batch execution failed."
+                  throw new TestException(statement, newMsg, t)
+              }
             }
           }
 


### PR DESCRIPTION
### Summary:

Scripted tests in batch mode load the build definition twice on the first test. This is because the sbt instance runs `LoadProject` during boot, then the scripted framework sends `reload;initialize` right after - which loads the project again unnecessarily.

The reload is only needed for subsequent tests in the batch, where new test files have been copied into the temp directory and the existing sbt instance needs to pick them up. For the first test, the instance is brand new and already has the correct files.

This fix checks whether an sbt instance already exists before sending `reload;initialize`. If no instance exists yet, we skip the reload and let the boot sequence handle it.

### Change:

One file: `scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala`

Wrapped the `reload;initialize` call with a check on the handler state:

```scala
if (states(sbtHandler) != None) {
  // send reload;initialize
}
```

### Before and after:

**Before** - first test in batch loads twice:
```
[info] welcome to sbt ...
[info] loading project definition ...
[info] *** Loading test1 ***
[info] welcome to sbt ...              ← redundant second load
[info] loading project definition ...
```

**After** - first test loads once:
```
[info] welcome to sbt ...
[info] loading project definition ...
[info] *** Loading test1 ***
[info] + scripted/test1
```

### Testing:

- Compiled `scriptedSbtProj/compile` - passes
- Unit tests `scriptedSbtProj/test` - passes
- Ran single and batched scripted tests (`actions/add-alias`, `actions/cross`, `project/append`) - all pass

Closes: #6033
