### PR TITLE
[2.x] fix: Parallelize dependency resolution when no progress bar is rendered

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/internal/ArtifactsRun.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/ArtifactsRun.scala
@@ -41,7 +41,10 @@ object ArtifactsRun {
     }
 
     Lock.maybeSynchronized(needsLock =
-      params.loggerOpt.nonEmpty || !RefreshLogger.defaultFallbackMode
+      Lock.progressBarActive(
+        hasCustomLogger = params.loggerOpt.nonEmpty,
+        fallbackMode = RefreshLogger.defaultFallbackMode
+      )
     ) {
       result(params, coursierLogger)
     }

--- a/lm-coursier/src/main/scala/lmcoursier/internal/Lock.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/Lock.scala
@@ -3,6 +3,14 @@ package lmcoursier.internal
 private[lmcoursier] object Lock {
   private val lock = new Object
 
+  /* The lock guards coursier's interactive progress bar (ProgressBarRefreshDisplay), the only thing
+   * here that cannot be driven from more than one module at a time. coursier renders it only when no
+   * custom cache logger is supplied and it is not in fallback mode; otherwise (a custom logger, or
+   * the line-based fallback display) modules can be resolved in parallel. A CacheLogger is already
+   * invoked concurrently within a single resolution, so it must be thread-safe regardless. */
+  def progressBarActive(hasCustomLogger: Boolean, fallbackMode: Boolean): Boolean =
+    !hasCustomLogger && !fallbackMode
+
   /* Progress bars require us to only work on one module at the time. Without those we can go faster */
   def maybeSynchronized[T](needsLock: Boolean)(f: => T): T =
     if (needsLock) lock.synchronized(f)

--- a/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
@@ -189,7 +189,10 @@ object ResolutionRun {
     SbtCoursierCache.default.resolutionOpt(params.resolutionKey).map(Right(_)).getOrElse {
       val resOrError =
         Lock.maybeSynchronized(needsLock =
-          params.loggerOpt.nonEmpty || !RefreshLogger.defaultFallbackMode
+          Lock.progressBarActive(
+            hasCustomLogger = params.loggerOpt.nonEmpty,
+            fallbackMode = RefreshLogger.defaultFallbackMode
+          )
         ) {
           val map = new mutable.HashMap[Configuration, Resolution]
           val either = params.orderedConfigs.foldLeft[Either[coursier.error.ResolutionError, Unit]](

--- a/lm-coursier/src/test/scala/lmcoursier/internal/LockSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/internal/LockSpec.scala
@@ -1,0 +1,23 @@
+package lmcoursier.internal
+
+import verify.*
+
+// progressBarActive decides whether resolution must be serialized. It is true only when coursier
+// renders its interactive progress bar (no custom logger and not in fallback mode) -- the one thing
+// that cannot be driven from more than one module at a time.
+object LockSpec extends BasicTestSuite:
+
+  test("a custom cache logger does not require the lock") {
+    assert(!Lock.progressBarActive(hasCustomLogger = true, fallbackMode = false))
+    assert(!Lock.progressBarActive(hasCustomLogger = true, fallbackMode = true))
+  }
+
+  test("the fallback (line-based) display does not require the lock") {
+    assert(!Lock.progressBarActive(hasCustomLogger = false, fallbackMode = true))
+  }
+
+  test("only the interactive progress bar requires the lock") {
+    assert(Lock.progressBarActive(hasCustomLogger = false, fallbackMode = false))
+  }
+
+end LockSpec

--- a/notes/2.0.0/parallel-dependency-resolution.md
+++ b/notes/2.0.0/parallel-dependency-resolution.md
@@ -1,0 +1,21 @@
+### `update` resolves modules in parallel
+
+Dependency resolution (`update`) no longer holds a process-global lock while
+coursier is *not* rendering its interactive progress bar -- that is, whenever a
+custom `csrLogger` is set, or coursier is in fallback display mode (the default
+under IntelliJ, CI, and any non-TTY environment, or with `COURSIER_PROGRESS=false`).
+
+Previously the lock was taken even for sbt's quiet default logger, so `update`
+processed one module at a time and its duration grew with the number of modules
+rather than the number of distinct artifacts. Large multi-module builds and
+IDE/CI re-imports could spend minutes serializing resolution.
+
+The lock is still held while coursier draws its live per-module progress bars in
+an interactive terminal, because that renderer is not safe to drive concurrently;
+to parallelize there as well, run with `COURSIER_PROGRESS=false`. Fully parallel
+resolution *with* live progress bars is tracked by [#5627][i5627].
+
+This addresses [#5508][i5508].
+
+[i5508]: https://github.com/sbt/sbt/issues/5508
+[i5627]: https://github.com/sbt/sbt/issues/5627


### PR DESCRIPTION
## Problem

`update` (dependency resolution) gets dramatically slower as the number of modules grows — wall-clock time scales with the *module count* rather than the number of distinct artifacts. The issue thread reports IntelliJ re-imports taking ~4 minutes and CI `update` taking 17–20 minutes on large multi-module builds. The long-known workaround, `COURSIER_PROGRESS=false`, cuts time 2–3× (see #5508).

## Root cause

`lmcoursier.internal.Lock.maybeSynchronized` wraps resolution and artifact fetching in a **process-global** monitor, so per-module `update` tasks that sbt would otherwise run in parallel are serialized. The guard was:

```scala
needsLock = params.loggerOpt.nonEmpty || !RefreshLogger.defaultFallbackMode
```

That lock's only purpose is to serialize coursier's interactive progress bar (`ProgressBarRefreshDisplay`), which lm-coursier creates **only** when no custom logger is supplied *and* coursier is not in fallback mode. The `loggerOpt.nonEmpty` clause therefore over-serialized the common non-interactive case: under IntelliJ, CI, and any non-TTY run, `useSuperShell` is off, so sbt supplies a quiet debug-only `CoursierLogger` (`loggerOpt.nonEmpty`) — no progress bar is rendered, yet the global lock was still taken. `COURSIER_PROGRESS=false` only relieved the interactive (no-logger) path, which is why parallelism never became the default.

## Fix

Narrow the predicate to reflect when a progress bar is actually rendered:

```scala
def progressBarActive(hasCustomLogger: Boolean, fallbackMode: Boolean): Boolean =
  !hasCustomLogger && !fallbackMode
```

Used in `ResolutionRun` and `ArtifactsRun`. Resolution and artifact fetching now run in parallel across modules unless coursier is genuinely drawing its interactive progress bar.

## Scope / what this does *not* do

Interactive terminals with live progress bars stay serialized, because `ProgressBarRefreshDisplay` is not safe to drive from multiple modules at once. Users wanting parallelism there keep `COURSIER_PROGRESS=false`. Fully parallel resolution *with* live per-module progress bars (rendering progress at the sbt task level) remains tracked by #5627.

## Why it's safe

- `SbtCoursierCache` is entirely `ConcurrentHashMap`-backed.
- A `CacheLogger` is already invoked concurrently from within a single resolution (parallel downloads), so loggers must be thread-safe regardless — cross-module concurrency imposes no new requirement.
- The `COURSIER_PROGRESS=false` parallel path has been exercised in production for years.
- In the test/CI context the locking decision is unchanged (no logger + fallback mode → no lock, before and after), so existing lm-coursier specs behave identically.

## Testing

- New `lmcoursier.internal.LockSpec` (Verify) pins `progressBarActive` across all four logger/fallback combinations.
- The behavioral effect (parallel vs. serial) is timing-based and too flaky to assert in CI, so the deterministic locking predicate is pinned instead; the issue thread documents the resulting 2–3× speedup via the equivalent `COURSIER_PROGRESS=false` path.

## Release note

Added `notes/2.0.0/parallel-dependency-resolution.md`.

Fixes #5508.

---

*Implemented with AI assistance (Claude Code); reviewed, formatted, and verified locally by me (scalafmt, compile, `LockSpec`, MiMa).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
