### PR TITLE
[2.x] fix: Add description and url to PomGenerator output

### DIFF
--- a/main/src/main/scala/sbt/internal/PomGenerator.scala
+++ b/main/src/main/scala/sbt/internal/PomGenerator.scala
@@ -46,6 +46,8 @@ private[sbt] object PomGenerator:
       <modelVersion>4.0.0</modelVersion>
       {makeModuleID(crossMid)}
       {info.map(i => <name>{i.nameFormal}</name>).getOrElse(NodeSeq.Empty)}
+      {info.map(makeDescription).getOrElse(NodeSeq.Empty)}
+      {info.map(makeHomePage).getOrElse(NodeSeq.Empty)}
       {info.map(makeStartYear).getOrElse(NodeSeq.Empty)}
       {info.map(makeOrganization).getOrElse(NodeSeq.Empty)}
       {info.map(makeScmInfo).getOrElse(NodeSeq.Empty)}
@@ -95,6 +97,16 @@ private[sbt] object PomGenerator:
 
   private val IgnoreTypes: Set[String] =
     Set(Artifact.SourceType, Artifact.DocType, Artifact.PomType)
+
+  private def makeDescription(info: ModuleInfo): NodeSeq =
+    if info.description != null && info.description.nonEmpty then
+      <description>{info.description}</description>
+    else NodeSeq.Empty
+
+  private def makeHomePage(info: ModuleInfo): NodeSeq =
+    info.homepage match
+      case Some(h) => <url>{h}</url>
+      case _       => NodeSeq.Empty
 
   private def makeStartYear(info: ModuleInfo): NodeSeq =
     info.startYear match

--- a/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/make-pom/build.sbt
@@ -6,6 +6,8 @@ lazy val root = (project in file(".")).settings(
     val converter = fileConverter.value
     XML.loadFile(converter.toPath(vf).toFile)
   },
+  description := "pom.xml test description",
+  homepage := Some(url("https://example.com/pom_test_url")),
   TaskKey[Unit]("checkPom") := checkPom.value,
   TaskKey[Unit]("checkExtra") := checkExtra.value,
   TaskKey[Unit]("checkVersionPlusMapping") := checkVersionPlusMapping.value,
@@ -65,6 +67,10 @@ lazy val checkReleaseNotesURL = readPom.map: pomXml =>
 lazy val checkPom = Def.task {
   val pomXML = readPom.value
   checkProject(pomXML)
+  val urlFromPom = (pomXML \ "url").text
+  assert(urlFromPom == "https://example.com/pom_test_url", s"Expected homepage url, got: $urlFromPom")
+  val descriptionFromPom = (pomXML \ "description").text
+  assert(descriptionFromPom == "pom.xml test description", s"Expected description, got: $descriptionFromPom")
   val ivyRepositories = fullResolvers.value
   withRepositories(pomXML) { repositoriesElement =>
     val repositories = repositoriesElement \ "repository"


### PR DESCRIPTION
## Summary
- Adds missing `<description>` and `<url>` elements to `PomGenerator` pom.xml output
- Adopts test from #9053

Fixes #9054

## Problem
`PomGenerator` (introduced in #8873) was missing `<description>` and `<url>` elements that the old Ivy-based `MakePom` included. Setting `description` and `homepage` in `build.sbt` had no effect on the generated pom.xml.

## Solution
- Add `makeDescription` and `makeHomePage` private helpers to `PomGenerator`, matching the behavior of `MakePom`
- Add test assertions for both fields in the existing `make-pom` scripted test

## Test plan
- [x] `scripted dependency-management/make-pom` passes
- [x] `mainProj/compile` passes