### PR TITLE
[2.x] fix: Update ++ help text to reflect SemanticSelector matching

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -362,10 +362,10 @@ defaults
     s"""$SwitchCommand <scala-version>[!] [-v] [<command>]
 	Changes the Scala version and runs a command.
 
-	Sets the `scalaVersion` of all projects that define a Scala cross version that is binary
-  compatible with <scala-version> and reloads the build.  If ! is supplied, then the
-  version is forced on all projects regardless of whether they are binary compatible or
-  not.
+	<scala-version> may be an actual Scala version such as 3.1.3, or a Semantic Version selector
+  pattern such as 2.13.x. Only subprojects whose crossScalaVersions match the version pattern
+  have their Scala version switched.  If ! is supplied, then all projects have
+  their Scala version switched.
 
   If -v is supplied, verbose logging of the Scala version switching is done.
 


### PR DESCRIPTION
## Summary

`help ++` says:

> Sets the `scalaVersion` of all projects that define a Scala cross version that is **binary compatible** with <scala-version>

But since #6946, `++` uses `SemanticSelector` pattern matching (e.g. `2.13.x`), not binary compatibility checking. The second paragraph of the same help text already describes the correct behavior. This updates the first paragraph to match.

**Before:**
```
Sets the `scalaVersion` of all projects that define a Scala cross version that is binary
compatible with <scala-version> and reloads the build.  If ! is supplied, then the
version is forced on all projects regardless of whether they are binary compatible or
not.
```

**After:**
```
<scala-version> may be an actual Scala version such as 3.1.3, or a Semantic Version selector
pattern such as 2.13.x. Only subprojects whose crossScalaVersions match the version pattern
have their Scala version switched.  If ! is supplied, then all projects have
their Scala version switched.
```

Fixes #6988

## Test plan

- [x] `sbt 'help ++'` — verified outdated text before, correct text after

🤖 Generated with [Claude Code](https://claude.com/claude-code)