### PR TITLE
[2.x] build: Remove `-Ymacro-expand` option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,6 @@ lazy val sbtRoot: Project = (project in file("."))
     },
     Utils.baseScalacOptions,
     Docs.settings,
-    scalacOptions += "-Ymacro-expand:none", // for both sxr and doc
     Utils.publishPomSettings,
     otherRootSettings,
     Utils.noPublish,


### PR DESCRIPTION
Scala 3 does not have this option.