### PR TITLE
[2.x] feat: Add dependencyMode setting to control classpath transitivity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -989,7 +989,13 @@ lazy val upperModules = (project in (file("internal") / "upper"))
   )
 
 lazy val sbtIgnoredProblems = {
+  import com.typesafe.tools.mima.core.*
   Vector(
+    // Adding DependencyMode to Import trait (new abstract members)
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.Import.DependencyMode"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "sbt.Import.sbt$Import$_setter_$DependencyMode_="
+    ),
   )
 }
 

--- a/lm-core/src/main/scala/sbt/librarymanagement/DependencyMode.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/DependencyMode.scala
@@ -6,7 +6,7 @@
  * Licensed under Apache License 2.0 (see LICENSE)
  */
 
-package sbt
+package sbt.librarymanagement
 
 /**
  * Controls which managed dependencies appear on the classpath.

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -248,6 +248,7 @@ object Defaults extends BuildCommon with DefExtra {
       internalConfigurationMap :== Configurations.internalMap,
       credentials :== SysProp.sbtCredentialsEnv.toList,
       exportJars :== true,
+      dependencyMode :== DependencyMode.Transitive,
       trackInternalDependencies :== TrackLevel.TrackAlways,
       exportToInternal :== TrackLevel.TrackAlways,
       retrieveManaged :== false,
@@ -2661,26 +2662,30 @@ object Classpaths {
         ClasspathImpl.internalDependencyClasspathTask.value
       ),
       unmanagedClasspath := Def.uncached(ClasspathImpl.unmanagedDependenciesTask.value),
-      managedClasspath := Def.uncached {
-        val converter = fileConverter.value
-        val isMeta = isMetaBuild.value
-        val force = reresolveSbtArtifacts.value
-        val app = appConfiguration.value
-        def isJansiOrJLine(f: File) = f.getName.contains("jline") || f.getName.contains("jansi")
-        val scalaInstanceJars = app.provider.scalaProvider.jars.filterNot(isJansiOrJLine)
-        val sbtCp = (scalaInstanceJars ++ app.provider.mainClasspath)
-          .map(_.toPath)
-          .map(p => converter.toVirtualFile(p): HashedVirtualFileRef)
-          .map(Attributed.blank)
-        val mjars = managedJars(
-          classpathConfiguration.value,
-          classpathTypes.value,
-          update.value,
-          converter,
-        )
-        if isMeta && !force then (mjars ++ sbtCp).distinct
-        else mjars
-      },
+      managedClasspath := Def
+        .uncached(Def.taskDyn {
+          val mode = dependencyMode.value
+          mode match
+            case DependencyMode.Transitive => managedClasspathTask
+            case DependencyMode.Direct =>
+              Def.task {
+                val mjars = managedClasspathTask.value
+                filterByDirectDeps(allDependencies.value, mjars)
+              }
+            case DependencyMode.PlusOne =>
+              Def.task {
+                val mjars = managedClasspathTask.value
+                val cpConfig = classpathConfiguration.value
+                filterByPlusOne(
+                  allDependencies.value,
+                  projectID.value,
+                  cpConfig,
+                  updateFull.value,
+                  mjars,
+                )
+              }
+        })
+        .value,
       exportedProducts := Def.uncached(
         ClasspathImpl.trackedExportedProducts(TrackLevel.TrackAlways).value
       ),
@@ -4434,6 +4439,94 @@ object Classpaths {
         )
       }
       .distinct
+
+  private lazy val managedClasspathTask: Initialize[Task[Classpath]] = Def.task {
+    val converter = fileConverter.value
+    val isMeta = isMetaBuild.value
+    val force = reresolveSbtArtifacts.value
+    val app = appConfiguration.value
+    def isJansiOrJLine(f: File) = f.getName.contains("jline") || f.getName.contains("jansi")
+    val scalaInstanceJars = app.provider.scalaProvider.jars.filterNot(isJansiOrJLine)
+    val sbtCp = (scalaInstanceJars ++ app.provider.mainClasspath)
+      .map(_.toPath)
+      .map(p => converter.toVirtualFile(p): HashedVirtualFileRef)
+      .map(Attributed.blank)
+    val cpConfig = classpathConfiguration.value
+    val up = update.value
+    val mjars = managedJars(cpConfig, classpathTypes.value, up, converter)
+    if isMeta && !force then (mjars ++ sbtCp).distinct
+    else mjars
+  }
+
+  private def isScalaLibraryModule(mid: ModuleID): Boolean =
+    import sbt.librarymanagement.ScalaArtifacts
+    mid.organization == ScalaArtifacts.Organization &&
+    (mid.name == ScalaArtifacts.LibraryID ||
+      mid.name == ScalaArtifacts.Scala3LibraryID ||
+      mid.name.startsWith(ScalaArtifacts.Scala3LibraryPrefix))
+
+  /** Build a lookup from org -> Set[baseName] for cross-version aware matching. */
+  private def directDepIndex(
+      directDeps: Seq[ModuleID],
+  ): Map[String, Set[String]] =
+    directDeps.groupMap(_.organization)(_.name).map((k, v) => k -> v.toSet)
+
+  /** Check if a resolved module matches any direct dep, accounting for cross-version suffixes. */
+  private def matchesDirectDep(
+      mid: ModuleID,
+      index: Map[String, Set[String]],
+  ): Boolean =
+    index.get(mid.organization) match
+      case None => false
+      case Some(names) =>
+        names.exists(n => mid.name == n || mid.name.startsWith(n + "_"))
+
+  private[sbt] def filterByDirectDeps(
+      directDeps: Seq[ModuleID],
+      jars: Classpath,
+  ): Classpath =
+    val index = directDepIndex(directDeps)
+    jars.filter: entry =>
+      entry.get(Keys.moduleIDStr) match
+        case Some(str) =>
+          val mid = moduleIdJsonKeyFormat.read(str)
+          matchesDirectDep(mid, index) || isScalaLibraryModule(mid)
+        case None => true
+
+  private[sbt] def filterByPlusOne(
+      directDeps: Seq[ModuleID],
+      projectId: ModuleID,
+      config: Configuration,
+      fullReport: UpdateReport,
+      jars: Classpath,
+  ): Classpath =
+    val index = directDepIndex(directDeps)
+    val rootKey = (projectId.organization, projectId.name)
+    fullReport.configuration(ConfigRef(config.name)) match
+      case None => jars
+      case Some(configReport) =>
+        val modules = configReport.modules
+        // Callers use resolved names (e.g., cats-core_3).
+        // Build the set of resolved direct dep keys from the full report.
+        val resolvedDirectKeys: Set[(String, String)] = modules
+          .filter(mr => matchesDirectDep(mr.module, index))
+          .map(mr => (mr.module.organization, mr.module.name))
+          .toSet
+        val plusOneKeys: Set[(String, String)] = modules
+          .filter: mr =>
+            mr.callers.exists: c =>
+              val ck = (c.caller.organization, c.caller.name)
+              resolvedDirectKeys.contains(ck) || ck == rootKey
+          .map(mr => (mr.module.organization, mr.module.name))
+          .toSet
+        val allowedKeys = resolvedDirectKeys ++ plusOneKeys
+        jars.filter: entry =>
+          entry.get(Keys.moduleIDStr) match
+            case Some(str) =>
+              val mid = moduleIdJsonKeyFormat.read(str)
+              allowedKeys.contains((mid.organization, mid.name)) ||
+              isScalaLibraryModule(mid)
+            case None => true
 
   def findUnmanagedJars(
       config: Configuration,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2670,13 +2670,13 @@ object Classpaths {
             case DependencyMode.Direct =>
               Def.task {
                 val mjars = managedClasspathTask.value
-                filterByDirectDeps(allDependencies.value, mjars)
+                ClasspathImpl.filterByDirectDeps(allDependencies.value, mjars)
               }
             case DependencyMode.PlusOne =>
               Def.task {
                 val mjars = managedClasspathTask.value
                 val cpConfig = classpathConfiguration.value
-                filterByPlusOne(
+                ClasspathImpl.filterByPlusOne(
                   allDependencies.value,
                   projectID.value,
                   cpConfig,
@@ -4457,76 +4457,6 @@ object Classpaths {
     if isMeta && !force then (mjars ++ sbtCp).distinct
     else mjars
   }
-
-  private def isScalaLibraryModule(mid: ModuleID): Boolean =
-    import sbt.librarymanagement.ScalaArtifacts
-    mid.organization == ScalaArtifacts.Organization &&
-    (mid.name == ScalaArtifacts.LibraryID ||
-      mid.name == ScalaArtifacts.Scala3LibraryID ||
-      mid.name.startsWith(ScalaArtifacts.Scala3LibraryPrefix))
-
-  /** Build a lookup from org -> Set[baseName] for cross-version aware matching. */
-  private def directDepIndex(
-      directDeps: Seq[ModuleID],
-  ): Map[String, Set[String]] =
-    directDeps.groupMap(_.organization)(_.name).map((k, v) => k -> v.toSet)
-
-  /** Check if a resolved module matches any direct dep, accounting for cross-version suffixes. */
-  private def matchesDirectDep(
-      mid: ModuleID,
-      index: Map[String, Set[String]],
-  ): Boolean =
-    index.get(mid.organization) match
-      case None => false
-      case Some(names) =>
-        names.exists(n => mid.name == n || mid.name.startsWith(n + "_"))
-
-  private[sbt] def filterByDirectDeps(
-      directDeps: Seq[ModuleID],
-      jars: Classpath,
-  ): Classpath =
-    val index = directDepIndex(directDeps)
-    jars.filter: entry =>
-      entry.get(Keys.moduleIDStr) match
-        case Some(str) =>
-          val mid = moduleIdJsonKeyFormat.read(str)
-          matchesDirectDep(mid, index) || isScalaLibraryModule(mid)
-        case None => true
-
-  private[sbt] def filterByPlusOne(
-      directDeps: Seq[ModuleID],
-      projectId: ModuleID,
-      config: Configuration,
-      fullReport: UpdateReport,
-      jars: Classpath,
-  ): Classpath =
-    val index = directDepIndex(directDeps)
-    val rootKey = (projectId.organization, projectId.name)
-    fullReport.configuration(ConfigRef(config.name)) match
-      case None => jars
-      case Some(configReport) =>
-        val modules = configReport.modules
-        // Callers use resolved names (e.g., cats-core_3).
-        // Build the set of resolved direct dep keys from the full report.
-        val resolvedDirectKeys: Set[(String, String)] = modules
-          .filter(mr => matchesDirectDep(mr.module, index))
-          .map(mr => (mr.module.organization, mr.module.name))
-          .toSet
-        val plusOneKeys: Set[(String, String)] = modules
-          .filter: mr =>
-            mr.callers.exists: c =>
-              val ck = (c.caller.organization, c.caller.name)
-              resolvedDirectKeys.contains(ck) || ck == rootKey
-          .map(mr => (mr.module.organization, mr.module.name))
-          .toSet
-        val allowedKeys = resolvedDirectKeys ++ plusOneKeys
-        jars.filter: entry =>
-          entry.get(Keys.moduleIDStr) match
-            case Some(str) =>
-              val mid = moduleIdJsonKeyFormat.read(str)
-              allowedKeys.contains((mid.organization, mid.name)) ||
-              isScalaLibraryModule(mid)
-            case None => true
 
   def findUnmanagedJars(
       config: Configuration,

--- a/main/src/main/scala/sbt/DependencyMode.scala
+++ b/main/src/main/scala/sbt/DependencyMode.scala
@@ -1,0 +1,29 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+/**
+ * Controls which managed dependencies appear on the classpath.
+ *
+ * This setting is used to enforce explicit dependency declarations
+ * by restricting the classpath to only include dependencies at a
+ * specified depth level.
+ */
+enum DependencyMode:
+
+  /** All transitive dependencies are included (default, current behavior). */
+  case Transitive
+
+  /** Only direct dependencies plus scala-library are included. */
+  case Direct
+
+  /** Direct dependencies plus their immediate transitive dependencies plus scala-library. */
+  case PlusOne
+
+end DependencyMode

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -440,6 +440,7 @@ object Keys {
   val dependencyPicklePath = taskKey[Classpath]("The classpath consisting of internal pickles and external, managed and unmanaged dependencies. This task is promise-blocked.")
   val internalDependencyPicklePath = taskKey[Classpath]("The internal (inter-project) pickles. This task is promise-blocked.")
   val fullClasspath = taskKey[Classpath]("The exported classpath, consisting of build products and unmanaged and managed, internal and external dependencies.").withRank(BPlusTask)
+  val dependencyMode = settingKey[DependencyMode]("Controls which managed dependencies appear on the classpath: Transitive (all), Direct (only direct + scala-library), or PlusOne (direct + their immediate deps + scala-library).").withRank(BSetting)
   val trackInternalDependencies = settingKey[TrackLevel]("The level of tracking for the internal (inter-project) dependency.").withRank(BSetting)
   val exportToInternal = settingKey[TrackLevel]("The level of tracking for this project by the internal callers.").withRank(BSetting)
   val exportedProductJars = taskKey[Classpath]("Build products that go on the exported classpath as JARs.")

--- a/main/src/main/scala/sbt/internal/ClasspathImpl.scala
+++ b/main/src/main/scala/sbt/internal/ClasspathImpl.scala
@@ -15,7 +15,15 @@ import sbt.nio.Keys.*
 import sbt.nio.file.{ Glob, RecursiveGlob }
 import sbt.Def.Initialize
 import sbt.internal.util.{ Attributed, Dag }
-import sbt.librarymanagement.{ Configuration, CrossVersion, TrackLevel }
+import sbt.librarymanagement.{
+  ConfigRef,
+  Configuration,
+  CrossVersion,
+  ModuleID,
+  ScalaArtifacts,
+  TrackLevel,
+  UpdateReport
+}
 import sbt.librarymanagement.Configurations.names
 import sbt.SlashSyntax0.*
 import sbt.std.TaskExtra.*
@@ -461,5 +469,76 @@ private[sbt] object ClasspathImpl {
       case Some(x) => x
       case _       => constant(Nil)
     }
+
+  // -- dependencyMode filtering --
+
+  private def isScalaLibraryModule(mid: ModuleID): Boolean =
+    mid.organization == ScalaArtifacts.Organization &&
+      (mid.name == ScalaArtifacts.LibraryID ||
+        mid.name == ScalaArtifacts.Scala3LibraryID ||
+        mid.name.startsWith(ScalaArtifacts.Scala3LibraryPrefix))
+
+  /** Build a lookup from org -> Set[baseName] for cross-version aware matching. */
+  private def directDepIndex(
+      directDeps: Seq[ModuleID],
+  ): Map[String, Set[String]] =
+    directDeps.groupMap(_.organization)(_.name).map((k, v) => k -> v.toSet)
+
+  /** Check if a resolved module matches any direct dep, accounting for cross-version suffixes. */
+  private def matchesDirectDep(
+      mid: ModuleID,
+      index: Map[String, Set[String]],
+  ): Boolean =
+    index.get(mid.organization) match
+      case None => false
+      case Some(names) =>
+        names.exists(n => mid.name == n || mid.name.startsWith(n + "_"))
+
+  def filterByDirectDeps(
+      directDeps: Seq[ModuleID],
+      jars: Classpath,
+  ): Classpath =
+    val index = directDepIndex(directDeps)
+    jars.filter: entry =>
+      entry.get(Keys.moduleIDStr) match
+        case Some(str) =>
+          val mid = Classpaths.moduleIdJsonKeyFormat.read(str)
+          matchesDirectDep(mid, index) || isScalaLibraryModule(mid)
+        case None => true
+
+  def filterByPlusOne(
+      directDeps: Seq[ModuleID],
+      projectId: ModuleID,
+      config: Configuration,
+      fullReport: UpdateReport,
+      jars: Classpath,
+  ): Classpath =
+    val index = directDepIndex(directDeps)
+    val rootKey = (projectId.organization, projectId.name)
+    fullReport.configuration(ConfigRef(config.name)) match
+      case None => jars
+      case Some(configReport) =>
+        val modules = configReport.modules
+        // Callers use resolved names (e.g., cats-core_3).
+        // Build the set of resolved direct dep keys from the full report.
+        val resolvedDirectKeys: Set[(String, String)] = modules
+          .filter(mr => matchesDirectDep(mr.module, index))
+          .map(mr => (mr.module.organization, mr.module.name))
+          .toSet
+        val plusOneKeys: Set[(String, String)] = modules
+          .filter: mr =>
+            mr.callers.exists: c =>
+              val ck = (c.caller.organization, c.caller.name)
+              resolvedDirectKeys.contains(ck) || ck == rootKey
+          .map(mr => (mr.module.organization, mr.module.name))
+          .toSet
+        val allowedKeys = resolvedDirectKeys ++ plusOneKeys
+        jars.filter: entry =>
+          entry.get(Keys.moduleIDStr) match
+            case Some(str) =>
+              val mid = Classpaths.moduleIdJsonKeyFormat.read(str)
+              allowedKeys.contains((mid.organization, mid.name)) ||
+              isScalaLibraryModule(mid)
+            case None => true
 
 }

--- a/sbt-app/src/main/scala/sbt/Import.scala
+++ b/sbt-app/src/main/scala/sbt/Import.scala
@@ -273,6 +273,8 @@ trait Import {
   val CrossVersion = sbt.librarymanagement.CrossVersion
   type CrossVersion = sbt.librarymanagement.CrossVersion
   val DefaultMavenRepository = sbt.librarymanagement.Resolver.DefaultMavenRepository
+  type DependencyMode = sbt.librarymanagement.DependencyMode
+  val DependencyMode = sbt.librarymanagement.DependencyMode
   val Developer = sbt.librarymanagement.Developer
   type Developer = sbt.librarymanagement.Developer
   val Disabled = sbt.librarymanagement.Disabled

--- a/sbt-app/src/sbt-test/dependency-management/dependency-mode/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/dependency-mode/build.sbt
@@ -1,0 +1,65 @@
+lazy val checkDirect = taskKey[Unit]("check direct dependency mode")
+lazy val checkPlusOne = taskKey[Unit]("check plusOne dependency mode")
+lazy val checkTransitive = taskKey[Unit]("check transitive dependency mode")
+lazy val checkDirectTest = taskKey[Unit]("check direct mode applies to Test config")
+lazy val checkDirectJava = taskKey[Unit]("check direct mode with Java (non-crossversioned) deps")
+
+lazy val root = (project in file(".")).settings(
+  scalaVersion := "3.7.4",
+  // cats-core has transitive dep on cats-kernel
+  libraryDependencies += "org.typelevel" %% "cats-core" % "2.12.0",
+  // A Java library with transitive deps (guava pulls in failureaccess, etc.)
+  libraryDependencies += "com.google.guava" % "guava" % "33.4.0-jre",
+  checkTransitive := {
+    val cp = (Compile / managedClasspath).value.map(_.data.id)
+    assert(cp.exists(_.contains("cats-core")),
+      s"Expected cats-core in transitive mode, got: $cp")
+    assert(cp.exists(_.contains("cats-kernel")),
+      s"Expected cats-kernel in transitive mode, got: $cp")
+    assert(cp.exists(_.contains("guava")),
+      s"Expected guava in transitive mode, got: $cp")
+  },
+  checkDirect := {
+    val cp = (Compile / managedClasspath).value.map(_.data.id)
+    // Direct deps should be present
+    assert(cp.exists(_.contains("cats-core")),
+      s"Expected cats-core in direct mode, got: $cp")
+    assert(cp.exists(_.contains("guava")),
+      s"Expected guava in direct mode, got: $cp")
+    // Transitive deps should be absent
+    assert(!cp.exists(_.contains("cats-kernel")),
+      s"Expected no cats-kernel in direct mode, got: $cp")
+    assert(!cp.exists(_.contains("failureaccess")),
+      s"Expected no failureaccess in direct mode, got: $cp")
+    // scala-library always present
+    assert(cp.exists(n => n.contains("scala3-library") || n.contains("scala-library")),
+      s"Expected scala library in direct mode, got: $cp")
+  },
+  checkPlusOne := {
+    val cp = (Compile / managedClasspath).value.map(_.data.id)
+    // Direct deps should be present
+    assert(cp.exists(_.contains("cats-core")),
+      s"Expected cats-core in plusOne mode, got: $cp")
+    // Immediate transitive of cats-core should be present
+    assert(cp.exists(_.contains("cats-kernel")),
+      s"Expected cats-kernel in plusOne mode (direct dep of cats-core), got: $cp")
+  },
+  checkDirectTest := {
+    val cp = (Test / managedClasspath).value.map(_.data.id)
+    // Direct deps should be present
+    assert(cp.exists(_.contains("cats-core")),
+      s"Expected cats-core in direct mode Test config, got: $cp")
+    // Transitive deps should be absent
+    assert(!cp.exists(_.contains("cats-kernel")),
+      s"Expected no cats-kernel in direct mode Test config, got: $cp")
+  },
+  checkDirectJava := {
+    val cp = (Compile / managedClasspath).value.map(_.data.id)
+    // Java dep (no cross-version) should be present
+    assert(cp.exists(_.contains("guava")),
+      s"Expected guava in direct mode, got: $cp")
+    // Its transitive deps should be absent
+    assert(!cp.exists(_.contains("failureaccess")),
+      s"Expected no failureaccess in direct mode, got: $cp")
+  },
+)

--- a/sbt-app/src/sbt-test/dependency-management/dependency-mode/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/dependency-mode/build.sbt
@@ -2,7 +2,6 @@ lazy val checkDirect = taskKey[Unit]("check direct dependency mode")
 lazy val checkPlusOne = taskKey[Unit]("check plusOne dependency mode")
 lazy val checkTransitive = taskKey[Unit]("check transitive dependency mode")
 lazy val checkDirectTest = taskKey[Unit]("check direct mode applies to Test config")
-lazy val checkDirectJava = taskKey[Unit]("check direct mode with Java (non-crossversioned) deps")
 
 lazy val root = (project in file(".")).settings(
   scalaVersion := "3.7.4",
@@ -52,14 +51,5 @@ lazy val root = (project in file(".")).settings(
     // Transitive deps should be absent
     assert(!cp.exists(_.contains("cats-kernel")),
       s"Expected no cats-kernel in direct mode Test config, got: $cp")
-  },
-  checkDirectJava := {
-    val cp = (Compile / managedClasspath).value.map(_.data.id)
-    // Java dep (no cross-version) should be present
-    assert(cp.exists(_.contains("guava")),
-      s"Expected guava in direct mode, got: $cp")
-    // Its transitive deps should be absent
-    assert(!cp.exists(_.contains("failureaccess")),
-      s"Expected no failureaccess in direct mode, got: $cp")
   },
 )

--- a/sbt-app/src/sbt-test/dependency-management/dependency-mode/test
+++ b/sbt-app/src/sbt-test/dependency-management/dependency-mode/test
@@ -1,0 +1,12 @@
+# Default mode is transitive
+> checkTransitive
+
+# Direct mode: only declared deps + scala-library
+> set dependencyMode := DependencyMode.Direct
+> checkDirect
+> checkDirectTest
+> checkDirectJava
+
+# PlusOne mode: direct deps + their immediate transitive deps
+> set dependencyMode := DependencyMode.PlusOne
+> checkPlusOne

--- a/sbt-app/src/sbt-test/dependency-management/dependency-mode/test
+++ b/sbt-app/src/sbt-test/dependency-management/dependency-mode/test
@@ -5,7 +5,6 @@
 > set dependencyMode := DependencyMode.Direct
 > checkDirect
 > checkDirectTest
-> checkDirectJava
 
 # PlusOne mode: direct deps + their immediate transitive deps
 > set dependencyMode := DependencyMode.PlusOne


### PR DESCRIPTION
## Summary

Implements the `dependencyMode` setting proposed in #8942, adding explicit dependency tracking similar to Bazel's [rules_scala dependency tracking](https://github.com/bazel-contrib/rules_scala/blob/master/docs/dependency-tracking.md) and [sbt-explicit-dependencies](https://github.com/cb372/sbt-explicit-dependencies).

- **`DependencyMode.Transitive`** (default) — all transitive dependencies on the classpath (current behavior, zero overhead)
- **`DependencyMode.Direct`** — only declared `libraryDependencies` plus `scala-library`
- **`DependencyMode.PlusOne`** — declared dependencies plus their immediate transitive dependencies plus `scala-library`

### Usage

```scala
// Only allow direct dependencies on the compile classpath
dependencyMode := DependencyMode.Direct

// Or allow one level of transitive deps
dependencyMode := DependencyMode.PlusOne
```

### Design decisions

- **Filtering at `managedClasspath` level, not resolution level** — `update` still resolves the full transitive graph. `dependencyTree`, eviction checks, and caching are unaffected.
- **Uses `Def.taskDyn`** to avoid evaluating `allDependencies`/`updateFull` when mode is `Transitive` — zero overhead for the default case.
- **Cross-version aware matching** — correctly matches `cats-core` (from `libraryDependencies`) against resolved `cats-core_3` on the classpath.
- **`scala-library` always included** regardless of mode, since the Scala standard library is a runtime requirement.

### Files changed

- `main/src/main/scala/sbt/DependencyMode.scala` — New Scala 3 enum
- `main/src/main/scala/sbt/Keys.scala` — `dependencyMode` setting key
- `main/src/main/scala/sbt/Defaults.scala` — Default value, `managedClasspath` filtering logic, helper methods in `Classpaths`
- `sbt-app/src/sbt-test/dependency-management/dependency-mode/` — Scripted integration test

## Test plan

- [x] Scripted test verifies all three modes with Scala (`cats-core`/`cats-kernel`) and Java (`guava`/`failureaccess`) dependencies
- [x] Test verifies `Direct` mode applies to both `Compile` and `Test` configurations
- [x] Default `Transitive` mode preserves existing behavior
- [ ] Manual testing with `publishLocalBin` + real projects

Fixes #8942