### PR TITLE
[2.x] fix:use sbt.AppendSupplier instead of sbt.internal.AppenderSupplier

### DIFF
--- a/main/src/main/scala/sbt/Appenders.scala
+++ b/main/src/main/scala/sbt/Appenders.scala
@@ -1,0 +1,21 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import sbt.internal.util.{ Appender, ConsoleAppender as InternalConsoleAppender, ConsoleOut }
+import java.io.{ PrintStream, PrintWriter }
+
+object Appenders {
+  def consoleAppender(): Appender = InternalConsoleAppender()
+  def consoleAppender(out: PrintStream): Appender = InternalConsoleAppender(out)
+  def consoleAppender(out: PrintWriter): Appender = InternalConsoleAppender(out)
+  def consoleAppender(name: String): Appender = InternalConsoleAppender(name)
+  def consoleAppender(name: String, out: ConsoleOut): Appender = InternalConsoleAppender(name, out)
+  def consoleAppender(name: String, out: PrintWriter): Appender = InternalConsoleAppender(name, ConsoleOut.printWriterOut(out))
+}

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -58,7 +58,7 @@ object Keys {
   val showTiming = settingKey[Boolean]("If true, the command success message includes the completion time.").withRank(CSetting)
   val timingFormat = settingKey[java.text.DateFormat]("The format used for displaying the completion time.").withRank(CSetting)
   @transient
-  val extraAppenders = settingKey[AppenderSupplier]("A function that provides additional loggers for a given setting.").withRank(DSetting)
+  val extraAppenders = settingKey[AppenderSupplier]("A function that provides additional appenders for custom logging. See sbt.AppenderSupplier for usage examples.").withRank(DSetting)
   @deprecated("will be removed", "2.0.0")
   val useLog4J = settingKey[Boolean]("Toggles whether or not to use log4j for sbt internal loggers.").withRank(Invisible)
   val logManager = settingKey[LogManager]("The log manager, which creates Loggers for different contexts.").withRank(DSetting)
@@ -757,6 +757,7 @@ object Keys {
 
   type Streams = std.Streams[ScopedKey[?]]
   type TaskStreams = std.TaskStreams[ScopedKey[?]]
+  type AppenderSupplier = sbt.internal.AppenderSupplier
 }
 
 // format: on

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -758,6 +758,7 @@ object Keys {
   type Streams = std.Streams[ScopedKey[?]]
   type TaskStreams = std.TaskStreams[ScopedKey[?]]
   type AppenderSupplier = sbt.internal.AppenderSupplier
+  type Appender = sbt.internal.util.Appender
 }
 
 // format: on

--- a/sbt-app/src/sbt-test/actions/custom-appender/build.sbt
+++ b/sbt-app/src/sbt-test/actions/custom-appender/build.sbt
@@ -1,0 +1,51 @@
+// Test for issue #7152 - custom appenders using public API
+
+import sbt._
+import sbt.Keys._
+import java.io.{ File, PrintWriter }
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.12",
+    
+    // Test that we can use extraAppenders with public API only
+    extraAppenders := {
+      new AppenderSupplier {
+        def apply(key: ScopedKey[_]): Seq[Appender] = {
+          // Create custom appender that writes to a file for verification
+          val outputFile = new File("target/appender-output.txt")
+          outputFile.getParentFile.mkdirs()
+          val fileWriter = new PrintWriter(outputFile)
+          
+          val customAppender = Appenders.consoleAppender(
+            s"test-${key.key.label}",
+            new PrintWriter(System.out) {
+              override def println(msg: String): Unit = {
+                val prefixed = s"[CUSTOM:${key.key.label}] $msg"
+                super.println(prefixed)
+                fileWriter.println(prefixed)
+                fileWriter.flush()
+              }
+            }
+          )
+          Seq(customAppender)
+        }
+      }
+    },
+    
+    TaskKey[Unit]("checkLogging") := {
+      streams.value.log.info("Test message from checkLogging task")
+    },
+    
+    TaskKey[Unit]("verifyPublicAPI") := {
+      // Verify we can create appenders using only public API
+      val appender1 = Appenders.consoleAppender()
+      val appender2 = Appenders.consoleAppender("test-appender")
+      val appender3 = Appenders.consoleAppender(new PrintWriter(System.out))
+      streams.value.log.info("Successfully created appenders using public API")
+    },
+    
+    TaskKey[Unit]("verifyMultipleTasks") := {
+      streams.value.log.info("Message from verifyMultipleTasks")
+    }
+  )

--- a/sbt-app/src/sbt-test/actions/custom-appender/test
+++ b/sbt-app/src/sbt-test/actions/custom-appender/test
@@ -1,0 +1,13 @@
+# Test that custom appenders work with public API
+
+# Test 1: Basic logging with custom appender
+> checkLogging
+
+# Test 2: Verify public API can create appenders without internal imports
+> verifyPublicAPI
+
+# Test 3: Verify custom appender works with multiple tasks
+> verifyMultipleTasks
+
+# Test 4: Verify output file was created by custom appender
+$ exists target/appender-output.txt


### PR DESCRIPTION
Closes: #7152 
Providing a stable public API without requiring internal package access.