### PR TITLE
[2.x] fix: Write maven-metadata-local.xml during publishM2 for SNAPSHOTs

### DIFF
--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -872,6 +872,35 @@ private[sbt] object LibraryManagement {
           writeChecksumsForFile(targetFile, checksumAlgorithms, log)
         else log.warn(s"$targetFile already exists, skipping (overwrite=$overwrite)")
 
+    if version.endsWith("-SNAPSHOT") then
+      writeMavenMetadataLocal(versionDir, groupId, artifactId, version, log)
+
+  private def writeMavenMetadataLocal(
+      versionDir: File,
+      groupId: String,
+      artifactId: String,
+      version: String,
+      log: Logger
+  ): Unit =
+    val timestamp = new java.text.SimpleDateFormat("yyyyMMddHHmmss").format(new java.util.Date())
+    val metadata =
+      s"""|<?xml version="1.0" encoding="UTF-8"?>
+          |<metadata modelVersion="1.1.0">
+          |  <groupId>$groupId</groupId>
+          |  <artifactId>$artifactId</artifactId>
+          |  <version>$version</version>
+          |  <versioning>
+          |    <snapshot>
+          |      <localCopy>true</localCopy>
+          |    </snapshot>
+          |    <lastUpdated>$timestamp</lastUpdated>
+          |  </versioning>
+          |</metadata>
+          |""".stripMargin
+    val metadataFile = new File(versionDir, "maven-metadata-local.xml")
+    IO.write(metadataFile, metadata)
+    log.info(s"Published $metadataFile")
+
   /**
    * Publishes artifacts to a remote Maven repo (HTTP) without using Apache Ivy.
    * Same layout as ivylessPublishMavenToFile; uses HTTP PUT with optional Basic auth.

--- a/sbt-app/src/sbt-test/dependency-management/publishm2-metadata/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/publishm2-metadata/build.sbt
@@ -1,0 +1,21 @@
+@transient
+lazy val checkMetadata = taskKey[Unit]("check maven-metadata-local.xml is written for SNAPSHOT")
+
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.16",
+    organization := "com.example.test.scripted",
+    version := "0.1.0-SNAPSHOT",
+    name := "publishm2-metadata-test",
+    checkMetadata := {
+      val m2Dir = new File(
+        System.getProperty("user.home"),
+        ".m2/repository/com/example/test/scripted/publishm2-metadata-test_2.13/0.1.0-SNAPSHOT"
+      )
+      val metadataFile = new File(m2Dir, "maven-metadata-local.xml")
+      assert(metadataFile.exists, s"maven-metadata-local.xml not found at $metadataFile")
+      val content = IO.read(metadataFile)
+      assert(content.contains("<localCopy>true</localCopy>"), s"Missing localCopy element in:\n$content")
+      assert(content.contains("<groupId>com.example.test.scripted</groupId>"), s"Wrong groupId in:\n$content")
+    },
+  )

--- a/sbt-app/src/sbt-test/dependency-management/publishm2-metadata/test
+++ b/sbt-app/src/sbt-test/dependency-management/publishm2-metadata/test
@@ -1,0 +1,2 @@
+> publishM2
+> checkMetadata


### PR DESCRIPTION
## Summary

`publishM2` never writes `maven-metadata-local.xml`, which Maven uses to identify locally installed artifacts. Without it, Maven cannot distinguish a local SNAPSHOT from a remote one — it re-downloads the remote copy even when a newer local install exists, making `publishM2` effectively broken for SNAPSHOT workflows in mixed sbt/Maven projects.

The fix writes `maven-metadata-local.xml` with `<localCopy>true</localCopy>` after publishing SNAPSHOT artifacts to `~/.m2/repository`. Non-SNAPSHOT versions are unaffected.

Fixes #2053

## Test plan

- [x] `scripted dependency-management/publishm2-metadata` — asserts `maven-metadata-local.xml` exists with correct content after `publishM2` of a SNAPSHOT project
- [x] First commit (test only) fails without the fix: `maven-metadata-local.xml not found`
- [x] Second commit (fix) makes it pass
- [x] Manual verification: non-SNAPSHOT `publishM2` does not write metadata file

🤖 Generated with [Claude Code](https://claude.com/claude-code)