### PR TITLE
[2.x] Avoid infix syntax in build files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ val sbt20Plus =
     "2.0.0-RC12",
   )
 val mimaSettings = mimaSettingsSince(sbt20Plus)
-def mimaSettingsSince(versions: Seq[String]): Seq[Def.Setting[?]] = Def settings (
+def mimaSettingsSince(versions: Seq[String]): Seq[Def.Setting[?]] = Def.settings(
   mimaPreviousArtifacts := {
     val crossVersion = if (crossPaths.value) CrossVersion.binary else CrossVersion.disabled
     if (sbtPlugin.value) {

--- a/project/HouseRulesPlugin.scala
+++ b/project/HouseRulesPlugin.scala
@@ -42,7 +42,7 @@ object HouseRulesPlugin extends AutoPlugin {
     (c / console / scalacOptions) --= Seq("-Ywarn-unused-import", "-Xlint")
   )
 
-  private def scalaPartV = Def setting (CrossVersion partialVersion scalaVersion.value)
+  private def scalaPartV = Def.setting(CrossVersion.partialVersion(scalaVersion.value))
 
   private implicit final class AnyWithIfScala[A](val __x: A) {
     def ifScala2x(p: Long => Boolean) =

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -18,7 +18,7 @@ object PublishBinPlugin extends AutoPlugin {
   private val dummyDoc = taskKey[File]("").withRank(Int.MaxValue)
   override val globalSettings = Seq(publishLocalBin := (()))
 
-  override val projectSettings: Seq[Def.Setting[?]] = Def settings (
+  override val projectSettings: Seq[Def.Setting[?]] = Def.settings(
     publishLocalBin := Classpaths
       .publishOrSkip(publishLocalBinConfig, publishLocalBin / skip)
       .value,

--- a/project/Scripted.scala
+++ b/project/Scripted.scala
@@ -31,7 +31,7 @@ object Scripted {
   // This is to workaround https://github.com/sbt/io/issues/110
   if (!sys.props.contains("jna.nosys")) sys.props.put("jna.nosys", "true")
 
-  val RepoOverrideTest = config("repoOverrideTest") extend Compile
+  val RepoOverrideTest = config("repoOverrideTest").extend(Compile)
 
   val sbtWindowsExcludeFilter: FileFilter =
     if (scala.util.Properties.isWin)
@@ -102,10 +102,10 @@ object Scripted {
       } yield files map (f => s"$group/$f")
 
     val testID = (for (group <- groupP; name <- nameP(group)) yield (group, name))
-    val testIdAsGroup = matched(testID) map (test => Seq(test))
+    val testIdAsGroup = matched(testID).map(test => Seq(test))
 
     // (token(Space) ~> matched(testID)).*
-    (token(Space) ~> (PagedIds | testIdAsGroup)).* map (_.flatten)
+    (token(Space) ~> (PagedIds | testIdAsGroup)).*.map(_.flatten)
   }
 
   @nowarn

--- a/project/Utils.scala
+++ b/project/Utils.scala
@@ -36,7 +36,7 @@ object Utils {
 
   def projectComponent: Setting[?] =
     projectID := (componentID.value match {
-      case Some(id) => projectID.value extra ("e:component" -> id)
+      case Some(id) => projectID.value.extra("e:component" -> id)
       case None     => projectID.value
     })
 
@@ -127,7 +127,7 @@ object Utils {
     excludePomArtifact(n.text)
   }
 
-  def excludePomArtifact(artifactId: String) = (artifactId startsWith "compiler-bridge")
+  def excludePomArtifact(artifactId: String) = artifactId.startsWith("compiler-bridge")
 
   val testExclusive = test / tags += (ExclusiveTest, 1)
 


### PR DESCRIPTION
- prepare for https://github.com/sbt/sbt/issues/9010

```
[warn] -- Warning: /home/runner/work/sbt/sbt/project/HouseRulesPlugin.scala:46:53 -----
[warn] 46 |  private def scalaPartV = Def setting (CrossVersion partialVersion scalaVersion.value)
[warn]    |                                                     ^^^^^^^^^^^^^^
[warn]    |Alphanumeric method partialVersion is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .partialVersion(...) or backticked identifier `partialVersion`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/HouseRulesPlugin.scala:46:31 -----
[warn] 46 |  private def scalaPartV = Def setting (CrossVersion partialVersion scalaVersion.value)
[warn]    |                               ^^^^^^^
[warn]    |Alphanumeric method setting is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .setting(...) or backticked identifier `setting`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/PublishBinPlugin.scala:22:58 -----
[warn] 22 |  override val projectSettings: Seq[Def.Setting[?]] = Def settings (
[warn]    |                                                          ^^^^^^^^
[warn]    |Alphanumeric method settings is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .settings(...) or backticked identifier `settings`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/Scripted.scala:35:52 -------------
[warn] 35 |  val RepoOverrideTest = config("repoOverrideTest") extend Compile
[warn]    |                                                    ^^^^^^
[warn]    |Alphanumeric method extend is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .extend(...) or backticked identifier `extend`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/Scripted.scala:106:40 ------------
[warn] 106 |    val testIdAsGroup = matched(testID) map (test => Seq(test))
[warn]     |                                        ^^^
[warn]     |Alphanumeric method map is not declared infix; it should not be used as infix operator.
[warn]     |Instead, use method syntax .map(...) or backticked identifier `map`.
[warn]     |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/Scripted.scala:109:51 ------------
[warn] 109 |    (token(Space) ~> (PagedIds | testIdAsGroup)).* map (_.flatten)
[warn]     |                                                   ^^^
[warn]     |Alphanumeric method map is not declared infix; it should not be used as infix operator.
[warn]     |Instead, use method syntax .map(...) or backticked identifier `map`.
[warn]     |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/Utils.scala:43:39 ----------------
[warn] 43 |      case Some(id) => projectID.value extra ("e:component" -> id)
[warn]    |                                       ^^^^^
[warn]    |Alphanumeric method extra is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .extra(...) or backticked identifier `extra`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt/sbt/project/Utils.scala:134:59 ---------------
[warn] 134 |  def excludePomArtifact(artifactId: String) = (artifactId startsWith "compiler-bridge")
[warn]     |                                                           ^^^^^^^^^^
[warn]     |Alphanumeric method startsWith is not declared infix; it should not be used as infix operator.
[warn]     |Instead, use method syntax .startsWith(...) or backticked identifier `startsWith`.
[warn]     |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
```