### PR TITLE
[2.x] refactor: Use `java.util.Arrays.copyOf` in `JsonRpcReader`

### DIFF
--- a/protocol/src/main/scala/sbt/protocol/JsonRpcReader.scala
+++ b/protocol/src/main/scala/sbt/protocol/JsonRpcReader.scala
@@ -33,8 +33,7 @@ object JsonRpcReader {
      */
     var headerBuffer = new Array[Byte](128)
     def expandHeaderBuffer(): Unit = {
-      val newHeaderBuffer = new Array[Byte](headerBuffer.length * 2)
-      headerBuffer.view.zipWithIndex.foreach { (b, i) => newHeaderBuffer(i) = b }
+      val newHeaderBuffer = java.util.Arrays.copyOf(headerBuffer, headerBuffer.length * 2)
       headerBuffer = newHeaderBuffer
     }
     def getLine(): String = {


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Arrays.html#copyOf(byte%5B%5D,int)