### PR TITLE
[2.x] Update `.gitattributes` for contraband files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@ launcher-package/src/windows/sbt text eol=lf
 **/contraband-scala/**/* -diff merge=ours
 **/contraband-scala/**/* linguist-generated=true
 **/contraband-scala/**/* diff
+
+*.contra linguist-language=graphql


### PR DESCRIPTION
For syntax highlight on GitHub.

https://github.com/sbt/contraband/blob/ae50d940b23073586de9e4a071dc60fb9fab4da7/docs/01-schema.md?plain=1#L15-L16

> Since we don't want to rely on a specific programming language syntax, to talk about Contraband schemas, we'll extend GraphQL's schema language.


## Before

<img width="616" height="785" alt="before" src="https://github.com/user-attachments/assets/6067d1a5-dece-4c82-8233-7dc692745ccb" />

<hr />

## After

my fork repo

<img width="688" height="803" alt="after" src="https://github.com/user-attachments/assets/6be1a080-f6f9-4617-8d44-377f9538e8ed" />

