### PR TITLE
[1.x] Update log4j to 2.25.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,7 +122,7 @@ object Dependencies {
   val scalaPar = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0"
 
   // specify all of log4j modules to prevent misalignment
-  def log4jModule = (n: String) => "org.apache.logging.log4j" % n % "2.25.3"
+  def log4jModule = (n: String) => "org.apache.logging.log4j" % n % "2.25.4"
   val log4jApi = log4jModule("log4j-api")
   val log4jCore = log4jModule("log4j-core")
   val log4jSlf4jImpl = log4jModule("log4j-slf4j-impl")


### PR DESCRIPTION
Fixes CVE-2026-34477, CVE-2026-34478, CVE-2026-34479, CVE-2026-34480
https://logging.apache.org/security.html#CVE-2026-34477
https://logging.apache.org/security.html#CVE-2026-34478
https://logging.apache.org/security.html#CVE-2026-34479
https://logging.apache.org/security.html#CVE-2026-34480


Tested locally: `sbt clean test`