### PR TITLE
[2.0.x] bport: Hide JDK warnings if JDK 26 or later

### DIFF
--- a/sbt
+++ b/sbt
@@ -361,7 +361,7 @@ addSbtScriptProperty () {
 }
 
 addJdkWorkaround () {
-  local is_25="$(expr $java_version "=" 25)"
+  local is_25="$(expr $java_version ">=" 25)"
   if [[ "$hide_jdk_warnings" == "0" ]]; then
     :
   else

--- a/sbtw/src/main/scala/sbtw/Main.scala
+++ b/sbtw/src/main/scala/sbtw/Main.scala
@@ -83,7 +83,7 @@ object Main:
     else Memory.addDefaultMemory(javaOpts, sbtOpts, javaVer, LauncherOptions.defaultMemMb)
     sbtOpts = finalSbt
 
-    if !opts.noHideJdkWarnings && javaVer == 25 then
+    if !opts.noHideJdkWarnings && javaVer >= 25 then
       sbtOpts = sbtOpts ++ Seq(
         "--sun-misc-unsafe-memory-access=allow",
         "--enable-native-access=ALL-UNNAMED"


### PR DESCRIPTION
This is a 2.0.x backport of #9068