### PR TITLE
[1.x] fix: dependency-submission branch set to 1.12.x

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -2,7 +2,7 @@
 name: Submit Dependency Graph
 on:
   push:
-    branches: [1.10.x, develop]
+    branches: [1.12.x, develop]
 permissions: {}
 jobs:
   submit-graph:


### PR DESCRIPTION
`sbt-dependency-submission` was watching for the changes on incorrect branch `1.12.x`

