### PR TITLE
[1.x] fix: Ensure resources are copied atomically

### DIFF
--- a/main-actions/src/main/scala/sbt/Package.scala
+++ b/main-actions/src/main/scala/sbt/Package.scala
@@ -221,9 +221,7 @@ object Package {
     val path = jar.getAbsolutePath
     log.debug("Packaging " + path + " ...")
     if (jar.exists)
-      if (jar.isFile)
-        IO.delete(jar)
-      else
+      if (!jar.isFile)
         sys.error(path + " exists, but is not a regular file")
     log.debug(sourcesDebugString(sources))
     IO.jar(sources, jar, manifest, time)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")
 
   // sbt modules
-  private val ioVersion = nightlyVersion.getOrElse("1.10.5")
+  private val ioVersion = nightlyVersion.getOrElse("1.12.0")
   private val lmVersion =
     sys.props.get("sbt.build.lm.version").orElse(nightlyVersion).getOrElse("1.12.2")
   val zincVersion = nightlyVersion.getOrElse("1.12.0")


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9190 for sbt 1.

Using io 1.12 appears to fix the issue in question for sbt 1.