### PR TITLE
[2.x] Fix warnings in launcherPackage sub project

### DIFF
--- a/launcher-package/build.sbt
+++ b/launcher-package/build.sbt
@@ -108,6 +108,7 @@ val launcherPackage = (project in file("."))
     name := "sbt-launcher-packaging",
     packageName := "sbt",
     crossTarget := target.value,
+    autoScalaLibrary := false,
     clean := {
       val _ = (dist / clean).value
       clean.value


### PR DESCRIPTION
```
[warn] scalaVersion for subproject launcherPackage fell back to a default value 2.12.21; declare it explicitly in build.sbt:
[warn]   scalaVersion := "2.12.21"
```