### PR TITLE
[2.0.x] bport: Port tests to use lm-coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -684,8 +684,9 @@ lazy val zincLmIntegrationProj = (project in file("zinc-lm-integration"))
       exclude[DirectMissingMethodProblem]("sbt.internal.inc.ZincLmUtil.*"),
     ),
     libraryDependencies += launcherInterface,
+    libraryDependencies += scalaCollectionCompat % Test,
   )
-  .dependsOn(lmCore, lmIvy)
+  .dependsOn(lmCore, lmCoursierShadedPublishing % Test)
   .configure(addSbtZincCompileCore)
 
 lazy val buildFileProj = (project in file("buildfile"))
@@ -711,6 +712,7 @@ lazy val mainProj = (project in file("main"))
     runProj,
     commandProj,
     collectionProj,
+    lmIvy,
     zincLmIntegrationProj,
     utilLogging,
   )
@@ -1279,8 +1281,9 @@ lazy val lmCoursierDependencies = Def.settings(
     coursierSbtMavenRepo,
     "io.get-coursier.jniutils" % "windows-jni-utils-lmcoursier" % jniUtilsVersion,
     "net.hamnaberg" %% "dataclass-annotation" % dataclassScalafixVersion % Provided,
-    "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   ),
+  libraryDependencies ++= Dependencies.scalatest,
+  libraryDependencies += scalaVerify % Test,
   excludeDependencies ++= Seq(
     ExclusionRule("org.scala-lang.modules", "scala-xml_2.13"),
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -840,7 +840,7 @@ lazy val sbtClientProj = (project in file("client"))
     bspEnabled := false,
     crossPaths := false,
     exportJars := true,
-    libraryDependencies += scalatest % Test,
+    libraryDependencies ++= Dependencies.scalatest,
     Compile / mainClass := Some("sbt.client.Client"),
     nativeImageReady := { () =>
       ()
@@ -1172,11 +1172,11 @@ lazy val lmCore = (project in file("lm-core"))
       scalaXml,
       sjsonNewScalaJson.value % Optional,
       sjsonNewCore.value % Optional,
-      scalatest % Test,
       scalacheck % Test,
       scalaVerify % Test,
       hedgehog % Test,
     ),
+    libraryDependencies ++= Dependencies.scalatest,
     Compile / resourceGenerators += Def
       .task(
         Utils.generateVersionFile(
@@ -1230,11 +1230,11 @@ lazy val lmIvy = (project in file("lm-ivy"))
       ivy,
       sjsonNewScalaJson.value,
       sjsonNewCore.value,
-      scalatest % Test,
       scalacheck % Test,
       scalaVerify % Test,
       hedgehog % Test,
     ),
+    libraryDependencies ++= Dependencies.scalatest,
     contrabandSettings,
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     mimaSettings,

--- a/lm-coursier/src/test/scala/lmcoursier/EvictionErrorSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/EvictionErrorSpec.scala
@@ -1,11 +1,12 @@
-package sbt.internal.librarymanagement
+package lmcoursier
 
 import sbt.librarymanagement.*
 import sbt.internal.librarymanagement.cross.CrossVersionUtil
 import sbt.librarymanagement.syntax.*
 import sbt.util.Level
+import TestKit.*
 
-object EvictionErrorSpec extends BaseIvySpecification {
+object EvictionErrorSpec extends verify.BasicTestSuite {
   // This is a specification to check the eviction errors
 
   import TestShowLines.*
@@ -14,93 +15,89 @@ object EvictionErrorSpec extends BaseIvySpecification {
   test("Eviction error should detect binary incompatible Scala libraries") {
     val deps = Vector(`scala2.10.4`, `akkaActor2.1.4`, `akkaActor2.3.0`)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionError(report, m, oldAkkaPvp).incompatibleEvictions.size == 1)
   }
 
   test("it should print out message about the eviction") {
     val deps = Vector(`scala2.10.4`, `akkaActor2.1.4`, `akkaActor2.3.0`)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionError(report, m, oldAkkaPvp).lines ==
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
           "\t* com.typesafe.akka:akka-actor_2.10:2.3.0 (pvp) is selected over 2.1.4 for {compile, test}",
-          "\t    +- com.example:foo:0.1.0                              (depends on 2.1.4)",
+          "\t    +- com.typesafe.akka:akka-actor_2.10:2.1.4            (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionError(report, m, oldAkkaPvp).lines.mkString("\n")
     )
   }
 
   test("it should print out message including the transitive dependencies") {
     val deps = Vector(`scala2.10.4`, `bananaSesame0.4`, `akkaRemote2.3.4`)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionError(report, m, oldAkkaPvp).lines ==
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp) is selected over 2.1.4 for {compile, test}",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp) is selected over {2.1.4, 2.1.4} for {compile, test}",
           "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
-          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
+          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionError(report, m, oldAkkaPvp).lines.mkString("\n")
     )
   }
 
   test("it should be able to emulate eviction warnings") {
     val deps = Vector(`scala2.10.4`, `bananaSesame0.4`, `akkaRemote2.3.4`)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionError(report, m, Nil, "pvp", "early-semver", Level.Warn).toAssumedLines ==
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp?) is selected over 2.1.4 for {compile, test}",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 (pvp?) is selected over {2.1.4, 2.1.4} for {compile, test}",
           "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
-          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
+          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionError(report, m, Nil, "pvp", "early-semver", Level.Warn).toAssumedLines.mkString("\n")
     )
   }
 
   test("it should detect Semantic Versioning violations") {
     val deps = Vector(`scala2.13.3`, `http4s0.21.11`, `cats-effect3.0.0-M4`)
     val m = module(defaultModuleId, deps, Some("2.13.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionError(report, m, Nil).lines ==
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0} for compile",
-          "\t    +- com.example:foo:0.1.0                              (depends on 3.0.0-M4)",
-          "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
+          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.2.0, 2.0.0, 2.0.0, 2.2.0} for {compile, test}",
           "\t    +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)",
           "\t    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)",
           "\t    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)",
-          "",
-          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0} for test",
-          "\t    +- com.example:foo:0.1.0                              (depends on 2.2.0)",
           "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
-          "\t    +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)",
-          "\t    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)",
-          "\t    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)",
           "",
-        )
+        ),
+      EvictionError(report, m, Nil).lines.mkString("\n") + "'"
     )
   }
 
   test("it should selectively allow opt-out from the error") {
     val deps = Vector(`scala2.13.3`, `http4s0.21.11`, `cats-effect3.0.0-M4`)
     val m = module(defaultModuleId, deps, Some("2.13.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     val overrideRules = List("org.typelevel" %% "cats-effect" % "always")
     assert(EvictionError(report, m, overrideRules).incompatibleEvictions.isEmpty)
   }
@@ -108,7 +105,7 @@ object EvictionErrorSpec extends BaseIvySpecification {
   test("it should selectively allow opt-out from the error despite assumed scheme") {
     val deps = Vector(`scala2.12.17`, `akkaActor2.6.0`, `swagger-akka-http1.4.0`)
     val m = module(defaultModuleId, deps, Some("2.12.17"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     val overrideRules = List("org.scala-lang.modules" %% "scala-java8-compat" % "always")
     assert(
       EvictionError(
@@ -154,20 +151,20 @@ object EvictionErrorSpec extends BaseIvySpecification {
     val deps =
       Vector(`scala2.13.3`, `http4s0.21.11`.withConfigurations(Some("test")), `cats-effect3.0.0-M4`)
     val m = module(defaultModuleId, deps, Some("2.13.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionError(report, m, Nil).lines ==
         List(
           "found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.0.0, 2.2.0} for test",
-          "\t    +- com.example:foo:0.1.0                              (depends on 2.2.0)",
-          "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
+          "\t* org.typelevel:cats-effect_2.13:3.0.0-M4 (early-semver) is selected over {2.2.0, 2.0.0, 2.0.0, 2.2.0} for test",
           "\t    +- org.http4s:http4s-core_2.13:0.21.11                (depends on 2.2.0)",
           "\t    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)",
           "\t    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)",
+          "\t    +- co.fs2:fs2-core_2.13:2.4.5                         (depends on 2.2.0)",
           ""
-        )
+        ),
+      EvictionError(report, m, Nil).lines.mkString("\n")
     )
   }
 

--- a/lm-coursier/src/test/scala/lmcoursier/EvictionWarningSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/EvictionWarningSpec.scala
@@ -1,10 +1,11 @@
-package sbt.internal.librarymanagement
+package lmcoursier
 
 import sbt.librarymanagement.*
 import sbt.internal.librarymanagement.cross.CrossVersionUtil
 import sbt.librarymanagement.syntax.*
+import TestKit.*
 
-object EvictionWarningSpec extends BaseIvySpecification {
+object EvictionWarningSpec extends verify.BasicTestSuite {
   // This is a specification to check the eviction warnings
 
   import TestShowLines.*
@@ -13,13 +14,13 @@ object EvictionWarningSpec extends BaseIvySpecification {
 
   test("Eviction of non-overridden scala-library whose scalaVersion should be detected") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"), overrideScalaVersion = false)
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).scalaEvictions.size == 1)
   }
 
   test("it should not be detected if it's disabled") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"), overrideScalaVersion = false)
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(
         m,
@@ -31,7 +32,7 @@ object EvictionWarningSpec extends BaseIvySpecification {
 
   test("it should print out message about the eviction") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"), overrideScalaVersion = false)
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions.withShowCallers(false), report).lines ==
         List(
@@ -46,24 +47,25 @@ object EvictionWarningSpec extends BaseIvySpecification {
 
   test("it should print out message about the eviction with callers") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"), overrideScalaVersion = false)
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions, report).lines ==
         List(
           "Scala version was updated by one of library dependencies:",
           "\t* org.scala-lang:scala-library:2.10.3 is selected over 2.10.2",
           "\t    +- com.typesafe.akka:akka-actor_2.10:2.3.0            (depends on 2.10.3)",
-          "\t    +- com.example:foo:0.1.0                              (depends on 2.10.2)",
+          "\t    +- org.scala-lang:scala-library:2.10.2                (depends on 2.10.2)",
           "",
           "To force scalaVersion, add the following:",
           "\tscalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(true)))"
-        )
+        ),
+      EvictionWarning(m, fullOptions, report).lines.mkString("\n")
     )
   }
 
   test("it should print out summary about the eviction if warn eviction summary enabled") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"), overrideScalaVersion = false)
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, EvictionWarningOptions.summary, report).lines ==
         List(
@@ -76,13 +78,13 @@ object EvictionWarningSpec extends BaseIvySpecification {
     """Non-eviction of overridden scala-library whose scalaVersion  should "not be detected if it's enabled""""
   ) {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).scalaEvictions.size == 0)
   }
 
   test("it should not be detected if it's disabled") {
     val m = module(defaultModuleId, scalaVersionDeps, Some("2.10.2"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(
         m,
@@ -96,13 +98,13 @@ object EvictionWarningSpec extends BaseIvySpecification {
     """Including two (suspect) binary incompatible Java libraries to direct dependencies should be detected as eviction"""
   ) {
     val m = module(defaultModuleId, javaLibDirectDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 1)
   }
 
   test("it should not be detected if it's disabled") {
     val m = module(defaultModuleId, javaLibDirectDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(
         m,
@@ -116,37 +118,39 @@ object EvictionWarningSpec extends BaseIvySpecification {
 
   test("it should print out message about the eviction") {
     val m = module(defaultModuleId, javaLibDirectDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions, report).lines ==
         List(
           "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
           "\t* commons-io:commons-io:2.4 is selected over 1.4",
-          "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
+          "\t    +- commons-io:commons-io:1.4                          (depends on 1.4)",
           ""
-        )
+        ),
+      EvictionWarning(m, fullOptions, report).lines.mkString("\n")
     )
   }
 
   test("it should print out message about the eviction with callers") {
     val m = module(defaultModuleId, javaLibDirectDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions.withShowCallers(true), report).lines ==
         List(
           "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
           "\t* commons-io:commons-io:2.4 is selected over 1.4",
-          "\t    +- com.example:foo:0.1.0                              (depends on 1.4)",
+          "\t    +- commons-io:commons-io:1.4                          (depends on 1.4)",
           ""
-        )
+        ),
+      EvictionWarning(m, fullOptions.withShowCallers(true), report).lines.mkString("\n")
     )
   }
 
   test("it should print out summary about the eviction if warn eviction summary enabled") {
     val m = module(defaultModuleId, javaLibDirectDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, EvictionWarningOptions.summary, report).lines ==
         List(
@@ -160,14 +164,14 @@ object EvictionWarningSpec extends BaseIvySpecification {
   ) {
     val deps = Vector(commonsIo14, commonsIo13)
     val m = module(defaultModuleId, deps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 0)
   }
 
   test("it should not print out message about the eviction") {
     val deps = Vector(commonsIo14, commonsIo13)
     val m = module(defaultModuleId, deps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).lines == Nil)
   }
 
@@ -175,7 +179,7 @@ object EvictionWarningSpec extends BaseIvySpecification {
     """Including two (suspect) transitively binary incompatible Java libraries to direct dependencies should be detected as eviction"""
   ) {
     val m = module(defaultModuleId, javaLibTransitiveDeps, Some("2.10.3"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 1)
   }
 
@@ -184,30 +188,31 @@ object EvictionWarningSpec extends BaseIvySpecification {
   ) {
     val deps = Vector(scala2104, akkaActor214, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 1)
   }
 
   test("it should print out message about the eviction") {
     val deps = Vector(scala2104, akkaActor214, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions, report).lines ==
         List(
           "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
           "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over 2.1.4",
-          "\t    +- com.example:foo:0.1.0                              (depends on 2.1.4)",
+          "\t    +- com.typesafe.akka:akka-actor_2.10:2.1.4            (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionWarning(m, fullOptions, report).lines.mkString("\n")
     )
   }
 
   test("it should print out summary about the eviction if warn eviction summary enabled") {
     val deps = Vector(scala2104, akkaActor214, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, EvictionWarningOptions.summary, report).lines ==
         List(
@@ -221,21 +226,21 @@ object EvictionWarningSpec extends BaseIvySpecification {
   ) {
     val deps = Vector(scala2104, akkaActor230, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 0)
   }
 
   test("it should not print out message about the eviction") {
     val deps = Vector(scala2104, akkaActor230, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).lines == Nil)
   }
 
   test("it should not print out summary about the eviction even if warn eviction summary enabled") {
     val deps = Vector(scala2104, akkaActor230, akkaActor234)
     val m = module(defaultModuleId, deps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, EvictionWarningOptions.summary, report).lines == Nil)
   }
 
@@ -243,30 +248,31 @@ object EvictionWarningSpec extends BaseIvySpecification {
     """Including two (suspect) transitively binary incompatible Scala libraries to direct dependencies should be detected as eviction"""
   ) {
     val m = module(defaultModuleId, scalaLibTransitiveDeps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(EvictionWarning(m, fullOptions, report).reportedEvictions.size == 1)
   }
 
   test("it should print out message about the eviction if it's enabled") {
     val m = module(defaultModuleId, scalaLibTransitiveDeps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, fullOptions, report).lines ==
         List(
           "Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:",
           "",
-          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over 2.1.4",
+          "\t* com.typesafe.akka:akka-actor_2.10:2.3.4 is selected over {2.1.4}",
           "\t    +- com.typesafe.akka:akka-remote_2.10:2.3.4           (depends on 2.3.4)",
-          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           "\t    +- org.w3:banana-sesame_2.10:0.4                      (depends on 2.1.4)",
+          "\t    +- org.w3:banana-rdf_2.10:0.4                         (depends on 2.1.4)",
           ""
-        )
+        ),
+      EvictionWarning(m, fullOptions, report).lines.mkString("\n")
     )
   }
 
   test("it should print out summary about the eviction if warn eviction summary enabled") {
     val m = module(defaultModuleId, scalaLibTransitiveDeps, Some("2.10.4"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     assert(
       EvictionWarning(m, EvictionWarningOptions.summary, report).lines ==
         List(
@@ -289,15 +295,6 @@ object EvictionWarningSpec extends BaseIvySpecification {
     assert(
       EvictionWarningOptions
         .defaultGuess((m1, Option(m2), Option(dummyScalaModuleInfo("2.12.4"))))
-    )
-  }
-
-  test("Comparing 2.13 libraries with pvp under Scala 3.0.0-M3 should work") {
-    val m1 = "org.scodec" % "scodec-bits_2.13" % "1.1.21"
-    val m2 = "org.scodec" % "scodec-bits_2.13" % "1.1.22"
-    assert(
-      EvictionWarningOptions
-        .evalPvp((m1, Option(m2), Option(dummyScalaModuleInfo("3.0.0-M3"))))
     )
   }
 
@@ -377,7 +374,7 @@ object EvictionWarningSpec extends BaseIvySpecification {
     "When winner satisfies version range [1.3.1,2.3], should not report eviction for json-smart (fixes #6244)"
   ) {
     val m = module(defaultModuleId, versionIntervalDeps6244, Some("2.12.12"))
-    val report = ivyUpdate(m)
+    val report = coursierUpdate(m)
     val warning = EvictionWarning(m, fullOptions, report)
     val jsonSmartEviction =
       warning.reportedEvictions.find(p => p.organization == "net.minidev" && p.name == "json-smart")

--- a/lm-coursier/src/test/scala/lmcoursier/InclExclSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/InclExclSpec.scala
@@ -1,51 +1,39 @@
-package sbt.internal.librarymanagement
+package lmcoursier
 
 import sbt.librarymanagement.*
 import sbt.librarymanagement.syntax.*
-import DependencyBuilders.OrganizationArtifactName
+import TestKit.*
 
-object InclExclSpec extends BaseIvySpecification {
+object InclExclSpec extends verify.BasicTestSuite {
   val scala210 = Some("2.10.4")
   test("it should exclude any version of lift-json via a new exclusion rule") {
     val toExclude = ExclusionRule("net.liftweb", "lift-json_2.10")
-    val report = getIvyReport(createLiftDep(toExclude), scala210)
+    val report = getUpdateReport(createLiftDep(toExclude), scala210)
     testLiftJsonIsMissing(report)
   }
 
   test("it should exclude any version of lift-json with explicit Scala version") {
-    val excluded: OrganizationArtifactName = "net.liftweb" % "lift-json_2.10"
-    val report = getIvyReport(createLiftDep(excluded), scala210)
-    testLiftJsonIsMissing(report)
-  }
-
-  test("it should exclude any version of cross-built lift-json") {
-    val excluded: OrganizationArtifactName = "net.liftweb" %% "lift-json"
-    val report = getIvyReport(createLiftDep(excluded), scala210)
+    val excluded = "net.liftweb" % "lift-json_2.10"
+    val report = getUpdateReport(createLiftDep(excluded), scala210)
     testLiftJsonIsMissing(report)
   }
 
   val scala2122 = Some("2.12.2")
   test("it should exclude a concrete version of lift-json when it's full cross version") {
     val excluded: ModuleID = ("org.scalameta" % "scalahost" % "1.7.0").cross(CrossVersion.full)
-    val report = getIvyReport(createMetaDep(excluded), scala2122)
-    testScalahostIsMissing(report)
-  }
-
-  test("it should exclude any version of lift-json when it's full cross version") {
-    val excluded = new OrganizationArtifactName("net.liftweb", "lift-json", CrossVersion.full)
-    val report = getIvyReport(createMetaDep(excluded), scala2122)
+    val report = getUpdateReport(createMetaDep(excluded), scala2122)
     testScalahostIsMissing(report)
   }
 
   test("it should exclude any version of scala-library via * artifact id") {
     val toExclude = ExclusionRule("org.scala-lang", "*")
-    val report = getIvyReport(createLiftDep(toExclude), scala210)
+    val report = getUpdateReport(createLiftDep(toExclude), scala210)
     testScalaLibraryIsMissing(report)
   }
 
   test("it should exclude any version of scala-library via * org id") {
     val toExclude = ExclusionRule("*", "scala-library")
-    val report = getIvyReport(createLiftDep(toExclude), scala210)
+    val report = getUpdateReport(createLiftDep(toExclude), scala210)
     testScalaLibraryIsMissing(report)
   }
 
@@ -57,10 +45,9 @@ object InclExclSpec extends BaseIvySpecification {
       .cross(CrossVersion.full)
       .excludeAll(toExclude)
 
-  def getIvyReport(dep: ModuleID, scalaVersion: Option[String]): UpdateReport = {
-    cleanIvyCache()
-    val ivyModule = module(defaultModuleId, Vector(dep), scalaVersion)
-    ivyUpdate(ivyModule)
+  def getUpdateReport(dep: ModuleID, scalaVersion: Option[String]): UpdateReport = {
+    val m = module(defaultModuleId, Vector(dep), scalaVersion)
+    coursierUpdate(m)
   }
 
   def testLiftJsonIsMissing(report: UpdateReport): Unit = {

--- a/lm-coursier/src/test/scala/lmcoursier/TestKit.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/TestKit.scala
@@ -1,0 +1,82 @@
+package lmcoursier
+
+import sbt.internal.librarymanagement.cross.CrossVersionUtil
+import sbt.internal.util.ConsoleLogger
+import sbt.librarymanagement.*
+import sbt.librarymanagement.Configurations.Component
+import sbt.librarymanagement.Resolver.{ DefaultMavenRepository, JavaNet2Repository }
+// import sbt.util.ShowLines.*
+import sbt.librarymanagement.syntax.*
+
+object TestKit:
+  lazy val lmEngine = CoursierDependencyResolution(CoursierConfiguration().withResolvers(resolvers))
+  lazy val log = ConsoleLogger()
+
+  def configurations = Vector(Compile, Test, Runtime, Provided, Optional, Component)
+
+  def resolvers = Vector(
+    DefaultMavenRepository,
+    JavaNet2Repository,
+    Resolver.sbtPluginRepo("releases")
+  )
+
+  def coursierUpdate(m: ModuleDescriptor): UpdateReport =
+    lmEngine.update(m, UpdateConfiguration(), UnresolvedWarningConfiguration(), log) match
+      case Right(ur) => ur
+      case Left(w)   => sys.error(w.toString)
+
+  def module(
+      moduleId: ModuleID,
+      deps: Vector[ModuleID],
+      scalaFullVersion: Option[String],
+  ): ModuleDescriptor =
+    module(
+      lmEngine = lmEngine,
+      moduleId = moduleId,
+      deps = deps,
+      scalaFullVersion = scalaFullVersion,
+      overrideScalaVersion = true,
+    )
+
+  def module(
+      moduleId: ModuleID,
+      deps: Vector[ModuleID],
+      scalaFullVersion: Option[String],
+      overrideScalaVersion: Boolean,
+  ): ModuleDescriptor =
+    module(
+      lmEngine = lmEngine,
+      moduleId = moduleId,
+      deps = deps,
+      scalaFullVersion = scalaFullVersion,
+      overrideScalaVersion = overrideScalaVersion,
+    )
+
+  def module(
+      lmEngine: DependencyResolution,
+      moduleId: ModuleID,
+      deps: Vector[ModuleID],
+      scalaFullVersion: Option[String],
+      overrideScalaVersion: Boolean,
+  ): ModuleDescriptor =
+    val scalaModuleInfo = scalaFullVersion map { fv =>
+      ScalaModuleInfo(
+        scalaFullVersion = fv,
+        scalaBinaryVersion = CrossVersionUtil.binaryScalaVersion(fv),
+        configurations = configurations,
+        checkExplicit = true,
+        filterImplicit = false,
+        overrideScalaVersion = overrideScalaVersion
+      )
+    }
+
+    val moduleSetting = ModuleDescriptorConfiguration(moduleId, ModuleInfo("foo"))
+      .withDependencies(deps)
+      .withConfigurations(configurations)
+      .withScalaModuleInfo(scalaModuleInfo)
+    lmEngine.moduleDescriptor(moduleSetting)
+
+  def defaultModuleId: ModuleID =
+    ModuleID("com.example", "foo", "0.1.0").withConfigurations(Some("compile"))
+
+end TestKit

--- a/lm-coursier/src/test/scala/lmcoursier/TestShowLines.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/TestShowLines.scala
@@ -1,0 +1,9 @@
+package lmcoursier
+
+import sbt.util.ShowLines
+
+object TestShowLines:
+  extension [A: ShowLines](a: A)
+    inline def lines: Seq[String] =
+      implicitly[ShowLines[A]].showLines(a)
+end TestShowLines

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,17 @@ object Dependencies {
   val jline3Native = "org.jline" % "jline-native" % jline3Version
   val jline3Reader = "org.jline" % "jline-reader" % jline3Version
   val jline3Builtins = "org.jline" % "jline-builtins" % jline3Version
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"
+  val scalatest = Seq(
+    "scalatest-diagrams",
+    "scalatest-flatspec",
+    "scalatest-freespec",
+    "scalatest-funspec",
+    "scalatest-funsuite",
+    "scalatest-propspec",
+    "scalatest-shouldmatchers",
+  ).map(
+    "org.scalatest" %% _ % "3.2.20" % Test
+  )
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.19.0"
   val junit = "junit" % "junit" % "4.13.2"
   val scalaVerify = "com.eed3si9n.verify" %% "verify" % "1.0.0"

--- a/project/NightlyPlugin.scala
+++ b/project/NightlyPlugin.scala
@@ -14,10 +14,9 @@ object NightlyPlugin extends AutoPlugin {
         Seq(
           scalacheck % Test,
           junit % Test,
-          scalatest % Test,
           scalaVerify % Test,
           hedgehog % Test
-        )
+        ) ++ scalatest
       else Seq()
     )
   }

--- a/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
@@ -151,14 +151,7 @@ object RunFromSourceMain {
             IvyDependencyResolution
           }
           val ivyConfig = InlineIvyConfiguration().withLog(log)
-          IvyDependencyResolution(
-            ivyConfig.withResolvers(
-              ivyConfig.resolvers ++ Seq(
-                "scala-ea" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
-                "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/",
-              )
-            )
-          )
+          IvyDependencyResolution(ivyConfig)
         }
         val Name = """(.*)(?:\-[\d.]+)\.jar""".r
         val BinPre = """(.*)(?:\-[\d.]+)-(?:bin|pre)-.*\.jar""".r

--- a/sbt-app/src/test/scala/sbt/internal/scriptedtest/ScriptedLauncher.java
+++ b/sbt-app/src/test/scala/sbt/internal/scriptedtest/ScriptedLauncher.java
@@ -341,13 +341,7 @@ public class ScriptedLauncher {
                 private final Repository[] repos =
                     new Repository[] {
                       (PredefinedRepository) () -> Predefined.Local,
-                      (PredefinedRepository) () -> Predefined.MavenCentral,
-                      newMavenRepo(
-                          "scala-ea",
-                          "https://scala-ci.typesafe.com/artifactory/scala-integration/"),
-                      newMavenRepo(
-                          "scala-pr",
-                          "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/")
+                      (PredefinedRepository) () -> Predefined.MavenCentral
                     };
                 private final Launcher launcher =
                     new Launcher() {

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/BridgeProviderSpecification.scala
@@ -13,19 +13,19 @@ import java.net.URLClassLoader
 
 import sbt.io.IO
 import sbt.io.syntax.*
-import sbt.internal.librarymanagement.ivy.*
 import sbt.librarymanagement.*
 import sbt.util.Logger
 import xsbti.compile.CompilerBridgeProvider
 import org.scalatest.*
 import org.scalatest.matchers.should.Matchers
+import lmcoursier.*
 
 /**
  * Base class for test suites that must be able to fetch and compile the compiler bridge.
  *
  * This is a very good example on how to instantiate the compiler bridge provider.
  */
-abstract class IvyBridgeProviderSpecification
+abstract class BridgeProviderSpecification
     extends flatspec.FixtureAnyFlatSpec
     with fixture.TestDataFixture
     with Matchers {
@@ -34,24 +34,20 @@ abstract class IvyBridgeProviderSpecification
   def currentManaged: File = currentBase / "target" / "lib_managed"
   def secondaryCacheDirectory: File = file("target").getAbsoluteFile / "zinc-components"
 
-  val resolvers = Array(
+  val resolvers = Vector(
     ZincComponentCompiler.LocalResolver: Resolver,
     Resolver.mavenCentral: Resolver,
-    MavenRepository(
-      "scala-integration",
-      "https://scala-ci.typesafe.com/artifactory/scala-integration/"
-    ): Resolver,
   )
-
-  private def ivyConfiguration(log: Logger) =
-    getDefaultConfiguration(currentBase, currentTarget, resolvers, log)
 
   def getZincProvider(bridge: ModuleID, targetDir: File, log: Logger): CompilerBridgeProvider = {
     val lock = ZincComponentCompiler.getDefaultLock
     val secondaryCache = Some(secondaryCacheDirectory)
     val componentProvider = ZincComponentCompiler.getDefaultComponentProvider(targetDir)
     val manager = new ZincComponentManager(lock, componentProvider, secondaryCache, log)
-    val dependencyResolution = IvyDependencyResolution(ivyConfiguration(log))
+    val dependencyResolution = CoursierDependencyResolution(
+      CoursierConfiguration().withResolvers(resolvers)
+    )
+    // IvyDependencyResolution(ivyConfiguration(log))
     ZincComponentCompiler.interfaceProvider(bridge, manager, dependencyResolution, currentManaged)
   }
 
@@ -80,22 +76,4 @@ abstract class IvyBridgeProviderSpecification
     target
   }
 
-  private def getDefaultConfiguration(
-      baseDirectory: File,
-      ivyHome: File,
-      resolvers0: Array[Resolver],
-      log: xsbti.Logger,
-  ): InlineIvyConfiguration = {
-    val resolvers = resolvers0.toVector
-    val chainResolver = ChainedResolver("zinc-chain", resolvers)
-    InlineIvyConfiguration()
-      .withPaths(IvyPaths(baseDirectory.toString, Some(ivyHome.toString)))
-      .withResolvers(resolvers)
-      .withModuleConfigurations(Vector(ModuleConfiguration("*", chainResolver)))
-      .withLock(None)
-      .withChecksums(Vector.empty)
-      .withResolutionCacheDir(ivyHome / "resolution-cache")
-      .withUpdateOptions(UpdateOptions())
-      .withLog(log)
-  }
 }

--- a/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
+++ b/zinc-lm-integration/src/test/scala/sbt/internal/inc/ZincComponentCompilerSpec.scala
@@ -11,31 +11,13 @@ package sbt.internal.inc
 import sbt.internal.util.ConsoleLogger
 import sbt.io.IO
 
-class ZincComponentCompilerSpec extends IvyBridgeProviderSpecification {
-  val scala2105 = "2.10.5"
-  val scala2106 = "2.10.6"
-  val scala2118 = "2.11.8"
-  val scala21111 = "2.11.11"
+class ZincComponentCompilerSpec extends BridgeProviderSpecification {
+  val scala2107 = "2.10.7"
+  val scala21112 = "2.11.12"
   val scala21221 = "2.12.21"
   val scala21311 = "2.13.11"
 
-  def isJava8: Boolean = sys.props("java.specification.version") == "1.8"
-
   val logger = ConsoleLogger()
-
-  it should "compile the bridge for Scala 2.10.5 and 2.10.6" in { case given FixtureParam =>
-    if (isJava8) {
-      IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2105) should exist)
-      IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2106) should exist)
-    } else ()
-  }
-
-  it should "compile the bridge for Scala 2.11.8 and 2.11.11" in { case given FixtureParam =>
-    if (isJava8) {
-      IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala2118) should exist)
-      IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala21111) should exist)
-    } else ()
-  }
 
   it should "compile the bridge for Scala 2.12.21" in { case given FixtureParam =>
     IO.withTemporaryDirectory(t => getCompilerBridge(t, logger, scala21221) should exist)


### PR DESCRIPTION
This is a 2.0.x backport of #9205

## Problem
Some tests are failing.

## Solution

* Port EvictionErrorSpec to lm-coursier
* Port EvictionWarningSpec to lm-coursier
* Port InclExclSpec to lm-coursier
* Port ZincComponentCompilerSpec to lm-coursier
* Apparently we still need lmIvy