### PR TITLE
[2.x] fix: Preserve configuration visibility in ivy.xml when publishing with coursier

### DIFF
--- a/lm-coursier/definitions/src/main/scala/lmcoursier/definitions/Project.scala
+++ b/lm-coursier/definitions/src/main/scala/lmcoursier/definitions/Project.scala
@@ -1,6 +1,6 @@
 package lmcoursier.definitions
 
-import dataclass.data
+import dataclass.{ data, since }
 
 @data class Project(
     module: Module,
@@ -10,5 +10,6 @@ import dataclass.data
     properties: Seq[(String, String)],
     packagingOpt: Option[Type],
     publications: Seq[(Configuration, Publication)],
-    info: Info
+    info: Info,
+    @since privateConfigs: Set[Configuration] = Set.empty
 )

--- a/lm-coursier/src/main/scala/lmcoursier/Inputs.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/Inputs.scala
@@ -21,6 +21,11 @@ object Inputs {
     configurations
       .map(cfg => Configuration(cfg.name) -> cfg.extendsConfigs.map(c => Configuration(c.name)))
 
+  def privateConfigs(
+      configurations: Seq[sbt.librarymanagement.Configuration]
+  ): Set[Configuration] =
+    configurations.filterNot(_.isPublic).map(cfg => Configuration(cfg.name)).toSet
+
   def coursierConfigurationsMap(
       configurations: Seq[sbt.librarymanagement.Configuration]
   ): Map[Configuration, Set[Configuration]] = {

--- a/lm-coursier/src/main/scala/lmcoursier/IvyXml.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/IvyXml.scala
@@ -63,7 +63,8 @@ object IvyXml {
     } % infoAttrs
 
     val confElems = project.configurations.toVector.collect { (name, extends0) =>
-      val n = <conf name={name.value} visibility="public" description="" />
+      val visibility = if (project.privateConfigs.contains(name)) "private" else "public"
+      val n = <conf name={name.value} visibility={visibility} description="" />
       if (extends0.nonEmpty)
         n % <x extends={extends0.map(_.value).mkString(",")} />.attributes
       else

--- a/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierInputsTasks.scala
@@ -37,15 +37,18 @@ object CoursierInputsTasks {
   ): CProject = {
 
     val configMap = Inputs.configExtendsSeq(configurations).toMap
+    val privConfigs = Inputs.privateConfigs(configurations)
 
-    val proj0 = FromSbt.project(
-      projId,
-      dependencies,
-      configMap,
-      sv,
-      sbv,
-      projectPlatform,
-    )
+    val proj0 = FromSbt
+      .project(
+        projId,
+        dependencies,
+        configMap,
+        sv,
+        sbv,
+        projectPlatform,
+      )
+      .withPrivateConfigs(privConfigs)
     val proj1 = auOpt match {
       case Some(au) =>
         proj0.withProperties(proj0.properties :+ (SbtPomExtraProperties.POM_API_KEY -> au.toString))

--- a/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -127,7 +127,9 @@ object IvyXml {
     val confElems = project.configurations.toVector.collect {
       case (name, extends0) if !shadedConfigOpt.exists(_.value == name.value) =>
         val extends1 = shadedConfigOpt.fold(extends0)(c => extends0.filter(_.value != c.value))
-        val n = <conf name={name.value} visibility="public" description="" />
+        val visibility =
+          if (project.privateConfigs.contains(name)) "private" else "public"
+        val n = <conf name={name.value} visibility={visibility} description="" />
         if (extends1.nonEmpty)
           n % <x extends={extends1.map(_.value).mkString(",")} />.attributes
         else


### PR DESCRIPTION
## Summary

- When publishing with coursier, the `visibility` attribute of `<conf />` elements in `ivy.xml` was hardcoded to `"public"`, ignoring the actual configuration visibility
- Configurations defined as hidden (e.g. `scala-tool`) were incorrectly published with `visibility="public"` instead of `"private"`
- The root cause was that `Inputs.configExtendsSeq` only extracted config names and extends relationships, discarding the `isPublic` flag from sbt's `Configuration` objects

Fixes #5455

## Changes

- Added `privateConfigs: Set[Configuration]` field to the lmcoursier `Project` data class (with `@since` for backward compatibility)
- Added `Inputs.privateConfigs` to extract non-public configuration names during the sbt-to-coursier conversion
- Both `IvyXml` implementations now emit `visibility="private"` for configurations where `isPublic` is false

## Test plan

- [x] `lmCoursierDefinitions/compile`, `lmCoursier/compile`, `sbtIvyProj/compile`, `mainProj/compile` all pass
- [ ] Existing tests pass (CI)