### PR TITLE
[2.0.x] bport: resolve virtual path in -Ypickle-write scalac option

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1085,7 +1085,11 @@ object Defaults extends BuildCommon {
           )
           if (shouldApplyFlags)
             Def.uncached(
-              Vector("-Ypickle-java", "-Ypickle-write", earlyOutput.value.toString) ++ old
+              Vector(
+                "-Ypickle-java",
+                "-Ypickle-write",
+                fileConverter.value.toPath(earlyOutput.value).toString
+              ) ++ old
             )
           else Def.uncached(old)
         } else Def.uncached(old)


### PR DESCRIPTION
 This is a backport of #9011

earlyOutput is a virtual file reference, so passing it directly via .toString produces a virtual path that scalac cannot resolve. Use fileConverter.value.toPath() to convert it to an actual filesystem path.