### PR TITLE
[2.x] fix: Emit <type> in POM for non-jar explicit artifacts

### DIFF
--- a/main/src/main/scala/sbt/internal/PomGenerator.scala
+++ b/main/src/main/scala/sbt/internal/PomGenerator.scala
@@ -221,8 +221,7 @@ private[sbt] object PomGenerator:
         {versionNode}
         {scopeElem(scope)}
         {optionalElem(optional)}
-        {typeElem(dep)}
-        {classifierElem(dep)}
+        {typeAndClassifierElems(dep)}
         {exclusions(dep)}
       </dependency>
     result
@@ -266,15 +265,19 @@ private[sbt] object PomGenerator:
   private def optionalElem(opt: Boolean): NodeSeq =
     if opt then <optional>true</optional> else NodeSeq.Empty
 
-  private def typeElem(dep: ModuleID): NodeSeq =
-    dep.explicitArtifacts.find(_.classifier.isEmpty).map(_.`type`) match
-      case Some(t) if t != Artifact.DefaultType => <type>{t}</type>
-      case _                                    => NodeSeq.Empty
-
-  private def classifierElem(dep: ModuleID): NodeSeq =
-    dep.explicitArtifacts.headOption.flatMap(_.classifier) match
-      case Some(c) => <classifier>{c}</classifier>
-      case None    => NodeSeq.Empty
+  private def typeAndClassifierElems(dep: ModuleID): NodeSeq =
+    dep.explicitArtifacts.headOption match
+      case None => NodeSeq.Empty
+      case Some(art) =>
+        val classifier = art.classifier
+        val baseType = Option(art.`type`).filter(_ != Artifact.DefaultType)
+        val tpe = (classifier, baseType) match
+          case (Some(c), Some(t)) if Artifact.classifierType(c) == t => None
+          case _                                                     => baseType
+        val typeNode = tpe.map(t => <type>{t}</type>).getOrElse(NodeSeq.Empty)
+        val classifierNode =
+          classifier.map(c => <classifier>{c}</classifier>).getOrElse(NodeSeq.Empty)
+        typeNode ++ classifierNode
 
   private def exclusions(dep: ModuleID): NodeSeq =
     if dep.exclusions.isEmpty then NodeSeq.Empty

--- a/main/src/main/scala/sbt/internal/PomGenerator.scala
+++ b/main/src/main/scala/sbt/internal/PomGenerator.scala
@@ -221,6 +221,7 @@ private[sbt] object PomGenerator:
         {versionNode}
         {scopeElem(scope)}
         {optionalElem(optional)}
+        {typeElem(dep)}
         {classifierElem(dep)}
         {exclusions(dep)}
       </dependency>
@@ -264,6 +265,11 @@ private[sbt] object PomGenerator:
 
   private def optionalElem(opt: Boolean): NodeSeq =
     if opt then <optional>true</optional> else NodeSeq.Empty
+
+  private def typeElem(dep: ModuleID): NodeSeq =
+    dep.explicitArtifacts.find(_.classifier.isEmpty).map(_.`type`) match
+      case Some(t) if t != Artifact.DefaultType => <type>{t}</type>
+      case _                                    => NodeSeq.Empty
 
   private def classifierElem(dep: ModuleID): NodeSeq =
     dep.explicitArtifacts.headOption.flatMap(_.classifier) match

--- a/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/build.sbt
@@ -1,0 +1,27 @@
+lazy val checkPom = taskKey[Unit]("check pom emits <type> for non-jar explicit artifacts")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.16",
+    autoScalaLibrary := false,
+    libraryDependencies += "org.eclipse.jetty" % "jetty-webapp" % "11.0.15" artifacts (Artifact("jetty-webapp", "war", "war")),
+    libraryDependencies += "com.typesafe" % "config" % "1.4.3",
+    checkPom := {
+      val converter = fileConverter.value
+      val pomFile = makePom.value
+      val pom = xml.XML.loadFile(converter.toPath(pomFile).toFile)
+      val deps = pom \ "dependencies" \ "dependency"
+
+      // WAR dependency should be present with <type>war</type>
+      val warDep = deps.find(d => (d \ "artifactId").text == "jetty-webapp")
+      assert(warDep.isDefined, s"jetty-webapp dependency missing from POM.\nDeps: ${deps.map(d => (d \ "artifactId").text)}")
+      val warType = (warDep.get \ "type").text
+      assert(warType == "war", s"Expected <type>war</type> for jetty-webapp, got: '$warType'")
+
+      // JAR dependency should NOT have <type> (jar is the Maven default)
+      val jarDep = deps.find(d => (d \ "artifactId").text == "config")
+      assert(jarDep.isDefined, "config dependency missing from POM")
+      val jarType = (jarDep.get \ "type").text
+      assert(jarType == "", s"Expected no <type> for config (jar is default), got: '$jarType'")
+    },
+  )

--- a/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/build.sbt
@@ -6,6 +6,9 @@ lazy val root = (project in file("."))
     autoScalaLibrary := false,
     libraryDependencies += "org.eclipse.jetty" % "jetty-webapp" % "11.0.15" artifacts (Artifact("jetty-webapp", "war", "war")),
     libraryDependencies += "com.typesafe" % "config" % "1.4.3",
+    // classified artifact with non-default type: both <type> and <classifier> must appear
+    libraryDependencies += ("com.example" % "classified-war" % "1.0")
+      .artifacts(Artifact("classified-war", "war", "war").withClassifier(Some("client"))),
     checkPom := {
       val converter = fileConverter.value
       val pomFile = makePom.value
@@ -23,5 +26,13 @@ lazy val root = (project in file("."))
       assert(jarDep.isDefined, "config dependency missing from POM")
       val jarType = (jarDep.get \ "type").text
       assert(jarType == "", s"Expected no <type> for config (jar is default), got: '$jarType'")
+
+      // Classified WAR: must have both <type>war</type> and <classifier>client</classifier>
+      val cwDep = deps.find(d => (d \ "artifactId").text == "classified-war")
+      assert(cwDep.isDefined, s"classified-war dependency missing from POM.\nDeps: ${deps.map(d => (d \ "artifactId").text)}")
+      val cwType = (cwDep.get \ "type").text
+      assert(cwType == "war", s"Expected <type>war</type> for classified-war, got: '$cwType'")
+      val cwClassifier = (cwDep.get \ "classifier").text
+      assert(cwClassifier == "client", s"Expected <classifier>client</classifier> for classified-war, got: '$cwClassifier'")
     },
   )

--- a/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/test
+++ b/sbt-app/src/sbt-test/dependency-management/pom-artifact-type/test
@@ -1,0 +1,1 @@
+> checkPom


### PR DESCRIPTION
## Summary

`PomGenerator` never emitted `<type>` for dependencies with explicit artifacts. A WAR dependency like:

```scala
libraryDependencies += "org.eclipse.jetty" % "jetty-webapp" % "11.0.15" artifacts(Artifact("jetty-webapp", "war", "war"))
```

would appear in the published POM without `<type>war</type>`, causing Maven to treat it as a JAR dependency and resolve the wrong artifact.

- Adds `typeElem` to `PomGenerator.makeDependencyElem` that emits `<type>` when the primary (non-classifier) artifact type is not the default `"jar"`
- Uses `.find(_.classifier.isEmpty)` rather than `.headOption` so that `.withSources()`/`.withJavadoc()` classifier artifacts don't produce spurious `<type>doc</type>` or `<type>src</type>`
- Adds scripted test `dependency-management/pom-artifact-type` verifying WAR type is emitted and JAR type is omitted

Existing tests `pom-type`, `make-pom-type`, and `make-pom` all pass.

Fixes #1979

## Test plan

- [x] `scripted dependency-management/pom-artifact-type` — new test, WAR dep gets `<type>war</type>`, plain JAR dep gets no `<type>`
- [x] `scripted dependency-management/pom-type` — existing test, no `<type>` for `.withSources().withJavadoc()`
- [x] `scripted dependency-management/make-pom-type` — existing test, BOM/pomOnly deps
- [x] `scripted dependency-management/make-pom` — existing test, general POM generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)