### PR TITLE
[2.x] ci: Update sbt-java-formatter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ ThisBuild / version := {
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / scalafmtOnCompile := !(Global / insideCI).value
 ThisBuild / Test / scalafmtOnCompile := !(Global / insideCI).value
+ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 // ThisBuild / turbo := true
 ThisBuild / usePipelining := false // !(Global / insideCI).value
 ThisBuild / organization := "org.scala-sbt"

--- a/internal/util-interface/src/main/java/xsbti/Problem.java
+++ b/internal/util-interface/src/main/java/xsbti/Problem.java
@@ -42,7 +42,9 @@ public interface Problem {
     return Optional.empty();
   }
 
-  /** @deprecated use {@link #diagnosticRelatedInformation()} instead. */
+  /**
+   * @deprecated use {@link #diagnosticRelatedInformation()} instead.
+   */
   @Deprecated
   default List<DiagnosticRelatedInformation> diagnosticRelatedInforamation() {
     return diagnosticRelatedInformation();

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.8.0")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
-addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.12.0")
 addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.4.0")
 addDependencyTreePlugin
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")

--- a/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
@@ -321,7 +321,8 @@ public class ForkTestMain {
       String params = this.gson.toJson(info, ForkGroupStart.class);
       String notification =
           String.format(
-              "{ \"jsonrpc\": \"2.0\", \"method\": \"startTestGroup\", \"params\": %s, \"re\": %d }",
+              "{ \"jsonrpc\": \"2.0\", \"method\": \"startTestGroup\", \"params\": %s, \"re\": %d"
+                  + " }",
               params, this.id);
       this.originalOut.println(notification);
       this.originalOut.flush();


### PR DESCRIPTION
- google-java-format runs in its CLI in dedicated JVM now 
  -  https://github.com/sbt/sbt-java-formatter/pull/264