### PR TITLE
[2.x] fix: Fix misleading error when .evaluated used outside macro context

### DIFF
--- a/main-settings/src/main/scala/sbt/std/InputWrapper.scala
+++ b/main-settings/src/main/scala/sbt/std/InputWrapper.scala
@@ -59,7 +59,7 @@ object InputWrapper:
   def `wrapInputTask_\u2603\u2603`[T](@deprecated("unused", "") in: Any): T = implDetailError
 
   @compileTimeOnly(
-    "`value` can only be called on an input task within a task definition macro, such as := or Def.inputTask."
+    "`evaluated` can only be called on an input task within a task definition macro, such as := or Def.inputTask. To use an input task from a regular task, use `.toTask(\" <args>\").value` instead."
   )
   def `wrapInitInputTask_\u2603\u2603`[T](@deprecated("unused", "") in: Any): T = implDetailError
 


### PR DESCRIPTION
## Summary

Fixes #1144

- The `@compileTimeOnly` message on `wrapInitInputTask` said `` `value` can only be called on an input task... `` when the user called `.evaluated`, not `.value`
- Changed to say `` `evaluated` `` and suggest `.toTask(" <args>").value` as an alternative

Before:
```
error: `value` can only be called on an input task within a task definition macro, such as := or Def.inputTask.
  val ignored = org.scalastyle.sbt.PluginKeys.scalastyle.evaluated
```

After:
```
error: `evaluated` can only be called on an input task within a task definition macro, such as := or Def.inputTask. To use an input task from a regular task, use `.toTask(" <args>").value` instead.
  val ignored = org.scalastyle.sbt.PluginKeys.scalastyle.evaluated
```

## Test plan

- [x] `mainSettingsProj/compile` succeeds
- This is a string literal in a `@compileTimeOnly` annotation — the compiler enforces the constraint, the message just needs to be accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)