### PR TITLE
[2.x] fix: Handle --branch for ssh template URLs in sbt new

### DIFF
--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -16,7 +16,6 @@ import sbt.io.*, syntax.*
 import sbt.util.*
 import sbt.internal.util.{ ConsoleAppender, Terminal as ITerminal }
 import sbt.internal.util.complete.{ DefaultParsers, Parser }, DefaultParsers.*
-import sbt.internal.VcsUriFragment
 import xsbti.AppConfiguration
 import sbt.librarymanagement.*
 import sbt.internal.inc.classpath.ClasspathUtil
@@ -51,16 +50,15 @@ private[sbt] object TemplateCommandUtil {
         case exec :: Nil if exec.commandLine == "shell" => Nil
         case xs                                         => xs map (_.commandLine)
       })
-    val args = normalizeTemplateArgs(args0)
     def terminate = TerminateAction :: s1.copy(remainingCommands = Nil)
     def reload = "reboot" :: s1.copy(remainingCommands = Nil)
-    if (args.nonEmpty) {
-      args match {
+    if (args0.nonEmpty) {
+      args0 match {
         case arg :: Nil if arg.endsWith(".local") =>
           extracted.runInputTask(Keys.templateRunLocal, " " + arg, s0)
           reload
         case _ =>
-          run(infos, args, s0.configuration, lm, globalBase, scalaModuleInfo, log)
+          run(infos, args0, s0.configuration, lm, globalBase, scalaModuleInfo, log)
           terminate
       }
     } else {
@@ -275,27 +273,6 @@ private[sbt] object TemplateCommandUtil {
     val ans0 = System.console.readLine()
     if (ans0 == "") default
     else ans0
-  }
-
-  // Work around resolver behavior for `ssh://` templates by encoding `--branch` as URI fragment.
-  // This keeps branch checkout working for `sbt new ssh://... --branch x`.
-  private[sbt] def normalizeTemplateArgs(arguments: List[String]): List[String] = {
-    val branchArgIndex = arguments.indexOf("--branch")
-    if (branchArgIndex < 0 || branchArgIndex + 1 >= arguments.length) arguments
-    else {
-      val branch = arguments(branchArgIndex + 1)
-      val sshTemplateIndex =
-        arguments.indexWhere(arg => arg.startsWith("ssh://") && !arg.contains("#"))
-      if (sshTemplateIndex < 0) arguments
-      else {
-        VcsUriFragment.validate(branch)
-        arguments.zipWithIndex.collect {
-          case (_, idx) if idx == branchArgIndex || idx == branchArgIndex + 1 => None
-          case (arg, idx) if idx == sshTemplateIndex => Some(s"$arg#$branch")
-          case (arg, _)                              => Some(arg)
-        }.flatten
-      }
-    }
   }
 
   // This is used by Defaults.runLocalTemplate, which implements

--- a/main/src/main/scala/sbt/TemplateCommandUtil.scala
+++ b/main/src/main/scala/sbt/TemplateCommandUtil.scala
@@ -16,6 +16,7 @@ import sbt.io.*, syntax.*
 import sbt.util.*
 import sbt.internal.util.{ ConsoleAppender, Terminal as ITerminal }
 import sbt.internal.util.complete.{ DefaultParsers, Parser }, DefaultParsers.*
+import sbt.internal.VcsUriFragment
 import xsbti.AppConfiguration
 import sbt.librarymanagement.*
 import sbt.internal.inc.classpath.ClasspathUtil
@@ -50,15 +51,16 @@ private[sbt] object TemplateCommandUtil {
         case exec :: Nil if exec.commandLine == "shell" => Nil
         case xs                                         => xs map (_.commandLine)
       })
+    val args = normalizeTemplateArgs(args0)
     def terminate = TerminateAction :: s1.copy(remainingCommands = Nil)
     def reload = "reboot" :: s1.copy(remainingCommands = Nil)
-    if (args0.nonEmpty) {
-      args0 match {
+    if (args.nonEmpty) {
+      args match {
         case arg :: Nil if arg.endsWith(".local") =>
           extracted.runInputTask(Keys.templateRunLocal, " " + arg, s0)
           reload
         case _ =>
-          run(infos, args0, s0.configuration, lm, globalBase, scalaModuleInfo, log)
+          run(infos, args, s0.configuration, lm, globalBase, scalaModuleInfo, log)
           terminate
       }
     } else {
@@ -273,6 +275,27 @@ private[sbt] object TemplateCommandUtil {
     val ans0 = System.console.readLine()
     if (ans0 == "") default
     else ans0
+  }
+
+  // Work around resolver behavior for `ssh://` templates by encoding `--branch` as URI fragment.
+  // This keeps branch checkout working for `sbt new ssh://... --branch x`.
+  private[sbt] def normalizeTemplateArgs(arguments: List[String]): List[String] = {
+    val branchArgIndex = arguments.indexOf("--branch")
+    if (branchArgIndex < 0 || branchArgIndex + 1 >= arguments.length) arguments
+    else {
+      val branch = arguments(branchArgIndex + 1)
+      val sshTemplateIndex =
+        arguments.indexWhere(arg => arg.startsWith("ssh://") && !arg.contains("#"))
+      if (sshTemplateIndex < 0) arguments
+      else {
+        VcsUriFragment.validate(branch)
+        arguments.zipWithIndex.collect {
+          case (_, idx) if idx == branchArgIndex || idx == branchArgIndex + 1 => None
+          case (arg, idx) if idx == sshTemplateIndex => Some(s"$arg#$branch")
+          case (arg, _)                              => Some(arg)
+        }.flatten
+      }
+    }
   }
 
   // This is used by Defaults.runLocalTemplate, which implements

--- a/main/src/test/scala/sbt/TemplateCommandUtilTest.scala
+++ b/main/src/test/scala/sbt/TemplateCommandUtilTest.scala
@@ -33,38 +33,3 @@ object TemplateCommandUtilTest extends verify.BasicTestSuite:
     assert(ex ne null)
     assert(ex.getMessage.contains("Local template not found for:"))
     assert(ex.getMessage.contains("unknown/template.local"))
-
-  test("normalizeTemplateArgs rewrites ssh url with branch option"):
-    val args = List(
-      "ssh://git@github.com/scala/scala-seed.g8.git",
-      "--branch",
-      "2.12.x"
-    )
-    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
-    assert(
-      normalized == List("ssh://git@github.com/scala/scala-seed.g8.git#2.12.x"),
-      s"unexpected normalized args: $normalized"
-    )
-
-  test("normalizeTemplateArgs keeps non-ssh url unchanged"):
-    val args = List(
-      "https://github.com/scala/scala-seed.g8.git",
-      "--branch",
-      "2.12.x"
-    )
-    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
-    assert(normalized == args, s"unexpected normalized args: $normalized")
-
-  test("normalizeTemplateArgs keeps ssh url unchanged when fragment already exists"):
-    val args = List(
-      "ssh://git@github.com/scala/scala-seed.g8.git#main",
-      "--branch",
-      "2.12.x"
-    )
-    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
-    assert(normalized == args, s"unexpected normalized args: $normalized")
-
-  test("normalizeTemplateArgs does not rewrite when branch value is missing"):
-    val args = List("ssh://git@github.com/scala/scala-seed.g8.git", "--branch")
-    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
-    assert(normalized == args, s"unexpected normalized args: $normalized")

--- a/main/src/test/scala/sbt/TemplateCommandUtilTest.scala
+++ b/main/src/test/scala/sbt/TemplateCommandUtilTest.scala
@@ -33,3 +33,38 @@ object TemplateCommandUtilTest extends verify.BasicTestSuite:
     assert(ex ne null)
     assert(ex.getMessage.contains("Local template not found for:"))
     assert(ex.getMessage.contains("unknown/template.local"))
+
+  test("normalizeTemplateArgs rewrites ssh url with branch option"):
+    val args = List(
+      "ssh://git@github.com/scala/scala-seed.g8.git",
+      "--branch",
+      "2.12.x"
+    )
+    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
+    assert(
+      normalized == List("ssh://git@github.com/scala/scala-seed.g8.git#2.12.x"),
+      s"unexpected normalized args: $normalized"
+    )
+
+  test("normalizeTemplateArgs keeps non-ssh url unchanged"):
+    val args = List(
+      "https://github.com/scala/scala-seed.g8.git",
+      "--branch",
+      "2.12.x"
+    )
+    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
+    assert(normalized == args, s"unexpected normalized args: $normalized")
+
+  test("normalizeTemplateArgs keeps ssh url unchanged when fragment already exists"):
+    val args = List(
+      "ssh://git@github.com/scala/scala-seed.g8.git#main",
+      "--branch",
+      "2.12.x"
+    )
+    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
+    assert(normalized == args, s"unexpected normalized args: $normalized")
+
+  test("normalizeTemplateArgs does not rewrite when branch value is missing"):
+    val args = List("ssh://git@github.com/scala/scala-seed.g8.git", "--branch")
+    val normalized = TemplateCommandUtil.normalizeTemplateArgs(args)
+    assert(normalized == args, s"unexpected normalized args: $normalized")


### PR DESCRIPTION
## Summary
- Fix `sbt new` handling for `ssh://` template URLs when `--branch` is provided.
- Normalize `ssh://... --branch <name>` into `ssh://...#<name>` before template resolver execution.
- Add unit tests for rewrite behavior and no-op cases (non-ssh URLs, existing fragment, missing branch value).

Closes #6545

## Problem
`sbt new ssh://... --branch <name>` can fail with `remote hung up unexpectedly`, while the same template URL without `--branch` works.

## Solution
- Add `normalizeTemplateArgs` in `TemplateCommandUtil`.
- Apply normalization in `runTemplate` before delegating to template resolvers.
- Validate branch values with `VcsUriFragment.validate`.
- Cover behavior with focused unit tests in `TemplateCommandUtilTest`.


## AI disclosure
N/A :)