### PR TITLE
[2.x] fix: Sort evicted output by organization and name

### DIFF
--- a/lm-core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/EvictionWarning.scala
@@ -313,7 +313,7 @@ object EvictionWarning {
       reports: Seq[OrganizationArtifactReport]
   ): EvictionWarning = {
     val directDependencies = module.directDependencies
-    val pairs = reports map { detail =>
+    val pairs = (reports map { detail =>
       val evicteds = detail.modules filter { _.evicted }
       val winner = (detail.modules filterNot { _.evicted }).headOption
       val includesDirect: Boolean =
@@ -329,7 +329,7 @@ object EvictionWarning {
         includesDirect,
         options.showCallers
       )
-    }
+    }).sortBy(p => (p.organization, p.name))
     val scalaEvictions: mutable.ListBuffer[EvictionPair] = mutable.ListBuffer()
     val directEvictions: mutable.ListBuffer[EvictionPair] = mutable.ListBuffer()
     val transitiveEvictions: mutable.ListBuffer[EvictionPair] = mutable.ListBuffer()

--- a/sbt-app/src/sbt-test/dependency-management/evicted-order/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-order/build.sbt
@@ -1,0 +1,28 @@
+@transient
+lazy val checkEvictedOrder = taskKey[Unit]("check evicted output is sorted")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.16",
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor" % "2.6.20",
+      "com.typesafe.akka" %% "akka-stream" % "2.6.19",
+      "io.circe" %% "circe-core" % "0.14.5",
+      "io.circe" %% "circe-parser" % "0.14.3",
+    ),
+    checkEvictedOrder := {
+      val pub = Keys.publisher.value
+      val module = pub.moduleDescriptor(
+        moduleSettings.value.asInstanceOf[sbt.librarymanagement.ModuleDescriptorConfiguration]
+      )
+      val report = update.value
+      val ew = sbt.librarymanagement.EvictionWarning(
+        module,
+        sbt.librarymanagement.EvictionWarningOptions.full.withShowCallers(false),
+        report
+      )
+      val allOrgs = ew.allEvictions.map(p => s"${p.organization}:${p.name}")
+      val sorted = allOrgs.sorted
+      assert(allOrgs == sorted, s"Evictions not sorted.\nGot:      $allOrgs\nExpected: $sorted")
+    },
+  )

--- a/sbt-app/src/sbt-test/dependency-management/evicted-order/test
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-order/test
@@ -1,0 +1,1 @@
+> checkEvictedOrder


### PR DESCRIPTION
## Summary

- `evicted` output order depended on the order of configuration reports from the resolver, which is non-deterministic. Repeated runs or different configurations could produce different orderings, making the output hard to scan.
- Sort eviction pairs by `(organization, name)` in `EvictionWarning.processEvictions` so output is stable across runs.

One-line change: wrap the existing `reports map { ... }` with `.sortBy(p => (p.organization, p.name))`.

Fixes #6084

## Test plan

- [x] `scripted dependency-management/evicted-order` — asserts `allEvictions` is sorted by org:name

🤖 Generated with [Claude Code](https://claude.com/claude-code)