### PR TITLE
[1.x] bport: Add Test configuration to evictionWarningOptions 

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -3840,6 +3840,7 @@ object Classpaths {
       transitiveUpdates = transitiveUpdate.value,
       uwConfig = (update / unresolvedWarningConfiguration).value,
       evictionLevel = evictionErrorLevel.value,
+      evictionWarningOptions = (update / evictionWarningOptions).value,
       versionSchemeOverrides = libraryDependencySchemes.value,
       assumedEvictionErrorLevel = assumedEvictionErrorLevel.value,
       assumedVersionScheme = assumedVersionScheme.value,

--- a/main/src/main/scala/sbt/internal/LibraryManagement.scala
+++ b/main/src/main/scala/sbt/internal/LibraryManagement.scala
@@ -41,6 +41,7 @@ private[sbt] object LibraryManagement {
       transitiveUpdates: Seq[UpdateReport],
       uwConfig: UnresolvedWarningConfiguration,
       evictionLevel: Level.Value,
+      evictionWarningOptions: EvictionWarningOptions,
       versionSchemeOverrides: Seq[ModuleID],
       assumedEvictionErrorLevel: Level.Value,
       assumedVersionScheme: String,
@@ -75,7 +76,8 @@ private[sbt] object LibraryManagement {
         versionSchemeOverrides,
         assumedVersionScheme,
         assumedVersionSchemeJava,
-        assumedEvictionErrorLevel
+        assumedEvictionErrorLevel,
+        evictionWarningOptions.configurations,
       )
       def extraLines = List(
         "",
@@ -341,6 +343,7 @@ private[sbt] object LibraryManagement {
           transitiveUpdates = transitiveUpdate.value,
           uwConfig = (update / unresolvedWarningConfiguration).value,
           evictionLevel = Level.Debug,
+          evictionWarningOptions = EvictionWarningOptions.default,
           versionSchemeOverrides = Nil,
           assumedEvictionErrorLevel = Level.Debug,
           assumedVersionScheme = VersionScheme.Always,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   // sbt modules
   private val ioVersion = nightlyVersion.getOrElse("1.10.5")
   private val lmVersion =
-    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.12.0")
+    sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.12.1")
   val zincVersion = nightlyVersion.getOrElse("1.12.0")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/sbt-app/src/sbt-test/dependency-management/evicted-test-config/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-test-config/build.sbt
@@ -1,0 +1,6 @@
+// https://github.com/sbt/sbt/issues/8410
+scalaVersion := "3.3.7"
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "weaver-cats" % "0.11.1" % Test,
+  "com.siriusxm" %% "snapshot4s-weaver" % "0.2.2" % Test,
+)

--- a/sbt-app/src/sbt-test/dependency-management/evicted-test-config/test
+++ b/sbt-app/src/sbt-test/dependency-management/evicted-test-config/test
@@ -1,0 +1,9 @@
+# Update should fail as test dependencies have version conflicts
+-> update
+# Update should succeed if the error level is reduced to Warn
+> set evictionErrorLevel := Level.Warn
+> update
+# Update should succeed if eviction options are less strict
+> set evictionErrorLevel := Level.Error
+> set update / evictionWarningOptions := EvictionWarningOptions.default.withConfigurations(Vector(Compile))
+> update


### PR DESCRIPTION
* Add Test configuration to evictionWarningOptions
* Add Test configuration to default evictionWarningOptions
* Deduplicate eviction errors based on callers.
* Update eviction error test for semantic versioning.
* Group evictions by configuration and update test.