### PR TITLE
[2.x] test: Add pending move-file test

### DIFF
--- a/sbt-app/src/sbt-test/source-dependencies/move-file/A.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/move-file/A.scala
@@ -1,0 +1,5 @@
+package example
+
+object Main {
+  def main(args: Array[String]): Unit = ()
+}

--- a/sbt-app/src/sbt-test/source-dependencies/move-file/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/move-file/build.sbt
@@ -1,0 +1,15 @@
+import sbt.internal.inc.Analysis
+import complete.DefaultParsers.*
+
+scalaVersion := "2.13.18"
+
+val checkStampSize = inputKey[Unit]("Verifies the accumulated number of iterations of incremental compilation.")
+checkStampSize := {
+  val expected: Int = (Space ~> NatBasic).parsed
+  val analysis = (Compile / compile).value match
+    case a: Analysis => a
+  println(s"analysis: $analysis")
+  val sourceStampSize = analysis.readStamps.getAllSourceStamps.size
+  assert(sourceStampSize == expected, s"sourceStampSize = $sourceStampSize")
+}
+

--- a/sbt-app/src/sbt-test/source-dependencies/move-file/pending
+++ b/sbt-app/src/sbt-test/source-dependencies/move-file/pending
@@ -1,0 +1,17 @@
+> checkStampSize 1
+
+# move A.scala elsewhere
+$ copy-file A.scala A.txt
+$ delete A.scala
+> checkStampSize 0
+
+# move A.scala back
+$ copy-file A.txt A.scala
+$ delete A.txt
+$ exists A.scala
+
+> show Compile/sources
+
+# if we recompile, we should regain stamp size 1
+> debug
+> checkStampSize 1


### PR DESCRIPTION
## Problem
Moving files around seems to break compile task.

This was inspired by @xuwei-k's https://github.com/sbt/sbt/issues/9195. I was able to minimize it further so it doesn't involve discoveredMainClasses.
