### PR TITLE
[2.x] refactor: Replace string Array with ju.List in scripted run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -522,6 +522,9 @@ lazy val scriptedSbtProj = (project in file("scripted-sbt"))
     libraryDependencies ++= Seq(launcherInterface % "provided"),
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
+      exclude[DirectMissingMethodProblem](
+        "sbt.scriptedtest.ScriptedTests.runInParallel$default$10"
+      ),
     ),
   )
   .dependsOn(lmCore)

--- a/main/src/main/scala/sbt/ScriptedPlugin.scala
+++ b/main/src/main/scala/sbt/ScriptedPlugin.scala
@@ -25,6 +25,7 @@ import sbt.io.syntax.*
 import sbt.librarymanagement.*
 import sbt.librarymanagement.syntax.*
 import sbt.nio.file.{ Glob, RecursiveGlob }
+import scala.jdk.CollectionConverters.*
 
 object ScriptedPlugin extends AutoPlugin {
 
@@ -179,10 +180,10 @@ object ScriptedPlugin extends AutoPlugin {
       scriptedRun.value.run(
         sbtTestDirectory.value,
         scriptedBufferLog.value,
-        args,
+        args.toList.asJava,
         sbtLauncher.value,
         Fork.javaCommand((scripted / javaHome).value, "java").getAbsolutePath,
-        scriptedLaunchOpts.value,
+        scriptedLaunchOpts.value.toList.asJava,
         new java.util.ArrayList[File](),
         scriptedParallelInstances.value,
         scriptedKeepTempDirectory.value,

--- a/main/src/main/scala/sbt/ScriptedRun.scala
+++ b/main/src/main/scala/sbt/ScriptedRun.scala
@@ -12,6 +12,7 @@ import java.io.{ File, FileFilter as JFileFilter }
 import java.lang.reflect.Method
 
 import sbt.io.{ AllPassFilter, NothingFilter }
+import scala.jdk.CollectionConverters.*
 
 sealed trait ScriptedRun {
   final def run(
@@ -64,13 +65,14 @@ sealed trait ScriptedRun {
     } catch { case e: java.lang.reflect.InvocationTargetException => throw e.getCause }
   }
 
+  // v4
   final def run(
       resourceBaseDirectory: File,
       bufferLog: Boolean,
-      tests: Seq[String],
+      tests: java.util.List[String],
       launcherJar: File,
       javaCommand: String,
-      launchOpts: Seq[String],
+      launchOpts: java.util.List[String],
       prescripted: java.util.List[File],
       instances: Int,
       keepTempDirectory: Boolean,
@@ -81,10 +83,10 @@ sealed trait ScriptedRun {
       invoke(
         resourceBaseDirectory,
         bufferLog,
-        tests.toArray,
+        tests,
         launcherJar,
         javaCommand,
-        launchOpts.toArray,
+        launchOpts,
         prescripted,
         instances,
         keepTempDirectory,
@@ -130,14 +132,14 @@ sealed trait ScriptedRun {
       keepTempDirectory: java.lang.Boolean,
   ): AnyRef
 
-  // Default drops filters and calls V3 invoke so V1/V2/V3 subclasses need not override.
+  // v4. Default drops filters and calls V3 invoke so V1/V2/V3 subclasses need not override.
   protected def invoke(
       resourceBaseDirectory: File,
       bufferLog: java.lang.Boolean,
-      tests: Array[String],
+      tests: java.util.List[String],
       launcherJar: File,
       javaCommand: String,
-      launchOpts: Array[String],
+      launchOpts: java.util.List[String],
       prescripted: java.util.List[File],
       instances: java.lang.Integer,
       keepTempDirectory: java.lang.Boolean,
@@ -147,10 +149,10 @@ sealed trait ScriptedRun {
     invoke(
       resourceBaseDirectory,
       bufferLog,
-      tests,
+      tests.toArray(Array.empty[String]),
       launcherJar,
       javaCommand,
-      launchOpts,
+      launchOpts.toArray(Array.empty[String]),
       prescripted,
       instances,
       keepTempDirectory,
@@ -167,6 +169,7 @@ object ScriptedRun {
     val asCls = classOf[Array[String]]
     val sCls = classOf[String]
     val lfCls = classOf[java.util.List[File]]
+    val lsCls = classOf[java.util.List[String]]
     val iCls = classOf[Int]
     val ffCls = classOf[JFileFilter]
 
@@ -179,10 +182,10 @@ object ScriptedRun {
             "runInParallel",
             fCls,
             bCls,
-            asCls,
+            lsCls,
             fCls,
             sCls,
-            asCls,
+            lsCls,
             lfCls,
             iCls,
             bCls,
@@ -223,10 +226,10 @@ object ScriptedRun {
             "run",
             fCls,
             bCls,
-            asCls,
+            lsCls,
             fCls,
             sCls,
-            asCls,
+            lsCls,
             lfCls,
             bCls,
             ffCls,
@@ -420,10 +423,10 @@ object ScriptedRun {
       invoke(
         resourceBaseDirectory,
         bufferLog,
-        tests,
+        tests.toList.asJava,
         launcherJar,
         javaCommand,
-        launchOpts,
+        launchOpts.toList.asJava,
         prescripted,
         instances,
         keepTempDirectory,
@@ -434,10 +437,10 @@ object ScriptedRun {
     override protected def invoke(
         resourceBaseDirectory: File,
         bufferLog: java.lang.Boolean,
-        tests: Array[String],
+        tests: java.util.List[String],
         launcherJar: File,
         javaCommand: String,
-        launchOpts: Array[String],
+        launchOpts: java.util.List[String],
         prescripted: java.util.List[File],
         instances: java.lang.Integer,
         keepTempDirectory: java.lang.Boolean,
@@ -474,10 +477,10 @@ object ScriptedRun {
       invoke(
         resourceBaseDirectory,
         bufferLog,
-        tests,
+        tests.toList.asJava,
         launcherJar,
         javaCommand,
-        launchOpts,
+        launchOpts.toList.asJava,
         prescripted,
         instances,
         keepTempDirectory,
@@ -488,10 +491,10 @@ object ScriptedRun {
     override protected def invoke(
         resourceBaseDirectory: File,
         bufferLog: java.lang.Boolean,
-        tests: Array[String],
+        tests: java.util.List[String],
         launcherJar: File,
         javaCommand: String,
-        launchOpts: Array[String],
+        launchOpts: java.util.List[String],
         prescripted: java.util.List[File],
         instances: Integer,
         keepTempDirectory: java.lang.Boolean,

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -6,6 +6,7 @@ import sbt.*
 import sbt.internal.inc.ScalaInstance
 import sbt.internal.inc.classpath.{ ClasspathUtilities, FilteredLoader }
 import scala.annotation.nowarn
+import scala.collection.JavaConverters.*
 
 object LocalScriptedPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
@@ -139,10 +140,10 @@ object Scripted {
       def runInParallel(
           resourceBaseDirectory: File,
           bufferLog: Boolean,
-          tests: Array[String],
+          tests: java.util.List[String],
           launcherJar: File,
           javaCommand: String,
-          launchOpts: Array[String],
+          launchOpts: java.util.List[String],
           prescripted: java.util.List[File],
           instance: Int,
           keepTempDirectory: Boolean,
@@ -175,10 +176,10 @@ object Scripted {
         bridge.runInParallel(
           sourcePath,
           bufferLog,
-          args.toArray,
+          args.toList.asJava,
           launcherJar,
           "java",
-          launchOpts.toArray,
+          launchOpts.toList.asJava,
           callback,
           instances,
           keepTempDirectory,

--- a/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
+++ b/scripted-sbt/src/main/scala/sbt/scriptedtest/ScriptedTests.scala
@@ -519,10 +519,10 @@ class ScriptedRunner {
   def run(
       resourceBaseDirectory: File,
       bufferLog: Boolean,
-      tests: Array[String],
+      tests: java.util.List[String],
       launcherJar: File,
       javaCommand: String,
-      launchOpts: Array[String],
+      launchOpts: java.util.List[String],
       prescripted: java.util.List[File],
       keepTempDirectory: Boolean,
       includeFilter: java.io.FileFilter,
@@ -532,10 +532,10 @@ class ScriptedRunner {
     run(
       resourceBaseDirectory,
       bufferLog,
-      tests,
+      tests.toArray(Array.empty[String]),
       logger,
       javaCommand,
-      launchOpts,
+      launchOpts.toArray(Array.empty[String]),
       prescripted,
       LauncherBased(launcherJar),
       Int.MaxValue,
@@ -572,6 +572,7 @@ class ScriptedRunner {
       prescripted,
       LauncherBased(launcherJar),
       instance,
+      keepTempDirectory = false,
     )
   }
 
@@ -601,6 +602,7 @@ class ScriptedRunner {
       prescripted,
       LauncherBased(launcherJar),
       instance,
+      keepTempDirectory = false,
     )
   }
 
@@ -634,10 +636,10 @@ class ScriptedRunner {
   def runInParallel(
       resourceBaseDirectory: File,
       bufferLog: Boolean,
-      tests: Array[String],
+      tests: java.util.List[String],
       launcherJar: File,
       javaCommand: String,
-      launchOpts: Array[String],
+      launchOpts: java.util.List[String],
       prescripted: java.util.List[File],
       instance: Int,
       keepTempDirectory: Boolean,
@@ -684,34 +686,8 @@ class ScriptedRunner {
       launchOpts,
       prescripted,
       RunFromSourceBased(scalaVersion, sbtVersion, classpath.toSeq),
-      instances
-    )
-
-  private[sbt] def runInParallel(
-      baseDir: File,
-      bufferLog: Boolean,
-      tests: Array[String],
-      logger: Logger,
-      javaCommand: String,
-      launchOpts: Array[String],
-      prescripted: java.util.List[File],
-      prop: RemoteSbtCreatorProp,
-      instances: Int,
-      keepTempDirectory: Boolean = false,
-  ): Unit =
-    runInParallel(
-      baseDir,
-      bufferLog,
-      tests,
-      logger,
-      javaCommand,
-      launchOpts,
-      prescripted,
-      prop,
       instances,
-      keepTempDirectory,
-      AllPassFilter,
-      NothingFilter,
+      keepTempDirectory = false,
     )
 
   private[sbt] def runInParallel(
@@ -725,8 +701,6 @@ class ScriptedRunner {
       prop: RemoteSbtCreatorProp,
       instances: Int,
       keepTempDirectory: Boolean,
-      includeFilter: java.io.FileFilter,
-      excludeFilter: java.io.FileFilter,
   ): Unit =
     run(
       baseDir,
@@ -735,6 +709,36 @@ class ScriptedRunner {
       logger,
       javaCommand,
       launchOpts,
+      prescripted,
+      prop,
+      instances,
+      parallelExecution = true,
+      keepTempDirectory,
+      includeFilter = AllPassFilter,
+      excludeFilter = NothingFilter,
+    )
+
+  private[sbt] def runInParallel(
+      baseDir: File,
+      bufferLog: Boolean,
+      tests: java.util.List[String],
+      logger: Logger,
+      javaCommand: String,
+      launchOpts: java.util.List[String],
+      prescripted: java.util.List[File],
+      prop: RemoteSbtCreatorProp,
+      instances: Int,
+      keepTempDirectory: Boolean,
+      includeFilter: java.io.FileFilter,
+      excludeFilter: java.io.FileFilter,
+  ): Unit =
+    run(
+      baseDir,
+      bufferLog,
+      tests.toArray(Array.empty[String]),
+      logger,
+      javaCommand,
+      launchOpts.toArray(Array.empty[String]),
       prescripted,
       prop,
       instances,


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9137

## Problem
Scala 3 supposedly has problem with String array in structural types.

## Solution
This works around the issue by using ju.List.