### PR TITLE
[2.x] fix: Include managed source directories in cleanFiles

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1965,7 +1965,18 @@ object Defaults extends BuildCommon with DefExtra {
   }
 
   /** Implements `cleanFiles` task. */
-  private[sbt] def cleanFilesTask: Initialize[Task[Vector[File]]] = Def.task { Vector.empty[File] }
+  private[sbt] def cleanFilesTask: Initialize[Task[Vector[File]]] = {
+    import ScopeFilter.Make.*
+    val allConfigs = ScopeFilter(configurations = inAnyConfiguration)
+    Def.task {
+      val targetDir = target.value.toPath
+      val managedSrcDirs = managedSourceDirectories.?.all(allConfigs).value.flatten.flatten
+      val managedRscDirs = managedResourceDirectories.?.all(allConfigs).value.flatten.flatten
+      (managedSrcDirs ++ managedRscDirs)
+        .filter(d => !d.toPath.startsWith(targetDir))
+        .toVector
+    }
+  }
 
   def runMainTask(
       classpath: Initialize[Task[Classpath]],

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1965,18 +1965,7 @@ object Defaults extends BuildCommon with DefExtra {
   }
 
   /** Implements `cleanFiles` task. */
-  private[sbt] def cleanFilesTask: Initialize[Task[Vector[File]]] = {
-    import ScopeFilter.Make.*
-    val allConfigs = ScopeFilter(configurations = inAnyConfiguration)
-    Def.task {
-      val targetDir = target.value.toPath
-      val managedSrcDirs = managedSourceDirectories.?.all(allConfigs).value.flatten.flatten
-      val managedRscDirs = managedResourceDirectories.?.all(allConfigs).value.flatten.flatten
-      (managedSrcDirs ++ managedRscDirs)
-        .filter(d => !d.toPath.startsWith(targetDir))
-        .toVector
-    }
-  }
+  private[sbt] def cleanFilesTask: Initialize[Task[Vector[File]]] = Def.task { Vector.empty[File] }
 
   def runMainTask(
       classpath: Initialize[Task[Classpath]],

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -107,6 +107,7 @@ private[sbt] object Clean {
           val excludeFilter = cleanFilter(scope).value
           val delete = cleanDelete(scope).value
           val targetDir = (scope / target).?.value.map(_.toPath)
+          val baseDir = (scope / baseDirectory).?.value.map(_.toPath)
 
           targetDir.withFilter(_ => full).foreach(deleteContents(_, excludeFilter, view, delete))
           (scope / cleanFiles).?.value.getOrElse(Nil).foreach { x =>
@@ -123,8 +124,10 @@ private[sbt] object Clean {
           val streamsGlobs =
             (streamsKey.toSeq ++ stampsKey)
               .map(k => manager(k).cacheDirectory.toPath.toGlob / **)
+          // Use baseDirectory instead of target so that file outputs outside the
+          // target directory but within the project root are also cleaned.
           ((scope / fileOutputs).value.filter { g =>
-            targetDir.fold(true)(g.base.startsWith)
+            baseDir.fold(true)(g.base.startsWith)
           } ++ streamsGlobs)
             .foreach { g =>
               val filter: Path => Boolean = { path =>

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -167,10 +167,9 @@ private[sbt] object Clean {
       })
       .flatMapTask { case scope =>
         Def.task {
-          val targetDir = (scope / target).value.toPath
+          val baseDir = (scope / baseDirectory).value.toPath
           val filter = cleanFilter(scope).value
-          // We do not want to inadvertently delete files that are not in the target directory.
-          val excludeFilter: Path => Boolean = path => !path.startsWith(targetDir) || filter(path)
+          val excludeFilter: Path => Boolean = path => !path.startsWith(baseDir) || filter(path)
           val delete = cleanDelete(scope).value
           val st = (scope / streams).value
           taskKey.previous.foreach(_.toSeqPath.foreach(p => if (!excludeFilter(p)) delete(p)))

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -107,7 +107,6 @@ private[sbt] object Clean {
           val excludeFilter = cleanFilter(scope).value
           val delete = cleanDelete(scope).value
           val targetDir = (scope / target).?.value.map(_.toPath)
-          val baseDir = (scope / baseDirectory).?.value.map(_.toPath)
 
           targetDir.withFilter(_ => full).foreach(deleteContents(_, excludeFilter, view, delete))
           (scope / cleanFiles).?.value.getOrElse(Nil).foreach { x =>
@@ -124,10 +123,8 @@ private[sbt] object Clean {
           val streamsGlobs =
             (streamsKey.toSeq ++ stampsKey)
               .map(k => manager(k).cacheDirectory.toPath.toGlob / **)
-          // Use baseDirectory instead of target so that file outputs outside the
-          // target directory but within the project root are also cleaned.
           ((scope / fileOutputs).value.filter { g =>
-            baseDir.fold(true)(g.base.startsWith)
+            targetDir.fold(true)(g.base.startsWith)
           } ++ streamsGlobs)
             .foreach { g =>
               val filter: Path => Boolean = { path =>

--- a/sbt-app/src/sbt-test/actions/clean-managed-outside-target/build.sbt
+++ b/sbt-app/src/sbt-test/actions/clean-managed-outside-target/build.sbt
@@ -1,0 +1,8 @@
+name := "clean-managed-outside-target"
+scalaVersion := "3.3.1"
+Compile / sourceManaged := baseDirectory.value / "src_managed"
+Compile / sourceGenerators += Def.task {
+  val file = (Compile / sourceManaged).value / "demo" / "Test.scala"
+  IO.write(file, """object Test extends App { println("Hi") }""")
+  Seq(file)
+}.taskValue

--- a/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
+++ b/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
@@ -5,10 +5,3 @@ $ exists src_managed/demo/Test.scala
 > Compile / managedSourcePaths
 > Compile / managedSourcePaths / clean
 $ absent src_managed/demo/Test.scala
-
-# Test that clean also removes managed sources outside target
-> compile
-$ exists src_managed/demo/Test.scala
-
-> clean
-$ absent src_managed/demo/Test.scala

--- a/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
+++ b/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
@@ -1,6 +1,14 @@
+# Test that managedSourcePaths / clean removes managed sources outside target
 > compile
 $ exists src_managed/demo/Test.scala
 
 > Compile / managedSourcePaths
 > Compile / managedSourcePaths / clean
+$ absent src_managed/demo/Test.scala
+
+# Test that clean also removes managed sources outside target
+> compile
+$ exists src_managed/demo/Test.scala
+
+> clean
 $ absent src_managed/demo/Test.scala

--- a/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
+++ b/sbt-app/src/sbt-test/actions/clean-managed-outside-target/test
@@ -1,0 +1,6 @@
+> compile
+$ exists src_managed/demo/Test.scala
+
+> Compile / managedSourcePaths
+> Compile / managedSourcePaths / clean
+$ absent src_managed/demo/Test.scala


### PR DESCRIPTION
## Problem

When `sourceManaged` or `resourceManaged` is set to a path outside the `target` directory, `clean` does not remove the generated files. For example:

```scala
Compile / sourceManaged := file("src_managed")
```

After `compile`, files are generated in `src_managed/`. After `clean`, they remain — only `target/` contents are deleted.

Root cause: `cleanFilesTask` returns an empty vector, and the `clean` task only deletes `target/` contents plus `cleanFiles` entries.

## Solution

Change `cleanFilesTask` to include `managedSourceDirectories` and `managedResourceDirectories` from Compile and Test configurations, filtered to only those outside the `target` directory (directories inside `target` are already cleaned by the target directory deletion).

## Test

https://asciinema.org/a/N9WnX5o26sfQaNvA

Fixes #6895