### PR TITLE
[2.0.x] bport: Fixes managedScalaInstance false support

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -771,9 +771,8 @@ object Defaults extends BuildCommon {
       scalaCompilerBridgeBin := Def
         .ifS(Def.task {
           val sv = scalaVersion.value
-          val managed = managedScalaInstance.value
           val hasSbtBridge = ScalaArtifacts.isScala3(sv) || ZincLmUtil.hasScala2SbtBridge(sv)
-          hasSbtBridge && managed
+          hasSbtBridge
         })(Def.cachedTask {
           // Use scalaDynVersion to resolve dynamic versions (e.g., "3-latest.candidate" -> "3.8.1-RC1")
           val sv = scalaDynVersion.value

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -62,12 +62,14 @@ object Compiler:
       val sh = Keys.scalaHome.value
       val app = Keys.appConfiguration.value
       val managed = Keys.managedScalaInstance.value
-      sh match
-        case Some(h) => scalaInstanceConfigFromHome(h)
-        case _ =>
-          val scalaProvider = app.provider.scalaProvider
-          if !managed then emptyScalaInstanceConfig
-          else scalaInstanceConfigFromUpdate(extraToolConf)
+      val configs = Keys.ivyConfigurations.value
+      (sh, extraToolConf) match
+        case (Some(h), _) => scalaInstanceConfigFromHome(h)
+        case _ if !managed =>
+          val extra = extraToolConf.getOrElse(Configurations.ScalaTool)
+          if configs.contains(extra) then scalaInstanceConfigFromUpdate(extraToolConf)
+          else emptyScalaInstanceConfig
+        case _ => scalaInstanceConfigFromUpdate(extraToolConf)
     }
 
   /**

--- a/sbt-app/src/sbt-test/project/scala-instance/A.scala
+++ b/sbt-app/src/sbt-test/project/scala-instance/A.scala
@@ -1,0 +1,5 @@
+package example
+
+class A {
+  val x = 1
+}

--- a/sbt-app/src/sbt-test/project/scala-instance/build.sbt
+++ b/sbt-app/src/sbt-test/project/scala-instance/build.sbt
@@ -1,0 +1,18 @@
+import Configurations.{ ScalaTool, ScalaDocTool }
+
+@transient
+lazy val check = taskKey[Unit]("")
+lazy val scala213 = "2.13.16"
+scalaVersion := scala213
+autoScalaLibrary := false
+managedScalaInstance := false
+ivyConfigurations ++= List(ScalaTool, ScalaDocTool)
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-library" % scala213,
+  "org.scala-lang" % "scala-compiler" % scala213 % ScalaTool,
+  "org.scala-lang" % "scala-compiler" % scala213 % ScalaDocTool,
+)
+check := {
+  val si = scalaInstance.value
+  assert(si.version == scala213, s"'${si.version}' was not '$scala213'")
+}

--- a/sbt-app/src/sbt-test/project/scala-instance/test
+++ b/sbt-app/src/sbt-test/project/scala-instance/test
@@ -1,0 +1,3 @@
+> compile
+> doc
+> check


### PR DESCRIPTION
This is a 2.x backport of https://github.com/sbt/sbt/pull/9121

## Problem
When managedScalaInstance is set to false, we stopped creating ScalaInstance, but the documentation says the user can pull in their own dependencies.

## Solution
Attempt to construct a ScalaInstance from update report even when managedScalaInstance is set to false.