### PR TITLE
[2.0.x] bport: Invalidate on JDK version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -745,7 +745,8 @@ lazy val mainProj = (project in file("main"))
     Compile / doc / sources := Nil,
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
-      exclude[DirectMissingMethodProblem]("sbt.internal.ClassStamper.stampVf")
+      exclude[DirectMissingMethodProblem]("sbt.internal.ClassStamper.stampVf"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.CompileInputs2.*"),
     ),
   )
   .dependsOn(lmCore, lmIvy, lmCoursierShadedPublishing)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2422,13 +2422,15 @@ object Defaults extends BuildCommon {
         val cp0 = classpathTask.value
         val inputs = compileInputs.value
         val c = fileConverter.value
+        val incrementalOptions = extraIncOptions.value.toVector
         CompileInputs2(
           data(cp0).toVector,
           sourcesVF.value,
           scalacOptions.value.toVector,
           javacOptions.value.toVector,
           c.toVirtualFile(inputs.options.classesDirectory),
-          c.toVirtualFile(inputs.setup.cacheFile.toPath)
+          c.toVirtualFile(inputs.setup.cacheFile.toPath),
+          incrementalOptions,
         )
       },
       bspCompileTask :=

--- a/main/src/main/scala/sbt/internal/CompileInputs2.scala
+++ b/main/src/main/scala/sbt/internal/CompileInputs2.scala
@@ -11,7 +11,8 @@ case class CompileInputs2(
     scalacOptions: Vector[String],
     javacOptions: Vector[String],
     outputPath: VirtualFileRef,
-    cachePath: VirtualFileRef
+    cachePath: VirtualFileRef,
+    incrementalOptions: Vector[(String, String)],
 )
 
 object CompileInputs2:
@@ -20,7 +21,7 @@ object CompileInputs2:
   given IsoLList.Aux[
     CompileInputs2,
     Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
-      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: LNil
+      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*: LNil
   ] =
     LList.iso(
       { (v: CompileInputs2) =>
@@ -30,18 +31,21 @@ object CompileInputs2:
           ("javacOptions", v.javacOptions) :*:
           ("outputPath", v.outputPath) :*:
           ("cachePath", v.cachePath) :*:
+          ("incrementalOptions", v.incrementalOptions) :*:
           LNil
       },
       {
         (in: Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
-          Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: LNil) =>
+          Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*:
+          LNil) =>
           CompileInputs2(
             in.head,
             in.tail.head,
             in.tail.tail.head,
             in.tail.tail.tail.head,
             in.tail.tail.tail.tail.head,
-            in.tail.tail.tail.tail.tail.head
+            in.tail.tail.tail.tail.tail.head,
+            in.tail.tail.tail.tail.tail.tail.head,
           )
       }
     )


### PR DESCRIPTION
This is a 2.0.x backport of #9216

## Problem
sbt 2.x caching doesn't invalidate on JDK version.

## Solution
Invalidate on JDK version.