### PR TITLE
[2.x] fix: Send multi-arg sbtn commands sequentially instead of joining with space

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -958,8 +958,12 @@ class NetworkClient(
     }
 
   def batchExecute(userCommands: List[String]): Int = {
-    val cmd = userCommands.mkString(" ")
-    sendAndWait(cmd, None)
+    var res = 0
+    val it = userCommands.iterator
+    while (it.hasNext && res == 0) {
+      res = sendAndWait(it.next(), None)
+    }
+    res
   }
 
   def getCompletions(query: String): Seq[String] = {

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -139,6 +139,12 @@ class ClientTest extends AbstractServerTest with BeforeAndAfterEach {
   test("three commands with middle failure") {
     assert(client("compile;willFail;willSucceed") == 1)
   }
+  test("multi-arg commands") {
+    assert(client("compile", "willSucceed") == 0)
+  }
+  test("multi-arg commands stop on first failure") {
+    assert(client("willFail", "willSucceed") == 1)
+  }
   test("run") {
     val (exitCode, lines) = clientWithStdoutLines("run")
     assert(exitCode == 0)


### PR DESCRIPTION
## Summary

`sbtn clean compile` (or `sbt --client clean compile`) fails with a parse error because
`NetworkClient.batchExecute` joins the arguments with a space and sends `"clean compile"` as
a single command. The sbt command parser doesn't accept space-separated commands — it expects
either separate invocations or semicolons (`clean;compile`).

```
> clean compile
[error] Expected whitespace character
[error] Expected '/'
[error] clean compile
[error]       ^
```

The fix sends each command sequentially, stopping on the first failure, matching the behavior
of `sbt clean compile` (without `--client`).

Fixes #5969

## Test plan

- [x] `serverTestProj/testOnly testpkg.ClientTest` — 13/13 pass
  - `multi-arg commands`: `client("compile", "willSucceed")` returns 0
  - `multi-arg commands stop on first failure`: `client("willFail", "willSucceed")` returns 1
- [x] First commit (test only) fails `multi-arg commands` against unfixed code
- [x] Second commit (fix) makes it pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)