### PR TITLE
[2.x] Fix stdout not appearing in forked `bgRun`

### DIFF
--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -424,6 +424,15 @@ private[sbt] final class CommandExchange {
         tryTo(_.notifyEvent(event))(c)
       case _ =>
 
+  // Route a log event to a specific channel, independent of currentExec.
+  // Used for background job output so messages reach the originating client
+  // even after the spawning task has completed and currentExec has been cleared.
+  private[sbt] def logMessage(channelName: String, event: LogEvent): Unit =
+    channels.foreach:
+      case c: NetworkChannel if c.name == channelName =>
+        tryTo(_.notifyEvent(event))(c)
+      case _ =>
+
   private def isChannelOwner(c: NetworkChannel): Boolean =
     currentExec.exists(_.source.exists(_.channelName == c.name))
 

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -429,7 +429,7 @@ private[sbt] final class CommandExchange {
   // even after the spawning task has completed and currentExec has been cleared.
   private[sbt] def logMessage(channelName: String, event: LogEvent): Unit =
     channels.foreach:
-      case c: NetworkChannel if c.name == channelName =>
+      case c: NetworkChannel if c.subscribeToAll || c.name == channelName =>
         tryTo(_.notifyEvent(event))(c)
       case _ =>
 

--- a/main/src/main/scala/sbt/internal/LogManager.scala
+++ b/main/src/main/scala/sbt/internal/LogManager.scala
@@ -123,7 +123,14 @@ object LogManager {
         context: LoggerContext
     ): ManagedLogger = {
       val console = ConsoleAppender.safe("bg-" + ConsoleAppender.generateName(), ITerminal.current)
-      LogManager.backgroundLog(data, state, task, console, relay(()), context)
+      // Use a channel-aware relay appender so background job log output reaches
+      // the originating client even after the spawning task completes and
+      // currentExec is cleared.
+      val channelName = state.currentCommand.flatMap(_.source.map(_.channelName))
+      val bgRelay = channelName match
+        case Some(_) => new RelayAppender("bg-Relay" + generateId.incrementAndGet, channelName)
+        case None    => relay(())
+      LogManager.backgroundLog(data, state, task, console, bgRelay, context)
     }
   }
 

--- a/main/src/main/scala/sbt/internal/RelayAppender.scala
+++ b/main/src/main/scala/sbt/internal/RelayAppender.scala
@@ -13,7 +13,7 @@ import sbt.internal.util.*
 import sbt.protocol.LogEvent
 import sbt.util.Level
 
-class RelayAppender(override val name: String)
+class RelayAppender(override val name: String, targetChannel: Option[String] = None)
     extends ConsoleAppender(
       name,
       ConsoleAppender.Properties.from(ConsoleOut.NullConsoleOut, true, true),
@@ -21,6 +21,9 @@ class RelayAppender(override val name: String)
     ) {
   lazy val exchange = StandardMain.exchange
   override def appendLog(level: Level.Value, message: => String): Unit = {
-    exchange.logMessage(LogEvent(level = level.toString, message = message))
+    val event = LogEvent(level = level.toString, message = message)
+    targetChannel match
+      case Some(ch) => exchange.logMessage(ch, event)
+      case None     => exchange.logMessage(event)
   }
 }

--- a/main/src/main/scala/sbt/internal/RelayAppender.scala
+++ b/main/src/main/scala/sbt/internal/RelayAppender.scala
@@ -19,6 +19,8 @@ class RelayAppender(override val name: String, targetChannel: Option[String] = N
       ConsoleAppender.Properties.from(ConsoleOut.NullConsoleOut, true, true),
       _ => None
     ) {
+  def this(name: String) = this(name, None)
+
   lazy val exchange = StandardMain.exchange
   override def appendLog(level: Level.Value, message: => String): Unit = {
     val event = LogEvent(level = level.toString, message = message)

--- a/main/src/main/scala/sbt/internal/RunUtil.scala
+++ b/main/src/main/scala/sbt/internal/RunUtil.scala
@@ -293,9 +293,16 @@ object RunUtil:
       val (mainClass, allArgs) = parser.parsed
       val (jvmArgs, appArgs) = splitArgs(allArgs)
       val hashClasspath = (bgRunMain / bgHashClasspath).value
-      val fo = (run / forkOptions).value
+      // Background runs must not inherit the terminal's stdin/stdout via connectInput.
+      // Without this, ForkRun.configLogged skips setting LoggedOutput, causing
+      // the fork to use inheritIO() which bypasses the background logger entirely.
+      val fo = (run / forkOptions).value.withConnectInput(false)
       val log = streams.value.log
-      val (modifiedRun, _) = applyJvmArgs(scalaRun.value, jvmArgs, fo, log)
+      // applyJvmArgs only builds a new ForkRun when jvmArgs is non-empty, so force
+      // construction of a ForkRun that uses the updated ForkOptions above.
+      val (modifiedRun, _) = applyJvmArgs(scalaRun.value, jvmArgs, fo, log) match
+        case (_: ForkRun, _) => (new ForkRun(fo.withRunJVMOptions(fo.runJVMOptions ++ jvmArgs)), fo)
+        case other           => other
       val wrapper = termWrapper(canonicalInput.value, echoInput.value)
       val converter = fileConverter.value
       setWindowTitle(mkWindowTitle("bgRunMain", organization.value, name.value, version.value))
@@ -337,9 +344,16 @@ object RunUtil:
       val service = bgJobService.value
       val mainClass = getMainClass(mainClassTask.value)
       val hashClasspath = (bgRun / bgHashClasspath).value
-      val fo = (run / forkOptions).value
+      // Background runs must not inherit the terminal's stdin/stdout via connectInput.
+      // Without this, ForkRun.configLogged skips setting LoggedOutput, causing
+      // the fork to use inheritIO() which bypasses the background logger entirely.
+      val fo = (run / forkOptions).value.withConnectInput(false)
       val log = streams.value.log
-      val (modifiedRun, _) = applyJvmArgs(scalaRun.value, jvmArgs, fo, log)
+      // applyJvmArgs only builds a new ForkRun when jvmArgs is non-empty, so force
+      // construction of a ForkRun that uses the updated ForkOptions above.
+      val (modifiedRun, _) = applyJvmArgs(scalaRun.value, jvmArgs, fo, log) match
+        case (_: ForkRun, _) => (new ForkRun(fo.withRunJVMOptions(fo.runJVMOptions ++ jvmArgs)), fo)
+        case other           => other
       val wrapper = termWrapper(canonicalInput.value, echoInput.value)
       val converter = fileConverter.value
       setWindowTitle(mkWindowTitle("bgRun", organization.value, name.value, version.value))

--- a/sbt-app/src/sbt-test/run/bg/build.sbt
+++ b/sbt-app/src/sbt-test/run/bg/build.sbt
@@ -1,0 +1,43 @@
+import sbt.internal.LogManager
+import sbt.internal.util.{ Appender, ConsoleAppender, ConsoleOut }
+import java.io.{ FileWriter, PrintWriter }
+
+lazy val checkBgOutput = taskKey[Unit]("Verify the bgRun forked process output was logged")
+lazy val waitForAllBgJobs = taskKey[Unit]("Wait for every bgJobService job to terminate")
+lazy val outFile = settingKey[File]("File where bgRun output is captured for the test")
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    run / fork := true,
+    outFile := baseDirectory.value / "target" / "bg-output.log",
+    // Override logManager so the background logger's relay appender writes
+    // to a file. This lets the test assert that forked-process output
+    // reached the managed logger (rather than going to the JVM's stdout via
+    // inheritIO, which is what happens when the bgRun fork-output bug is
+    // present). In a scripted test there are no network channels, so the
+    // default relay appender has no observable effect anyway.
+    logManager := {
+      val ea = extraAppenders.value
+      val f = outFile.value
+      IO.touch(f)
+      val fileRelay: Unit => Appender = _ => {
+        val pw = new PrintWriter(new FileWriter(f, true), true)
+        ConsoleAppender("bg-file-test", ConsoleOut.printWriterOut(pw))
+      }
+      LogManager.withLoggers(
+        screen = (task, state) => ConsoleAppender(s"screen-${task.key.label}"),
+        relay = fileRelay,
+        extra = ea
+      )
+    },
+    waitForAllBgJobs := Def.uncached {
+      val service = bgJobService.value
+      service.jobs.foreach(service.waitFor)
+    },
+    checkBgOutput := Def.uncached {
+      val f = outFile.value
+      val content = IO.read(f)
+      assert(content.contains("foobar"), s"Expected 'foobar' in $f, got:\n$content")
+    }
+  )

--- a/sbt-app/src/sbt-test/run/bg/src/main/scala/Test.scala
+++ b/sbt-app/src/sbt-test/run/bg/src/main/scala/Test.scala
@@ -1,0 +1,1 @@
+@main def test: Unit = println("foobar")

--- a/sbt-app/src/sbt-test/run/bg/test
+++ b/sbt-app/src/sbt-test/run/bg/test
@@ -1,0 +1,3 @@
+> bgRun
+> waitForAllBgJobs
+> checkBgOutput


### PR DESCRIPTION
Fixes #9100.

Note I pretty much one-shotted this with Claude, so I appreciate a thorough review to make sure it's logical. Claude's description below:

## Background

When `run / fork := true`, running `bgRun` (or `bgRunMain`) silently swallows the forked process's stdout/stderr. The forked JVM runs to completion, but the user never sees its output — neither in `sbt --server` mode nor in the default thin-client mode.

There are actually two independent bugs that combine to produce this symptom. Both must be fixed for output to reach the user.

## Bug 1: `bgRun` forks with `inheritIO()` instead of `LoggedOutput`

`bgRunTask` / `bgRunMainTask` resolve their fork options via `(run / forkOptions)`, which inherits `run / connectInput := true`. That has two downstream consequences:

1. `ForkRun.configLogged` (in `run/src/main/scala/sbt/Run.scala`) skips installing `OutputStrategy.LoggedOutput(log)` whenever `config.connectInput == true`.
2. `Fork.apply` (in `run/src/main/scala/sbt/Fork.scala`) sees `connectInput && outputStrategy == StdoutOutput` and takes the `interactiveFork` path, which calls `jpb.inheritIO()`.

`inheritIO()` wires the forked JVM's stdio directly to the sbt server JVM's stdio — bypassing the managed logger entirely. In server mode that output goes nowhere observable to the client.

A background process has no business being attached to the terminal's stdin anyway, so the fix is to force `connectInput = false` for `bgRun`/`bgRunMain`.

There was also a subtle interaction with `applyJvmArgs`: it only constructs a new `ForkRun` when `jvmArgs` is non-empty, so a naive `withConnectInput(false)` on the resolved `ForkOptions` was silently discarded for the common case of `bgRun` with no JVM args. The fix forces construction of a fresh `ForkRun` that uses the updated `ForkOptions` regardless.

### Fix
- `main/src/main/scala/sbt/internal/RunUtil.scala`: in `bgRunTask` and `bgRunMainTask`, take `(run / forkOptions).value.withConnectInput(false)`, and always rebuild the `ForkRun` with that updated `ForkOptions`.

## Bug 2: Background-job log relay drops messages after the spawning task ends

Even after Bug 1 is fixed, `LoggedOutput` routes the forked process's stdout into the background `ManagedLogger`, whose appenders include a shared `RelayAppender`. The relay calls `CommandExchange.logMessage(event)`, which uses `isChannelOwner(c)` to pick the target channel:

```scala
private def isChannelOwner(c: NetworkChannel): Boolean =
  currentExec.exists(_.source.exists(_.channelName == c.name))
```

`bgRun` returns a `JobHandle` immediately, so by the time the forked JVM produces output, the spawning command has finished and `currentExec` has been cleared. `isChannelOwner` returns `false` for every channel. With the default sbt client (subscribeToAll = false), the log event is silently dropped and never reaches the client.

The background `ManagedLogger` already knows its originating channel name — it's captured at construction time — but the shared `RelayAppender` does not.

### Fix

- `main/src/main/scala/sbt/internal/RelayAppender.scala`: give `RelayAppender` an optional `targetChannel` parameter.
- `main/src/main/scala/sbt/internal/CommandExchange.scala`: add a `logMessage(channelName: String, event: LogEvent)` overload that routes directly to the named channel without consulting `currentExec`.
- `main/src/main/scala/sbt/internal/LogManager.scala`: in the background-log setup, capture the originating channel name from `state.currentCommand` and construct a per-job `RelayAppender` bound to that channel. With this in place, output from the background logger reaches the originating client even after the spawning task has completed.

## Notes

The scripted test at `sbt-app/src/sbt-test/run/bg/` defines a custom `logManager` whose `relay` appender writes to a file (in scripted mode there are no network channels, so the default relay has no observable effect). The test runs `bgRun`, waits for the background job to terminate via a small `waitForAllBgJobs` helper, and asserts that the captured file contains `foobar`.

This test does not actually reproduce the original bug on its own — even without these fixes, the forked process's stdout reaches *somewhere* during a scripted run. The test guards against future regressions of the `LoggedOutput` path being silently dropped, but the bug itself was reproduced manually and the fix was confirmed using the code described in #9100.