### PR TITLE
[2.x] fix: Fixes libraryDependencySchemes on cross-platform dependencies

### DIFF
--- a/lm-core/src/main/scala/sbt/librarymanagement/EvictionError.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/EvictionError.scala
@@ -89,18 +89,18 @@ object EvictionError {
       VersionSchemes.validateScheme(s.revision)
       val versionScheme = s.revision
       (s.crossVersion, sbvOpt) match {
-        case (_: Binary, Some("2.13")) =>
+        case (b: Binary, Some("2.13")) =>
           List(
-            (s.organization, s"${s.name}_2.13") -> versionScheme,
-            (s.organization, s"${s.name}_3") -> versionScheme
+            (s.organization, s"${s.name}${b.suffix}_2.13") -> versionScheme,
+            (s.organization, s"${s.name}${b.suffix}_3") -> versionScheme
           )
-        case (_: Binary, Some(sbv)) if sbv.startsWith("3.0") || sbv == "3" =>
+        case (b: Binary, Some(sbv)) if sbv.startsWith("3.0") || sbv == "3" =>
           List(
-            (s.organization, s"${s.name}_$sbv") -> versionScheme,
-            (s.organization, s"${s.name}_2.13") -> versionScheme
+            (s.organization, s"${s.name}${b.suffix}_$sbv") -> versionScheme,
+            (s.organization, s"${s.name}${b.suffix}_2.13") -> versionScheme
           )
-        case (_: Binary, Some(sbv)) =>
-          List((s.organization, s"${s.name}_$sbv") -> versionScheme)
+        case (b: Binary, Some(sbv)) =>
+          List((s.organization, s"${s.name}${b.suffix}_$sbv") -> versionScheme)
         case _ =>
           List((s.organization, s.name) -> versionScheme)
       }

--- a/lm-ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
+++ b/lm-ivy/src/test/scala/sbt/internal/librarymanagement/EvictionErrorSpec.scala
@@ -115,6 +115,34 @@ object EvictionErrorSpec extends BaseIvySpecification {
     )
   }
 
+  test("it should handle cross-platform dependencies with %%% operator") {
+    // Test that the userDefinedSchemes map correctly includes platform suffixes
+    // when using Binary CrossVersion with a suffix (as created by %%% operator)
+    val scalaVersion = "2.12.19"
+    val schemes = List(
+      ModuleID("com.lihaoyi", "geny", "always")
+        .cross(CrossVersion.binaryWith("", "_sjs1"))
+    )
+    val scalaModuleInfo = dummyScalaModuleInfo(scalaVersion)
+
+    // Simulate what happens in EvictionError.processEvictions
+    val sbvOpt = Some(scalaModuleInfo.scalaBinaryVersion)
+    val userDefinedSchemes: Map[(String, String), String] = Map(schemes flatMap { s =>
+      val organization = s.organization
+      val versionScheme = s.revision
+      (s.crossVersion, sbvOpt) match {
+        case (b: Binary, Some(sbv)) =>
+          List((s.organization, s"${s.name}${b.suffix}_$sbv") -> versionScheme)
+        case _ =>
+          List((s.organization, s.name) -> versionScheme)
+      }
+    }*)
+
+    // The key should include the platform suffix "_sjs1" before the Scala version
+    assert(userDefinedSchemes.contains(("com.lihaoyi", "geny_sjs1_2.12")))
+    assert(userDefinedSchemes(("com.lihaoyi", "geny_sjs1_2.12")) == "always")
+  }
+
   // older Akka was on pvp
   def oldAkkaPvp = List("com.typesafe.akka" % "*" % "pvp")
 


### PR DESCRIPTION
Closes: #7140 

## Problem
`libraryDependencySchemes` didn't work for platforms like `Scala.JS`

## Solution
Modified `EvictionError.scala` to extract the suffix.
Changed from `_: Binary` to `b: Binary` and added `${b.suffix}` to the module name.

## Test
Unit Test: with `EvictionErrorSpec.scala`
Regression Tests: Ran all existing EvictionError tests