### PR TITLE
[2.x] fix: Report a missing input file clearly instead of an opaque SerializationException

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -369,7 +369,7 @@ lazy val utilCache = project
     // we generate JsonCodec only for actionresult.contra
     JsonCodecPlugin,
   )
-  .dependsOn(utilLogging)
+  .dependsOn(utilLogging, utilControl)
   .settings(
     testedBaseSettings,
     name := "Util Cache",

--- a/notes/2.0.0/missing-file-error.md
+++ b/notes/2.0.0/missing-file-error.md
@@ -1,0 +1,17 @@
+### Clearer error when a referenced file does not exist
+
+If a file added to a task's inputs/outputs (e.g. `Compile / resources += file("nope.txt")`)
+does not exist, tasks such as `package` previously failed while hashing the task's cache
+key with an opaque `sjsonnew.SerializationException` that dumped the entire input list, with
+the real cause (`NoSuchFileException`) buried several `Caused by:` levels down. This was
+routinely mistaken for a corrupt cache.
+
+sbt now reports the missing file directly:
+
+```
+[error] file referenced by the build does not exist: nope.txt
+```
+
+This addresses [#9217][i9217].
+
+[i9217]: https://github.com/sbt/sbt/issues/9217

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -10,10 +10,18 @@ package sbt.util
 
 import java.io.{ File, IOException, PrintWriter }
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ AtomicMoveNotSupportedException, Files, Path, Paths, StandardCopyOption }
+import java.nio.file.{
+  AtomicMoveNotSupportedException,
+  Files,
+  NoSuchFileException,
+  Path,
+  Paths,
+  StandardCopyOption
+}
 import sbt.internal.util.{
   ActionCacheEvent,
   CacheEventLog,
+  MessageOnlyException,
   SpawnExec,
   SpawnInput,
   StringVirtualFile1
@@ -295,16 +303,33 @@ object ActionCache:
       extraHash: Digest,
       cacheVersion: Long,
   ): Digest =
+    // Hashing serializes every task input; surface a missing input file directly rather than as an
+    // opaque serialization failure that buries it.
+    val inputHash =
+      try Hasher.hashUnsafe[I](key)
+      catch
+        case NonFatal(t) =>
+          findMissingFile(t) match
+            case Some(path) =>
+              throw MessageOnlyException(s"file referenced by the build does not exist: $path")
+            case None => throw t
     Digest.sha256Hash(
       (Vector(
         codeContentHash,
-        Digest.dummy(Hasher.hashUnsafe[I](key)),
+        Digest.dummy(inputHash),
         extraHash
       ) ++ {
         if cacheVersion == 0 then Vector.empty
         else Vector(Digest.dummy(cacheVersion))
       })*
     )
+
+  /** Walks `t`'s cause chain for a `NoSuchFileException`, returning the missing file's path. */
+  private[sbt] def findMissingFile(t: Throwable): Option[String] =
+    t match
+      case null                   => None
+      case e: NoSuchFileException => Option(e.getFile)
+      case _                      => findMissingFile(t.getCause)
 
   private inline def mkValuePath(inputDigest: Digest): String =
     s"$${OUT}/value/${inputDigest}.json"

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -2,7 +2,7 @@ package sbt.util
 
 import java.io.{ IOException, InputStream }
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
 import java.util.Optional
 import java.util.concurrent.{ CyclicBarrier, ExecutorService, Executors, TimeUnit }
 
@@ -26,6 +26,20 @@ import ActionCache.InternalActionResult
 
 object ActionCacheTest extends BasicTestSuite:
   val tags = CacheLevelTag.all.toList
+
+  test("findMissingFile extracts the path from a wrapped NoSuchFileException"):
+    val chain = new RuntimeException(
+      "error while writing LList",
+      new RuntimeException(
+        "error while writing the field sources",
+        new NoSuchFileException("not-exists.txt")
+      )
+    )
+    assert(ActionCache.findMissingFile(chain) == Some("not-exists.txt"))
+
+  test("findMissingFile returns None when no file is missing"):
+    val chain = new RuntimeException("boom", new IllegalStateException("unrelated"))
+    assert(ActionCache.findMissingFile(chain) == None)
 
   test("Disk cache can hold a blob"):
     withDiskCache(testHoldBlob)


### PR DESCRIPTION
## Problem

When a file referenced by a task's inputs/outputs does not exist, the build fails while hashing the task's cache key with an opaque `sjsonnew.SerializationException` that dumps the entire input list, with the real cause buried several `Caused by:` levels down. Users routinely mistake this for a corrupt cache (see #9217, and the sibling report #9206).

Repro:
```scala
// build.sbt
Compile / resources += file("not-exists.txt")
```
`sbt packageSrc` previously produced a ~100-line `SerializationException` whose message dumped the whole `LList`, ending in a buried `Caused by: java.nio.file.NoSuchFileException: not-exists.txt`.

## Fix

`ActionCache.mkInput` (the single chokepoint where the input key is hashed) now catches the hashing failure, detects a `NoSuchFileException` anywhere in the cause chain (`ActionCache.findMissingFile`), and throws a `MessageOnlyException` naming the file. After:

```
[error] file referenced by the build does not exist: not-exists.txt
[error] (Compile / packageSrc / packageConfiguration) file referenced by the build does not exist: not-exists.txt
```

`MessageOnlyException` is sbt's standard "user error, no stack trace" exception; surfacing it requires a dependency from `util-cache` on `util-control` (a leaf module, no cycle).

## Scope

This is the error-message fix only. The deeper behavioral question (re-running a source generator / invalidating a stale cache when a declared output goes missing) is tracked separately in #9206 and intentionally not addressed here.

## Performance

The added `try/catch` wraps the input-hashing path (`mkInput`), but it is zero-cost on the happy path — the JVM only pays when an exception is thrown, and `findMissingFile` runs solely on the (already-aborting) failure path. Successful hashing does the same work as before; `hashUnsafe` itself is unchanged.

## Testing

- Unit test (`ActionCacheTest`, Verify) on `findMissingFile`, covering a deeply-wrapped `NoSuchFileException` and the no-missing-file case. This is the deterministic guard for the cause-detection logic.
- End-to-end verified by hand with the repro above (output shown). A committed scripted assertion isn't practical here: the error is *thrown* (not logged to a task's streams), so it isn't readable by the scripted DSL, and a bare `-> packageSrc` would pass with or without the fix.

## Release note

Added `notes/2.0.0/missing-file-error.md`.

Fixes #9217.

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by me (compile, `ActionCacheTest`, MiMa, end-to-end scripted repro).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
