### PR TITLE
[2.x] fix: resolve virtual path in -Ypickle-write scalac option

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1029,7 +1029,11 @@ object Defaults extends BuildCommon with DefExtra {
           )
           if (shouldApplyFlags)
             Def.uncached(
-              Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old
+              Vector(
+                "-Ypickle-java",
+                "-Ypickle-write",
+                fileConverter.value.toPath(earlyOutput.value).toString
+              ) ++ old
             )
           else Def.uncached(old)
         } else Def.uncached(old)


### PR DESCRIPTION
## Problem

When `usePipelining := true`, sbt passes `earlyOutput.value.toString` directly
as the `-Ypickle-write` argument. Since `earlyOutput` is a `HashedVirtualFileRef`,
`.toString` produces a virtual file reference (e.g. `${BASE}/target/early/early.jar`)
rather than an actual filesystem path that `scalac` can resolve.

## Solution

Use `fileConverter.value.toPath(earlyOutput.value).toString` to convert the
virtual file reference to a real filesystem path before passing it to `-Ypickle-write`.

## Note

Split out from #8921 fix per reviewer request — the console REPL fix is in a
separate PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
