### PR TITLE
[2.0.x] bport: Fix duplicate autoplugins packageBin mappings

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1722,10 +1722,18 @@ object Defaults extends BuildCommon {
   def packageBinMappings: Initialize[Task[Seq[(HashedVirtualFileRef, String)]]] =
     Def.task {
       val converter = fileConverter.value
+      val classDirPath = classDirectory.value.toPath.toAbsolutePath.normalize
       val xs = products.value
-      xs
+      val allMappings = xs
         .flatMap(Path.allSubpaths)
-        .withFilter(_._1.isFile())
+        .filter(_._1.isFile())
+      val resourcePaths = allMappings.collect {
+        case (p, path) if !p.toPath.toAbsolutePath.normalize.startsWith(classDirPath) => path
+      }.toSet
+      allMappings
+        .filterNot { (p, path) =>
+          resourcePaths(path) && p.toPath.toAbsolutePath.normalize.startsWith(classDirPath)
+        }
         .map { (p, path) =>
           val vf = converter.toVirtualFile(p.toPath())
           (vf: HashedVirtualFileRef) -> path

--- a/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/build.sbt
@@ -1,0 +1,4 @@
+ThisBuild / organization := "com.example"
+ThisBuild / version      := "0.1.0-SNAPSHOT"
+
+val `scalac-options` = project.enablePlugins(SbtPlugin)

--- a/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/scalac-options/src/main/scala/example/ScalacOptionsPlugin.scala
+++ b/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/scalac-options/src/main/scala/example/ScalacOptionsPlugin.scala
@@ -1,0 +1,5 @@
+package example
+
+import sbt.*
+
+object ScalacOptionsPlugin extends AutoPlugin

--- a/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/test
+++ b/sbt-app/src/sbt-test/plugins/duplicate-autoplugins-packagebin/test
@@ -1,0 +1,3 @@
+> scalac-options / Compile / packageBin
+> scalac-options / Compile / copyResources
+> scalac-options / Compile / packageBin


### PR DESCRIPTION
This is a 2.0.x backport of #9255

Deduplicate executable jar package entries. In the issue, the duplicate was something like:

(resource_managed/.../sbt/sbt.autoplugins, "sbt/sbt.autoplugins")
(classes/.../sbt/sbt.autoplugins,          "sbt/sbt.autoplugins")

This is because copyResources copied autoplugin metadata to the classes directory.

Solution: when composing the packageBinMappings, differentiate between artifacts that come from class directory and from outside of it. If there is a duplicate, prefer resource that comes from outside of it.