### PR TITLE
[2.x] fix: Invalidate on JDK version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -780,7 +780,8 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.Resolvers.uniqueSubdirectoryFor"),
       exclude[DirectMissingMethodProblem]("sbt.Resolvers.run"),
       exclude[MissingClassProblem]("sbt.Resolvers$DistributedVCS"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.ClassStamper.stampVf")
+      exclude[DirectMissingMethodProblem]("sbt.internal.ClassStamper.stampVf"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.CompileInputs2.*"),
     ),
   )
   .dependsOn(lmCore, lmCoursierShadedPublishing)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2387,13 +2387,15 @@ object Defaults extends BuildCommon with DefExtra {
         val cp0 = classpathTask.value
         val inputs = compileInputs.value
         val c = fileConverter.value
+        val incrementalOptions = extraIncOptions.value.toVector
         CompileInputs2(
           data(cp0).toVector,
           sourcesVF.value,
           scalacOptions.value.toVector,
           javacOptions.value.toVector,
           c.toVirtualFile(inputs.options.classesDirectory),
-          c.toVirtualFile(inputs.setup.cacheFile.toPath)
+          c.toVirtualFile(inputs.setup.cacheFile.toPath),
+          incrementalOptions,
         )
       },
       bspCompileTask :=

--- a/main/src/main/scala/sbt/internal/CompileInputs2.scala
+++ b/main/src/main/scala/sbt/internal/CompileInputs2.scala
@@ -11,7 +11,8 @@ case class CompileInputs2(
     scalacOptions: Vector[String],
     javacOptions: Vector[String],
     outputPath: VirtualFileRef,
-    cachePath: VirtualFileRef
+    cachePath: VirtualFileRef,
+    incrementalOptions: Vector[(String, String)],
 )
 
 object CompileInputs2:
@@ -20,7 +21,7 @@ object CompileInputs2:
   given IsoLList.Aux[
     CompileInputs2,
     Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
-      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: LNil
+      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*: LNil
   ] =
     LList.iso(
       { (v: CompileInputs2) =>
@@ -30,18 +31,21 @@ object CompileInputs2:
           ("javacOptions", v.javacOptions) :*:
           ("outputPath", v.outputPath) :*:
           ("cachePath", v.cachePath) :*:
+          ("incrementalOptions", v.incrementalOptions) :*:
           LNil
       },
       {
         (in: Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
-          Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: LNil) =>
+          Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*:
+          LNil) =>
           CompileInputs2(
             in.head,
             in.tail.head,
             in.tail.tail.head,
             in.tail.tail.tail.head,
             in.tail.tail.tail.tail.head,
-            in.tail.tail.tail.tail.tail.head
+            in.tail.tail.tail.tail.tail.head,
+            in.tail.tail.tail.tail.tail.tail.head,
           )
       }
     )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9201
Fixes https://github.com/sbt/sbt/issues/9202

## Problem
sbt 2.x caching doesn't invalidate on JDK version.

## Solution
Invalidate on JDK version.