### PR TITLE
[2.x] fix: Return JSON-RPC error for unknown server methods

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
+++ b/main-command/src/main/scala/sbt/internal/server/ServerHandler.scala
@@ -30,7 +30,10 @@ object ServerHandler {
 
   lazy val fallback: ServerHandler = ServerHandler({ handler =>
     ServerIntent(
-      onRequest = { case x => handler.log.debug(s"Unhandled request received: ${x.method}: $x") },
+      onRequest = { case x =>
+        handler.log.debug(s"Unhandled request received: ${x.method}: $x")
+        handler.jsonRpcRespondError(Some(x.id), -32601, s"Unknown method: ${x.method}")
+      },
       onResponse = { case x => handler.log.debug(s"Unhandled response received") },
       onNotification = { case x =>
         handler.log.debug(s"Unhandled notification received: ${x.method}: $x")

--- a/server-test/src/test/scala/testpkg/ResponseTest.scala
+++ b/server-test/src/test/scala/testpkg/ResponseTest.scala
@@ -79,6 +79,16 @@ class ResponseTest extends AbstractServerTest {
     }
   }
 
+  test("unknown method returns error") {
+    val id = svr.session.nextId()
+    svr.session.sendJsonRpc(id, "build/foo", "{}").get
+    val response = svr.session.waitForResponseMsg(10.seconds, id).get
+    assert(
+      response.error.exists(_.code == -32601),
+      s"Expected method-not-found error, got: $response"
+    )
+  }
+
   private def neverReceiveResponse(
       duration: FiniteDuration
   )(predicate: sbt.internal.protocol.JsonRpcResponseMessage => Boolean): Unit =


### PR DESCRIPTION
## Summary

The sbt server silently drops JSON-RPC requests with unknown methods. Per the JSON-RPC spec, it should respond with error code `-32601` (Method not found). This can cause timeouts in LSP clients like Metals that send requests the server doesn't recognize.

The fallback `ServerHandler` now calls `jsonRpcRespondError` instead of only logging at debug level.

Fixes #6637

## Test plan

- [x] `serverTestProj/testOnly testpkg.ResponseTest` — 9/9 pass
  - `unknown method returns error`: sends `build/foo`, asserts error code `-32601`
- [x] First commit (test only) fails without the fix: times out waiting for response
- [x] Second commit (fix) makes it pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)