### PR TITLE
[2.x] fix: Remove will-be-ignored warning

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2042,20 +2042,6 @@ object Defaults extends BuildCommon with DefExtra {
       s.log.debug(s"javaOptions: $options")
       new ForkRun(opts)
     } else {
-      if (options.nonEmpty) {
-        val mask = ScopeMask(project = false)
-        val showJavaOptions = Scope.displayMasked(
-          (resolvedScope / javaOptions).scopedKey.scope,
-          (resolvedScope / javaOptions).key.label,
-          mask
-        )
-        val showFork = Scope.displayMasked(
-          (resolvedScope / fork).scopedKey.scope,
-          (resolvedScope / fork).key.label,
-          mask
-        )
-        s.log.warn(s"$showJavaOptions will be ignored, $showFork is set to false")
-      }
       new Run(si, trap, tmp)
     }
   }

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -95,21 +95,6 @@ private[sbt] object ClassLoaders {
         val s = streams.value
         val opts = forkOptions.value
         val options = javaOptions.value
-
-        if options.nonEmpty then
-          val mask = ScopeMask(project = false)
-          val showJavaOptions = Scope.displayMasked(
-            (resolvedScope / javaOptions).scopedKey.scope,
-            (resolvedScope / javaOptions).key.label,
-            mask
-          )
-          val showFork = Scope.displayMasked(
-            (resolvedScope / fork).scopedKey.scope,
-            (resolvedScope / fork).key.label,
-            mask
-          )
-          s.log.warn(s"$showJavaOptions will be ignored, $showFork is set to false")
-
         val exclude = dependencyJars(exportedProducts).value
           .map(converter.toPath)
           .map(_.toFile)

--- a/main/src/main/scala/sbt/internal/RunUtil.scala
+++ b/main/src/main/scala/sbt/internal/RunUtil.scala
@@ -44,9 +44,6 @@ object RunUtil:
           val newFo = fo.withRunJVMOptions(fo.runJVMOptions ++ jvmArgs)
           (new ForkRun(newFo), newFo)
         case _ =>
-          log.warn(
-            s"JVM options (${jvmArgs.mkString(" ")}) will be ignored, fork is set to false"
-          )
           (scalaRun, fo)
 
   private def setWindowTitle(title: String): Unit =


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9116

## Problem
run warns about jvm option not being applied,
but it is applied for client-side run.

## Solution
Remove the warning.