### PR TITLE
[2.x] Fix warning in Settings.scala

### DIFF
--- a/util-collection/src/main/scala/sbt/internal/util/Settings.scala
+++ b/util-collection/src/main/scala/sbt/internal/util/Settings.scala
@@ -66,17 +66,19 @@ trait Init:
     def values: Iterable[Any] = data.values
 
     def get[A](key: ScopedKey[A]): Option[A] =
-      delegates(key).flatMap(data.get).nextOption.asInstanceOf[Option[A]]
+      delegates(key).flatMap(data.get).nextOption().asInstanceOf[Option[A]]
 
     def definingKey[A](key: ScopedKey[A]): Option[ScopedKey[A]] =
       delegates(key).find(data.contains)
 
     def getKeyValue[A](key: ScopedKey[A]): Option[(ScopedKey[A], A)] =
-      delegates(key).flatMap { k =>
-        data.get(k) match
-          case None    => None
-          case Some(v) => Some(k -> v.asInstanceOf[A])
-      }.nextOption
+      delegates(key)
+        .flatMap { k =>
+          data.get(k) match
+            case None    => None
+            case Some(v) => Some(k -> v.asInstanceOf[A])
+        }
+        .nextOption()
 
     def getDirect[A](key: ScopedKey[A]): Option[A] = data.get(key).asInstanceOf[Option[A]]
 


### PR DESCRIPTION
```
[warn] -- [E100] Syntax Warning: /home/runner/work/sbt/sbt/util-collection/src/main/scala/sbt/internal/util/Settings.scala:69:39 
[warn] 69 |      delegates(key).flatMap(data.get).nextOption.asInstanceOf[Option[A]]
[warn]    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |      method nextOption must be called with () argument
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E100] Syntax Warning: /home/runner/work/sbt/sbt/util-collection/src/main/scala/sbt/internal/util/Settings.scala:79:8 
[warn] 75 |      delegates(key).flatMap { k =>
[warn] 76 |        data.get(k) match
[warn] 77 |          case None    => None
[warn] 78 |          case Some(v) => Some(k -> v.asInstanceOf[A])
[warn] 79 |      }.nextOption
[warn]    |      ^
[warn]    |      method nextOption must be called with () argument
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
```