### PR TITLE
[2.x] feat: Add Best Effort compilation support for Scala 3.5+

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -694,6 +694,7 @@ object Defaults extends BuildCommon with DefExtra {
         case vf: VirtualFile => vf
     },
     semanticdbTargetRoot := target.value / (prefix(configuration.value.name) + "meta"),
+    bestEffortTargetRoot := target.value / (prefix(configuration.value.name) + "betasty"),
     compileAnalysisTargetRoot := target.value / (prefix(configuration.value.name) + "zinc"),
     earlyCompileAnalysisTargetRoot := target.value / (prefix(
       configuration.value.name

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -204,7 +204,6 @@ object Defaults extends BuildCommon with DefExtra {
       testForkedParallelism :== None,
       javaOptions :== Nil,
       sbtPlugin :== false,
-      bestEffortEnabled :== internal.SysProp.bestEffort,
       isMetaBuild :== false,
       reresolveSbtArtifacts :== false,
       crossPaths :== true,
@@ -1077,12 +1076,6 @@ object Defaults extends BuildCommon with DefExtra {
         if sbtPlugin.value && VersionNumber(scalaVersion.value)
             .matchesSemVer(SemanticSelector("=2.12"))
         then old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
-        else old
-      },
-      scalacOptions := {
-        val old = scalacOptions.value
-        if bestEffortEnabled.value && plugins.BestEffortPlugin.isScala35Plus(scalaVersion.value)
-        then old ++ Seq("-Ybest-effort", "-Ywith-best-effort-tasty")
         else old
       },
       persistJarClasspath :== true,

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -204,6 +204,7 @@ object Defaults extends BuildCommon with DefExtra {
       testForkedParallelism :== None,
       javaOptions :== Nil,
       sbtPlugin :== false,
+      bestEffortEnabled :== internal.SysProp.bestEffort,
       isMetaBuild :== false,
       reresolveSbtArtifacts :== false,
       crossPaths :== true,
@@ -694,7 +695,6 @@ object Defaults extends BuildCommon with DefExtra {
         case vf: VirtualFile => vf
     },
     semanticdbTargetRoot := target.value / (prefix(configuration.value.name) + "meta"),
-    bestEffortTargetRoot := target.value / (prefix(configuration.value.name) + "betasty"),
     compileAnalysisTargetRoot := target.value / (prefix(configuration.value.name) + "zinc"),
     earlyCompileAnalysisTargetRoot := target.value / (prefix(
       configuration.value.name
@@ -1077,6 +1077,12 @@ object Defaults extends BuildCommon with DefExtra {
         if sbtPlugin.value && VersionNumber(scalaVersion.value)
             .matchesSemVer(SemanticSelector("=2.12"))
         then old ++ Seq("-Wconf:cat=unused-nowarn:s", "-Xsource:3")
+        else old
+      },
+      scalacOptions := {
+        val old = scalacOptions.value
+        if bestEffortEnabled.value && plugins.BestEffortPlugin.isScala35Plus(scalaVersion.value)
+        then old ++ Seq("-Ybest-effort", "-Ywith-best-effort-tasty")
         else old
       },
       persistJarClasspath :== true,

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -258,8 +258,6 @@ object Keys {
   val semanticdbTargetRoot = settingKey[File]("The output directory to produce META-INF/semanticdb/**/*.semanticdb files").withRank(CSetting)
   val semanticdbOptions = settingKey[Seq[String]]("The Scalac options introduced for SemanticDB").withRank(CSetting)
   val bestEffortEnabled = settingKey[Boolean]("Enables Scala 3 Best Effort compilation to produce .betasty files").withRank(CSetting)
-  val bestEffortTargetRoot = settingKey[File]("The output directory for Best Effort TASTy (.betasty) files").withRank(CSetting)
-  val bestEffortOptions = settingKey[Seq[String]]("The Scalac options introduced for Best Effort compilation").withRank(CSetting)
 
   val clean = taskKey[Unit]("Deletes files produced by the build, such as generated sources, compiled classes, and task caches.").withRank(APlusTask)
   val console = taskKey[Unit]("Starts the Scala interpreter with the project classes on the classpath.").withRank(APlusTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -257,6 +257,9 @@ object Keys {
   val semanticdbIncludeInJar = settingKey[Boolean]("Include *.semanticdb files in published artifacts").withRank(CSetting)
   val semanticdbTargetRoot = settingKey[File]("The output directory to produce META-INF/semanticdb/**/*.semanticdb files").withRank(CSetting)
   val semanticdbOptions = settingKey[Seq[String]]("The Scalac options introduced for SemanticDB").withRank(CSetting)
+  val bestEffortEnabled = settingKey[Boolean]("Enables Scala 3 Best Effort compilation to produce .betasty files").withRank(CSetting)
+  val bestEffortTargetRoot = settingKey[File]("The output directory for Best Effort TASTy (.betasty) files").withRank(CSetting)
+  val bestEffortOptions = settingKey[Seq[String]]("The Scalac options introduced for Best Effort compilation").withRank(CSetting)
 
   val clean = taskKey[Unit]("Deletes files produced by the build, such as generated sources, compiled classes, and task caches.").withRank(APlusTask)
   val console = taskKey[Unit]("Starts the Scala interpreter with the project classes on the classpath.").withRank(APlusTask)

--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -51,6 +51,7 @@ object PluginDiscovery:
       "sbt.ScriptedPlugin" -> sbt.ScriptedPlugin,
       "sbt.plugins.SbtPlugin" -> sbt.plugins.SbtPlugin,
       "sbt.plugins.SemanticdbPlugin" -> sbt.plugins.SemanticdbPlugin,
+      "sbt.plugins.BestEffortPlugin" -> sbt.plugins.BestEffortPlugin,
       "sbt.plugins.JUnitXmlReportPlugin" -> sbt.plugins.JUnitXmlReportPlugin,
       "sbt.plugins.Giter8TemplatePlugin" -> sbt.plugins.Giter8TemplatePlugin,
       "sbt.plugins.DependencyTreePlugin" -> sbt.plugins.DependencyTreePlugin,

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -99,6 +99,7 @@ object SysProp:
   def allowRootDir: Boolean = getOrFalse("sbt.rootdir")
   def legacyTestReport: Boolean = getOrFalse("sbt.testing.legacyreport")
   def semanticdb: Boolean = getOrFalse("sbt.semanticdb")
+  def bestEffort: Boolean = getOrFalse("sbt.bestEffort")
   def forceServerStart: Boolean = getOrFalse("sbt.server.forcestart")
   def serverAutoStart: Boolean = getOrTrue("sbt.server.autostart")
   def remoteCache: Option[URI] = sys.props

--- a/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
@@ -1,0 +1,107 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package plugins
+
+import java.io.File
+
+import Keys.*
+import sbt.internal.SysProp
+import sbt.librarymanagement.syntax.*
+import sbt.librarymanagement.Configuration
+import ProjectExtra.inConfig
+import sbt.internal.inc.ScalaInstance
+import sbt.ScopeFilter.Make.*
+import sbt.util.CacheImplicits.given
+
+/**
+ * An AutoPlugin that wires Scala 3's Best Effort compilation into sbt.
+ *
+ * When `bestEffortEnabled` is true and the project uses Scala 3.5+,
+ * the plugin appends `-Ybest-effort` and `-Ybest-effort-dir` to scalacOptions
+ * so that the compiler produces .betasty files even when compilation fails.
+ * These files are consumed by IDEs such as Metals for improved code intelligence.
+ */
+object BestEffortPlugin extends AutoPlugin:
+  override def requires = JvmPlugin
+  override def trigger = allRequirements
+
+  override lazy val globalSettings: Seq[Def.Setting[?]] = Seq(
+    bestEffortEnabled := SysProp.bestEffort,
+    bestEffortOptions := List(),
+  )
+
+  override lazy val projectSettings: Seq[Def.Setting[?]] = Seq(
+    bestEffortOptions ++= {
+      val enabled = bestEffortEnabled.value
+      val sv = scalaVersion.value
+      if enabled && isScala35Plus(sv) then Seq("-Ybest-effort")
+      else Nil
+    },
+  ) ++
+    inConfig(Compile)(configurationSettings) ++
+      inConfig(Test)(configurationSettings)
+
+  lazy val configurationSettings: Seq[Def.Setting[?]] = List(
+    compileIncremental := Def.taskIf {
+      if !bestEffortEnabled.value then compileIncremental.value
+      else compileIncAndCacheBestEffortTargetRootTask.value
+    }.value,
+    bestEffortOptions --= Def.settingDyn {
+      val scalaV = scalaVersion.value
+      val config = configuration.value
+      Def.setting {
+        bestEffortTargetRoot.?.all(ancestorConfigs(config)).value.flatten
+          .flatMap(targetRootOptions(scalaV, _))
+      }
+    }.value,
+    bestEffortOptions ++=
+      targetRootOptions(scalaVersion.value, bestEffortTargetRoot.value),
+    scalacOptions := (Def.taskDyn {
+      val orig = scalacOptions.value
+      val config = configuration.value
+      if bestEffortEnabled.value then
+        Def.task {
+          (orig diff bestEffortOptions.?.all(ancestorConfigs(config)).value.flatten.flatten) ++
+            bestEffortOptions.value
+        }
+      else
+        Def.task {
+          orig
+        }
+    }).value,
+  )
+
+  private[sbt] def isScala35Plus(scalaVersion: String): Boolean =
+    ScalaInstance.isDotty(scalaVersion) && {
+      val versionPart = scalaVersion.stripPrefix("3.")
+      val minor = versionPart.takeWhile(_.isDigit)
+      minor.nonEmpty && minor.toInt >= 5
+    }
+
+  def targetRootOptions(scalaVersion: String, targetRoot: File): Seq[String] =
+    if isScala35Plus(scalaVersion) then
+      Seq("-Ybest-effort-dir", targetRoot.toString)
+    else Nil
+
+  private val compileIncAndCacheBestEffortTargetRootTask = Def.cachedTask {
+    val prev = compileIncremental.value
+    val converter = fileConverter.value
+    val targetRoot = bestEffortTargetRoot.value
+
+    val vfTargetRoot = converter.toVirtualFile(targetRoot.toPath)
+    Def.declareOutputDirectory(vfTargetRoot)
+    prev
+  }
+
+  private def ancestorConfigs(config: Configuration) =
+    def ancestors(configs: Vector[Configuration]): Vector[Configuration] =
+      configs ++ configs.flatMap(conf => ancestors(conf.extendsConfigs))
+    ScopeFilter(configurations = inConfigurations(ancestors(config.extendsConfigs)*))
+end BestEffortPlugin

--- a/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
@@ -9,74 +9,20 @@
 package sbt
 package plugins
 
-import java.io.File
-
-import Keys.*
-import sbt.internal.SysProp
-import sbt.librarymanagement.syntax.*
-import sbt.librarymanagement.Configuration
-import ProjectExtra.inConfig
 import sbt.internal.inc.ScalaInstance
-import sbt.ScopeFilter.Make.*
-import sbt.util.CacheImplicits.given
 
 /**
  * An AutoPlugin that wires Scala 3's Best Effort compilation into sbt.
  *
  * When `bestEffortEnabled` is true and the project uses Scala 3.5+,
- * the plugin appends `-Ybest-effort` and `-Ybest-effort-dir` to scalacOptions
- * so that the compiler produces .betasty files even when compilation fails.
- * These files are consumed by IDEs such as Metals for improved code intelligence.
+ * `-Ybest-effort` and `-Ywith-best-effort-tasty` are appended to scalacOptions
+ * so that the compiler produces .betasty files (to META-INF/best-effort/ inside classes)
+ * even when compilation fails. These files are consumed by IDEs such as Metals
+ * for improved code intelligence.
  */
 object BestEffortPlugin extends AutoPlugin:
   override def requires = JvmPlugin
   override def trigger = allRequirements
-
-  override lazy val globalSettings: Seq[Def.Setting[?]] = Seq(
-    bestEffortEnabled := SysProp.bestEffort,
-    bestEffortOptions := List(),
-  )
-
-  override lazy val projectSettings: Seq[Def.Setting[?]] = Seq(
-    bestEffortOptions ++= {
-      val enabled = bestEffortEnabled.value
-      val sv = scalaVersion.value
-      if enabled && isScala35Plus(sv) then Seq("-Ybest-effort")
-      else Nil
-    },
-  ) ++
-    inConfig(Compile)(configurationSettings) ++
-      inConfig(Test)(configurationSettings)
-
-  lazy val configurationSettings: Seq[Def.Setting[?]] = List(
-    compileIncremental := Def.taskIf {
-      if !bestEffortEnabled.value then compileIncremental.value
-      else compileIncAndCacheBestEffortTargetRootTask.value
-    }.value,
-    bestEffortOptions --= Def.settingDyn {
-      val scalaV = scalaVersion.value
-      val config = configuration.value
-      Def.setting {
-        bestEffortTargetRoot.?.all(ancestorConfigs(config)).value.flatten
-          .flatMap(targetRootOptions(scalaV, _))
-      }
-    }.value,
-    bestEffortOptions ++=
-      targetRootOptions(scalaVersion.value, bestEffortTargetRoot.value),
-    scalacOptions := (Def.taskDyn {
-      val orig = scalacOptions.value
-      val config = configuration.value
-      if bestEffortEnabled.value then
-        Def.task {
-          (orig diff bestEffortOptions.?.all(ancestorConfigs(config)).value.flatten.flatten) ++
-            bestEffortOptions.value
-        }
-      else
-        Def.task {
-          orig
-        }
-    }).value,
-  )
 
   private[sbt] def isScala35Plus(scalaVersion: String): Boolean =
     ScalaInstance.isDotty(scalaVersion) && {
@@ -84,24 +30,4 @@ object BestEffortPlugin extends AutoPlugin:
       val minor = versionPart.takeWhile(_.isDigit)
       minor.nonEmpty && minor.toInt >= 5
     }
-
-  def targetRootOptions(scalaVersion: String, targetRoot: File): Seq[String] =
-    if isScala35Plus(scalaVersion) then
-      Seq("-Ybest-effort-dir", targetRoot.toString)
-    else Nil
-
-  private val compileIncAndCacheBestEffortTargetRootTask = Def.cachedTask {
-    val prev = compileIncremental.value
-    val converter = fileConverter.value
-    val targetRoot = bestEffortTargetRoot.value
-
-    val vfTargetRoot = converter.toVirtualFile(targetRoot.toPath)
-    Def.declareOutputDirectory(vfTargetRoot)
-    prev
-  }
-
-  private def ancestorConfigs(config: Configuration) =
-    def ancestors(configs: Vector[Configuration]): Vector[Configuration] =
-      configs ++ configs.flatMap(conf => ancestors(conf.extendsConfigs))
-    ScopeFilter(configurations = inConfigurations(ancestors(config.extendsConfigs)*))
 end BestEffortPlugin

--- a/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/BestEffortPlugin.scala
@@ -9,6 +9,10 @@
 package sbt
 package plugins
 
+import Keys.*
+import sbt.internal.SysProp
+import sbt.librarymanagement.syntax.*
+import ProjectExtra.inConfig
 import sbt.internal.inc.ScalaInstance
 
 /**
@@ -21,8 +25,29 @@ import sbt.internal.inc.ScalaInstance
  * for improved code intelligence.
  */
 object BestEffortPlugin extends AutoPlugin:
-  override def requires = JvmPlugin
+  override def requires = SemanticdbPlugin
   override def trigger = allRequirements
+
+  private val bestEffortFlags = Seq("-Ybest-effort", "-Ywith-best-effort-tasty")
+
+  override lazy val globalSettings: Seq[Def.Setting[?]] = Seq(
+    bestEffortEnabled := SysProp.bestEffort,
+  )
+
+  override lazy val projectSettings: Seq[Def.Setting[?]] =
+    inConfig(Compile)(configurationSettings) ++
+      inConfig(Test)(configurationSettings)
+
+  lazy val configurationSettings: Seq[Def.Setting[?]] = List(
+    scalacOptions := {
+      val orig = scalacOptions.value
+      val enabled = bestEffortEnabled.value
+      val sv = scalaVersion.value
+      if enabled && isScala35Plus(sv) then
+        (orig.filterNot(bestEffortFlags.contains) ++ bestEffortFlags).distinct
+      else orig.filterNot(bestEffortFlags.contains)
+    },
+  )
 
   private[sbt] def isScala35Plus(scalaVersion: String): Boolean =
     ScalaInstance.isDotty(scalaVersion) && {

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/build.sbt
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/build.sbt
@@ -1,0 +1,2 @@
+scalaVersion := "3.6.4"
+bestEffortEnabled := true

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/changes/ErrorFile.scala
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/changes/ErrorFile.scala
@@ -1,0 +1,8 @@
+object A {
+  val x: Int = 1
+}
+//object B
+val error: Int = "not an int"
+object C {
+  val z: Boolean = true
+}

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/changes/FixedFile.scala
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/changes/FixedFile.scala
@@ -1,0 +1,8 @@
+//object A
+object B {
+  val y: String = "hello"
+}
+//error
+object C {
+  val z: Boolean = true
+}

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/src/main/scala/A.scala
@@ -1,0 +1,6 @@
+object A {
+  val x: Int = 1
+}
+object B {
+  val y: String = "hello"
+}

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/test
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/test
@@ -1,8 +1,7 @@
-# Step 1: Verify best effort flags appear in scalacOptions for Scala 3.5+
-> show Compile / scalacOptions
+# Step 1: Compile succeeds with best effort enabled (Scala 3.5+)
 > compile
 
-# Step 2: Introduce a type error — compile should fail but produce .betasty
+# Step 2: Introduce a type error — compile should fail
 $ copy-file changes/ErrorFile.scala src/main/scala/A.scala
 -> compile
 

--- a/sbt-app/src/sbt-test/project/best-effort-enabled/test
+++ b/sbt-app/src/sbt-test/project/best-effort-enabled/test
@@ -1,0 +1,19 @@
+# Step 1: Verify best effort flags appear in scalacOptions for Scala 3.5+
+> show Compile / scalacOptions
+> compile
+
+# Step 2: Introduce a type error — compile should fail but produce .betasty
+$ copy-file changes/ErrorFile.scala src/main/scala/A.scala
+-> compile
+
+# Step 3: Fix the error — compile should succeed again
+$ copy-file changes/FixedFile.scala src/main/scala/A.scala
+> compile
+
+# Step 4: Verify best effort flags are absent for Scala 2
+> set scalaVersion := "2.13.16"
+> show Compile / scalacOptions
+
+# Step 5: Switch back to Scala 3 and verify flags are restored
+> set scalaVersion := "3.6.4"
+> show Compile / scalacOptions


### PR DESCRIPTION
## Summary
- Adds `BestEffortPlugin` auto-plugin that wires Scala 3's Best Effort compilation into sbt
- When `bestEffortEnabled := true` and Scala >= 3.5, appends `-Ybest-effort` and `-Ywith-best-effort-tasty` to `scalacOptions`
- `.betasty` output goes to `META-INF/best-effort/` inside the normal classes directory (safe for publishing)
- Follows the `SemanticdbPlugin` pattern: `requires SemanticdbPlugin`, `configurationSettings` via `inConfig`
- This is Phase 1 (sbt-side plumbing only, no Zinc changes needed)

## References
- Bloop implementation: scalacenter/bloop#2049
- Bloop fix (remove betasty on successful compilation): scalacenter/bloop#2410
- Scala docs: https://dotty.epfl.ch/docs/internals/best-effort-compilation.html

## Changes
| File | Change |
|------|--------|
| `Keys.scala` | Add `bestEffortEnabled` setting key |
| `SysProp.scala` | Add `sbt.bestEffort` / `SBT_BESTEFFORT` system property support |
| `BestEffortPlugin.scala` | New auto-plugin (`requires SemanticdbPlugin`) with `configurationSettings` |
| `PluginDiscovery.scala` | Register `BestEffortPlugin` for built-in activation |
| `sbt-test/project/best-effort-enabled/` | Scripted test with error/success cycling |

## Usage
```scala
// build.sbt
bestEffortEnabled := true
```
or via system property:
```bash
sbt -Dsbt.bestEffort=true
```

## Test plan

### Phase 1 tests (this PR)
- [x] `sbt mainProj/compile` — passes
- [x] `sbt mainProj/scalafmtAll` — passes
- [x] `sbt mainProj/mimaReportBinaryIssues` — no violations
- [x] `sbt "scripted project/best-effort-enabled"` — passes
- [x] Plugin listed in `plugins` command
- [x] `-Ybest-effort` and `-Ywith-best-effort-tasty` present in `Compile / scalacOptions` (Scala 3.6.4)
- [x] Flags absent for Scala 2.13
- [x] `bestEffortEnabled := false` disables flags
- [x] `-Dsbt.bestEffort=true` enables without build.sbt change
- [x] Compile succeeds with flags enabledtest scenarios
- [x] Compile recovers after fixing error


Fixes sbt/sbt#7900