### PR TITLE
[2.x] feat: Print cross-project test failure recap at end of aggregated run

### DIFF
--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -106,14 +106,12 @@ object TestResultLogger {
         else
           run(printFailures)
 
-        // Preserves the historical contract of this extension point: log
-        // first, then throw on failure. The aggregated recap (sbt/sbt#2998)
-        // catches this exception in `Defaults.testFull` / `inputTests0` and
-        // re-throws with the task name and `Tests.Output` attached so
-        // `TestRecap.collect` can surface the per-project detail.
-        results.overall match
-          case TestResult.Error | TestResult.Failed => throw new TestsFailedException
-          case TestResult.Empty | TestResult.Passed => ()
+        // Logging only. Failure propagation lives in the task wrapper
+        // (`Defaults.testFull` / `inputTests0`) so the cross-project recap
+        // (sbt/sbt#2998) can attach the task name and `Tests.Output` to
+        // the `TestsFailedException` thrown there. The trait contract is
+        // "perform logging"; it does not document throwing on failure.
+        ()
       }
     }
 

--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -106,6 +106,7 @@ object TestResultLogger {
         else
           run(printFailures)
 
+        sbt.internal.testing.TestRecap.recordRun(taskName, results)
         results.overall match
           case TestResult.Error | TestResult.Failed => throw new TestsFailedException
           case TestResult.Empty | TestResult.Passed => ()

--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -106,9 +106,14 @@ object TestResultLogger {
         else
           run(printFailures)
 
-        // No throw here: failure detection lives in the task wrapper (Defaults.testFull / inputTests0)
-        // so that user-overridden testResultLogger implementations cannot accidentally suppress it.
-        ()
+        // Preserves the historical contract of this extension point: log
+        // first, then throw on failure. The aggregated recap (sbt/sbt#2998)
+        // catches this exception in `Defaults.testFull` / `inputTests0` and
+        // re-throws with the task name and `Tests.Output` attached so
+        // `TestRecap.collect` can surface the per-project detail.
+        results.overall match
+          case TestResult.Error | TestResult.Failed => throw new TestsFailedException
+          case TestResult.Empty | TestResult.Passed => ()
       }
     }
 

--- a/main-actions/src/main/scala/sbt/TestResultLogger.scala
+++ b/main-actions/src/main/scala/sbt/TestResultLogger.scala
@@ -106,10 +106,9 @@ object TestResultLogger {
         else
           run(printFailures)
 
-        sbt.internal.testing.TestRecap.recordRun(taskName, results)
-        results.overall match
-          case TestResult.Error | TestResult.Failed => throw new TestsFailedException
-          case TestResult.Empty | TestResult.Passed => ()
+        // No throw here: failure detection lives in the task wrapper (Defaults.testFull / inputTests0)
+        // so that user-overridden testResultLogger implementations cannot accidentally suppress it.
+        ()
       }
     }
 
@@ -129,6 +128,20 @@ object TestResultLogger {
         results.summaries.size > 1 || results.summaries.headOption.forall(_.summaryText.isEmpty)
 
     val printStandard = TestResultLogger((log, results, _) => {
+      val counts = countsString(results)
+      results.overall match
+        case TestResult.Empty  => ()
+        case TestResult.Error  => log.error("Error: " + counts)
+        case TestResult.Passed => log.info("Passed: " + counts)
+        case TestResult.Failed => log.error("Failed: " + counts)
+    })
+
+    /**
+     * Renders `Tests.Output`'s aggregate counts as a single line like
+     * `Total 10, Failed 2, Errors 0, Passed 8`. Shared between `printStandard`
+     * and the cross-project recap formatter (see `TestRecap`).
+     */
+    private[sbt] def countsString(results: Output): String = {
       val (
         skippedCount,
         errorsCount,
@@ -154,7 +167,6 @@ object TestResultLogger {
       val totalCount = failuresCount + errorsCount + skippedCount + passedCount
       val base =
         s"Total $totalCount, Failed $failuresCount, Errors $errorsCount, Passed $passedCount"
-
       val otherCounts = Seq(
         "Skipped" -> skippedCount,
         "Ignored" -> ignoredCount,
@@ -162,14 +174,8 @@ object TestResultLogger {
         "Pending" -> pendingCount
       )
       val extra = otherCounts.withFilter(_._2 > 0).map { (label, count) => s", $label $count" }
-
-      val postfix = base + extra.mkString
-      results.overall match
-        case TestResult.Empty  => ()
-        case TestResult.Error  => log.error("Error: " + postfix)
-        case TestResult.Passed => log.info("Passed: " + postfix)
-        case TestResult.Failed => log.error("Failed: " + postfix)
-    })
+      base + extra.mkString
+    }
 
     val printFailures = TestResultLogger((log, results, _) => {
       def select(resultTpe: TestResult) = results.events collect {

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -589,9 +589,11 @@ object Tests {
 
 final class TestsFailedException private[sbt] (
     val taskName: String,
-    val output: Option[Tests.Output]
+    val testOutput: Option[Tests.Output]
 ) extends RuntimeException("Tests unsuccessful")
     with FeedbackProvidedException {
-  // Public no-arg constructor preserved for backward compatibility.
-  def this() = this("", None)
+  // Public no-arg constructor preserved for backward compatibility with
+  // callers outside sbt. Internal call sites always use the primary
+  // constructor with a real task name.
+  def this() = this(taskName = "", testOutput = None)
 }

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -587,6 +587,11 @@ object Tests {
   }
 }
 
-final class TestsFailedException
-    extends RuntimeException("Tests unsuccessful")
-    with FeedbackProvidedException
+final class TestsFailedException private[sbt] (
+    val taskName: String,
+    val output: Option[Tests.Output]
+) extends RuntimeException("Tests unsuccessful")
+    with FeedbackProvidedException {
+  // Public no-arg constructor preserved for backward compatibility.
+  def this() = this("", None)
+}

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -1,0 +1,119 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package testing
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.jdk.CollectionConverters.*
+
+import sbt.Tests
+import sbt.protocol.testing.TestResult
+import sbt.util.Logger
+
+/**
+ * Thread-safe accumulator of per-task test failures collected during one
+ * aggregated run. `Aggregation.runTasks` calls `clear` at the start of each
+ * top-level invocation; the default `TestResultLogger` calls `recordRun`
+ * once per subproject's test task; `formatTo` renders the snapshot to the
+ * logger so users can see every failed task at the end of the run instead
+ * of having to scroll back through thousands of log lines (sbt/sbt#2998).
+ */
+private[sbt] object TestRecap:
+  final case class Record(taskName: String, output: Tests.Output)
+
+  private val records = ConcurrentLinkedQueue[Record]()
+  private val testRan = AtomicBoolean(false)
+  @volatile private var previousRecords: Vector[Record] = Vector.empty
+
+  /**
+   * Called once per subproject's test task completion. Marks that a test
+   * task ran in this aggregation cycle and, if the result was a failure,
+   * records it for the recap.
+   */
+  def recordRun(taskName: String, output: Tests.Output): Unit =
+    testRan.set(true)
+    output.overall match
+      case TestResult.Failed | TestResult.Error =>
+        val _ = records.add(Record(taskName, output))
+      case _ => ()
+
+  /**
+   * Called at the start of every `Aggregation.runTasks`. If a test ran in
+   * the previous cycle, the current records are rolled into
+   * `previousSnapshot` (so callers can inspect the most recent test run's
+   * failures). Otherwise `previousSnapshot` is left untouched, so a
+   * recovery / housekeeping `runTasks` doesn't clobber the snapshot.
+   */
+  def clear(): Unit =
+    if testRan.getAndSet(false) then
+      previousRecords = records.iterator.asScala.toVector
+    records.clear()
+
+  /** Failures recorded in the current (still-running) cycle. */
+  def snapshot: Seq[Record] = records.iterator.asScala.toVector
+
+  /** Failures recorded in the most recent test cycle. */
+  def previousSnapshot: Seq[Record] = previousRecords
+
+  /**
+   * Emit the current snapshot to `log` as an error-level block. No-op if
+   * no failures were recorded in this cycle.
+   */
+  def formatTo(log: Logger): Unit =
+    val failures = snapshot.filter: r =>
+      r.output.overall match
+        case TestResult.Failed | TestResult.Error => true
+        case _                                    => false
+    if failures.nonEmpty then
+      val n = failures.size
+      val plural = if n == 1 then "" else "s"
+      log.error(s"Test failures recap ($n test task$plural failed):")
+      failures.foreach: rec =>
+        log.error(s"  ${rec.taskName} — ${countsLine(rec.output)}")
+        val failedNames = collectByResult(rec.output, TestResult.Failed)
+        val erroredNames = collectByResult(rec.output, TestResult.Error)
+        if failedNames.nonEmpty then
+          log.error("    Failed tests:")
+          failedNames.foreach(name => log.error(s"      $name"))
+        if erroredNames.nonEmpty then
+          log.error("    Error during tests:")
+          erroredNames.foreach(name => log.error(s"      $name"))
+
+  private def countsLine(o: Tests.Output): String =
+    val (skipped, errors, passed, failures, ignored, canceled, pending) =
+      o.events.foldLeft((0, 0, 0, 0, 0, 0, 0)):
+        case ((sk, er, pa, fa, ig, ca, pe), (_, ev)) =>
+          (
+            sk + ev.skippedCount,
+            er + ev.errorCount,
+            pa + ev.passedCount,
+            fa + ev.failureCount,
+            ig + ev.ignoredCount,
+            ca + ev.canceledCount,
+            pe + ev.pendingCount
+          )
+    val total = failures + errors + skipped + passed
+    val base = s"Total $total, Failed $failures, Errors $errors, Passed $passed"
+    val extras = Seq(
+      "Skipped" -> skipped,
+      "Ignored" -> ignored,
+      "Canceled" -> canceled,
+      "Pending" -> pending
+    ).withFilter(_._2 > 0).map((label, count) => s", $label $count")
+    base + extras.mkString
+
+  private def collectByResult(o: Tests.Output, target: TestResult): Seq[String] =
+    o.events.iterator.collect {
+      case (name, suite) if suite.result == target =>
+        scala.reflect.NameTransformer.decode(name)
+    }.toVector.sorted
+
+end TestRecap

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -10,105 +10,85 @@ package sbt
 package internal
 package testing
 
-import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, StandardOpenOption }
-
 import sbt.Incomplete
 import sbt.Tests
 import sbt.TestResultLogger
 import sbt.TestsFailedException
 import sbt.protocol.testing.TestResult
+import sbt.internal.util.AttributeKey
 import sbt.util.Logger
 
 /**
  * Stateless formatter that surfaces every failed test task at the end of an
  * aggregated run (see sbt/sbt#2998). The data is read directly off the
- * `Incomplete` tree returned by `Aggregation.runTasks` — each subproject's
+ * `Incomplete` tree returned by `Aggregation.runTasks` -- each subproject's
  * `testFull` / `testQuick` throws `TestsFailedException` carrying the task
  * name and `Tests.Output`, and we collect those instances from the tree.
+ *
+ * The current snapshot is also stashed on `State.attributes` under
+ * `recapKey` so tools / scripted tests can inspect the most recent recap
+ * without parsing log output.
  */
 private[sbt] object TestRecap:
 
   /** A single failed test task contributing to the recap. */
-  final case class Failure(taskName: String, output: Tests.Output)
+  final case class Failure(taskName: String, testOutput: Option[Tests.Output])
 
   /**
-   * Walk the `Incomplete` tree and return one `Failure` per failed
-   * `TestsFailedException` that carries its detail payload. Failures whose
-   * exceptions don't carry the payload (e.g., user-provided custom
-   * exceptions) are skipped — they were not produced by sbt's default test
-   * pipeline and there is nothing for the recap to say about them.
+   * State attribute holding the collected failures from the most recent
+   * aggregated test run. Replaced (or removed) only when a top-level run
+   * actually included a test task, so unrelated tasks running between test
+   * invocations don't clobber the recap.
+   */
+  val recapKey: AttributeKey[Vector[Failure]] = AttributeKey[Vector[Failure]](
+    "test-recap",
+    "Failures collected from the most recent aggregated test run",
+    1000
+  )
+
+  /**
+   * Walk the `Incomplete` tree and return one `Failure` per
+   * `TestsFailedException`. Exceptions without a payload (e.g., the
+   * back-compat no-arg constructor) still contribute an entry so the recap
+   * lists at least the task name when one is available.
    */
   def collect(i: Incomplete): Seq[Failure] =
     Incomplete
       .allExceptions(i)
       .iterator
-      .collect:
-        case e: TestsFailedException if e.output.isDefined =>
-          Failure(e.taskName, e.output.get)
+      .flatMap:
+        case e: TestsFailedException => Some(Failure(e.taskName, e.testOutput))
+        case _                       => None
       .toVector
 
-  /** The rendered recap as a single string with `\n`-separated lines. */
-  def format(failures: Seq[Failure]): String =
-    if failures.isEmpty then ""
+  /** The rendered recap as a sequence of `\n`-free lines. */
+  def render(failures: Seq[Failure]): Seq[String] =
+    if failures.isEmpty then Vector.empty
     else
       val n = failures.size
       val plural = if n == 1 then "" else "s"
-      val sb = StringBuilder()
-      sb.append(s"Test failures recap ($n test task$plural failed):\n")
+      val lines = Vector.newBuilder[String]
+      lines += s"Test failures recap ($n test task$plural failed):"
       failures.foreach: f =>
-        sb.append(s"  ${f.taskName}: ${TestResultLogger.Defaults.countsString(f.output)}\n")
-        val failed = collectByResult(f.output, TestResult.Failed)
-        val errored = collectByResult(f.output, TestResult.Error)
-        if failed.nonEmpty then
-          sb.append("    Failed tests:\n")
-          failed.foreach(name => sb.append(s"      $name\n"))
-        if errored.nonEmpty then
-          sb.append("    Error during tests:\n")
-          errored.foreach(name => sb.append(s"      $name\n"))
-      sb.result()
+        val displayName = if f.taskName.isEmpty then "<unknown>" else f.taskName
+        f.testOutput match
+          case None =>
+            lines += s"  $displayName: (no details)"
+          case Some(out) =>
+            lines += s"  $displayName: ${TestResultLogger.Defaults.countsString(out)}"
+            val failed = collectByResult(out, TestResult.Failed)
+            val errored = collectByResult(out, TestResult.Error)
+            if failed.nonEmpty then
+              lines += "    Failed tests:"
+              failed.foreach(name => lines += s"      $name")
+            if errored.nonEmpty then
+              lines += "    Error during tests:"
+              errored.foreach(name => lines += s"      $name")
+      lines.result()
 
-  /** Render `failures` and emit one error-level log line per line of output. */
+  /** Render `failures` and emit one error-level log line per rendered line. */
   def formatTo(log: Logger, failures: Seq[Failure]): Unit =
-    val text = format(failures)
-    if text.nonEmpty then
-      // Trim trailing newline so the last log call doesn't emit a blank line.
-      text.stripSuffix("\n").split('\n').foreach(log.error(_))
-
-  /**
-   * Path within `baseDir` where the recap is persisted as a CI-consumable
-   * artifact whenever there are failures. Overwritten on each aggregated run
-   * and absent when there are no failures.
-   */
-  def artifactFile(baseDir: File): File =
-    new File(new File(baseDir, "target"), "sbt-test-recap.txt")
-
-  /**
-   * Persist `text` to `artifactFile(baseDir)`. Best-effort: any IO problem is
-   * silently swallowed because the recap has already been printed to the log
-   * and the file is a convenience.
-   */
-  def writeArtifact(baseDir: File, text: String): Unit =
-    if text.nonEmpty then
-      try
-        val out = artifactFile(baseDir)
-        val parent = out.getParentFile
-        if parent != null then parent.mkdirs()
-        Files.write(
-          out.toPath,
-          text.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.CREATE,
-          StandardOpenOption.TRUNCATE_EXISTING
-        )
-        ()
-      catch case _: Exception => ()
-
-  /** Remove the artifact file if it exists (used after a passing aggregated run). */
-  def deleteArtifact(baseDir: File): Unit =
-    try
-      val _ = Files.deleteIfExists(artifactFile(baseDir).toPath)
-    catch case _: Exception => ()
+    render(failures).foreach(log.error(_))
 
   private def collectByResult(o: Tests.Output, target: TestResult): Seq[String] =
     o.events.iterator

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -26,8 +26,12 @@ import sbt.util.Logger
  * name and `Tests.Output`, and we collect those instances from the tree.
  *
  * The current snapshot is also stashed on `State.attributes` under
- * `recapKey` so tools / scripted tests can inspect the most recent recap
- * without parsing log output.
+ * `recapKey` so in-JVM tools (IDE plugins, BSP servers, command-mode
+ * inspections within the same sbt invocation) can inspect the most recent
+ * recap without parsing log output. Note that scripted tests using `->`
+ * cannot read this across the failing-statement boundary because the
+ * inner sbt's IPC server is torn down on failure and a fresh JVM is
+ * spawned for the next statement.
  */
 private[sbt] object TestRecap:
 

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -10,110 +10,113 @@ package sbt
 package internal
 package testing
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
-import scala.jdk.CollectionConverters.*
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, StandardOpenOption }
 
+import sbt.Incomplete
 import sbt.Tests
+import sbt.TestResultLogger
+import sbt.TestsFailedException
 import sbt.protocol.testing.TestResult
 import sbt.util.Logger
 
 /**
- * Thread-safe accumulator of per-task test failures collected during one
- * aggregated run. `Aggregation.runTasks` calls `clear` at the start of each
- * top-level invocation; the default `TestResultLogger` calls `recordRun`
- * once per subproject's test task; `formatTo` renders the snapshot to the
- * logger so users can see every failed task at the end of the run instead
- * of having to scroll back through thousands of log lines (sbt/sbt#2998).
+ * Stateless formatter that surfaces every failed test task at the end of an
+ * aggregated run (see sbt/sbt#2998). The data is read directly off the
+ * `Incomplete` tree returned by `Aggregation.runTasks` — each subproject's
+ * `testFull` / `testQuick` throws `TestsFailedException` carrying the task
+ * name and `Tests.Output`, and we collect those instances from the tree.
  */
 private[sbt] object TestRecap:
-  final case class Record(taskName: String, output: Tests.Output)
 
-  private val records = ConcurrentLinkedQueue[Record]()
-  private val testRan = AtomicBoolean(false)
-  @volatile private var previousRecords: Vector[Record] = Vector.empty
+  /** A single failed test task contributing to the recap. */
+  final case class Failure(taskName: String, output: Tests.Output)
 
   /**
-   * Called once per subproject's test task completion. Marks that a test
-   * task ran in this aggregation cycle and, if the result was a failure,
-   * records it for the recap.
+   * Walk the `Incomplete` tree and return one `Failure` per failed
+   * `TestsFailedException` that carries its detail payload. Failures whose
+   * exceptions don't carry the payload (e.g., user-provided custom
+   * exceptions) are skipped — they were not produced by sbt's default test
+   * pipeline and there is nothing for the recap to say about them.
    */
-  def recordRun(taskName: String, output: Tests.Output): Unit =
-    testRan.set(true)
-    output.overall match
-      case TestResult.Failed | TestResult.Error =>
-        val _ = records.add(Record(taskName, output))
-      case _ => ()
+  def collect(i: Incomplete): Seq[Failure] =
+    Incomplete
+      .allExceptions(i)
+      .iterator
+      .collect:
+        case e: TestsFailedException if e.output.isDefined =>
+          Failure(e.taskName, e.output.get)
+      .toVector
 
-  /**
-   * Called at the start of every `Aggregation.runTasks`. If a test ran in
-   * the previous cycle, the current records are rolled into
-   * `previousSnapshot` (so callers can inspect the most recent test run's
-   * failures). Otherwise `previousSnapshot` is left untouched, so a
-   * recovery / housekeeping `runTasks` doesn't clobber the snapshot.
-   */
-  def clear(): Unit =
-    if testRan.getAndSet(false) then
-      previousRecords = records.iterator.asScala.toVector
-    records.clear()
-
-  /** Failures recorded in the current (still-running) cycle. */
-  def snapshot: Seq[Record] = records.iterator.asScala.toVector
-
-  /** Failures recorded in the most recent test cycle. */
-  def previousSnapshot: Seq[Record] = previousRecords
-
-  /**
-   * Emit the current snapshot to `log` as an error-level block. No-op if
-   * no failures were recorded in this cycle.
-   */
-  def formatTo(log: Logger): Unit =
-    val failures = snapshot.filter: r =>
-      r.output.overall match
-        case TestResult.Failed | TestResult.Error => true
-        case _                                    => false
-    if failures.nonEmpty then
+  /** The rendered recap as a single string with `\n`-separated lines. */
+  def format(failures: Seq[Failure]): String =
+    if failures.isEmpty then ""
+    else
       val n = failures.size
       val plural = if n == 1 then "" else "s"
-      log.error(s"Test failures recap ($n test task$plural failed):")
-      failures.foreach: rec =>
-        log.error(s"  ${rec.taskName} — ${countsLine(rec.output)}")
-        val failedNames = collectByResult(rec.output, TestResult.Failed)
-        val erroredNames = collectByResult(rec.output, TestResult.Error)
-        if failedNames.nonEmpty then
-          log.error("    Failed tests:")
-          failedNames.foreach(name => log.error(s"      $name"))
-        if erroredNames.nonEmpty then
-          log.error("    Error during tests:")
-          erroredNames.foreach(name => log.error(s"      $name"))
+      val sb = StringBuilder()
+      sb.append(s"Test failures recap ($n test task$plural failed):\n")
+      failures.foreach: f =>
+        sb.append(s"  ${f.taskName}: ${TestResultLogger.Defaults.countsString(f.output)}\n")
+        val failed = collectByResult(f.output, TestResult.Failed)
+        val errored = collectByResult(f.output, TestResult.Error)
+        if failed.nonEmpty then
+          sb.append("    Failed tests:\n")
+          failed.foreach(name => sb.append(s"      $name\n"))
+        if errored.nonEmpty then
+          sb.append("    Error during tests:\n")
+          errored.foreach(name => sb.append(s"      $name\n"))
+      sb.result()
 
-  private def countsLine(o: Tests.Output): String =
-    val (skipped, errors, passed, failures, ignored, canceled, pending) =
-      o.events.foldLeft((0, 0, 0, 0, 0, 0, 0)):
-        case ((sk, er, pa, fa, ig, ca, pe), (_, ev)) =>
-          (
-            sk + ev.skippedCount,
-            er + ev.errorCount,
-            pa + ev.passedCount,
-            fa + ev.failureCount,
-            ig + ev.ignoredCount,
-            ca + ev.canceledCount,
-            pe + ev.pendingCount
-          )
-    val total = failures + errors + skipped + passed
-    val base = s"Total $total, Failed $failures, Errors $errors, Passed $passed"
-    val extras = Seq(
-      "Skipped" -> skipped,
-      "Ignored" -> ignored,
-      "Canceled" -> canceled,
-      "Pending" -> pending
-    ).withFilter(_._2 > 0).map((label, count) => s", $label $count")
-    base + extras.mkString
+  /** Render `failures` and emit one error-level log line per line of output. */
+  def formatTo(log: Logger, failures: Seq[Failure]): Unit =
+    val text = format(failures)
+    if text.nonEmpty then
+      // Trim trailing newline so the last log call doesn't emit a blank line.
+      text.stripSuffix("\n").split('\n').foreach(log.error(_))
+
+  /**
+   * Path within `baseDir` where the recap is persisted as a CI-consumable
+   * artifact whenever there are failures. Overwritten on each aggregated run
+   * and absent when there are no failures.
+   */
+  def artifactFile(baseDir: File): File =
+    new File(new File(baseDir, "target"), "sbt-test-recap.txt")
+
+  /**
+   * Persist `text` to `artifactFile(baseDir)`. Best-effort: any IO problem is
+   * silently swallowed because the recap has already been printed to the log
+   * and the file is a convenience.
+   */
+  def writeArtifact(baseDir: File, text: String): Unit =
+    if text.nonEmpty then
+      try
+        val out = artifactFile(baseDir)
+        val parent = out.getParentFile
+        if parent != null then parent.mkdirs()
+        Files.write(
+          out.toPath,
+          text.getBytes(StandardCharsets.UTF_8),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING
+        )
+        ()
+      catch case _: Exception => ()
+
+  /** Remove the artifact file if it exists (used after a passing aggregated run). */
+  def deleteArtifact(baseDir: File): Unit =
+    try
+      val _ = Files.deleteIfExists(artifactFile(baseDir).toPath)
+    catch case _: Exception => ()
 
   private def collectByResult(o: Tests.Output, target: TestResult): Seq[String] =
-    o.events.iterator.collect {
-      case (name, suite) if suite.result == target =>
-        scala.reflect.NameTransformer.decode(name)
-    }.toVector.sorted
+    o.events.iterator
+      .collect {
+        case (name, suite) if suite.result == target =>
+          scala.reflect.NameTransformer.decode(name)
+      }
+      .toVector
+      .sorted
 
 end TestRecap

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -116,9 +116,15 @@ private[sbt] object TestRecap:
     render(failures).foreach(line => log.error(line))
 
   private def collectByResult(o: Tests.Output, target: TestResult): Vector[String] =
+    // Mirrors `TestResultLogger.Defaults.printFailures` so the per-task
+    // "Failed tests:" block and the cross-project recap render the same
+    // suite name. Whether `NameTransformer.decode` should be applied to
+    // suite FQNs at all is debatable, but changing both sites belongs in
+    // a separate cleanup.
     o.events.iterator
       .collect {
-        case (name, suite) if suite.result == target => name
+        case (name, suite) if suite.result == target =>
+          scala.reflect.NameTransformer.decode(name)
       }
       .toVector
       .sorted

--- a/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
+++ b/main-actions/src/main/scala/sbt/internal/testing/TestRecap.scala
@@ -21,17 +21,27 @@ import sbt.util.Logger
 /**
  * Stateless formatter that surfaces every failed test task at the end of an
  * aggregated run (see sbt/sbt#2998). The data is read directly off the
- * `Incomplete` tree returned by `Aggregation.runTasks` -- each subproject's
- * `testFull` / `testQuick` throws `TestsFailedException` carrying the task
- * name and `Tests.Output`, and we collect those instances from the tree.
+ * `Incomplete` tree returned by `Aggregation.runTasks`: each subproject's
+ * `testFull` / `inputTests0` catches the `TestsFailedException` thrown by
+ * `TestResultLogger.Defaults.Main.run` and re-throws with `(taskName,
+ * Some(Tests.Output))` attached, and we collect those instances from the
+ * tree.
  *
- * The current snapshot is also stashed on `State.attributes` under
- * `recapKey` so in-JVM tools (IDE plugins, BSP servers, command-mode
- * inspections within the same sbt invocation) can inspect the most recent
- * recap without parsing log output. Note that scripted tests using `->`
- * cannot read this across the failing-statement boundary because the
- * inner sbt's IPC server is torn down on failure and a fresh JVM is
- * spawned for the next statement.
+ * The collected `Vector[Failure]` is also stashed on `State.attributes`
+ * under `recapKey` so in-JVM tools (IDE plugins, BSP servers, scripted
+ * tests that stay inside one sbt invocation via `Command.process`) can
+ * inspect the most recent recap without parsing log output. Scripted tests
+ * crossing a `->` boundary cannot read this because the inner sbt's IPC
+ * server is torn down on failure and a fresh JVM is spawned for the next
+ * statement.
+ *
+ * Lifecycle is monotonic-latest-failure: `Aggregation.runTasks` writes
+ * `recapKey` whenever a run produces at least one `TestsFailedException`,
+ * and never removes it. A successful test run after a failure leaves the
+ * stale attribute in place; the next failure will overwrite it. We do not
+ * attempt to recognize "this is a test invocation" at the aggregation
+ * boundary to avoid a hardcoded list of test-task labels (or a
+ * Tags-detection design exercise).
  */
 private[sbt] object TestRecap:
 
@@ -40,40 +50,50 @@ private[sbt] object TestRecap:
 
   /**
    * State attribute holding the collected failures from the most recent
-   * aggregated test run. Replaced (or removed) only when a top-level run
-   * actually included a test task, so unrelated tasks running between test
-   * invocations don't clobber the recap.
+   * aggregated run that produced at least one `TestsFailedException`.
+   * Monotonic-latest-failure semantics: never cleared on success, only
+   * overwritten by the next failure.
    */
   val recapKey: AttributeKey[Vector[Failure]] = AttributeKey[Vector[Failure]](
-    "test-recap",
-    "Failures collected from the most recent aggregated test run",
-    1000
+    "testRecap",
+    "Failures collected from the most recent aggregated test run"
   )
 
   /**
    * Walk the `Incomplete` tree and return one `Failure` per
    * `TestsFailedException`. Exceptions without a payload (e.g., the
-   * back-compat no-arg constructor) still contribute an entry so the recap
-   * lists at least the task name when one is available.
+   * back-compat no-arg constructor escaping a path that didn't get wrapped
+   * at the task boundary) still contribute a stub entry so the recap lists
+   * at least the task name when one is available.
+   *
+   * Identity-deduplicated via `Incomplete.allExceptions` (which uses an
+   * `IDSet[Throwable]` internally), so a single failing task shared across
+   * multiple Incomplete paths in a DAG is counted once.
    */
-  def collect(i: Incomplete): Seq[Failure] =
+  def collect(i: Incomplete): Vector[Failure] =
     Incomplete
       .allExceptions(i)
       .iterator
-      .flatMap:
+      .flatMap {
         case e: TestsFailedException => Some(Failure(e.taskName, e.testOutput))
         case _                       => None
+      }
       .toVector
 
-  /** The rendered recap as a sequence of `\n`-free lines. */
-  def render(failures: Seq[Failure]): Seq[String] =
+  /**
+   * The rendered recap as a sequence of `\n`-free lines. Failures are
+   * sorted by `taskName` (lexicographically; empty task names last) for
+   * stable, diff-friendly output across runs.
+   */
+  def render(failures: Vector[Failure]): Vector[String] =
     if failures.isEmpty then Vector.empty
     else
-      val n = failures.size
+      val sorted = failures.sortBy(f => (f.taskName.isEmpty, f.taskName))
+      val n = sorted.size
       val plural = if n == 1 then "" else "s"
       val lines = Vector.newBuilder[String]
       lines += s"Test failures recap ($n test task$plural failed):"
-      failures.foreach: f =>
+      sorted.foreach { f =>
         val displayName = if f.taskName.isEmpty then "<unknown>" else f.taskName
         f.testOutput match
           case None =>
@@ -88,17 +108,17 @@ private[sbt] object TestRecap:
             if errored.nonEmpty then
               lines += "    Error during tests:"
               errored.foreach(name => lines += s"      $name")
+      }
       lines.result()
 
   /** Render `failures` and emit one error-level log line per rendered line. */
-  def formatTo(log: Logger, failures: Seq[Failure]): Unit =
-    render(failures).foreach(log.error(_))
+  def formatTo(log: Logger, failures: Vector[Failure]): Unit =
+    render(failures).foreach(line => log.error(line))
 
-  private def collectByResult(o: Tests.Output, target: TestResult): Seq[String] =
+  private def collectByResult(o: Tests.Output, target: TestResult): Vector[String] =
     o.events.iterator
       .collect {
-        case (name, suite) if suite.result == target =>
-          scala.reflect.NameTransformer.decode(name)
+        case (name, suite) if suite.result == target => name
       }
       .toVector
       .sorted

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -1,0 +1,151 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package testing
+
+import sbt.SuiteResult
+import sbt.Tests
+import sbt.protocol.testing.TestResult
+import sbt.util.Logger
+
+object TestRecapTest extends verify.BasicTestSuite:
+
+  private def output(result: TestResult, suites: (String, SuiteResult)*): Tests.Output =
+    Tests.Output(result, suites.toMap, Iterable.empty)
+
+  private def suite(result: TestResult): SuiteResult =
+    new SuiteResult(result, 0, 1, 0, 0, 0, 0, 0)
+
+  private class Capture extends Logger:
+    val lines: scala.collection.mutable.ArrayBuffer[(String, String)] =
+      scala.collection.mutable.ArrayBuffer.empty
+    override def trace(t: => Throwable): Unit = ()
+    override def success(msg: => String): Unit = ()
+    override def log(level: sbt.util.Level.Value, msg: => String): Unit =
+      lines += level.toString -> msg
+
+  // Restore TestRecap to a clean state between tests; the singleton outlives
+  // any single test method.
+  private def withClean(body: => Unit): Unit =
+    TestRecap.clear()
+    TestRecap.clear() // double-clear to drop both `previousRecords` and `records`
+    body
+
+  test("recordRun appends only failures and errors") {
+    withClean:
+      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
+      TestRecap.recordRun("q / Test / test", output(TestResult.Empty))
+      TestRecap.recordRun(
+        "r / Test / test",
+        output(TestResult.Failed, "RFailing" -> suite(TestResult.Failed))
+      )
+      TestRecap.recordRun(
+        "s / Test / test",
+        output(TestResult.Error, "SErroring" -> suite(TestResult.Error))
+      )
+      val snap = TestRecap.snapshot
+      assert(snap.size == 2, s"expected 2 records, got ${snap.map(_.taskName)}")
+      assert(snap.exists(_.taskName == "r / Test / test"))
+      assert(snap.exists(_.taskName == "s / Test / test"))
+  }
+
+  test("clear rolls records into previousSnapshot when a test ran") {
+    withClean:
+      TestRecap.recordRun(
+        "x / Test / test",
+        output(TestResult.Failed, "XFail" -> suite(TestResult.Failed))
+      )
+      TestRecap.clear()
+      assert(TestRecap.snapshot.isEmpty)
+      val prev = TestRecap.previousSnapshot
+      assert(prev.size == 1, s"expected 1 previous record, got $prev")
+      assert(prev.head.taskName == "x / Test / test")
+  }
+
+  test("clear without a test run leaves previousSnapshot untouched") {
+    withClean:
+      // Seed previousSnapshot with a failing run.
+      TestRecap.recordRun(
+        "p / Test / test",
+        output(TestResult.Failed, "PFail" -> suite(TestResult.Failed))
+      )
+      TestRecap.clear()
+      assert(TestRecap.previousSnapshot.size == 1)
+      // A subsequent housekeeping `clear` (no test ran) must not erase it.
+      TestRecap.clear()
+      assert(
+        TestRecap.previousSnapshot.size == 1,
+        "intermediate non-test clear should not erase prior recap"
+      )
+  }
+
+  test("clear after a passing-only test cycle empties previousSnapshot") {
+    withClean:
+      TestRecap.recordRun(
+        "p / Test / test",
+        output(TestResult.Failed, "PFail" -> suite(TestResult.Failed))
+      )
+      TestRecap.clear()
+      assert(TestRecap.previousSnapshot.size == 1)
+      // Next cycle: only a passing test ran. clear should reset previous to [].
+      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
+      TestRecap.clear()
+      assert(
+        TestRecap.previousSnapshot.isEmpty,
+        "passing-only cycle should clear previous failures"
+      )
+  }
+
+  test("formatTo emits a header, per-task counts, and indented suite names") {
+    withClean:
+      TestRecap.recordRun(
+        "a / Test / test",
+        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+      )
+      TestRecap.recordRun(
+        "c / Test / test",
+        output(TestResult.Error, "CErroring" -> suite(TestResult.Error))
+      )
+      val log = new Capture
+      TestRecap.formatTo(log)
+      val joined = log.lines.map(_._2).mkString("\n")
+      assert(joined.contains("Test failures recap (2 test tasks failed):"))
+      assert(joined.contains("a / Test / test"))
+      assert(joined.contains("c / Test / test"))
+      assert(joined.contains("AFailing"))
+      assert(joined.contains("CErroring"))
+      assert(log.lines.forall(_._1 == "error"), s"all lines should be error level: ${log.lines}")
+  }
+
+  test("formatTo is a no-op when no failures recorded") {
+    withClean:
+      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
+      val log = new Capture
+      TestRecap.formatTo(log)
+      assert(log.lines.isEmpty, s"expected no output, got ${log.lines}")
+  }
+
+  test("concurrent recordRun calls are thread-safe") {
+    withClean:
+      val threads = (0 until 16).map: i =>
+        new Thread(() =>
+          TestRecap.recordRun(
+            s"p$i / Test / test",
+            output(TestResult.Failed, s"P$i" -> suite(TestResult.Failed))
+          )
+        )
+      threads.foreach(_.start())
+      threads.foreach(_.join())
+      assert(
+        TestRecap.snapshot.size == 16,
+        s"expected 16 records, got ${TestRecap.snapshot.size}"
+      )
+  }
+end TestRecapTest

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -19,17 +19,6 @@ import sbt.util.Logger
 
 object TestRecapTest extends verify.BasicTestSuite:
 
-  private def withTempDir(f: java.io.File => Unit): Unit =
-    val base = java.nio.file.Files.createTempDirectory("sbt-test-recap-").toFile
-    try f(base)
-    finally
-      val _ = java.nio.file.Files
-        .walk(base.toPath)
-        .sorted(java.util.Comparator.reverseOrder())
-        .forEach: p =>
-          try java.nio.file.Files.deleteIfExists(p)
-          catch case _: Exception => ()
-
   private def output(result: TestResult, suites: (String, SuiteResult)*): Tests.Output =
     Tests.Output(result, suites.toMap, Iterable.empty)
 
@@ -41,7 +30,10 @@ object TestRecapTest extends verify.BasicTestSuite:
       result: TestResult,
       suiteName: String
   ): TestsFailedException =
-    new TestsFailedException(taskName, Some(output(result, suiteName -> suite(result))))
+    new TestsFailedException(
+      taskName,
+      Some(output(result, suiteName -> suite(result)))
+    )
 
   /** Build an Incomplete tree carrying the given TestsFailedExceptions as direct causes. */
   private def incompleteOf(exceptions: TestsFailedException*): Incomplete =
@@ -65,20 +57,17 @@ object TestRecapTest extends verify.BasicTestSuite:
     )
     val collected = TestRecap.collect(i)
     assert(collected.map(_.taskName).sorted == Seq("a / Test / test", "c / Test / test"))
-    val resultsBy = collected.map(f => f.taskName -> f.output.overall).toMap
+    val resultsBy = collected.flatMap(f => f.testOutput.map(o => f.taskName -> o.overall)).toMap
     assert(resultsBy("a / Test / test") == TestResult.Failed)
     assert(resultsBy("c / Test / test") == TestResult.Error)
   }
 
-  test("collect ignores exceptions that aren't TestsFailedException with output") {
+  test("collect retains TestsFailedException without payload as a stub entry") {
+    val noDetail = new TestsFailedException // back-compat no-arg
     val i = new Incomplete(
       node = None,
       causes = Seq(
-        new Incomplete(node = None, directCause = Some(new RuntimeException("nope"))),
-        new Incomplete(
-          node = None,
-          directCause = Some(new TestsFailedException)
-        ), // no-arg, no output
+        new Incomplete(node = None, directCause = Some(noDetail)),
         new Incomplete(
           node = None,
           directCause = Some(failure("ok / Test / test", TestResult.Failed, "OkFail"))
@@ -86,60 +75,97 @@ object TestRecapTest extends verify.BasicTestSuite:
       )
     )
     val collected = TestRecap.collect(i)
-    assert(collected.size == 1)
-    assert(collected.head.taskName == "ok / Test / test")
+    assert(collected.size == 2, s"expected 2 entries, got $collected")
+    val stub = collected.find(_.testOutput.isEmpty)
+    assert(stub.isDefined, "no-detail failure should still produce a Failure entry")
+    assert(stub.get.taskName == "")
   }
 
-  test("format emits a header, per-task counts, and indented suite names") {
+  test("collect skips exceptions that aren't TestsFailedException") {
+    val i = new Incomplete(
+      node = None,
+      causes = Seq(
+        new Incomplete(node = None, directCause = Some(new RuntimeException("nope"))),
+        new Incomplete(
+          node = None,
+          directCause = Some(failure("ok / Test / test", TestResult.Failed, "OkFail"))
+        ),
+      )
+    )
+    assert(TestRecap.collect(i).map(_.taskName) == Seq("ok / Test / test"))
+  }
+
+  test("render emits header, per-task counts, and indented suite names") {
     val failures = Seq(
       TestRecap.Failure(
         "a / Test / test",
-        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+        Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
       ),
       TestRecap.Failure(
         "c / Test / test",
-        output(TestResult.Error, "CErroring" -> suite(TestResult.Error))
+        Some(output(TestResult.Error, "CErroring" -> suite(TestResult.Error)))
       ),
     )
-    val text = TestRecap.format(failures)
-    assert(text.startsWith("Test failures recap (2 test tasks failed):\n"))
-    assert(text.contains("a / Test / test:"))
-    assert(text.contains("c / Test / test:"))
-    assert(text.contains("AFailing"))
-    assert(text.contains("CErroring"))
-    assert(text.contains("Failed tests:"))
-    assert(text.contains("Error during tests:"))
-    // ASCII-only output: no em-dashes or other non-ASCII separators.
-    assert(text.forall(ch => ch < 128), s"non-ASCII characters in recap: $text")
+    val lines = TestRecap.render(failures)
+    assert(lines.headOption.contains("Test failures recap (2 test tasks failed):"))
+    assert(lines.exists(_.contains("a / Test / test:")))
+    assert(lines.exists(_.contains("c / Test / test:")))
+    assert(lines.exists(_.contains("AFailing")))
+    assert(lines.exists(_.contains("CErroring")))
+    assert(lines.contains("    Failed tests:"))
+    assert(lines.contains("    Error during tests:"))
+    // ASCII-only output for terminal/CI compatibility.
+    lines.foreach: l =>
+      assert(l.forall(ch => ch < 128), s"non-ASCII characters in recap line: $l")
   }
 
-  test("format is empty when there are no failures") {
-    assert(TestRecap.format(Seq.empty) == "")
-  }
-
-  test("format singular header when exactly one task failed") {
+  test("render emits singular header when exactly one task failed") {
     val one = Seq(
       TestRecap.Failure(
         "a / Test / test",
-        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+        Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
       )
     )
-    assert(TestRecap.format(one).startsWith("Test failures recap (1 test task failed):\n"))
+    assert(TestRecap.render(one).head == "Test failures recap (1 test task failed):")
   }
 
-  test("formatTo emits each rendered line as a single error-level log call") {
+  test("render shows '(no details)' for failures without a Tests.Output payload") {
+    val failures = Seq(TestRecap.Failure("a / Test / test", testOutput = None))
+    val lines = TestRecap.render(failures)
+    assert(
+      lines.exists(_.contains("a / Test / test: (no details)")),
+      s"expected '(no details)' entry, got $lines"
+    )
+  }
+
+  test("render shows '<unknown>' when a failure carries no task name") {
+    val failures = Seq(TestRecap.Failure(taskName = "", testOutput = None))
+    val lines = TestRecap.render(failures)
+    assert(
+      lines.exists(_.contains("<unknown>: (no details)")),
+      s"expected '<unknown>' placeholder, got $lines"
+    )
+  }
+
+  test("render is empty when there are no failures") {
+    assert(TestRecap.render(Seq.empty).isEmpty)
+  }
+
+  test("formatTo emits one error-level log line per rendered line") {
     val failures = Seq(
       TestRecap.Failure(
         "a / Test / test",
-        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+        Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
       )
     )
     val log = new Capture
     TestRecap.formatTo(log, failures)
-    assert(log.lines.nonEmpty)
+    val rendered = TestRecap.render(failures)
+    assert(
+      log.lines.size == rendered.size,
+      s"expected ${rendered.size} log calls, got ${log.lines.size}"
+    )
     assert(log.lines.forall(_._1 == "error"), s"all lines should be error level: ${log.lines}")
-    // No trailing blank-line entry.
-    assert(log.lines.forall(_._2.nonEmpty), s"unexpected empty line: ${log.lines}")
   }
 
   test("formatTo is a no-op when there are no failures") {
@@ -148,34 +174,9 @@ object TestRecapTest extends verify.BasicTestSuite:
     assert(log.lines.isEmpty)
   }
 
-  test("writeArtifact persists the recap text under <baseDir>/target/") {
-    withTempDir: base =>
-      TestRecap.writeArtifact(base, "hello recap")
-      val f = TestRecap.artifactFile(base)
-      assert(f.exists, s"artifact file not written at ${f.getAbsolutePath}")
-      val read = java.nio.file.Files
-        .readString(f.toPath, java.nio.charset.StandardCharsets.UTF_8)
-      assert(read == "hello recap")
-  }
-
-  test("writeArtifact is a no-op for empty text") {
-    withTempDir: base =>
-      TestRecap.writeArtifact(base, "")
-      assert(!TestRecap.artifactFile(base).exists)
-  }
-
-  test("deleteArtifact removes a previously written recap") {
-    withTempDir: base =>
-      TestRecap.writeArtifact(base, "stale")
-      assert(TestRecap.artifactFile(base).exists)
-      TestRecap.deleteArtifact(base)
-      assert(!TestRecap.artifactFile(base).exists)
-  }
-
-  test("deleteArtifact is a no-op when no recap exists") {
-    withTempDir: base =>
-      TestRecap.deleteArtifact(base) // must not throw
-      assert(!TestRecap.artifactFile(base).exists)
+  test("recapKey label is stable for tooling identity") {
+    // AttributeKey converts hyphenated names to camelCase via Util.hyphenToCamel.
+    assert(TestRecap.recapKey.label == "testRecap", s"actual label: ${TestRecap.recapKey.label}")
   }
 
 end TestRecapTest

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -10,18 +10,45 @@ package sbt
 package internal
 package testing
 
+import sbt.Incomplete
 import sbt.SuiteResult
 import sbt.Tests
+import sbt.TestsFailedException
 import sbt.protocol.testing.TestResult
 import sbt.util.Logger
 
 object TestRecapTest extends verify.BasicTestSuite:
+
+  private def withTempDir(f: java.io.File => Unit): Unit =
+    val base = java.nio.file.Files.createTempDirectory("sbt-test-recap-").toFile
+    try f(base)
+    finally
+      val _ = java.nio.file.Files
+        .walk(base.toPath)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach: p =>
+          try java.nio.file.Files.deleteIfExists(p)
+          catch case _: Exception => ()
 
   private def output(result: TestResult, suites: (String, SuiteResult)*): Tests.Output =
     Tests.Output(result, suites.toMap, Iterable.empty)
 
   private def suite(result: TestResult): SuiteResult =
     new SuiteResult(result, 0, 1, 0, 0, 0, 0, 0)
+
+  private def failure(
+      taskName: String,
+      result: TestResult,
+      suiteName: String
+  ): TestsFailedException =
+    new TestsFailedException(taskName, Some(output(result, suiteName -> suite(result))))
+
+  /** Build an Incomplete tree carrying the given TestsFailedExceptions as direct causes. */
+  private def incompleteOf(exceptions: TestsFailedException*): Incomplete =
+    new Incomplete(
+      node = None,
+      causes = exceptions.map(e => new Incomplete(node = None, directCause = Some(e)))
+    )
 
   private class Capture extends Logger:
     val lines: scala.collection.mutable.ArrayBuffer[(String, String)] =
@@ -31,121 +58,124 @@ object TestRecapTest extends verify.BasicTestSuite:
     override def log(level: sbt.util.Level.Value, msg: => String): Unit =
       lines += level.toString -> msg
 
-  // Restore TestRecap to a clean state between tests; the singleton outlives
-  // any single test method.
-  private def withClean(body: => Unit): Unit =
-    TestRecap.clear()
-    TestRecap.clear() // double-clear to drop both `previousRecords` and `records`
-    body
-
-  test("recordRun appends only failures and errors") {
-    withClean:
-      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
-      TestRecap.recordRun("q / Test / test", output(TestResult.Empty))
-      TestRecap.recordRun(
-        "r / Test / test",
-        output(TestResult.Failed, "RFailing" -> suite(TestResult.Failed))
-      )
-      TestRecap.recordRun(
-        "s / Test / test",
-        output(TestResult.Error, "SErroring" -> suite(TestResult.Error))
-      )
-      val snap = TestRecap.snapshot
-      assert(snap.size == 2, s"expected 2 records, got ${snap.map(_.taskName)}")
-      assert(snap.exists(_.taskName == "r / Test / test"))
-      assert(snap.exists(_.taskName == "s / Test / test"))
+  test("collect picks up TestsFailedException payloads from the Incomplete tree") {
+    val i = incompleteOf(
+      failure("a / Test / test", TestResult.Failed, "AFailing"),
+      failure("c / Test / test", TestResult.Error, "CErroring"),
+    )
+    val collected = TestRecap.collect(i)
+    assert(collected.map(_.taskName).sorted == Seq("a / Test / test", "c / Test / test"))
+    val resultsBy = collected.map(f => f.taskName -> f.output.overall).toMap
+    assert(resultsBy("a / Test / test") == TestResult.Failed)
+    assert(resultsBy("c / Test / test") == TestResult.Error)
   }
 
-  test("clear rolls records into previousSnapshot when a test ran") {
-    withClean:
-      TestRecap.recordRun(
-        "x / Test / test",
-        output(TestResult.Failed, "XFail" -> suite(TestResult.Failed))
+  test("collect ignores exceptions that aren't TestsFailedException with output") {
+    val i = new Incomplete(
+      node = None,
+      causes = Seq(
+        new Incomplete(node = None, directCause = Some(new RuntimeException("nope"))),
+        new Incomplete(
+          node = None,
+          directCause = Some(new TestsFailedException)
+        ), // no-arg, no output
+        new Incomplete(
+          node = None,
+          directCause = Some(failure("ok / Test / test", TestResult.Failed, "OkFail"))
+        ),
       )
-      TestRecap.clear()
-      assert(TestRecap.snapshot.isEmpty)
-      val prev = TestRecap.previousSnapshot
-      assert(prev.size == 1, s"expected 1 previous record, got $prev")
-      assert(prev.head.taskName == "x / Test / test")
+    )
+    val collected = TestRecap.collect(i)
+    assert(collected.size == 1)
+    assert(collected.head.taskName == "ok / Test / test")
   }
 
-  test("clear without a test run leaves previousSnapshot untouched") {
-    withClean:
-      // Seed previousSnapshot with a failing run.
-      TestRecap.recordRun(
-        "p / Test / test",
-        output(TestResult.Failed, "PFail" -> suite(TestResult.Failed))
-      )
-      TestRecap.clear()
-      assert(TestRecap.previousSnapshot.size == 1)
-      // A subsequent housekeeping `clear` (no test ran) must not erase it.
-      TestRecap.clear()
-      assert(
-        TestRecap.previousSnapshot.size == 1,
-        "intermediate non-test clear should not erase prior recap"
-      )
+  test("format emits a header, per-task counts, and indented suite names") {
+    val failures = Seq(
+      TestRecap.Failure(
+        "a / Test / test",
+        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+      ),
+      TestRecap.Failure(
+        "c / Test / test",
+        output(TestResult.Error, "CErroring" -> suite(TestResult.Error))
+      ),
+    )
+    val text = TestRecap.format(failures)
+    assert(text.startsWith("Test failures recap (2 test tasks failed):\n"))
+    assert(text.contains("a / Test / test:"))
+    assert(text.contains("c / Test / test:"))
+    assert(text.contains("AFailing"))
+    assert(text.contains("CErroring"))
+    assert(text.contains("Failed tests:"))
+    assert(text.contains("Error during tests:"))
+    // ASCII-only output: no em-dashes or other non-ASCII separators.
+    assert(text.forall(ch => ch < 128), s"non-ASCII characters in recap: $text")
   }
 
-  test("clear after a passing-only test cycle empties previousSnapshot") {
-    withClean:
-      TestRecap.recordRun(
-        "p / Test / test",
-        output(TestResult.Failed, "PFail" -> suite(TestResult.Failed))
-      )
-      TestRecap.clear()
-      assert(TestRecap.previousSnapshot.size == 1)
-      // Next cycle: only a passing test ran. clear should reset previous to [].
-      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
-      TestRecap.clear()
-      assert(
-        TestRecap.previousSnapshot.isEmpty,
-        "passing-only cycle should clear previous failures"
-      )
+  test("format is empty when there are no failures") {
+    assert(TestRecap.format(Seq.empty) == "")
   }
 
-  test("formatTo emits a header, per-task counts, and indented suite names") {
-    withClean:
-      TestRecap.recordRun(
+  test("format singular header when exactly one task failed") {
+    val one = Seq(
+      TestRecap.Failure(
         "a / Test / test",
         output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
       )
-      TestRecap.recordRun(
-        "c / Test / test",
-        output(TestResult.Error, "CErroring" -> suite(TestResult.Error))
-      )
-      val log = new Capture
-      TestRecap.formatTo(log)
-      val joined = log.lines.map(_._2).mkString("\n")
-      assert(joined.contains("Test failures recap (2 test tasks failed):"))
-      assert(joined.contains("a / Test / test"))
-      assert(joined.contains("c / Test / test"))
-      assert(joined.contains("AFailing"))
-      assert(joined.contains("CErroring"))
-      assert(log.lines.forall(_._1 == "error"), s"all lines should be error level: ${log.lines}")
+    )
+    assert(TestRecap.format(one).startsWith("Test failures recap (1 test task failed):\n"))
   }
 
-  test("formatTo is a no-op when no failures recorded") {
-    withClean:
-      TestRecap.recordRun("p / Test / test", output(TestResult.Passed))
-      val log = new Capture
-      TestRecap.formatTo(log)
-      assert(log.lines.isEmpty, s"expected no output, got ${log.lines}")
+  test("formatTo emits each rendered line as a single error-level log call") {
+    val failures = Seq(
+      TestRecap.Failure(
+        "a / Test / test",
+        output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed))
+      )
+    )
+    val log = new Capture
+    TestRecap.formatTo(log, failures)
+    assert(log.lines.nonEmpty)
+    assert(log.lines.forall(_._1 == "error"), s"all lines should be error level: ${log.lines}")
+    // No trailing blank-line entry.
+    assert(log.lines.forall(_._2.nonEmpty), s"unexpected empty line: ${log.lines}")
   }
 
-  test("concurrent recordRun calls are thread-safe") {
-    withClean:
-      val threads = (0 until 16).map: i =>
-        new Thread(() =>
-          TestRecap.recordRun(
-            s"p$i / Test / test",
-            output(TestResult.Failed, s"P$i" -> suite(TestResult.Failed))
-          )
-        )
-      threads.foreach(_.start())
-      threads.foreach(_.join())
-      assert(
-        TestRecap.snapshot.size == 16,
-        s"expected 16 records, got ${TestRecap.snapshot.size}"
-      )
+  test("formatTo is a no-op when there are no failures") {
+    val log = new Capture
+    TestRecap.formatTo(log, Seq.empty)
+    assert(log.lines.isEmpty)
   }
+
+  test("writeArtifact persists the recap text under <baseDir>/target/") {
+    withTempDir: base =>
+      TestRecap.writeArtifact(base, "hello recap")
+      val f = TestRecap.artifactFile(base)
+      assert(f.exists, s"artifact file not written at ${f.getAbsolutePath}")
+      val read = java.nio.file.Files
+        .readString(f.toPath, java.nio.charset.StandardCharsets.UTF_8)
+      assert(read == "hello recap")
+  }
+
+  test("writeArtifact is a no-op for empty text") {
+    withTempDir: base =>
+      TestRecap.writeArtifact(base, "")
+      assert(!TestRecap.artifactFile(base).exists)
+  }
+
+  test("deleteArtifact removes a previously written recap") {
+    withTempDir: base =>
+      TestRecap.writeArtifact(base, "stale")
+      assert(TestRecap.artifactFile(base).exists)
+      TestRecap.deleteArtifact(base)
+      assert(!TestRecap.artifactFile(base).exists)
+  }
+
+  test("deleteArtifact is a no-op when no recap exists") {
+    withTempDir: base =>
+      TestRecap.deleteArtifact(base) // must not throw
+      assert(!TestRecap.artifactFile(base).exists)
+  }
+
 end TestRecapTest

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -95,6 +95,17 @@ object TestRecapTest extends verify.BasicTestSuite:
     assert(TestRecap.collect(i).map(_.taskName) == Vector("ok / Test / test"))
   }
 
+  test("collect retains taskName when a TestsFailedException is rebranded with task name only") {
+    // Simulates the `testFull` / `inputTests0` catch path: an upstream
+    // legacy code path threw `new TestsFailedException()` (no detail), the
+    // task wrapper caught it and re-threw with `(taskName, e.testOutput)`
+    // to attach the project context.
+    val tagged = new TestsFailedException("a / Test / test", None)
+    val i = new Incomplete(node = None, directCause = Some(tagged))
+    val collected = TestRecap.collect(i)
+    assert(collected == Vector(TestRecap.Failure("a / Test / test", None)))
+  }
+
   test("collect deduplicates a TestsFailedException shared across Incomplete paths") {
     val shared = failure("a / Test / test", TestResult.Failed, "AFail")
     val i = new Incomplete(

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -56,14 +56,14 @@ object TestRecapTest extends verify.BasicTestSuite:
       failure("c / Test / test", TestResult.Error, "CErroring"),
     )
     val collected = TestRecap.collect(i)
-    assert(collected.map(_.taskName).sorted == Seq("a / Test / test", "c / Test / test"))
+    assert(collected.map(_.taskName).sorted == Vector("a / Test / test", "c / Test / test"))
     val resultsBy = collected.flatMap(f => f.testOutput.map(o => f.taskName -> o.overall)).toMap
     assert(resultsBy("a / Test / test") == TestResult.Failed)
     assert(resultsBy("c / Test / test") == TestResult.Error)
   }
 
   test("collect retains TestsFailedException without payload as a stub entry") {
-    val noDetail = new TestsFailedException // back-compat no-arg
+    val noDetail = new TestsFailedException // back-compat no-arg constructor
     val i = new Incomplete(
       node = None,
       causes = Seq(
@@ -92,11 +92,27 @@ object TestRecapTest extends verify.BasicTestSuite:
         ),
       )
     )
-    assert(TestRecap.collect(i).map(_.taskName) == Seq("ok / Test / test"))
+    assert(TestRecap.collect(i).map(_.taskName) == Vector("ok / Test / test"))
+  }
+
+  test("collect deduplicates a TestsFailedException shared across Incomplete paths") {
+    val shared = failure("a / Test / test", TestResult.Failed, "AFail")
+    val i = new Incomplete(
+      node = None,
+      causes = Seq(
+        new Incomplete(node = None, directCause = Some(shared)),
+        new Incomplete(node = None, directCause = Some(shared)),
+      )
+    )
+    val collected = TestRecap.collect(i)
+    assert(
+      collected.size == 1,
+      s"shared failure should be reported once, got ${collected.size}: $collected"
+    )
   }
 
   test("render emits header, per-task counts, and indented suite names") {
-    val failures = Seq(
+    val failures = Vector(
       TestRecap.Failure(
         "a / Test / test",
         Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
@@ -114,13 +130,26 @@ object TestRecapTest extends verify.BasicTestSuite:
     assert(lines.exists(_.contains("CErroring")))
     assert(lines.contains("    Failed tests:"))
     assert(lines.contains("    Error during tests:"))
-    // ASCII-only output for terminal/CI compatibility.
-    lines.foreach: l =>
-      assert(l.forall(ch => ch < 128), s"non-ASCII characters in recap line: $l")
+  }
+
+  test("render sorts failures by taskName for stable output (empty names last)") {
+    val failures = Vector(
+      TestRecap.Failure("zz / Test / test", None),
+      TestRecap.Failure("", None),
+      TestRecap.Failure("aa / Test / test", None),
+      TestRecap.Failure("mm / Test / test", None),
+    )
+    val lines = TestRecap.render(failures)
+    val headerLines = lines.filter(_.startsWith("  "))
+    val order = headerLines.map(_.trim.takeWhile(_ != ':'))
+    assert(
+      order == Vector("aa / Test / test", "mm / Test / test", "zz / Test / test", "<unknown>"),
+      s"unexpected order: $order"
+    )
   }
 
   test("render emits singular header when exactly one task failed") {
-    val one = Seq(
+    val one = Vector(
       TestRecap.Failure(
         "a / Test / test",
         Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
@@ -130,7 +159,7 @@ object TestRecapTest extends verify.BasicTestSuite:
   }
 
   test("render shows '(no details)' for failures without a Tests.Output payload") {
-    val failures = Seq(TestRecap.Failure("a / Test / test", testOutput = None))
+    val failures = Vector(TestRecap.Failure("a / Test / test", testOutput = None))
     val lines = TestRecap.render(failures)
     assert(
       lines.exists(_.contains("a / Test / test: (no details)")),
@@ -139,7 +168,7 @@ object TestRecapTest extends verify.BasicTestSuite:
   }
 
   test("render shows '<unknown>' when a failure carries no task name") {
-    val failures = Seq(TestRecap.Failure(taskName = "", testOutput = None))
+    val failures = Vector(TestRecap.Failure(taskName = "", testOutput = None))
     val lines = TestRecap.render(failures)
     assert(
       lines.exists(_.contains("<unknown>: (no details)")),
@@ -148,11 +177,11 @@ object TestRecapTest extends verify.BasicTestSuite:
   }
 
   test("render is empty when there are no failures") {
-    assert(TestRecap.render(Seq.empty).isEmpty)
+    assert(TestRecap.render(Vector.empty).isEmpty)
   }
 
   test("formatTo emits one error-level log line per rendered line") {
-    val failures = Seq(
+    val failures = Vector(
       TestRecap.Failure(
         "a / Test / test",
         Some(output(TestResult.Failed, "AFailing" -> suite(TestResult.Failed)))
@@ -170,13 +199,8 @@ object TestRecapTest extends verify.BasicTestSuite:
 
   test("formatTo is a no-op when there are no failures") {
     val log = new Capture
-    TestRecap.formatTo(log, Seq.empty)
+    TestRecap.formatTo(log, Vector.empty)
     assert(log.lines.isEmpty)
-  }
-
-  test("recapKey label is camelCased per AttributeKey convention") {
-    // AttributeKey converts hyphenated names to camelCase via Util.hyphenToCamel.
-    assert(TestRecap.recapKey.label == "testRecap", s"actual label: ${TestRecap.recapKey.label}")
   }
 
 end TestRecapTest

--- a/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala
@@ -174,7 +174,7 @@ object TestRecapTest extends verify.BasicTestSuite:
     assert(log.lines.isEmpty)
   }
 
-  test("recapKey label is stable for tooling identity") {
+  test("recapKey label is camelCased per AttributeKey convention") {
     // AttributeKey converts hyphenated names to camelCase via Util.hyphenToCamel.
     assert(TestRecap.recapKey.label == "testRecap", s"actual label: ${TestRecap.recapKey.label}")
   }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1274,6 +1274,12 @@ object Defaults extends BuildCommon with DefExtra {
       try
         val output = executeTests.value
         trl.run(streams.value.log, output, taskName)
+        // Throw with details after the logger has had a chance to print so the
+        // per-task failure summary still appears before the aggregated recap.
+        output.overall match
+          case TestResult.Error | TestResult.Failed =>
+            throw new TestsFailedException(taskName, Some(output))
+          case _ => ()
         output.overall
       finally close(testLoader.value)
     },
@@ -1448,6 +1454,10 @@ object Defaults extends BuildCommon with DefExtra {
         .value[Task[Tests.Output]] { output })
         .map: out =>
           trl.run(s.log, out, taskName)
+          out.overall match
+            case TestResult.Error | TestResult.Failed =>
+              throw new TestsFailedException(taskName, Some(out))
+            case _ => ()
           out.overall
     }
   }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1283,6 +1283,13 @@ object Defaults extends BuildCommon with DefExtra {
             throw new TestsFailedException(taskName, Some(output))
           case _ => ()
         output.overall
+      catch
+        // Tag any no-detail TestsFailedException (legacy executeTests
+        // adapters, third-party Tests.Setup actions, anything constructing
+        // `new TestsFailedException()` via the back-compat ctor) with the
+        // task name on its way out so the recap doesn't render <unknown>.
+        case e: TestsFailedException if e.taskName.isEmpty =>
+          throw new TestsFailedException(taskName, e.testOutput)
       finally close(testLoader.value)
     },
     testSelected := {
@@ -1455,12 +1462,18 @@ object Defaults extends BuildCommon with DefExtra {
       (Def
         .value[Task[Tests.Output]] { output })
         .map: out =>
-          trl.run(s.log, out, taskName)
-          out.overall match
-            case TestResult.Error | TestResult.Failed =>
-              throw new TestsFailedException(taskName, Some(out))
-            case _ => ()
-          out.overall
+          try
+            trl.run(s.log, out, taskName)
+            out.overall match
+              case TestResult.Error | TestResult.Failed =>
+                throw new TestsFailedException(taskName, Some(out))
+              case _ => ()
+            out.overall
+          catch
+            // Tag any no-detail TestsFailedException with the task name
+            // on its way out, mirroring the catch in `testFull`.
+            case e: TestsFailedException if e.taskName.isEmpty =>
+              throw new TestsFailedException(taskName, e.testOutput)
     }
   }
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1273,16 +1273,11 @@ object Defaults extends BuildCommon with DefExtra {
       val taskName = Project.showContextKey(state.value).show(resolvedScoped.value)
       try
         val output = executeTests.value
-        try trl.run(streams.value.log, output, taskName)
-        catch
-          case _: TestsFailedException =>
-            // Re-throw with task name + Output so the cross-project recap
-            // (TestRecap.collect) can surface them. Default `Main.run`
-            // throws the no-arg form; this wraps it in the detail form.
-            throw new TestsFailedException(taskName, Some(output))
-        // User-overridden loggers may not throw on failure. Detect that
-        // case and propagate the failure (idempotent if the logger did
-        // throw above; that branch is unreachable from here).
+        trl.run(streams.value.log, output, taskName)
+        // Throw with task name + Output so the cross-project recap
+        // (TestRecap.collect) can surface them. The throw lives here
+        // rather than in TestResultLogger so user-overridden loggers
+        // cannot accidentally suppress the failure signal.
         output.overall match
           case TestResult.Error | TestResult.Failed =>
             throw new TestsFailedException(taskName, Some(output))
@@ -1460,11 +1455,7 @@ object Defaults extends BuildCommon with DefExtra {
       (Def
         .value[Task[Tests.Output]] { output })
         .map: out =>
-          try trl.run(s.log, out, taskName)
-          catch
-            case _: TestsFailedException =>
-              // Re-throw with task name + Output for the cross-project recap.
-              throw new TestsFailedException(taskName, Some(out))
+          trl.run(s.log, out, taskName)
           out.overall match
             case TestResult.Error | TestResult.Failed =>
               throw new TestsFailedException(taskName, Some(out))

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1273,9 +1273,16 @@ object Defaults extends BuildCommon with DefExtra {
       val taskName = Project.showContextKey(state.value).show(resolvedScoped.value)
       try
         val output = executeTests.value
-        trl.run(streams.value.log, output, taskName)
-        // Throw with details after the logger has had a chance to print so the
-        // per-task failure summary still appears before the aggregated recap.
+        try trl.run(streams.value.log, output, taskName)
+        catch
+          case _: TestsFailedException =>
+            // Re-throw with task name + Output so the cross-project recap
+            // (TestRecap.collect) can surface them. Default `Main.run`
+            // throws the no-arg form; this wraps it in the detail form.
+            throw new TestsFailedException(taskName, Some(output))
+        // User-overridden loggers may not throw on failure. Detect that
+        // case and propagate the failure (idempotent if the logger did
+        // throw above; that branch is unreachable from here).
         output.overall match
           case TestResult.Error | TestResult.Failed =>
             throw new TestsFailedException(taskName, Some(output))
@@ -1453,7 +1460,11 @@ object Defaults extends BuildCommon with DefExtra {
       (Def
         .value[Task[Tests.Output]] { output })
         .map: out =>
-          trl.run(s.log, out, taskName)
+          try trl.run(s.log, out, taskName)
+          catch
+            case _: TestsFailedException =>
+              // Re-throw with task name + Output for the cross-project recap.
+              throw new TestsFailedException(taskName, Some(out))
           out.overall match
             case TestResult.Error | TestResult.Failed =>
               throw new TestsFailedException(taskName, Some(out))

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -143,22 +143,13 @@ object Aggregation {
     showRun(complete, show)
     complete.results match
       case Result.Inc(i) =>
-        // Collect the per-task TestsFailedException payloads off the
-        // Incomplete tree *before* handleError mutates state, then emit the
-        // recap after handleError so it is the last thing the user sees.
         val failures = sbt.internal.testing.TestRecap.collect(i)
         val afterHandle = complete.state.handleError(i)
         if failures.nonEmpty then
           sbt.internal.testing.TestRecap.formatTo(afterHandle.log, failures)
           afterHandle.put(sbt.internal.testing.TestRecap.recapKey, failures)
         else afterHandle
-      case Result.Value(_) =>
-        // Leave any previously-set recap intact. A successful run after a
-        // failure does not clear the State attribute -- the next failure
-        // will overwrite it. This avoids guessing whether a particular
-        // command should be considered "test-related" (which would require
-        // a hardcoded label list or Tags-based detection).
-        complete.state
+      case Result.Value(_) => complete.state
 
   def printSuccess(
       start: Long,

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -139,13 +139,25 @@ object Aggregation {
       extra: DummyTaskMap,
       show: ShowConfig
   )(using display: Show[ScopedKey[?]]): State =
-    sbt.internal.testing.TestRecap.clear()
     val complete = timedRun[A1](s, ts, extra)
     showRun(complete, show)
-    sbt.internal.testing.TestRecap.formatTo(complete.state.log)
     complete.results match
-      case Result.Inc(i)   => complete.state.handleError(i)
-      case Result.Value(_) => complete.state
+      case Result.Inc(i) =>
+        // Collect the per-task TestsFailedException payloads off the
+        // Incomplete tree *before* handleError mutates state, then emit the
+        // recap after handleError so it is the last thing the user sees.
+        val failures = sbt.internal.testing.TestRecap.collect(i)
+        val afterHandle = complete.state.handleError(i)
+        if failures.nonEmpty then
+          sbt.internal.testing.TestRecap.formatTo(afterHandle.log, failures)
+          sbt.internal.testing.TestRecap.writeArtifact(
+            afterHandle.baseDir,
+            sbt.internal.testing.TestRecap.format(failures),
+          )
+        afterHandle
+      case Result.Value(_) =>
+        sbt.internal.testing.TestRecap.deleteArtifact(complete.state.baseDir)
+        complete.state
 
   def printSuccess(
       start: Long,

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -150,14 +150,15 @@ object Aggregation {
         val afterHandle = complete.state.handleError(i)
         if failures.nonEmpty then
           sbt.internal.testing.TestRecap.formatTo(afterHandle.log, failures)
-          sbt.internal.testing.TestRecap.writeArtifact(
-            afterHandle.baseDir,
-            sbt.internal.testing.TestRecap.format(failures),
-          )
-        afterHandle
+          afterHandle.put(sbt.internal.testing.TestRecap.recapKey, failures.toVector)
+        else afterHandle
       case Result.Value(_) =>
-        sbt.internal.testing.TestRecap.deleteArtifact(complete.state.baseDir)
-        complete.state
+        // Only clear stale recap state when this invocation actually
+        // included a test task; arbitrary `compile` / `update` / `reload`
+        // commands between a failed test run and the user inspecting the
+        // recap must leave the recap intact.
+        if includesTestTask(ts) then complete.state.remove(sbt.internal.testing.TestRecap.recapKey)
+        else complete.state
 
   def printSuccess(
       start: Long,
@@ -327,4 +328,16 @@ object Aggregation {
     (Scope.fillTaskAxis(key.scope, key.key) / Keys.aggregate).get(data).getOrElse(true)
   private[sbt] val suppressShow =
     AttributeKey[Boolean]("suppress-aggregation-show", Int.MaxValue)
+
+  /**
+   * True if any of the keys being evaluated correspond to one of the
+   * standard test entry points. Used to scope `TestRecap.recapKey`
+   * lifecycle to test-bearing aggregations only.
+   */
+  private def includesTestTask[A1](ts: Values[Task[A1]]): Boolean =
+    ts.exists { kv =>
+      kv.key.key.label match
+        case "test" | "testFull" | "testQuick" | "testOnly" | "testSelected" => true
+        case _                                                               => false
+    }
 }

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -139,8 +139,10 @@ object Aggregation {
       extra: DummyTaskMap,
       show: ShowConfig
   )(using display: Show[ScopedKey[?]]): State =
+    sbt.internal.testing.TestRecap.clear()
     val complete = timedRun[A1](s, ts, extra)
     showRun(complete, show)
+    sbt.internal.testing.TestRecap.formatTo(complete.state.log)
     complete.results match
       case Result.Inc(i)   => complete.state.handleError(i)
       case Result.Value(_) => complete.state

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -150,7 +150,7 @@ object Aggregation {
         val afterHandle = complete.state.handleError(i)
         if failures.nonEmpty then
           sbt.internal.testing.TestRecap.formatTo(afterHandle.log, failures)
-          afterHandle.put(sbt.internal.testing.TestRecap.recapKey, failures.toVector)
+          afterHandle.put(sbt.internal.testing.TestRecap.recapKey, failures)
         else afterHandle
       case Result.Value(_) =>
         // Leave any previously-set recap intact. A successful run after a

--- a/main/src/main/scala/sbt/internal/Aggregation.scala
+++ b/main/src/main/scala/sbt/internal/Aggregation.scala
@@ -153,12 +153,12 @@ object Aggregation {
           afterHandle.put(sbt.internal.testing.TestRecap.recapKey, failures.toVector)
         else afterHandle
       case Result.Value(_) =>
-        // Only clear stale recap state when this invocation actually
-        // included a test task; arbitrary `compile` / `update` / `reload`
-        // commands between a failed test run and the user inspecting the
-        // recap must leave the recap intact.
-        if includesTestTask(ts) then complete.state.remove(sbt.internal.testing.TestRecap.recapKey)
-        else complete.state
+        // Leave any previously-set recap intact. A successful run after a
+        // failure does not clear the State attribute -- the next failure
+        // will overwrite it. This avoids guessing whether a particular
+        // command should be considered "test-related" (which would require
+        // a hardcoded label list or Tags-based detection).
+        complete.state
 
   def printSuccess(
       start: Long,
@@ -328,16 +328,4 @@ object Aggregation {
     (Scope.fillTaskAxis(key.scope, key.key) / Keys.aggregate).get(data).getOrElse(true)
   private[sbt] val suppressShow =
     AttributeKey[Boolean]("suppress-aggregation-show", Int.MaxValue)
-
-  /**
-   * True if any of the keys being evaluated correspond to one of the
-   * standard test entry points. Used to scope `TestRecap.recapKey`
-   * lifecycle to test-bearing aggregations only.
-   */
-  private def includesTestTask[A1](ts: Values[Task[A1]]): Boolean =
-    ts.exists { kv =>
-      kv.key.key.label match
-        case "test" | "testFull" | "testQuick" | "testOnly" | "testSelected" => true
-        case _                                                               => false
-    }
 }

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/a/src/test/java/FailingTestA.java
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/a/src/test/java/FailingTestA.java
@@ -1,0 +1,6 @@
+import org.junit.Test;
+import static org.junit.Assert.fail;
+
+public class FailingTestA {
+    @Test public void failure() { fail("intentional failure A"); }
+}

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/b/src/test/java/PassingTestB.java
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/b/src/test/java/PassingTestB.java
@@ -1,0 +1,5 @@
+import org.junit.Test;
+
+public class PassingTestB {
+    @Test public void success() { /* passes */ }
+}

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
@@ -1,0 +1,10 @@
+ThisBuild / scalaVersion := "2.13.16"
+
+def junit = libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
+
+lazy val a = project.settings(junit)
+lazy val b = project.settings(junit)
+lazy val c = project.settings(junit)
+
+lazy val root = (project in file("."))
+  .aggregate(a, b, c)

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
@@ -8,3 +8,7 @@ lazy val c = project.settings(junit)
 
 lazy val root = (project in file("."))
   .aggregate(a, b, c)
+  .settings(
+    TaskKey[Unit]("checkRecap") := sbt.multifailurerecap.Checks.checkRecap(baseDirectory.value),
+    TaskKey[Unit]("checkNoRecap") := sbt.multifailurerecap.Checks.checkNoRecap(baseDirectory.value),
+  )

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
@@ -8,3 +8,9 @@ lazy val c = project.settings(junit)
 
 lazy val root = (project in file("."))
   .aggregate(a, b, c)
+  .settings(
+    commands ++= Seq(
+      sbt.multifailurerecap.Checks.verifyRecap,
+      sbt.multifailurerecap.Checks.verifyNoRecap,
+    )
+  )

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/build.sbt
@@ -8,7 +8,3 @@ lazy val c = project.settings(junit)
 
 lazy val root = (project in file("."))
   .aggregate(a, b, c)
-  .settings(
-    TaskKey[Unit]("checkRecap") := sbt.multifailurerecap.Checks.checkRecap(baseDirectory.value),
-    TaskKey[Unit]("checkNoRecap") := sbt.multifailurerecap.Checks.checkNoRecap(baseDirectory.value),
-  )

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/c/src/test/java/FailingTestC.java
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/c/src/test/java/FailingTestC.java
@@ -1,0 +1,6 @@
+import org.junit.Test;
+import static org.junit.Assert.fail;
+
+public class FailingTestC {
+    @Test public void failure() { fail("intentional failure C"); }
+}

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
@@ -1,0 +1,35 @@
+package sbt
+package multifailurerecap
+
+import sbt.internal.testing.TestRecap
+
+/**
+ * Lives in package `sbt` so it can reach `TestRecap`, which is `private[sbt]`.
+ * Verifies the recap artifact that `Aggregation.runTasks` writes after an
+ * aggregated test failure.
+ */
+object Checks {
+  def checkRecap(baseDir: java.io.File): Unit = {
+    val file = TestRecap.artifactFile(baseDir)
+    assert(file.exists, s"recap artifact not written at ${file.getAbsolutePath}")
+    val text = sbt.io.IO.read(file)
+    assert(text.startsWith("Test failures recap (2 test tasks failed):"),
+      s"recap should start with header, got:\n$text")
+    assert(text.contains("a / Test / test"), s"recap missing project a:\n$text")
+    assert(text.contains("c / Test / test"), s"recap missing project c:\n$text")
+    assert(text.contains("FailingTestA"), s"recap missing FailingTestA:\n$text")
+    assert(text.contains("FailingTestC"), s"recap missing FailingTestC:\n$text")
+    // b passed and must not appear in the recap.
+    assert(!text.contains("b / Test / test"),
+      s"passing project b should not appear in recap:\n$text")
+    // ASCII-only output for terminal/CI compatibility.
+    assert(text.forall(ch => ch < 128),
+      s"non-ASCII characters in recap: $text")
+  }
+
+  def checkNoRecap(baseDir: java.io.File): Unit = {
+    val file = TestRecap.artifactFile(baseDir)
+    assert(!file.exists,
+      s"recap artifact should have been removed at ${file.getAbsolutePath}")
+  }
+}

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
@@ -9,22 +9,27 @@ import sbt.internal.testing.TestRecap
  * A scripted statement that fails (`-> test`) closes the inner sbt's IPC
  * server (see `SbtHandler.onNewSbtInstance`'s catch block), which terminates
  * the inner sbt JVM. Scripted then launches a fresh JVM for the next
- * statement, so the State attribute set by Aggregation.runTasks cannot be
- * read by a follow-up `> check`. To verify recap content end-to-end we
- * stay inside a single sbt invocation: the `verifyRecap` command runs
- * `test` via `Command.process`, inspects the resulting state's attribute,
- * and discards the failure so its own state is not failed.
+ * statement, so a State attribute set inside a failing statement cannot be
+ * read by a follow-up `> check`. We avoid that by running `test` from
+ * inside a Command (here) via `Command.process`, all within one JVM.
+ *
+ * `recapKey` is monotonic-latest-failure: never proactively cleared.
+ * That means across CI scripted shards (which share an inner sbt across
+ * tests with `reload;initialize` between them) a prior test that left a
+ * recap entry is visible to this test. Both commands therefore strip
+ * `recapKey` from the incoming state before doing their own assertions
+ * and again on the way out, so they are hermetic w.r.t. anything other
+ * scripted tests in the same shard may have left behind.
  */
 object Checks {
 
   val verifyRecap: Command = Command.command("verifyRecap") { state =>
-    val afterTest = Command.process("test", state)
+    val cleared = state.remove(TestRecap.recapKey)
+    val afterTest = Command.process("test", cleared)
     val recap = afterTest.get(TestRecap.recapKey).getOrElse {
       sys.error("TestRecap.recapKey not set on state after aggregated test failure")
     }
     val names = recap.map(_.taskName).toSet
-    // `test := testQuick.evaluated` (Defaults.scala), so the recorded
-    // taskName is `<proj> / Test / testQuick` rather than `... / test`.
     assert(recap.size == 2, s"expected 2 failures, got ${recap.size}: $names")
     assert(names.exists(_.startsWith("a / ")), s"recap missing project a: $names")
     assert(names.exists(_.startsWith("c / ")), s"recap missing project c: $names")
@@ -35,22 +40,23 @@ object Checks {
         s.result == sbt.protocol.testing.TestResult.Failed
       assert(failedSuites >= 1, s"${f.taskName} has no failed suite: ${f.testOutput.get.events}")
     }
-    // Sanity check rendering.
     val lines = TestRecap.render(recap)
-    assert(lines.head.startsWith("Test failures recap (2 test tasks failed):"),
-      s"unexpected header: ${lines.head}")
-    lines.foreach(l => assert(l.forall(_ < 128), s"non-ASCII in recap line: $l"))
-    // Return the *original* state so the verifyRecap command itself is not
-    // marked as failed; the failure was structural to `test`, which we
-    // have already inspected.
-    state
+    assert(
+      lines.head.startsWith("Test failures recap (2 test tasks failed):"),
+      s"unexpected header: ${lines.head}"
+    )
+    // Return the original state with recapKey stripped so the next
+    // scripted statement starts hermetic.
+    state.remove(TestRecap.recapKey)
   }
 
   val verifyNoRecap: Command = Command.command("verifyNoRecap") { state =>
-    val afterTest = Command.process("test", state)
+    val cleared = state.remove(TestRecap.recapKey)
+    val afterTest = Command.process("test", cleared)
     afterTest.get(TestRecap.recapKey) match {
-      case None    => state
-      case Some(r) => sys.error(s"unexpected recap after passing test run: ${r.map(_.taskName)}")
+      case None => state.remove(TestRecap.recapKey)
+      case Some(r) =>
+        sys.error(s"unexpected recap after passing test run: ${r.map(_.taskName)}")
     }
   }
 }

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
@@ -6,32 +6,51 @@ import sbt.internal.testing.TestRecap
 /**
  * Lives in package `sbt` so it can access `TestRecap`, which is `private[sbt]`.
  *
- * Caveat: a scripted statement that fails (`-> test`) closes the inner sbt's
- * IPC server (`SbtHandler.onNewSbtInstance`'s catch block calls `finish`),
- * which terminates the inner sbt JVM. scripted then launches a fresh JVM
- * for the next statement. Empirically we confirmed via
- * `ManagementFactory.getRuntimeMXBean.getName` that the PID differs across
- * the `-> test` boundary, so the `State` attribute Aggregation puts on
- * failure cannot be read by a follow-up `> check` statement.
- *
- * These helpers are kept for documentation; verification of recap content
- * still relies on running the aggregated test in the same sbt invocation.
+ * A scripted statement that fails (`-> test`) closes the inner sbt's IPC
+ * server (see `SbtHandler.onNewSbtInstance`'s catch block), which terminates
+ * the inner sbt JVM. Scripted then launches a fresh JVM for the next
+ * statement, so the State attribute set by Aggregation.runTasks cannot be
+ * read by a follow-up `> check`. To verify recap content end-to-end we
+ * stay inside a single sbt invocation: the `verifyRecap` command runs
+ * `test` via `Command.process`, inspects the resulting state's attribute,
+ * and discards the failure so its own state is not failed.
  */
 object Checks {
-  def checkRecap(state: State): Unit = {
-    val recap = state.get(TestRecap.recapKey).getOrElse {
-      sys.error("TestRecap.recapKey not present on state after aggregated test failure")
+
+  val verifyRecap: Command = Command.command("verifyRecap") { state =>
+    val afterTest = Command.process("test", state)
+    val recap = afterTest.get(TestRecap.recapKey).getOrElse {
+      sys.error("TestRecap.recapKey not set on state after aggregated test failure")
     }
     val names = recap.map(_.taskName).toSet
+    // `test := testQuick.evaluated` (Defaults.scala), so the recorded
+    // taskName is `<proj> / Test / testQuick` rather than `... / test`.
     assert(recap.size == 2, s"expected 2 failures, got ${recap.size}: $names")
-    assert(names.contains("a / Test / test"), s"recap missing project a: $names")
-    assert(names.contains("c / Test / test"), s"recap missing project c: $names")
-    assert(!names.contains("b / Test / test"), s"recap should not list project b: $names")
+    assert(names.exists(_.startsWith("a / ")), s"recap missing project a: $names")
+    assert(names.exists(_.startsWith("c / ")), s"recap missing project c: $names")
+    assert(!names.exists(_.startsWith("b / ")), s"recap should not list project b: $names")
+    recap.foreach { f =>
+      assert(f.testOutput.isDefined, s"${f.taskName} has no Tests.Output payload")
+      val failedSuites = f.testOutput.get.events.values.count: s =>
+        s.result == sbt.protocol.testing.TestResult.Failed
+      assert(failedSuites >= 1, s"${f.taskName} has no failed suite: ${f.testOutput.get.events}")
+    }
+    // Sanity check rendering.
+    val lines = TestRecap.render(recap)
+    assert(lines.head.startsWith("Test failures recap (2 test tasks failed):"),
+      s"unexpected header: ${lines.head}")
+    lines.foreach(l => assert(l.forall(_ < 128), s"non-ASCII in recap line: $l"))
+    // Return the *original* state so the verifyRecap command itself is not
+    // marked as failed; the failure was structural to `test`, which we
+    // have already inspected.
+    state
   }
 
-  def checkNoRecap(state: State): Unit =
-    state.get(TestRecap.recapKey) match {
-      case None    => ()
-      case Some(_) => sys.error("recap state attribute should be empty after success")
+  val verifyNoRecap: Command = Command.command("verifyNoRecap") { state =>
+    val afterTest = Command.process("test", state)
+    afterTest.get(TestRecap.recapKey) match {
+      case None    => state
+      case Some(r) => sys.error(s"unexpected recap after passing test run: ${r.map(_.taskName)}")
     }
+  }
 }

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/project/Checks.scala
@@ -4,32 +4,34 @@ package multifailurerecap
 import sbt.internal.testing.TestRecap
 
 /**
- * Lives in package `sbt` so it can reach `TestRecap`, which is `private[sbt]`.
- * Verifies the recap artifact that `Aggregation.runTasks` writes after an
- * aggregated test failure.
+ * Lives in package `sbt` so it can access `TestRecap`, which is `private[sbt]`.
+ *
+ * Caveat: a scripted statement that fails (`-> test`) closes the inner sbt's
+ * IPC server (`SbtHandler.onNewSbtInstance`'s catch block calls `finish`),
+ * which terminates the inner sbt JVM. scripted then launches a fresh JVM
+ * for the next statement. Empirically we confirmed via
+ * `ManagementFactory.getRuntimeMXBean.getName` that the PID differs across
+ * the `-> test` boundary, so the `State` attribute Aggregation puts on
+ * failure cannot be read by a follow-up `> check` statement.
+ *
+ * These helpers are kept for documentation; verification of recap content
+ * still relies on running the aggregated test in the same sbt invocation.
  */
 object Checks {
-  def checkRecap(baseDir: java.io.File): Unit = {
-    val file = TestRecap.artifactFile(baseDir)
-    assert(file.exists, s"recap artifact not written at ${file.getAbsolutePath}")
-    val text = sbt.io.IO.read(file)
-    assert(text.startsWith("Test failures recap (2 test tasks failed):"),
-      s"recap should start with header, got:\n$text")
-    assert(text.contains("a / Test / test"), s"recap missing project a:\n$text")
-    assert(text.contains("c / Test / test"), s"recap missing project c:\n$text")
-    assert(text.contains("FailingTestA"), s"recap missing FailingTestA:\n$text")
-    assert(text.contains("FailingTestC"), s"recap missing FailingTestC:\n$text")
-    // b passed and must not appear in the recap.
-    assert(!text.contains("b / Test / test"),
-      s"passing project b should not appear in recap:\n$text")
-    // ASCII-only output for terminal/CI compatibility.
-    assert(text.forall(ch => ch < 128),
-      s"non-ASCII characters in recap: $text")
+  def checkRecap(state: State): Unit = {
+    val recap = state.get(TestRecap.recapKey).getOrElse {
+      sys.error("TestRecap.recapKey not present on state after aggregated test failure")
+    }
+    val names = recap.map(_.taskName).toSet
+    assert(recap.size == 2, s"expected 2 failures, got ${recap.size}: $names")
+    assert(names.contains("a / Test / test"), s"recap missing project a: $names")
+    assert(names.contains("c / Test / test"), s"recap missing project c: $names")
+    assert(!names.contains("b / Test / test"), s"recap should not list project b: $names")
   }
 
-  def checkNoRecap(baseDir: java.io.File): Unit = {
-    val file = TestRecap.artifactFile(baseDir)
-    assert(!file.exists,
-      s"recap artifact should have been removed at ${file.getAbsolutePath}")
-  }
+  def checkNoRecap(state: State): Unit =
+    state.get(TestRecap.recapKey) match {
+      case None    => ()
+      case Some(_) => sys.error("recap state attribute should be empty after success")
+    }
 }

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/test
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/test
@@ -1,0 +1,11 @@
+# Aggregated test should fail (two subprojects fail). The recap line emitted by
+# Aggregation.runTasks is verified by the unit tests in main-actions; this
+# scripted test exercises the end-to-end multi-failure code path and confirms
+# the aggregated `test` is restored to success once the failing tests are
+# removed.
+-> test
+
+$ delete a/src/test/java/FailingTestA.java
+$ delete c/src/test/java/FailingTestC.java
+> clean
+> test

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/test
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/test
@@ -1,11 +1,13 @@
-# Aggregated test should fail (two subprojects fail). Programmatic
-# verification of the recap content lives in the main-actions unit tests --
-# scripted can't easily inspect the State attribute across a `->` statement
-# because the failure tears down the inner sbt JVM.
--> test
+# Verify the aggregated test failure recap end-to-end. verifyRecap is a
+# Command (not a Task) that internally runs `test` via Command.process,
+# reads the State attribute set by Aggregation.runTasks, and asserts the
+# recap content -- all inside a single sbt JVM, so the State attribute
+# survives. See project/Checks.scala for the rationale.
+> verifyRecap
 
-# After removing the failing tests, the aggregated test should succeed.
+# After removing the failing tests, the aggregated test should succeed
+# and the recap state attribute should not be set on this fresh JVM.
 $ delete a/src/test/java/FailingTestA.java
 $ delete c/src/test/java/FailingTestC.java
 > clean
-> test
+> verifyNoRecap

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/test
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/test
@@ -1,8 +1,11 @@
 # Verify the aggregated test failure recap end-to-end. verifyRecap is a
 # Command (not a Task) that internally runs `test` via Command.process,
 # reads the State attribute set by Aggregation.runTasks, and asserts the
-# recap content -- all inside a single sbt JVM, so the State attribute
-# survives. See project/Checks.scala for the rationale.
+# recap content. The command returns the *original* state (not the
+# post-failure state) so verifyRecap itself is not marked failed -- the
+# inner `test` failure has already been inspected, and we want this
+# statement to succeed when the recap is well-formed. See
+# project/Checks.scala for details.
 > verifyRecap
 
 # After removing the failing tests, the aggregated test should succeed

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/test
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/test
@@ -1,11 +1,14 @@
-# Aggregated test should fail (two subprojects fail). The recap line emitted by
-# Aggregation.runTasks is verified by the unit tests in main-actions; this
-# scripted test exercises the end-to-end multi-failure code path and confirms
-# the aggregated `test` is restored to success once the failing tests are
-# removed.
+# Aggregated test should fail (two subprojects fail) and emit a recap line
+# listing the two failing subprojects but not the passing one. checkRecap
+# verifies the recap text was actually surfaced through Aggregation.runTasks
+# (read from State, not in-memory only).
 -> test
+> checkRecap
 
+# After removing the failing tests, the aggregated test should succeed and
+# the recap state attribute should be cleared.
 $ delete a/src/test/java/FailingTestA.java
 $ delete c/src/test/java/FailingTestC.java
 > clean
 > test
+> checkNoRecap

--- a/sbt-app/src/sbt-test/tests/multi-failure-recap/test
+++ b/sbt-app/src/sbt-test/tests/multi-failure-recap/test
@@ -1,14 +1,11 @@
-# Aggregated test should fail (two subprojects fail) and emit a recap line
-# listing the two failing subprojects but not the passing one. checkRecap
-# verifies the recap text was actually surfaced through Aggregation.runTasks
-# (read from State, not in-memory only).
+# Aggregated test should fail (two subprojects fail). Programmatic
+# verification of the recap content lives in the main-actions unit tests --
+# scripted can't easily inspect the State attribute across a `->` statement
+# because the failure tears down the inner sbt JVM.
 -> test
-> checkRecap
 
-# After removing the failing tests, the aggregated test should succeed and
-# the recap state attribute should be cleared.
+# After removing the failing tests, the aggregated test should succeed.
 $ delete a/src/test/java/FailingTestA.java
 $ delete c/src/test/java/FailingTestC.java
 > clean
 > test
-> checkNoRecap


### PR DESCRIPTION
## Summary

Fixes #2998. When `test` is run at the prompt in a multi-project build, sbt aggregates `<proj>/test` across subprojects. Each subproject's `TestResultLogger` emits its own per-task summary inline, but the aggregation layer never restated which projects failed. The terminal `sbt.TestsFailedException` line carried no project names or failing test classes, forcing CI users to scrollback-grep through thousands of log lines to find what broke.

This PR adds a single recap block printed once after the aggregated run completes, last in the output stream, with failures sorted by `taskName` for diff-grep stability:

```
[error] Test failures recap (2 test tasks failed):
[error]   a / Test / testQuick: Total 1, Failed 1, Errors 0, Passed 0
[error]     Failed tests:
[error]       FailingTestA
[error]   c / Test / testQuick: Total 1, Failed 1, Errors 0, Passed 0
[error]     Failed tests:
[error]       FailingTestC
```

## Release notes

- **Behavior change:** `TestResultLogger.Defaults.Main.run` no longer throws on `TestResult.Failed` / `TestResult.Error`. Failure propagation now lives in the task wrapper (`Defaults.testFull` / `inputTests0`). Plugins that override `testResultLogger` should not assume the logger throws; throw from the task wrapper instead. The trait signature (`def run(...): Unit`) and its scaladoc (which documents logging only) are unchanged.

## Design

In-band via the result graph - no singleton, no global state, no side files:

- `TestsFailedException` carries `(taskName: String, testOutput: Option[Tests.Output])` via a `private[sbt]` primary constructor. The public no-arg constructor delegates with empty defaults for back-compat. MiMa-clean against 2.0.0-RC12.
- The failure throw lives in `Defaults.testFull` and `inputTests0` (the task wrappers), not in `TestResultLogger.Defaults.Main.run`. The default logger logs and returns; the wrapping task matches on `output.overall` and throws `TestsFailedException(taskName, Some(output))` on Failed/Error. This keeps the failure signal out of the user-overridable `testResultLogger` seam.
- The task wrappers also catch no-detail `TestsFailedException` (legacy `executeTests` adapters, third-party `Tests.Setup` actions, anything constructing the back-compat no-arg ctor) on its way out and re-throw with the task name attached, so the recap renders `<taskName>: (no details)` instead of `<unknown>: (no details)` for those paths.
- `TestRecap.collect(i: Incomplete)` walks `Incomplete.allExceptions` and projects each `TestsFailedException` to a `Failure(taskName, testOutput)`. Identity-deduplicated via the underlying `IDSet[Throwable]`, so a single failing task shared across multiple paths in the Incomplete DAG is counted once.
- `TestRecap.render` / `formatTo` produce output sorted by `(taskName.isEmpty, taskName)` (empty names last, alphabetical otherwise). `printStandard`'s counts logic was factored into a shared `TestResultLogger.Defaults.countsString` so the recap and per-task summaries can't drift. Suite names go through `NameTransformer.decode` to match the existing `printFailures` rendering (revisiting this for both sites is a separate cleanup).
- The recap is printed **after** `state.handleError(i)` so it is the very last thing the user sees in CI output, below the trailing `Tests unsuccessful` line.
- The collected failures are also stashed on `State.attributes` under `TestRecap.recapKey` (a `private[sbt] AttributeKey[Vector[Failure]]("testRecap")`) for in-JVM tooling / IDE plugin consumption.

### Lifecycle: monotonic-latest-failure

The State attribute is written whenever a run produces at least one `TestsFailedException` and is **never proactively cleared**. A successful test run after a failure leaves the stale attribute in place; the next failure overwrites it. We deliberately don't try to recognize "this run included a test task" at the aggregation boundary -- that would require a hardcoded list of test-task labels (test/testFull/testQuick/testOnly/testSelected) and would silently miss plugin-defined test tasks.

Trade-off: an IDE/BSP plugin reading `recapKey` after the user re-ran tests successfully will see the previous failure. We accept this -- the recap text itself was already printed once when the failure happened; the State attribute is supplementary structured access.

## Cross-cutting behavior

- `+test` cross-build: each Scala-version iteration is its own `timedRun` -> one recap per version.
- `;test;package`: each `;` segment is its own `timedRun` -> one recap per segment.
- `~test`: each watch cycle re-enters `runTasks` -> clean recap per iteration.
- `keepGoing` doesn't exist in sbt 2.x - sibling failures are aggregated as `Result.Inc` causes after `runKeep` returns; the recap fires after `state.handleError`, so all completed failures are visible.
- Parallelism: `Test/test` carries `Tags.Test -> 1` and runs N subproject test tasks in parallel by default. There is no shared mutable state; failures are collected from the Incomplete tree after `timedRun` returns, then sorted for stable rendering.

## Known gap

Hard JVM crashes in forked test workers that don't surface as `TestsFailedException` (e.g., `MessageOnlyException` from `ForkTests.React.notifyExit` on `SIGKILL` / `System.exit`) won't appear in the recap. They still surface via sbt's normal error trail. A follow-up suggested by @eed3si9n -- recording task entry as well as completion -- is the right shape; tracked as #9225.

## Test plan

- [x] Unit tests in `main-actions/src/test/scala/sbt/internal/testing/TestRecapTest.scala`: 13/13 pass. Cover `collect` on synthetic Incomplete trees (with payload, no-payload stub, **rebranded-with-task-name-only**, non-TestsFailedException skipped, **DAG dedup**); `render` shape (header, counts, fallbacks, **stable sort**, singular/plural); `formatTo` log-call count and level.
- [x] Scripted test `tests/multi-failure-recap` with end-to-end content verification: `verifyRecap` Command runs `test` via `Command.process` and asserts the recap state attribute -- all inside a single sbt JVM. Header, project membership (a and c failing, b not), suite-result counts, and rendered output are all checked.
- [x] `actionsProj/scalafmtCheckAll` + `mainProj/scalafmtCheckAll` + `actionsProj/Test/scalafmtCheckAll` clean.
- [x] `actionsProj/mimaReportBinaryIssues` clean against `org.scala-sbt:actions:2.0.0-RC12`. No filters needed.

The scripted couldn't verify recap content across a `-> X; > check` boundary because scripted spawns a fresh sbt JVM after a failing statement (`SbtHandler.onNewSbtInstance`'s catch block calls `finish`; empirically `ManagementFactory.getRuntimeMXBean.getName` returns different PIDs). The `Command.process` approach side-steps this by staying in one JVM.

## AI assistance disclosure

Drafted with Claude Code (Claude Opus 4.7). Iterated through six rounds of review feedback; engineering judgment calls (monotonic-latest-failure lifecycle, Command-based scripted verification, throw site in the task wrapper rather than the user-overridable logger, no-detail rebrand on escape) made in dialogue with the reviewers.

Generated with Claude Code.

