### PR TITLE
[1.x] bport: Fixes managedScalaInstance false support

### DIFF
--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -35,14 +35,18 @@ private[sbt] object Compiler {
       val app = Keys.appConfiguration.value
       val managed = Keys.managedScalaInstance.value
       val sv = Keys.scalaVersion.value
+      val configs = Keys.ivyConfigurations.value
       // if this logic changes, ensure that `unmanagedScalaInstanceOnly` and `update` are changed
       //  appropriately to avoid cycles
-      sh match {
-        case Some(h) => scalaInstanceFromHome(h)
+      (sh, extraToolConf) match {
+        case (Some(h), _) => scalaInstanceFromHome(h)
+        case _ if !managed =>
+          val extra = extraToolConf.getOrElse(Configurations.ScalaTool)
+          if (configs.contains(extra)) scalaInstanceFromUpdate(extraToolConf)
+          else emptyScalaInstance
         case _ =>
           val scalaProvider = app.provider.scalaProvider
-          if (!managed) emptyScalaInstance
-          else if (sv == scalaProvider.version) optimizedScalaInstance(sv, scalaProvider)
+          if (sv == scalaProvider.version) optimizedScalaInstance(sv, scalaProvider)
           else scalaInstanceFromUpdate(extraToolConf)
       }
     }

--- a/sbt-app/src/sbt-test/project/scala-instance/A.scala
+++ b/sbt-app/src/sbt-test/project/scala-instance/A.scala
@@ -1,0 +1,5 @@
+package example
+
+class A {
+  val x = 1
+}

--- a/sbt-app/src/sbt-test/project/scala-instance/build.sbt
+++ b/sbt-app/src/sbt-test/project/scala-instance/build.sbt
@@ -1,0 +1,18 @@
+import Configurations.{ ScalaTool, ScalaDocTool }
+
+@transient
+lazy val check = taskKey[Unit]("")
+lazy val scala213 = "2.13.16"
+scalaVersion := scala213
+autoScalaLibrary := false
+managedScalaInstance := false
+ivyConfigurations ++= List(ScalaTool, ScalaDocTool)
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-library" % scala213,
+  "org.scala-lang" % "scala-compiler" % scala213 % ScalaTool,
+  "org.scala-lang" % "scala-compiler" % scala213 % ScalaDocTool,
+)
+check := {
+  val si = scalaInstance.value
+  assert(si.version == scala213, s"'${si.version}' was not '$scala213'")
+}

--- a/sbt-app/src/sbt-test/project/scala-instance/test
+++ b/sbt-app/src/sbt-test/project/scala-instance/test
@@ -1,0 +1,3 @@
+> compile
+> doc
+> check


### PR DESCRIPTION
This is a 1.x backport of https://github.com/sbt/sbt/pull/9121

## Problem
When managedScalaInstance is set to false, we stopped creating ScalaInstance, but the documentation says the user can pull in their own dependencies.

## Solution
Attempt to construct a ScalaInstance from update report even when managedScalaInstance is set to false.