### PR TITLE
[2.x] refactor: Use Files.writeString instead of Files.write

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
@@ -31,7 +31,7 @@ object LockFile {
       val json = Converter.toJson(data).get
       val content = PrettyPrinter(json)
       lockFile.getParentFile.mkdirs()
-      Files.write(lockFile.toPath, content.getBytes(StandardCharsets.UTF_8))
+      Files.writeString(lockFile.toPath, content)
     } match {
       case Success(_)  => Right(())
       case Failure(ex) => Left(s"Failed to write lock file: ${ex.getMessage}")

--- a/sbt-app/src/sbt-test/dependency-management/aar-packaging/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/aar-packaging/src/main/scala/Main.scala
@@ -3,6 +3,6 @@ import java.nio.file.Files
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/exclude-dependencies2/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/exclude-dependencies2/src/main/scala/Main.scala
@@ -29,6 +29,6 @@ object Main {
       "Expected not to find classes from argonaut"
     )
 
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/exclude-dependencies3/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/exclude-dependencies3/src/main/scala/Main.scala
@@ -34,6 +34,6 @@ object Main {
       "Expected not to find class from cats-mtl"
     )
 
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/hadoop-yarn-server-resourcemanager/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/hadoop-yarn-server-resourcemanager/src/main/scala/Main.scala
@@ -5,6 +5,6 @@ import org.apache.zookeeper.ZooKeeper
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, classOf[ZooKeeper].getSimpleName.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, classOf[ZooKeeper].getSimpleName)
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/i4847-inter-project-variant-scala/baz/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/i4847-inter-project-variant-scala/baz/src/main/scala/Main.scala
@@ -4,6 +4,6 @@ import java.nio.file.Paths
 object Main {
   def main(args: Array[String]): Unit = {
     val msg = Bar.value
-    Files.write(Paths.get("baz/output"), msg.getBytes("UTF-8"))
+    Files.writeString(Paths.get("baz/output"), msg)
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/inter-project/b/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/inter-project/b/src/main/scala/Main.scala
@@ -10,6 +10,6 @@ object Main {
   def main(args: Array[String]): Unit = {
     val msg = CC(2, A.msg).asJson.spaces2
 
-    Files.write(new File("output").toPath, msg.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, msg)
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/profiles/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/profiles/src/main/scala/Main.scala
@@ -16,6 +16,6 @@ object Main {
 
     assert(hadoopVersion == "2.6.0")
 
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/dependency-management/url-no-head/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/dependency-management/url-no-head/src/main/scala/Main.scala
@@ -8,6 +8,6 @@ object Main {
   // assert(Thread.currentThread.getContextClassLoader.getResource("org/nlogo/nvm/Task.class") != null)
   // Thread.currentThread.getContextClassLoader.getResource("org/nlogo/nvm/Task.class")
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/credentials-from-file/build.sbt
+++ b/sbt-app/src/sbt-test/lm-coursier/credentials-from-file/build.sbt
@@ -13,7 +13,7 @@ csrExtraCredentials += {
        |foo.https-only=false
      """.stripMargin
   val dest = (ThisBuild / baseDirectory).value / "project" / "target" / "cred"
-  Files.write(dest.toPath, content.getBytes("UTF-8"))
+  Files.writeString(dest.toPath, content)
   lmcoursier.credentials.FileCredentials(dest.toString)
 }
 

--- a/sbt-app/src/sbt-test/lm-coursier/from-no-head/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/from-no-head/src/main/scala/Main.scala
@@ -8,6 +8,6 @@ object Main {
   // assert(Thread.currentThread.getContextClassLoader.getResource("org/nlogo/nvm/Task.class") != null)
   // Thread.currentThread.getContextClassLoader.getResource("org/nlogo/nvm/Task.class")
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/from-wrong-url/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/from-wrong-url/src/main/scala/Main.scala
@@ -11,6 +11,6 @@ object Main {
     val l = Generic[CC].to(cc)
     val msg = l.head
 
-    Files.write(new File("output").toPath, msg.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, msg)
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/from/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/from/src/main/scala/Main.scala
@@ -11,6 +11,6 @@ object Main {
     val l = Generic[CC].to(cc)
     val msg = l.head
 
-    Files.write(new File("output").toPath, msg.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, msg)
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/inter-project-resolvers/b/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/inter-project-resolvers/b/src/main/scala/Main.scala
@@ -6,6 +6,6 @@ object Main {
   // TODO Use some jvm-repr stuff as a test
 
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, A.default.msg.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, A.default.msg)
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/inter-project-scala-tool/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/inter-project-scala-tool/src/main/scala/Main.scala
@@ -10,6 +10,6 @@ import java.nio.file.Files
  */
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/maven-compatible/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/maven-compatible/src/main/scala/Main.scala
@@ -6,6 +6,6 @@ object Main {
   // TODO Use some jvm-repr stuff
 
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/maven-plugin-classpath-type/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/maven-plugin-classpath-type/src/main/scala/Main.scala
@@ -3,6 +3,6 @@ import java.nio.file.Files
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/scala-jars/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/scala-jars/src/main/scala/Main.scala
@@ -63,6 +63,6 @@ object Main {
     notFromCoursierCache("scala-library")
     assert(props.lengthCompare(1) == 0, s"Found several library.properties files in classpath: $props")
 
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/scala-sources-javadoc-jars/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/scala-sources-javadoc-jars/src/main/scala/Main.scala
@@ -3,6 +3,6 @@ import java.nio.file.Files
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/simple/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/simple/src/main/scala/Main.scala
@@ -3,6 +3,6 @@ import java.nio.file.Files
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, "OK")
   }
 }

--- a/sbt-app/src/sbt-test/lm-coursier/zookeeper/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/lm-coursier/zookeeper/src/main/scala/Main.scala
@@ -5,6 +5,6 @@ import org.apache.zookeeper.ZooKeeper
 
 object Main {
   def main(args: Array[String]): Unit = {
-    Files.write(new File("output").toPath, classOf[ZooKeeper].getSimpleName.getBytes("UTF-8"))
+    Files.writeString(new File("output").toPath, classOf[ZooKeeper].getSimpleName)
   }
 }

--- a/sbt-app/src/sbt-test/plugins/sbt-native-packager/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/plugins/sbt-native-packager/src/main/scala/Main.scala
@@ -2,4 +2,4 @@ import java.io.File
 import java.nio.file.Files
 
 @main def hello() =
-  Files.write(new File("output").toPath, "OK".getBytes("UTF-8"))
+  Files.writeString(new File("output").toPath, "OK")

--- a/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
+++ b/sbt-ivy/src/main/scala/sbt/internal/librarymanagement/IvyXml.scala
@@ -10,7 +10,6 @@ package sbt
 package internal
 package librarymanagement
 
-import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 
 import lmcoursier.definitions.{ Configuration, Project }
@@ -66,7 +65,7 @@ object IvyXml {
     val content0 = rawContent(currentProject, shadedConfigOpt, bomForcedDeps)
     cacheIvyFile.getParentFile.mkdirs()
     log.debug(s"writing Ivy file $cacheIvyFile")
-    Files.write(cacheIvyFile.toPath, content0.getBytes(UTF_8))
+    Files.writeString(cacheIvyFile.toPath, content0)
 
     // Just writing an empty file here... Are these only used?
     cacheIvyPropertiesFile.getParentFile.mkdirs()


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Files.html#writeString(java.nio.file.Path,java.lang.CharSequence,java.nio.file.OpenOption...)

> Write a [CharSequence](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/CharSequence.html) to a file. Characters are encoded into bytes using the [UTF-8](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/charset/StandardCharsets.html#UTF_8) [charset](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/charset/Charset.html).