### PR TITLE
[2.x] fix: Fixes metabuild reloading

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -74,10 +74,10 @@ private[sbt] object Load {
     val launcher = scalaProvider.launcher
     val stagingDirectory = getStagingDirectory(state, globalBase).getCanonicalFile
     val javaHome = Util.javaHome
-    val out = baseDirectory.toPath.resolve("target").resolve("out")
+    val out = app.baseDirectory.toPath.resolve("target").resolve("out")
     val rootPaths = Map(
       "OUT" -> out,
-      "BASE" -> baseDirectory.toPath,
+      "BASE" -> app.baseDirectory.toPath,
       "SBT_BOOT" -> launcher.bootDirectory.toPath,
       "IVY_HOME" -> launcher.ivyHome.toPath,
       "JAVA_HOME" -> javaHome,
@@ -116,7 +116,9 @@ private[sbt] object Load {
     )
     val evalPluginDef: (BuildStructure, State) => PluginData = EvaluateTask.evalPluginDef
     val delegates = defaultDelegates
-    val pluginMgmt = PluginManagement(loader)
+    import sbt.ProjectExtra.projectReturn
+    val pluginContext = PluginManagement.Context(false, Project.projectReturn(state).size - 1)
+    val pluginMgmt = PluginManagement(loader, pluginContext)
     val inject = InjectSettings(injectGlobal(state), Nil, const(Nil))
     SysProp.setSwovalTempDir()
     SysProp.setIpcSocketTempDir()

--- a/main/src/main/scala/sbt/internal/PluginManagement.scala
+++ b/main/src/main/scala/sbt/internal/PluginManagement.scala
@@ -54,12 +54,15 @@ object PluginManagement {
   val emptyContext: Context = Context(false, 0)
 
   def apply(initialLoader: ClassLoader): PluginManagement =
+    PluginManagement(initialLoader, emptyContext)
+
+  def apply(initialLoader: ClassLoader, context: Context): PluginManagement =
     PluginManagement(
       Set.empty,
       Set.empty,
       new PluginClassLoader(initialLoader),
       initialLoader,
-      emptyContext
+      context
     )
 
   def extractOverrides(classpath: Classpath): Set[ModuleID] =

--- a/sbt-app/src/sbt-test/project-load/metabuild/project/FooPlugin.scala
+++ b/sbt-app/src/sbt-test/project-load/metabuild/project/FooPlugin.scala
@@ -1,0 +1,24 @@
+package example
+
+import sbt.*
+import Keys.*
+import complete.DefaultParsers.{ *, given }
+
+object FooPlugin extends AutoPlugin:
+  override def requires = empty
+  override def trigger = allRequirements
+
+  lazy object autoImport:
+    @transient
+    lazy val foo = taskKey[Unit]("foo")
+    lazy val check = inputKey[Unit]("check")
+
+  import autoImport.*
+  override def projectSettings: Seq[Def.Setting[?]] = Seq(
+    foo := println("foo"),
+    check := {
+      val args = spaceDelimited("<arg>").parsed
+      assert(name.value.endsWith(args.head), s"${name.value} does not end with ${args.head}")
+    },
+  )
+end FooPlugin

--- a/sbt-app/src/sbt-test/project-load/metabuild/project/project/FooPlugin.scala
+++ b/sbt-app/src/sbt-test/project-load/metabuild/project/project/FooPlugin.scala
@@ -1,0 +1,24 @@
+package example
+
+import sbt.*
+import Keys.*
+import complete.DefaultParsers.{ *, given }
+
+object FooPlugin extends AutoPlugin:
+  override def requires = empty
+  override def trigger = allRequirements
+
+  lazy object autoImport:
+    @transient
+    lazy val foo = taskKey[Unit]("foo")
+    lazy val check = inputKey[Unit]("check")
+
+  import autoImport.*
+  override def projectSettings: Seq[Def.Setting[?]] = Seq(
+    foo := println("foo"),
+    check := {
+      val args = spaceDelimited("<arg>").parsed
+      assert(name.value.endsWith(args.head), s"${name.value} does not end with ${args.head}")
+    },
+  )
+end FooPlugin

--- a/sbt-app/src/sbt-test/project-load/metabuild/test
+++ b/sbt-app/src/sbt-test/project-load/metabuild/test
@@ -1,0 +1,9 @@
+> foo
+> reload plugins
+> check -build
+> foo
+> reload plugins
+> reload return
+> reload return
+> compile
+> foo


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9006

## Problem
There seems to be multiple problems around metabuild reloading (reload plugins).

Part 1 was split to https://github.com/sbt/sbt/pull/9020

1. Originally reported issue 9006 states that the build can't come back from reload plugins.
2. During the course of fixing, I discovered that when reload plugins is used the project name is set to "project" instead of foo-build etc.
3. Also there was a bug in the rootPaths when reload plugins is used, which results in class not defined error.

## Solution

1. Fix the plugin context so reload plugin still behaves like a metabuild.
2. Fix the rootPaths.
