### PR TITLE
[2.x] refactor: Use `Files.readString` instead of `readAllBytes`

### DIFF
--- a/buildfile/src/main/scala/sbt/internal/Eval.scala
+++ b/buildfile/src/main/scala/sbt/internal/Eval.scala
@@ -123,7 +123,7 @@ class Eval(
         }
 
       override def read(file: Path): String =
-        String(Files.readAllBytes(file), StandardCharsets.UTF_8)
+        Files.readString(file)
 
       override def write(value: String, file: Path): Unit =
         Files.write(
@@ -185,7 +185,7 @@ class Eval(
         }(using run.runContext)
 
       override def read(file: Path): Seq[String] =
-        new String(Files.readAllBytes(file), StandardCharsets.UTF_8).linesIterator.toList
+        Files.readString(file).linesIterator.toList
 
       override def write(value: Seq[String], file: Path): Unit =
         Files.write(

--- a/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/LockFile.scala
@@ -2,7 +2,6 @@ package lmcoursier.internal
 
 import java.io.File
 import java.nio.file.Files
-import java.nio.charset.StandardCharsets
 import sjsonnew.support.scalajson.unsafe.{ Converter, Parser, PrettyPrinter }
 import scala.util.{ Try, Success, Failure }
 
@@ -16,7 +15,7 @@ object LockFile {
       Left(s"Lock file does not exist: ${lockFile.getAbsolutePath}")
     } else {
       Try {
-        val content = new String(Files.readAllBytes(lockFile.toPath), StandardCharsets.UTF_8)
+        val content = Files.readString(lockFile.toPath)
         val json = Parser.parseFromString(content).get
         Converter.fromJson[LockFileData](json).get
       } match {

--- a/sbt-app/src/sbt-test/classloader-cache/resources/libraries/foo/src/main/scala/resource/Resource.scala
+++ b/sbt-app/src/sbt-test/classloader-cache/resources/libraries/foo/src/main/scala/resource/Resource.scala
@@ -10,7 +10,7 @@ object Resource {
       val fileSystem =
         if (uri.getScheme != "jar") None
         else Some(FileSystems.newFileSystem(uri, Collections.emptyMap[String, Object]))
-      try new String(Files.readAllBytes(Paths.get(uri)))
+      try Files.readString(Paths.get(uri))
       finally fileSystem.foreach(_.close())
   }
   def getStringResource(name: String): String = {

--- a/sbt-app/src/sbt-test/lm-coursier/api-url/build.sbt
+++ b/sbt-app/src/sbt-test/lm-coursier/api-url/build.sbt
@@ -19,6 +19,6 @@ check := {
   import java.nio.file._
   val f = (ThisBuild / baseDirectory).value / "b-repo/b/b_3/0.1.0-SNAPSHOT/ivys/ivy.xml"
   assert(f.exists(), s"missing $f")
-  val content = new String(Files.readAllBytes(f.toPath), "UTF-8")
+  val content = Files.readString(f.toPath)
   assert(content.contains("""e:info.apiURL="http://example.org/b""""))
 }

--- a/sbt-app/src/sbt-test/nio/code-formatter/project/src/main/scala/ScalafmtPlugin.scala
+++ b/sbt-app/src/sbt-test/nio/code-formatter/project/src/main/scala/ScalafmtPlugin.scala
@@ -33,7 +33,7 @@ object ScalafmtPlugin extends AutoPlugin {
         case (p, s) =>
           try {
             println(s"Formatting $p")
-            Files.write(p, formatter.format(config, p, new String(Files.readAllBytes(p))).getBytes)
+            Files.write(p, formatter.format(config, p, Files.readString(p)).getBytes)
             Some(p)
           } catch {
             case e: Exception =>

--- a/sbt-app/src/sbt-test/run/classpath/Main.scala
+++ b/sbt-app/src/sbt-test/run/classpath/Main.scala
@@ -4,6 +4,6 @@ import java.nio._, charset._, file._
 
 object Main {
   def main(args: Array[String]): Unit = {
-    println(new String(Files.readAllBytes(Paths.get(getClass().getResource("/a.txt").toURI()))))
+    println(Files.readString(Paths.get(getClass().getResource("/a.txt").toURI())))
   }
 }

--- a/sbt-app/src/sbt-test/watch/managed/build.sbt
+++ b/sbt-app/src/sbt-test/watch/managed/build.sbt
@@ -15,7 +15,7 @@ runTest := Def.taskDyn {
 runTest / watchTriggers += baseDirectory.value.toGlob / "*.txt"
 watchAntiEntropy := 0.milliseconds
 watchOnFileInputEvent := { (count, e) =>
-  if (new String(Files.readAllBytes(e.path)) == "ok") Watch.CancelWatch
+  if (Files.readString(e.path) == "ok") Watch.CancelWatch
   else if (count < 2) Watch.Trigger
   else new Watch.HandleError(new IllegalStateException(s"Wrong event triggered the build: $e"))
 }

--- a/sbt-app/src/sbt-test/watch/on-change/build.sbt
+++ b/sbt-app/src/sbt-test/watch/on-change/build.sbt
@@ -17,7 +17,7 @@ watchOnIteration := { (i: Int, _, _) =>
   val changes = base.resolve("changes")
   def copy(fileName: String): Unit = {
     val content =
-      new String(Files.readAllBytes(changes.resolve(fileName))) + "\n" + ("//" * i)
+      Files.readString(changes.resolve(fileName)) + "\n" + ("//" * i)
     Files.write(src.resolve(fileName), content.getBytes)
   }
   val c = src.resolve("C.scala")

--- a/sbt-app/src/sbt-test/watch/overlapping/build.sbt
+++ b/sbt-app/src/sbt-test/watch/overlapping/build.sbt
@@ -17,7 +17,7 @@ foo := {
 watchAntiEntropy := 0.seconds
 watchOnFileInputEvent := { (count, event: Watch.Event) =>
   assert(event.path.getFileName.toString == "foo.txt")
-  if (new String(Files.readAllBytes(event.path)) == "foo") {
+  if (Files.readString(event.path) == "foo") {
     if (count < 3) Watch.Trigger
     else Watch.CancelWatch
   } else new Watch.HandleError(new IllegalStateException("Wrong stamp was set"))


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Files.html#readString(java.nio.file.Path)