### PR TITLE
Don't inherit javacOptions in doc task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ ThisBuild / organization := "org.scala-sbt"
 ThisBuild / description := "sbt is an interactive build tool"
 ThisBuild / licenses := List("Apache-2.0" -> url("https://github.com/sbt/sbt/blob/develop/LICENSE"))
 ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
-ThisBuild / Compile / doc / javacOptions := Nil
 ThisBuild / developers := List(
   Developer("harrah", "Mark Harrah", "@harrah", url("https://github.com/harrah")),
   Developer("eed3si9n", "Eugene Yokota", "@eed3si9n", url("https://github.com/eed3si9n")),
@@ -232,7 +231,6 @@ lazy val bundledLauncherProj =
       description := "sbt application launcher",
       autoScalaLibrary := false,
       crossPaths := false,
-      Compile / doc / javacOptions := Nil,
       Compile / packageBin := sbtLaunchJar.value,
       mimaSettings,
       mimaPreviousArtifacts := Set()
@@ -284,7 +282,6 @@ lazy val utilInterface = (project in file("internal") / "util-interface").settin
   Utils.javaOnlySettings,
   crossPaths := false,
   autoScalaLibrary := false,
-  Compile / doc / javacOptions := Nil,
   name := "Util Interface",
   exportJars := true,
   mimaSettings,
@@ -446,7 +443,6 @@ lazy val workerProj = (project in file("worker"))
   .settings(
     name := "worker",
     testedBaseSettings,
-    Compile / doc / javacOptions := Nil,
     crossPaths := false,
     autoScalaLibrary := false,
     libraryDependencies ++= Seq(gson, testInterface),

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2065,6 +2065,7 @@ object Defaults extends BuildCommon with DefExtra {
           if autoAPIMappings.value then APIMappings.extract(dependencyCp, log).toMap
           else Map.empty[HashedVirtualFileRef, URI]
         },
+        javacOptions := Nil,
         fileInputOptions := Seq("-doc-root-content", "-diagrams-dot-path"),
         scalacOptions ++= {
           val sv = scalaVersion.value


### PR DESCRIPTION
## Summary

Fixes #1785

The `doc` task inherited `javacOptions` from compile scope, so compile-only flags like `-g` were passed to `javadoc`, which rejects them. sbt's own `build.sbt` worked around this in 4 places:

```scala
Compile / doc / javacOptions := Nil
```

Set `javacOptions := Nil` inside `docTaskSettings` so the doc task starts with empty javac options by default. Removed the 4 workarounds from sbt's own build.

Users who need javadoc-specific flags can still use `doc / javacOptions += ...`.

## Test plan

- [x] `mainProj/compile` succeeds
- Removing the 4 workarounds from `build.sbt` is itself the test — if the default didn't work, sbt's own `doc` task would break

🤖 Generated with [Claude Code](https://claude.com/claude-code)