### PR TITLE
[2.0.x] bport: Remove will-be-ignored warning

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2006,20 +2006,6 @@ object Defaults extends BuildCommon {
       s.log.debug(s"javaOptions: $options")
       new ForkRun(opts)
     } else {
-      if (options.nonEmpty) {
-        val mask = ScopeMask(project = false)
-        val showJavaOptions = Scope.displayMasked(
-          (resolvedScope / javaOptions).scopedKey.scope,
-          (resolvedScope / javaOptions).key.label,
-          mask
-        )
-        val showFork = Scope.displayMasked(
-          (resolvedScope / fork).scopedKey.scope,
-          (resolvedScope / fork).key.label,
-          mask
-        )
-        s.log.warn(s"$showJavaOptions will be ignored, $showFork is set to false")
-      }
       new Run(si, trap, tmp)
     }
   }

--- a/main/src/main/scala/sbt/internal/ClassLoaders.scala
+++ b/main/src/main/scala/sbt/internal/ClassLoaders.scala
@@ -95,21 +95,6 @@ private[sbt] object ClassLoaders {
         val s = streams.value
         val opts = forkOptions.value
         val options = javaOptions.value
-
-        if options.nonEmpty then
-          val mask = ScopeMask(project = false)
-          val showJavaOptions = Scope.displayMasked(
-            (resolvedScope / javaOptions).scopedKey.scope,
-            (resolvedScope / javaOptions).key.label,
-            mask
-          )
-          val showFork = Scope.displayMasked(
-            (resolvedScope / fork).scopedKey.scope,
-            (resolvedScope / fork).key.label,
-            mask
-          )
-          s.log.warn(s"$showJavaOptions will be ignored, $showFork is set to false")
-
         val exclude = dependencyJars(exportedProducts).value
           .map(converter.toPath)
           .map(_.toFile)


### PR DESCRIPTION
This is a 2.0.x backport of #9143 

## Problem
run warns about jvm option not being applied,
but it is applied for client-side run.

## Solution
Remove the warning.