### PR TITLE
[2.x] Add `-source-links` option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,19 +84,21 @@ def commonSettings: Seq[Setting[?]] = Def.settings(
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2"),
   compile / javacOptions ++= Seq("-Xlint", "-Xlint:-serial"),
-  /*
   Compile / doc / scalacOptions ++= {
-    import scala.sys.process._
-    val devnull = ProcessLogger(_ => ())
-    val tagOrSha = ("git describe --exact-match" #|| "git rev-parse HEAD").lineStream(devnull).head
-    Seq(
-      "-sourcepath",
-      (LocalRootProject / baseDirectory).value.getAbsolutePath,
-      "-doc-source-url",
-      s"https://github.com/sbt/sbt/tree/$tagOrSha€{FILE_PATH}.scala"
-    )
+    if (Dependencies.sbtIoPath.isEmpty && Dependencies.sbtZincPath.isEmpty) {
+      import scala.sys.process.*
+      val devnull = ProcessLogger(_ => ())
+      val tagOrSha =
+        ("git describe --exact-match" #|| "git rev-parse HEAD").lineStream(devnull).head
+      Seq(
+        "-source-links:github://sbt/sbt",
+        "-revision",
+        tagOrSha
+      )
+    } else {
+      Nil
+    }
   },
-   */
   Compile / javafmtOnCompile := scalafmtOnCompile.value,
   Test / javafmtOnCompile := (Test / scalafmtOnCompile).value,
   Compile / unmanagedSources / inputFileStamps :=


### PR DESCRIPTION
https://github.com/scala/scala3/blob/0f8dfa1716bf28f56da122dc9221422a580699b8/scaladoc/src/dotty/tools/scaladoc/SourceLinks.scala#L124-L145

## Before

<img width="380" height="510" alt="image" src="https://github.com/user-attachments/assets/d8f9784c-6b1e-473f-ba9d-d07f8e4edef5" />

## After

<img width="384" height="564" alt="image" src="https://github.com/user-attachments/assets/ac9d00eb-6c44-44ea-9e2f-8c7b28822ec6" />
