### PR TITLE
[2.x] fix: Fixes client-side run status

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -181,6 +181,7 @@ class NetworkClient(
     def success(message: => String): Unit = ()
     def log(level: Level.Value, message: => String): Unit = console.appendLog(level, message)
   }
+  private val interactive = arguments.commandArguments.isEmpty
 
   private[sbt] def connectOrStartServerAndConnect(
       promptCompleteUsers: Boolean,
@@ -712,8 +713,19 @@ class NetworkClient(
         case (`clientJob`, Some(json)) =>
           import sbt.internal.worker.codec.JsonProtocol.given
           Converter.fromJson[ClientJobParams](json) match {
-            case Success(params) => clientSideRun(params).get; Vector.empty
-            case Failure(_)      => Vector.empty
+            case Success(params) =>
+              clientSideRun(params) match
+                case Success(_) =>
+                  if interactive then console.success("ok")
+                  else ()
+                  Vector.empty
+                case Failure(e) =>
+                  if interactive then
+                    Vector(
+                      (Level.Error, e.getMessage)
+                    )
+                  else throw e
+            case Failure(_) => Vector.empty
           }
         case (`Shutdown`, Some(_))                => Vector.empty
         case (msg, _) if msg.startsWith("build/") => Vector.empty
@@ -921,9 +933,8 @@ class NetworkClient(
     withSignalHandler(contHandler, Signals.CONT) {
       interactiveThread.set(Thread.currentThread)
       val cleaned = arguments.commandArguments
-      val userCommands = cleaned.takeWhile(_ != TerminateAction)
-      val interactive = cleaned.isEmpty
-      val exit = cleaned.nonEmpty && userCommands.isEmpty
+      val userCommands = arguments.commandArguments.takeWhile(_ != TerminateAction)
+      val exit = arguments.commandArguments.nonEmpty && userCommands.isEmpty
       attachUUID.set(sendJson(attach, s"""{"interactive": $interactive}"""))
       val handler: () => Unit = () => {
         def exitAbruptly() = {

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -17,6 +17,7 @@ import sbt.internal.util.complete.Parser
 import sbt.internal.util.complete.Parser.{ failure, seq, success }
 import sbt.internal.util.*
 import sbt.internal.client.NetworkClient
+import sbt.internal.worker.ClientJobParams
 import sbt.std.Transform.DummyTaskMap
 import sbt.util.{ Logger, Show }
 import scala.annotation.tailrec
@@ -87,16 +88,18 @@ object Aggregation {
     import complete.*
     val log = state.log
     val extracted = Project.extract(state)
-    val success = results match
-      case Result.Value(_) => true
-      case Result.Inc(_)   => false
+    // omit success printing for client-side run
+    val (success, jobParams) = results match
+      case Result.Value(Seq(KeyValue(_, p: ClientJobParams))) => (true, true)
+      case Result.Value(_)                                    => (true, false)
+      case Result.Inc(_)                                      => (false, false)
     val isPaused = currentChannel(state) match
       case Some(channel) => channel.isPaused
       case None          => false
     results.toEither.foreach { r =>
       if show.taskValues then printSettings(r, show.print) else ()
     }
-    if !isPaused && show.success && !state.get(suppressShow).getOrElse(false) then
+    if !isPaused && show.success && !state.get(suppressShow).getOrElse(false) && !jobParams then
       printSuccess(start, stop, extracted, success, cacheSummary, log)
     else ()
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9022

## Problem
In sbt 2.x, if we execute a run task from the shell, and if the program fails, it ends up taking down the entire shell because client-side run rethrows, which is not desirable for the sbt shell.

## Solution
1. Omit printing out success for ClientJobParams, which is the runinfo.
2. Print out success or error on the client-side for shell usage case.

## Test


```scala
sbt:run> run
[info] running (fork) example.main
hi
[success] ok
sbt:run> run
[info] running (fork) example.main
Exception in thread "main" java.lang.RuntimeException: Hello
	at scala.sys.package$.error(package.scala:28)
	at example.Hello$package$.main(Hello.scala:5)
	at example.main.main(Hello.scala:3)
[error] nonzero exit code returned from runner: 1
sbt:run> exit
[info] disconnected
```

```bash
$ /Users/xxx/sbt/client/target/bin/sbtn run
[info] running (fork) example.main
Exception in thread "main" java.lang.RuntimeException: Hello
	at scala.sys.package$.error(package.scala:28)
	at example.Hello$package$.main(Hello.scala:5)
	at example.main.main(Hello.scala:3)
Exception in thread "sbt-serverconnection-0" nonzero exit code returned from runner: 1
	at sbt.Run$.processExitCode(Run.scala:257)
	at sbt.ForkRun.run(Run.scala:45)
	at sbt.internal.util.RunHandler$.jvmRun(RunHandler.scala:43)
	at sbt.internal.client.NetworkClient.clientSideRun(NetworkClient.scala:819)
	at sbt.internal.client.NetworkClient.clientSideRun(NetworkClient.scala:785)
	at sbt.internal.client.NetworkClient.splitToMessage$1(NetworkClient.scala:717)
	at sbt.internal.client.NetworkClient.onNotification(NetworkClient.scala:747)
	at sbt.internal.client.NetworkClient$$anon$8.onNotification(NetworkClient.scala:308)
	at sbt.protocol.ServerSessionImpl$$anon$1.run$$anonfun$2(ServerSessionImpl.scala:110)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.util.Either.fold(Either.scala:199)
	at sbt.protocol.ServerSessionImpl$$anon$1.run(ServerSessionImpl.scala:107)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
```