### PR TITLE
[2.x] Update sbt-java-formatter

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.8.0")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
-addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter-add-opens" % "0.11.1-M1")
 addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.4.0")
 addDependencyTreePlugin
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")


### PR DESCRIPTION
- https://github.com/sbt/sbt/pull/8892

> The latest version of sbt-java-formatter is 0.10.0 but I have added version 0.9.0.
>
> https://github.com/sbt/sbt-java-formatter/tags
>
> Because latest version throw IllegalAccessError.
>
>> google-java-format uses internal javac APIs for parsing Java source. The following JVM flags are required when running on JDK 16 and newer, due to [JEP 396: Strongly Encapsulate JDK Internals by Default](https://openjdk.java.net/jeps/396)


- https://github.com/sbt/sbt-java-formatter/pull/261