### PR TITLE
[1.x] bport: Hide JDK warnings if JDK 26 or later

### DIFF
--- a/sbt
+++ b/sbt
@@ -358,7 +358,7 @@ addSbtScriptProperty () {
 }
 
 addJdkWorkaround () {
-  local is_25="$(expr $java_version "=" 25)"
+  local is_25="$(expr $java_version ">=" 25)"
   if [[ "$hide_jdk_warnings" == "0" ]]; then
     :
   else


### PR DESCRIPTION
This is a 1.x backport of #9068