### PR TITLE
[2.x] Remove unnecessary reflection in `IvyXml`

### DIFF
--- a/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -18,7 +18,6 @@ import org.apache.ivy.core.module.id.ModuleRevisionId
 import Def.Setting
 import sbt.Keys.{ csrProject, csrPublications, publishLocalConfiguration, publishConfiguration }
 import sbt.ProjectExtra.*
-import sbt.librarymanagement.PublishConfiguration
 import scala.jdk.CollectionConverters.*
 import scala.xml.{ Node, PrefixedAttribute }
 
@@ -233,23 +232,12 @@ object IvyXml {
       )
     }.value)
 
-  private lazy val needsIvyXmlLocal = Seq(publishLocalConfiguration) ++ getPubConf(
-    "makeIvyXmlLocalConfiguration"
+  private lazy val needsIvyXmlLocal = Seq(publishLocalConfiguration) ++ List(
+    sbt.Keys.makeIvyXmlLocalConfiguration
   )
-  private lazy val needsIvyXml = Seq(publishConfiguration) ++ getPubConf(
-    "makeIvyXmlConfiguration"
+  private lazy val needsIvyXml = Seq(publishConfiguration) ++ List(
+    sbt.Keys.makeIvyXmlConfiguration
   )
-
-  private def getPubConf(method: String): List[TaskKey[PublishConfiguration]] =
-    try {
-      val cls = sbt.Keys.getClass
-      val m = cls.getMethod(method)
-      val task = m.invoke(sbt.Keys).asInstanceOf[TaskKey[PublishConfiguration]]
-      List(task)
-    } catch {
-      case _: Throwable => // FIXME Too wide
-        Nil
-    }
 
   def generateIvyXmlSettings(
       shadedConfigOpt: Option[Configuration] = None


### PR DESCRIPTION
Maybe this is old sbt 1.0.x version compatibility because `makeIvyXmlConfiguration` and `makeIvyXmlLocalConfiguration` were addes since sbt 1.0.2 🤔 

- https://github.com/sbt/sbt/commit/f11b1e086f1ff9a6bf8ccef8a1c235fe4d77ef2b
- https://github.com/sbt/sbt/commit/38f94a6e314f58022b7ea3618580a55d9a316249
