### PR TITLE
[2.x] fix: Add --fail to curl in launcher to prevent corrupt jars

### DIFF
--- a/sbt
+++ b/sbt
@@ -142,7 +142,7 @@ download_url () {
   local jar="$2"
   mkdir -p $(dirname "$jar") && {
     if command -v curl > /dev/null; then
-      curl --silent -L "$url" --output "$jar"
+      curl --fail --silent -L "$url" --output "$jar"
     elif command -v wget > /dev/null; then
       wget --quiet -O "$jar" "$url"
     else


### PR DESCRIPTION
## Summary

The `download_url` function in the `sbt` launcher script uses `curl` without `--fail`. When the download URL returns an HTTP error (404, 500, etc.), `curl` exits 0 and writes the error page HTML to the output file, creating a corrupt jar. Subsequent sbt runs then fail with confusing errors because the "jar" is actually HTML.

```
$ curl --silent -L "https://repo1.maven.org/maven2/.../sbt-launch-99.99.99.jar" --output test.jar
$ file test.jar
test.jar: HTML document, ASCII text
```

With `--fail`, `curl` returns exit code 22 on HTTP errors and does not write the response body.

Fixes #6654

## Test plan

```bash
# Without --fail: saves HTML as jar, exits 0
$ curl --silent -L "$bad_url" --output test.jar && file test.jar
test.jar: HTML document, ASCII text

# With --fail: no file created, exits 22
$ curl --fail --silent -L "$bad_url" --output test.jar; echo $?
22
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)