### PR TITLE
[2.x] ci: Avoid deprecated replaceAllLiterally

### DIFF
--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -360,7 +360,7 @@ val launcherPackage = (project in file("."))
           val x = IO.read(k)
           IO.write(
             t / "sbt.bat",
-            x.replaceAllLiterally(
+            x.replace(
               "set init_sbt_version=_to_be_replaced",
               s"set init_sbt_version=$sbtVersionToRelease"
             )


### PR DESCRIPTION
- https://github.com/scala/scala3/commit/b4aa12d2b04ee02f871ff973a21903184a1fce99
- https://github.com/scala/scala/blob/v2.12.21/src/library/scala/collection/immutable/StringLike.scala#L177-L184
- https://github.com/scala/scala3/blob/3.8.2/library/src/scala/collection/StringOps.scala#L746-L747