### PR TITLE
Replace defunct link

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/EditDistance.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/EditDistance.scala
@@ -15,8 +15,9 @@ import java.lang.Character.{ toLowerCase as lower }
 object EditDistance {
 
   /**
-   * Translated from the java version at http://www.merriampark.com/ld.htm which is declared to be
-   * public domain.
+   * Translated from the java version at
+   * https://web.archive.org/web/20120526085419/http://www.merriampark.com/ld.htm which is declared to be public
+   * domain.
    */
   def levenshtein(
       s: String,


### PR DESCRIPTION
Link is defunct for a number of years already. Replaced with a link from the Internet Archive.