### PR TITLE
[2.x] Organize scalatest dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -879,7 +879,7 @@ lazy val sbtClientProj = (project in file("client"))
     bspEnabled := false,
     crossPaths := false,
     exportJars := true,
-    libraryDependencies += scalatest % Test,
+    libraryDependencies ++= scalatest,
     Compile / mainClass := Some("sbt.client.Client"),
     nativeImageReady := { () =>
       ()
@@ -1206,11 +1206,11 @@ lazy val lmCore = (project in file("lm-core"))
       scalaXml,
       sjsonNewScalaJson.value % Optional,
       sjsonNewCore.value % Optional,
-      scalatest % Test,
       scalacheck % Test,
       scalaVerify % Test,
       hedgehog % Test,
     ),
+    libraryDependencies ++= scalatest,
     Compile / resourceGenerators += Def
       .task(
         Utils.generateVersionFile(
@@ -1249,11 +1249,11 @@ lazy val lmIvy = (project in file("lm-ivy"))
       ivy,
       sjsonNewScalaJson.value,
       sjsonNewCore.value,
-      scalatest % Test,
       scalacheck % Test,
       scalaVerify % Test,
       hedgehog % Test,
     ),
+    libraryDependencies ++= scalatest,
     contrabandSettings,
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     mimaSettings,
@@ -1300,8 +1300,8 @@ lazy val lmCoursierDependencies = Def.settings(
     coursierSbtMavenRepo,
     "io.get-coursier.jniutils" % "windows-jni-utils-lmcoursier" % jniUtilsVersion,
     "net.hamnaberg" %% "dataclass-annotation" % dataclassScalafixVersion % Provided,
-    "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   ),
+  libraryDependencies ++= Dependencies.scalatest,
   excludeDependencies ++= Seq(
     ExclusionRule("org.scala-lang.modules", "scala-xml_2.13"),
   ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,17 @@ object Dependencies {
   val jline3Native = "org.jline" % "jline-native" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"
+  val scalatest = Seq(
+    "scalatest-diagrams",
+    "scalatest-flatspec",
+    "scalatest-freespec",
+    "scalatest-funspec",
+    "scalatest-funsuite",
+    "scalatest-propspec",
+    "scalatest-shouldmatchers",
+  ).map(
+    "org.scalatest" %% _ % "3.2.20" % Test
+  )
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.19.0"
   val junit = "junit" % "junit" % "4.13.2"
   val scalaVerify = "com.eed3si9n.verify" %% "verify" % "1.0.0"

--- a/project/NightlyPlugin.scala
+++ b/project/NightlyPlugin.scala
@@ -14,10 +14,9 @@ object NightlyPlugin extends AutoPlugin {
         Seq(
           scalacheck % Test,
           junit % Test,
-          scalatest % Test,
           scalaVerify % Test,
           hedgehog % Test
-        )
+        ) ++ scalatest
       else Seq()
     )
   }


### PR DESCRIPTION
https://www.scalatest.org/release_notes/3.2.0

Avoid `All in one` dependency

<img width="1978" height="1254" alt="image" src="https://github.com/user-attachments/assets/b6d791d1-b272-4e28-a0fe-a2303e48955b" />
