### PR TITLE
[2.0.x] Add GitHub Action for SDKMAN releases

### DIFF
--- a/.github/workflows/sdkman.yml
+++ b/.github/workflows/sdkman.yml
@@ -1,0 +1,88 @@
+name: Publish to SDKMAN!
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release assets
+        id: release
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const release = context.payload.release
+            const version = release.tag_name.startsWith("v")
+              ? release.tag_name.slice(1)
+              : release.tag_name
+            const archiveName = `sbt-${version}.tgz`
+            const checksumName = `${archiveName}.sha256`
+
+            const assets = await github.paginate(
+              github.rest.repos.listReleaseAssets,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+                per_page: 100,
+              },
+            )
+
+            const archive = assets.find((asset) => asset.name === archiveName)
+            if (!archive) {
+              core.setFailed(
+                `Release ${release.tag_name} is missing ${archiveName}; SDKMAN publication requires the packaged .tgz asset.`,
+              )
+              return
+            }
+
+            const checksumAsset = assets.find((asset) => asset.name === checksumName)
+
+            let checksumSha256 = ""
+            if (typeof archive.digest === "string" && archive.digest.startsWith("sha256:")) {
+              checksumSha256 = archive.digest.slice("sha256:".length)
+            } else if (checksumAsset) {
+              const response = await fetch(checksumAsset.browser_download_url)
+              if (!response.ok) {
+                core.setFailed(
+                  `Could not download ${checksumName} from ${checksumAsset.browser_download_url}.`,
+                )
+                return
+              }
+
+              const text = (await response.text()).trim()
+              checksumSha256 = text.split(/\s+/)[0]
+            } else {
+              core.setFailed(
+                `Release ${release.tag_name} is missing both an asset digest and ${checksumName}; SDKMAN publication requires a SHA-256 checksum.`,
+              )
+              return
+            }
+
+            core.setOutput("version", version)
+            core.setOutput("archive_url", archive.browser_download_url)
+            core.setOutput("checksum_sha256", checksumSha256)
+            core.setOutput("prerelease", String(Boolean(release.prerelease)))
+
+      - name: Release candidate on SDKMAN!
+        uses: sdkman/sdkman-release-action@3eb9347b254fc89b9af3a1ed08b874228f3dcd1f
+        with:
+          consumer-key: ${{ secrets.SDKMAN_CONSUMER_KEY }}
+          consumer-token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
+          candidate: sbt
+          version: ${{ steps.release.outputs.version }}
+          url: ${{ steps.release.outputs.archive_url }}
+          checksum-sha-256: ${{ steps.release.outputs.checksum_sha256 }}
+
+      - name: Set default SDKMAN! version
+        if: ${{ steps.release.outputs.prerelease != 'true' }}
+        uses: sdkman/sdkman-default-action@38ca710dbacfada85ccfb609953e4c92a717e557
+        with:
+          CONSUMER-KEY: ${{ secrets.SDKMAN_CONSUMER_KEY }}
+          CONSUMER-TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
+          CANDIDATE: sbt
+          VERSION: ${{ steps.release.outputs.version }}


### PR DESCRIPTION
- Attempt to come up with a solution for #9048

## Summary

This PR adds a GitHub Actions workflow to publish sbt releases to SDKMAN automatically when a GitHub release is published.

The workflow is designed to support both stable releases and release candidates:

- Stable releases are published to SDKMAN and then promoted to the default version.
- Release candidates are published to SDKMAN, but are not promoted to default.

This addresses the gap discussed in:
- #7461
- #9048

In particular, it makes RCs available via `sdk list sbt` without making them the version users get by default.

## What this PR changes

Adds a new workflow:

- `.github/workflows/sdkman.yml`

The workflow:

1. Triggers on `release.published`
2. Resolves the GitHub release version from the tag
3. Looks for the matching release archive:
   - `sbt-<version>.tgz`
   - and its checksum `sbt-<version>.tgz.sha256`
4. Publishes that archive to SDKMAN using the official SDKMAN release action
5. Promotes the version to default only if the GitHub release is not marked as a prerelease

## Why this shape

SDKMAN’s current vendor documentation distinguishes between:

- `release`: publish a candidate version
- `default`: make an existing candidate the stable/default version

That maps directly to sbt’s release model:

- RCs should be visible and installable
- stable releases should become the default SDKMAN version

Using the GitHub release’s `prerelease` flag is more reliable than inferring release type from the version string.

## What this does not automate

This PR does **not** build or upload sbt release artifacts.

The workflow assumes that, by the time a GitHub release is published, the release already contains:

- `sbt-<version>.tgz`
- `sbt-<version>.tgz.sha256`

That is the current missing piece for full end-to-end automation.

At the moment, the repo still appears to rely on a separate/manual packaging and upload flow, with evidence in:

- [launcher-package/build.sbt](https://github.com/sbt/sbt/blob/develop/launcher-package/build.sbt)
- [launcher-package/upload/sbt-upload.sh](https://github.com/sbt/sbt/blob/develop/launcher-package/upload/sbt-upload.sh)

This means the SDKMAN workflow added here is the publication step only, not the packaging step.

## Maintainer steps to bring this over the finish line

Before this can work in production, the maintainer needs to complete the remaining release pipeline setup.

### 1. Confirm the intended public artifact source

Choose where SDKMAN should download sbt archives from.

Options:

- GitHub release assets
- existing sbt CDN/object storage, if that remains the canonical distribution location

This PR currently assumes GitHub release assets because that is easiest to wire from `release.published` and easiest to validate in workflow logic.

### 2. Ensure release artifacts are built before publishing the GitHub release

The release process must produce at least:

- `sbt-<version>.tgz`
- `sbt-<version>.tgz.sha256`

If the current maintainer flow builds these locally, that step still needs to happen before publishing the GitHub release.

### 3. Ensure those artifacts are attached to the GitHub release

The workflow will fail fast if the expected `.tgz` asset is missing.

That is intentional: SDKMAN publication should not silently succeed against the wrong archive or a nonexistent URL.

### 4. Add SDKMAN credentials to GitHub repository secrets

Required secrets:

- `SDKMAN_CONSUMER_KEY`
- `SDKMAN_CONSUMER_TOKEN`

These come from the SDKMAN vendor onboarding / vendor API credentials.

### 5. Decide whether GitHub releases are the canonical trigger point

This PR uses:

- `release.published`

That is consistent with the current WinGet workflow and with SDKMAN’s documented GitHub Actions examples.

If the maintainer prefers to publish SDKMAN earlier or later in the release flow, the trigger can be adjusted, but then the artifact availability assumptions should be revisited.

### 6. Test with a real prerelease first

Recommended first end-to-end validation:

1. Build RC artifacts
2. Attach them to a prerelease GitHub release
3. Publish the release
4. Confirm:
   - the version appears in `sdk list sbt`
   - it is installable explicitly
   - it is **not** the default SDKMAN version

This is the safest first rollout because it exercises the new path without changing the default stable sbt seen by SDKMAN users.

### 7. Test a stable release after that

For a normal stable release, confirm:

- the version is published to SDKMAN
- it becomes the default version
- `sdk install sbt` / `sdk upgrade sbt` behavior matches expectation

### 8. Consider automating packaging in a follow-up PR

To get to full hands-off release automation, a follow-up PR should automate:

- building release archives
- generating checksums
- uploading assets
- publishing the GitHub release
- then letting this SDKMAN workflow run

Without that packaging step, the maintainer still needs to prepare release assets manually.

## Notes from issue history

Issue [#7461](https://github.com/sbt/sbt/issues/7461) strongly suggests SDKMAN publication has been manual so far. The maintainer comment there was:

> oops sorry. I just released it on sdkman.

That same thread also explicitly suggested moving SDKMAN publication into a GitHub workflow.

Issue [#9048](https://github.com/sbt/sbt/issues/9048) extends that idea to RCs, which this workflow now supports by publishing prereleases without making them default.

## Verification performed

- Checked `.github/workflows` and found no existing SDKMAN publishing workflow
- Verified the new workflow YAML parses successfully
- Confirmed SDKMAN vendor docs support:
  - candidate release publication
  - separate default promotion
- Confirmed official SDKMAN GitHub actions exist for both operations

## Known limitation

The current `v2.0.0-RC11` GitHub release does not include release assets, so this workflow would currently fail for that release until the corresponding `.tgz` and checksum are uploaded.

## Possible follow-up work

- Automate sbt release packaging and asset upload
- Add release announcement support via the SDKMAN vendor API
- Align WinGet and SDKMAN release automation under a single documented release process
