### PR TITLE
[2.x] override `sbt.Tests.Group` hashCode

### DIFF
--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -200,6 +200,8 @@ object Tests {
       new Group(name, tests, runPolicy, tags)
     }
 
+    override def hashCode(): Int = (name, tests, runPolicy, tags).##
+
     override def equals(x$1: Any): Boolean = {
       this.eq(x$1.asInstanceOf[Object]) || (x$1.isInstanceOf[Group] && ({
         val Group$1: Group = x$1.asInstanceOf[Group]


### PR DESCRIPTION
history

- [Update Tests.Group to be bin compat by manually implementing case class methods](https://github.com/sbt/sbt/commit/d1cf37b2cad1f8db0164b8fe881db7fe1407b61f)
  - There is consistent `equals` and `hashCode` 
- Remove `hashCode`
  - https://github.com/sbt/sbt/commit/3b4547718e03c7a386a2ef4df9ec6ece4941c067
