### PR TITLE
[2.x] fix: Forward WarnOnSourceChanges warning to sbt client

### DIFF
--- a/main/src/main/scala/sbt/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/nio/CheckBuildSources.scala
@@ -19,6 +19,7 @@ import sbt.Scope.Global
 import sbt.internal.CommandStrings.LoadProject
 import sbt.internal.SysProp
 import sbt.internal.server.BuildServerProtocol
+import sbt.internal.server.NetworkChannel
 import sbt.internal.util.{ AttributeKey, Terminal }
 import sbt.io.syntax.*
 import sbt.nio.FileChanges
@@ -114,11 +115,13 @@ private[sbt] class CheckBuildSources extends AutoCloseable {
       exec: Exec
   ): Boolean = {
     val name = exec.source.map(_.channelName)
-    val loggerOrTerminal =
-      name.flatMap(StandardMain.exchange.channelForName(_).map(_.terminal)) match {
-        case Some(t) => Right(t)
-        case _       => Left(state.globalLogging.full)
-      }
+    val loggerOrTerminal = name.flatMap(StandardMain.exchange.channelForName) match {
+      // Non-interactive network clients only consume build/logMessage notifications.
+      // Route these warnings through the logger so they are delivered to sbt -client.
+      case Some(c: NetworkChannel) if !c.isAttached => Left(state.globalLogging.full)
+      case Some(c)                                  => Right(c.terminal)
+      case None                                     => Left(state.globalLogging.full)
+    }
 
     needsReload(state, loggerOrTerminal, exec.commandLine)
   }

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -8,6 +8,8 @@
 package testpkg
 
 import java.io.{ InputStream, OutputStream, PrintStream }
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, StandardOpenOption }
 import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit, TimeoutException }
 import sbt.internal.client.NetworkClient
 import sbt.internal.util.Util
@@ -145,6 +147,25 @@ class ClientTest extends AbstractServerTest with BeforeAndAfterEach {
     assert(
       lines.toList.exists(_.contains("running (fork) hello")),
       lines.toList.mkString(",")
+    )
+  }
+  test("warn on changed build source is forwarded to non-interactive client") {
+    assert(client("""set Global / onChangedBuildSource := WarnOnSourceChanges""") == 0)
+    val buildFile = testPath.resolve("build.sbt")
+    Files.write(
+      buildFile,
+      "\n// trigger build source change warning\n".getBytes(StandardCharsets.UTF_8),
+      StandardOpenOption.APPEND
+    )
+    val (exitCode, lines) = clientWithStdoutLines("willSucceed")
+    assert(exitCode == 0)
+    assert(
+      lines.exists(_.contains("build source files have changed")),
+      lines.mkString("\n")
+    )
+    assert(
+      lines.exists(_.contains("Apply these changes by running `reload`.")),
+      lines.mkString("\n")
     )
   }
   test("compi completions") {


### PR DESCRIPTION
## Summary
- Fixes [#6831](https://github.com/sbt/sbt/issues/6831) by forwarding `WarnOnSourceChanges` warnings to non-interactive `sbt -client` sessions.
- Updates build-source warning routing so non-attached network channels use logger-based events (`build/logMessage`) instead of terminal-only output.
- Adds a regression test in `server-test` to verify changed `build.sbt` warnings are visible in client output.

Closes #6831

## Problem
When running via `sbt -client`, modifying build definition files can fail to show the expected warning:
- `build source files have changed`
- suggestion to run `reload`
This happened because the warning was emitted through terminal output for network channels, while non-interactive clients consume log notifications rather than attached terminal streams.

## Solution
- Detect non-attached `NetworkChannel` execution in build-source reload checks.
- Route warning messages through the standard logger for those channels.
- Keep existing terminal behavior for attached/interactive channels.
- Validate behavior with a client-focused regression test.

## AI disclosure
N/A
