### PR TITLE
[2.x] Remove duplicate `packageSrc/mappings`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1229,14 +1229,6 @@ lazy val lmCore = (project in file("lm-core"))
       )
       .taskValue,
     contrabandSettings,
-    // WORKAROUND sbt/sbt#2205 include managed sources in packageSrc
-    Compile / packageSrc / mappings ++= {
-      val srcs = (Compile / managedSources).value
-      val sdirs = (Compile / managedSourceDirectories).value
-      val base = baseDirectory.value
-      import Path.*
-      (((srcs --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq)
-    },
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[IncompatibleMethTypeProblem](


### PR DESCRIPTION
- prepare for https://github.com/sbt/sbt/issues/9010


## more simple example

`build.sbt` for sbt 1

```scala
Compile / sourceGenerators += task {
  val f = (Compile / sourceManaged).value / "A.scala"
  IO.write(f, "class A")
  Seq(f)
}

Compile / packageSrc / mappings ++= {
  val srcs = (Compile / managedSources).value
  val sdirs = (Compile / managedSourceDirectories).value
  val base = baseDirectory.value
  import Path.*
  ((srcs --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq.
}
```

`build.sbt` for sbt 2

```diff
   import Path.*
-  ((srcs --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq
+  ((srcs --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq.map {
+    (k, v) => fileConverter.value.toVirtualFile(k.toPath) -> v
+  }
 }
```

run `sbt packageSrc`

- sbt 1.12.10 : no error
- sbt 2.0.0-RC12

```
[error] java.util.zip.ZipException: duplicate entry: A.scala
[error] 	at java.base/java.util.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:259)
[error] 	at java.base/java.util.jar.JarOutputStream.putNextEntry(JarOutputStream.java:115)
[error] 	at sbt.io.IO$.addFileEntry$1(IO.scala:717)
[error] 	at sbt.io.IO$.writeZip$$anonfun$2(IO.scala:726)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[error] 	at scala.collection.immutable.List.foreach(List.scala:327)
[error] 	at sbt.io.IO$.writeZip(IO.scala:726)
[error] 	at sbt.io.IO$.archive$$anonfun$1(IO.scala:676)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[error] 	at sbt.io.IO$.withZipOutput$$anonfun$1(IO.scala:773)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
[error] 	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
[error] 	at sbt.io.Using.apply(Using.scala:41)
[error] 	at sbt.io.IO$.withZipOutput(IO.scala:753)
[error] 	at sbt.io.IO$.archive(IO.scala:673)
[error] 	at sbt.io.IO$.jar(IO.scala:638)
[error] 	at sbt.Pkg$.makeJar(Pkg.scala:234)
[error] 	at sbt.Pkg$.apply(Pkg.scala:159)
[error] 	at sbt.Defaults$.packageTask$lzyINIT1$$anonfun$1$$anonfun$1(Defaults.scala:1914)
[error] 	at sbt.util.ActionCache$.organicTask$1(ActionCache.scala:77)
[error] 	at sbt.util.ActionCache$.cache(ActionCache.scala:127)
[error] 	at sbt.Defaults$.packageTask$lzyINIT1$$anonfun$1(Defaults.scala:1919)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:79)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:79)
[error] 	at sbt.std.Transform$$anon$3.work(Transform.scala:79)
[error] 	at sbt.std.Transform$$anon$3.work(Transform.scala:79)
[error] 	at sbt.Execute.submit$$anonfun$1$$anonfun$1(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:294)
[error] 	at sbt.Execute.submit$$anonfun$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$2(ConcurrentRestrictions.scala:269)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:75)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:73)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
[error] 	at java.base/java.lang.Thread.run(Thread.java:1583)
[error] (Compile / packageSrc) java.util.zip.ZipException: duplicate entry: A.scala
```