### PR TITLE
[2.0.x] Zinc 2.0.0-M19 + Opt bspBuildTargetOutputPathsItem out of caching

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -331,7 +331,6 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     )
 
   testOutput("sbt --experimental_execution_log=true")("--experimental_execution_log=true", "-v"):
-    (out: List[String]) =>
-      assert(out.contains[String]("-Dsbt.experimental_execution_log=true"))
+    (out: List[String]) => assert(out.contains[String]("-Dsbt.experimental_execution_log=true"))
 
 end RunnerScriptTest

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -483,6 +483,7 @@ object Keys {
   val bspBuildTargetDependencySources = inputKey[Unit]("").withRank(DTask)
   val bspBuildTargetDependencySourcesItem = taskKey[DependencySourcesItem]("").withRank(DTask)
   val bspBuildTargetOutputPaths = inputKey[Unit]("").withRank(DTask)
+  @transient
   val bspBuildTargetOutputPathsItem = taskKey[OutputPathsItem]("").withRank(DTask)
   val bspBuildTargetCompile = inputKey[Unit]("").withRank(DTask)
   val bspBuildTargetCompileItem = taskKey[Int]("").withRank(DTask)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
 
   // sbt modules
   val ioVersion = nightlyVersion.getOrElse("1.12.0")
-  val zincVersion = nightlyVersion.getOrElse("2.0.0-M18")
+  val zincVersion = nightlyVersion.getOrElse("2.0.0-M19")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/update-sbt-classifiers/build.sbt
@@ -41,7 +41,6 @@ lazy val root = (project in file("."))
         "junit:junit",
         "net.java.dev.jna:jna",
         "net.java.dev.jna:jna-platform",
-        "net.openhft:zero-allocation-hashing",
         "org.checkerframework:checker-qual",
         "org.fusesource.jansi:jansi",
         "org.hamcrest:hamcrest-core",

--- a/sbt-app/src/sbt-test/server/bsp-output-paths-cache/build.sbt
+++ b/sbt-app/src/sbt-test/server/bsp-output-paths-cache/build.sbt
@@ -1,0 +1,30 @@
+import sbt.internal.bsp.OutputPathsItem
+
+ThisBuild / scalaVersion := "3.8.2"
+
+name := "bsp-output-paths-cache"
+
+Compile / target := baseDirectory.value / "target-a"
+
+@transient
+lazy val checkProjectA = taskKey[Unit]("")
+
+@transient
+lazy val checkProjectB = taskKey[Unit]("")
+
+def checkOutputPath(item: OutputPathsItem, expectedSegment: String): Unit = {
+  val actual = item.outputPaths.map(_.uri.toString).mkString("\n")
+  if (!actual.contains(expectedSegment)) {
+    sys.error(
+      s"stale bspBuildTargetOutputPathsItem: expected segment $expectedSegment in output paths, got: $actual"
+    )
+  }
+}
+
+checkProjectA := Def.uncached {
+  checkOutputPath((Compile / bspBuildTargetOutputPathsItem).value, "target-a")
+}
+
+checkProjectB := Def.uncached {
+  checkOutputPath((Compile / bspBuildTargetOutputPathsItem).value, "target-b")
+}

--- a/sbt-app/src/sbt-test/server/bsp-output-paths-cache/test
+++ b/sbt-app/src/sbt-test/server/bsp-output-paths-cache/test
@@ -1,0 +1,3 @@
+> checkProjectA
+> set Compile / target := baseDirectory.value / "target-b"
+> checkProjectB


### PR DESCRIPTION
This is a 2.0.x backport of https://github.com/sbt/sbt/pull/9272