### PR TITLE
[1.x] fix: Pump forked stdout/stderr through System.out/err in interactive mode

### DIFF
--- a/run/src/main/scala/sbt/Fork.scala
+++ b/run/src/main/scala/sbt/Fork.scala
@@ -8,12 +8,11 @@
 
 package sbt
 
-import java.io.File
-import java.io.PrintWriter
+import java.io.{ File, IOException, InputStream, OutputStream, PrintWriter }
 import java.lang.ProcessBuilder.Redirect
 import scala.sys.process.Process
 import OutputStrategy._
-import sbt.internal.util.{ RunningProcesses, Util }
+import sbt.internal.util.{ RunningProcesses, Terminal, Util }
 import Util.{ AnyOps, none }
 
 import java.lang.{ ProcessBuilder => JProcessBuilder, Process => JProcess }
@@ -214,14 +213,24 @@ object Fork {
     val environment: List[(String, String)] = env.toList ++ extraEnv
     workingDirectory.foreach(jpb.directory(_))
     environment.foreach { case (k, v) => jpb.environment.put(k, v) }
-    jpb.inheritIO()
+    // Inherit stdin for REPL/raw-mode keystrokes. Stdout/stderr stay PIPE so
+    // `blockJForExitCode` can pump them to the active terminal directly.
+    jpb.redirectInput(Redirect.INHERIT)
     jpb.start()
   }
 
   private[sbt] def blockJForExitCode(p: JProcess): Int = {
     RunningProcesses.add(p)
     try {
+      // Capture the active terminal's streams once on the task thread. The
+      // System.out/err proxy resolves `activeTerminal` at every write, so a
+      // concurrent terminal swap can route mid-pump bytes to the wrong client.
+      val active = Terminal.current
+      val outT = pumpStream(p.getInputStream, active.outputStream, "sbt-fork-stdout")
+      val errT = pumpStream(p.getErrorStream, active.errorStream, "sbt-fork-stderr")
       p.waitFor()
+      outT.join()
+      errT.join()
       p.exitValue()
     } finally {
       if (p.isAlive()) p.destroy()
@@ -236,5 +245,24 @@ object Fork {
       if (p.isAlive()) p.destroy()
       RunningProcesses.remove(p)
     }
+  }
+
+  private[sbt] def pumpStream(in: InputStream, out: OutputStream, name: String): Thread = {
+    val t = new Thread(name) {
+      setDaemon(true)
+      override def run(): Unit = {
+        val buf = new Array[Byte](4096)
+        try {
+          var n = in.read(buf)
+          while (n != -1) {
+            out.write(buf, 0, n)
+            out.flush()
+            n = in.read(buf)
+          }
+        } catch { case _: IOException => () }
+      }
+    }
+    t.start()
+    t
   }
 }

--- a/server-test/src/server-test/client/build.sbt
+++ b/server-test/src/server-test/client/build.sbt
@@ -7,3 +7,8 @@ TaskKey[Unit]("willFail") := { throw new Exception("failed") }
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 
 TaskKey[Unit]("fooBar") := { () }
+
+// Exercise the forked interactive code path (connectInput + StdoutOutput).
+run / fork := true
+run / connectInput := true
+run / outputStrategy := Some(StdoutOutput)

--- a/server-test/src/server-test/client/src/main/scala/A.scala
+++ b/server-test/src/server-test/client/src/main/scala/A.scala
@@ -1,3 +1,6 @@
 class A
 
-@main def hello() = println("Hello, World!")
+@main def hello() =
+  println("STDOUT_MARKER_9185")
+  Console.err.println("STDERR_MARKER_9185")
+  println("Hello, World!")

--- a/server-test/src/test/scala/testpkg/ClientTest.scala
+++ b/server-test/src/test/scala/testpkg/ClientTest.scala
@@ -157,4 +157,12 @@ object ClientTest extends AbstractServerTest {
   test("quote with semi") { _ =>
     assert(complete("\"compile; fooB") == Vector("compile; fooBar"))
   }
+  test("forked run with connectInput relays stdout to --client") { _ =>
+    val (exit, lines) = clientWithStdoutLines("run")
+    assert(exit == 0, s"non-zero exit; lines=${lines.mkString("\n")}")
+    assert(
+      lines.exists(_.contains("STDOUT_MARKER_9185")),
+      s"missing STDOUT_MARKER_9185 in: ${lines.mkString("\n")}"
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Since #8678 (sbt 1.12.2), `Fork.apply` has routed the `connectInput && outputStrategy == StdoutOutput` case through a new JProcess path that calls `jpb.inheritIO()`. `inheritIO` ties the child JVM's stdio to the sbt server JVM's OS-level fd 1/2, bypassing the `Terminal.withOut` `System.out`/`System.err` proxies. In server mode (which `sbt --client` uses), those proxies are how task output reaches the client terminal — so the child's stdout/stderr go nowhere observable to the client.

This forced scala/scala3 CI to downgrade from sbt 1.12.10 to 1.12.1 (scala/scala3#25995). mbovel's diagnosis in #9185 is the definitive analysis.

## Fix

Keep `redirectInput(Redirect.INHERIT)` so REPL/raw-mode keystrokes still reach the child (preserves what #8678 was for), but leave stdout/stderr as `PIPE` and pump them through `System.out`/`System.err` in two daemon threads. The proxies pick them up and relay to the active terminal.

Stdin direction is unchanged. The only thing the child loses vs `inheritIO` is direct ownership of fd 1/2 — programs that call `isatty(1)` will now see "not a tty". That was already the case for every non-interactive forked run before #8678 (via `scala.sys.process.Process`'s PIPE-backed stdio), so this isn't a new regression.

Fixes #9185.

## Test plan

- [x] New `ClientTest` case `forked run with connectInput relays stdout to --client`. Asserts `STDOUT_MARKER_9185` reaches the in-process `--client` stdout when running a forked main with `connectInput := true` + `outputStrategy := Some(StdoutOutput)`.
- [x] Confirmed the test **fails** on this branch *without* the `Fork.scala` change (client receives only sbt's `running (fork) hello` line) and **passes** with it.
- [x] All 11 `ClientTest` cases pass (10 pre-existing + 1 new).
- [x] `runProj/scalafmtCheckAll`, `serverTestProj/scalafmtCheckAll`, `runProj/mimaReportBinaryIssues` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)