### PR TITLE
[1.x] bport: Make custom-scala-org scripted test hermetic (#9260)

### DIFF
--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/A.scala
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/A.scala
@@ -1,1 +1,0 @@
-object A

--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/build.sbt
@@ -1,4 +1,43 @@
-ThisBuild / scalaOrganization := "io.github.scala-wasm"
-ThisBuild / scalaVersion := "3.8.3-RC1-wasm-bin-SNAPSHOT"
+// Regression test for sbt/sbt#8731: scalaOrganization must thread into the
+// compiler-bridge ModuleID instead of being hardcoded to org.scala-lang.
+// See sbt/sbt#9259 for why this is a settings-graph assertion rather than a
+// real cross-org compile.
 
-ThisBuild / resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
+ThisBuild / scalaOrganization := "io.example.testorg"
+ThisBuild / scalaVersion := "3.7.4"
+
+lazy val checkScala3 =
+  taskKey[Unit]("scalaOrganization threads into scala3-sbt-bridge for Scala 3")
+lazy val checkScala2 =
+  taskKey[Unit]("scalaOrganization threads into scala2-sbt-bridge for Scala 2.13.12+")
+
+lazy val root = (project in file("."))
+  .settings(
+    checkScala3 := {
+      val m = scalaCompilerBridgeSource.value
+      assert(
+        m.organization == "io.example.testorg",
+        s"expected organization io.example.testorg, got $m",
+      )
+      assert(
+        m.name == "scala3-sbt-bridge",
+        s"expected name scala3-sbt-bridge, got $m",
+      )
+    }
+  )
+
+lazy val s213 = (project in file("s213"))
+  .settings(
+    scalaVersion := "2.13.12",
+    checkScala2 := {
+      val m = scalaCompilerBridgeSource.value
+      assert(
+        m.organization == "io.example.testorg",
+        s"expected organization io.example.testorg, got $m",
+      )
+      assert(
+        m.name == "scala2-sbt-bridge",
+        s"expected name scala2-sbt-bridge, got $m",
+      )
+    },
+  )

--- a/sbt-app/src/sbt-test/dependency-management/custom-scala-org/test
+++ b/sbt-app/src/sbt-test/dependency-management/custom-scala-org/test
@@ -1,1 +1,2 @@
-> compile
+> checkScala3
+> s213/checkScala2


### PR DESCRIPTION
This is a 1.x backport of https://github.com/sbt/sbt/pull/9260

The original fixture pinned
  scalaOrganization := "io.github.scala-wasm"
  scalaVersion := "3.8.3-RC1-wasm-bin-SNAPSHOT"
and ran compile. The wasm fork never published a release of scala3-library_3 -- only a snapshot to Sonatype's central-snapshots repo, which has ~90-day retention. #8732 merged 2026-02-21; the snapshot was GC'd ~2026-05-22 and develop CI began failing deterministically.

Fixes #9259.