### PR TITLE
[2.x] fix: Expand virtualized plugin paths in forked console

### DIFF
--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -481,12 +481,14 @@ object Compiler:
         workingDir,
         conv,
       )
+      val consoleScalacOptions =
+        resolveVirtualizedScalacOptions((task / Keys.scalacOptions).value, conv)
       val param = ConsoleInfo(
         ArrayList(toolJars.asJava),
         ArrayList(bridgeJars.toVector.map(vf => conv.toPath(vf).toUri()).asJava),
         ArrayList(),
         ArrayList(Attributed.data(cp).toVector.map(vf => conv.toPath(vf).toUri()).asJava),
-        ArrayList((task / Keys.scalacOptions).value.asJava),
+        ArrayList(consoleScalacOptions.asJava),
         (task / Keys.initialCommands).value,
         (task / Keys.cleanupCommands).value,
       )
@@ -567,13 +569,7 @@ object Compiler:
               if (ScalaArtifacts.isScala3(sv)) Opts.doc.externalAPIScala3(xapisFiles)
               else Opts.doc.externalAPI(xapisFiles)
             val options = sOpts ++ externalApiOpts
-            def convertVfRef(value: String): String =
-              if !value.contains("$") then value
-              else converter.toPath(xsbti.VirtualFileRef.of(value)).toString
-            val resolvedOptions = options.map { x =>
-              if !x.contains("$") then x
-              else x.split(":").map(_.split(",").map(convertVfRef).mkString(",")).mkString(":")
-            }
+            val resolvedOptions = resolveVirtualizedScalacOptions(options, converter)
             val scalac = cs.scalac match
               case ac: AnalyzingCompiler => ac.onArgs(exported(s, "scaladoc"))
             val docSrcFiles = if ScalaArtifacts.isScala3(sv) then tFiles else srcs
@@ -640,5 +636,24 @@ object Compiler:
       case "-Ypickle-java" +: rest         => toConsoleScalacOptions(rest)
       case head +: rest                    => head +: toConsoleScalacOptions(rest)
       case _                               => Seq.empty
+
+  /**
+   * Converts mapped virtual file ids in scalac options back to machine paths.
+   *
+   * Compiler plugin options are often encoded using `FileConverter.toVirtualFile` to keep
+   * paths portable in persisted settings (for example `-Xplugin:${CSR_CACHE}/...`). Before we
+   * launch tools that expect concrete filesystem paths (forked console, scaladoc), these ids
+   * must be resolved via the active `FileConverter`.
+   */
+  private[sbt] def resolveVirtualizedScalacOptions(
+      options: Seq[String],
+      converter: FileConverter
+  ): Seq[String] =
+    def convertValue(value: String): String =
+      if !value.contains("$") then value
+      else converter.toPath(xsbti.VirtualFileRef.of(value)).toString
+    options.map: option =>
+      if !option.contains("$") then option
+      else option.split(":").map(_.split(",").map(convertValue).mkString(",")).mkString(":")
 
 end Compiler

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -649,11 +649,8 @@ object Compiler:
       options: Seq[String],
       converter: FileConverter
   ): Seq[String] =
-    def convertValue(value: String): String =
-      if !value.contains("$") then value
-      else converter.toPath(xsbti.VirtualFileRef.of(value)).toString
     options.map: option =>
-      if !option.contains("$") then option
-      else option.split(":").map(_.split(",").map(convertValue).mkString(",")).mkString(":")
+      if !option.startsWith("-Xplugin:") then option
+      else "-Xplugin:" + converter.toPath(xsbti.VirtualFileRef.of(option.stripPrefix("-Xplugin:")))
 
 end Compiler

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -37,7 +37,7 @@ import sbt.librarymanagement.{
 import sbt.util.Logger
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
-import xsbti.{ HashedVirtualFileRef, ScalaProvider }
+import xsbti.{ FileConverter, HashedVirtualFileRef, ScalaProvider }
 
 object Compiler:
   private val r = Random()

--- a/main/src/test/scala/sbt/internal/CompilerConsoleOptsTest.scala
+++ b/main/src/test/scala/sbt/internal/CompilerConsoleOptsTest.scala
@@ -2,7 +2,6 @@ package sbt.internal
 
 import hedgehog.*
 import hedgehog.runner.*
-import sbt.internal.inc.MappedFileConverter
 
 import java.nio.file.Files
 import scala.collection.immutable.ListMap
@@ -139,7 +138,11 @@ object CompilerConsoleOptsTest extends Properties:
 
   private def checkResolvedVirtualizedOptions: Result =
     val cacheRoot = Files.createTempDirectory("compiler-console-opts")
-    val converter = MappedFileConverter(ListMap("CSR_CACHE" -> cacheRoot), allowMachinePath = false)
+    val converter =
+      _root_.sbt.internal.inc.MappedFileConverter(
+        ListMap("CSR_CACHE" -> cacheRoot),
+        allowMachinePath = false
+      )
     val pluginJar = cacheRoot.resolve("plugins/acyclic.jar")
     val pluginRef = converter.toVirtualFile(pluginJar).toString
     val input = Seq(s"-Xplugin:$pluginRef", "-P:acyclic:force")

--- a/main/src/test/scala/sbt/internal/CompilerConsoleOptsTest.scala
+++ b/main/src/test/scala/sbt/internal/CompilerConsoleOptsTest.scala
@@ -2,6 +2,10 @@ package sbt.internal
 
 import hedgehog.*
 import hedgehog.runner.*
+import sbt.internal.inc.MappedFileConverter
+
+import java.nio.file.Files
+import scala.collection.immutable.ListMap
 
 /**
  * Tests for [[Compiler.toConsoleScalacOptions]] — pipelining flags must be stripped before
@@ -102,6 +106,10 @@ object CompilerConsoleOptsTest extends Properties:
         Seq("-encoding", "utf8")
       )
     ),
+    example(
+      "virtualized compiler plugin paths are resolved for tool invocation",
+      checkResolvedVirtualizedOptions
+    ),
 
     // ── property-based cases ──────────────────────────────────────────────────
 
@@ -123,6 +131,20 @@ object CompilerConsoleOptsTest extends Properties:
 
   private def check(input: Seq[String], expected: Seq[String]): Result =
     val got = Compiler.toConsoleScalacOptions(input)
+    Result
+      .assert(got == expected)
+      .log(s"input:    $input")
+      .log(s"expected: $expected")
+      .log(s"got:      $got")
+
+  private def checkResolvedVirtualizedOptions: Result =
+    val cacheRoot = Files.createTempDirectory("compiler-console-opts")
+    val converter = MappedFileConverter(ListMap("CSR_CACHE" -> cacheRoot), allowMachinePath = false)
+    val pluginJar = cacheRoot.resolve("plugins/acyclic.jar")
+    val pluginRef = converter.toVirtualFile(pluginJar).toString
+    val input = Seq(s"-Xplugin:$pluginRef", "-P:acyclic:force")
+    val expected = Seq(s"-Xplugin:${pluginJar.toString}", "-P:acyclic:force")
+    val got = Compiler.resolveVirtualizedScalacOptions(input, converter)
     Result
       .assert(got == expected)
       .log(s"input:    $input")


### PR DESCRIPTION
## Problem
Fixes #9096 

Compiler plugin options can contain virtualized paths (for example `${CSR_CACHE}/...`).
In forked `console`, these scalac options were forwarded to the REPL worker without
expanding virtual paths to real filesystem paths, which caused plugin jars not to load
and plugin options like `-P:...` to fail.

## Solution
- Resolve virtualized scalac options via the active `FileConverter` before serializing
  `ConsoleInfo` for forked `console`.
- Reuse the same option-resolution helper in doc option handling to avoid duplicate logic.
- Add a regression unit test that verifies `-Xplugin:${CSR_CACHE}/...` is expanded to a
  machine path before tool invocation.
