### PR TITLE
[2.x] feat: Resolve dependencies in parallel under the super shell

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -727,6 +727,8 @@ object Keys {
   }
   private[sbt] val currentCommandProgress = AttributeKey[ExecuteProgress2]("current-command-progress")
   private[sbt] val taskProgress = AttributeKey[sbt.internal.TaskProgress]("active-task-progress")
+  private[sbt] val resolutionProgress =
+    AttributeKey[sbt.coursierint.ResolutionProgress]("resolution-progress", Invisible)
   val useSuperShell = settingKey[Boolean]("Enables (true) or disables the super shell.")
   val superShellMaxTasks = settingKey[Int]("The max number of tasks to display in the supershell progress report")
   val superShellSleep = settingKey[FiniteDuration]("The minimum duration to sleep between progress reports")

--- a/main/src/main/scala/sbt/MainLoop.scala
+++ b/main/src/main/scala/sbt/MainLoop.scala
@@ -168,11 +168,13 @@ private[sbt] object MainLoop:
       state.get(Keys.superShellSleep.key).getOrElse(SysProp.supershellSleep.millis)
     val superShellThreshold =
       state.get(Keys.superShellThreshold.key).getOrElse(SysProp.supershellThreshold)
+    val resolutionProgress = new sbt.coursierint.ResolutionProgress
     val taskProgress =
       new TaskProgress(
         superShellSleep,
         superShellThreshold,
         state.log,
+        resolutionProgress,
         Project.configNameToIdent(state)
       )
     val gcMonitor = if (SysProp.gcMonitor) Some(new sbt.internal.GCMonitor(state.log)) else None
@@ -181,6 +183,7 @@ private[sbt] object MainLoop:
         state
           .put(Keys.loggerContext, context)
           .put(Keys.taskProgress, taskProgress)
+          .put(Keys.resolutionProgress, resolutionProgress)
           .process(processCommand)
       } match {
         case Right(s)                  => s.remove(Keys.loggerContext)

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -255,7 +255,17 @@ object LMCoursier {
   def coursierLoggerTask: Def.Initialize[Task[Option[CacheLogger]]] = Def.task {
     val st = Keys.streams.value
     val progress = (ThisBuild / useSuperShell).value
-    if (progress) None
+    // Always supply a logger: this suppresses coursier's own per-module progress bar and lets
+    // resolution run in parallel across modules. Under the super shell we feed the per-command
+    // resolution-progress sink (rendered as one task-level line by TaskProgress); otherwise the
+    // quiet debug logger.
+    if (progress)
+      Some(
+        Keys.state.value
+          .get(Keys.resolutionProgress)
+          .map(new ResolutionProgressLogger(_))
+          .getOrElse(CacheLogger.nop)
+      )
     else Some(new CoursierLogger(st.log))
   }
 

--- a/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
+++ b/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
@@ -82,7 +82,7 @@ private[sbt] final class ResolutionProgress {
       val mib = bytes.get().toDouble / (1024.0 * 1024.0)
       val label = if (n == 1) "file" else "files"
       val elapsedMicros = math.max(0L, (System.nanoTime() - burstStartNanos.get()) / 1000L)
-      Some((f"Updating $n $label, $mib%.1f MiB", elapsedMicros))
+      Some((f"downloading $n $label, $mib%.1f MiB", elapsedMicros))
     }
 }
 

--- a/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
+++ b/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
@@ -18,21 +18,31 @@ import lmcoursier.definitions.CacheLogger
  *
  * One instance is created per command in `MainLoop.next` (held under `Keys.resolutionProgress`, the
  * same lifecycle as `Keys.taskProgress`). It is fed by [[ResolutionProgressLogger]] from coursier's
- * download-pool threads and read by `TaskProgress` to render a single super-shell line. Because
- * those callbacks run in parallel across modules, every field is atomic and byte accounting uses a
- * monotonic per-url delta and so can never go backwards. There is no cross-command reset: the
- * instance is born empty and discarded with the command.
+ * download-pool threads and read by `TaskProgress` to render a single super-shell line.
+ *
+ * The counting model matches how coursier actually drives a `CacheLogger`:
+ *   - `init`/`stop` arrive once per logger session — one per configuration resolution and one per
+ *     artifacts run, plus network retries — NOT once per module, so no module count is reported;
+ *     `inFlight` only controls when the line is visible.
+ *   - `foundLocally`/`downloadedArtifact` fire on every cache check, repeating the same url across
+ *     sessions and including checksum companions, so files are counted as distinct urls with
+ *     checksum/signature companions excluded.
+ *   - `downloadProgress` carries a cumulative per-url byte count; byte accounting takes a monotonic
+ *     per-url delta and so can never double-count or go backwards.
+ *
+ * There is no cross-command reset: the instance is born empty and discarded with the command.
  */
 private[sbt] final class ResolutionProgress {
   private val inFlight = new AtomicInteger(0)
-  private val modules = new AtomicInteger(0)
-  private val artifacts = new AtomicLong(0L)
+  private val burstStartNanos = new AtomicLong(System.nanoTime())
+  private val files = ConcurrentHashMap.newKeySet[String]
   private val bytes = new AtomicLong(0L)
   private val seen = new ConcurrentHashMap[String, java.lang.Long]
 
   def onInit(): Unit = {
-    inFlight.incrementAndGet()
-    modules.incrementAndGet()
+    val now = System.nanoTime()
+    // 0 -> 1 starts a new burst (e.g. the artifacts phase after an idle gap): restart the clock.
+    if (inFlight.getAndIncrement() == 0) burstStartNanos.set(now)
     ()
   }
 
@@ -41,8 +51,8 @@ private[sbt] final class ResolutionProgress {
     ()
   }
 
-  def onArtifact(): Unit = {
-    artifacts.incrementAndGet()
+  def onFile(url: String): Unit = {
+    if (!ResolutionProgress.isChecksumLike(url)) files.add(url)
     ()
   }
 
@@ -60,17 +70,30 @@ private[sbt] final class ResolutionProgress {
     ()
   }
 
-  /** A render string while at least one resolution is in flight, else None (the line disappears). */
-  def snapshot(): Option[String] =
+  /**
+   * While at least one resolution is in flight: the render line plus the elapsed micros of the
+   * current burst (the super shell appends elapsed to every item, so this renders as a live
+   * counter). Else None (the line disappears).
+   */
+  def snapshot(): Option[(String, Long)] =
     if (inFlight.get() <= 0) None
     else {
-      val m = modules.get()
-      val a = artifacts.get()
+      val n = files.size()
       val mib = bytes.get().toDouble / (1024.0 * 1024.0)
-      val mLabel = if (m == 1) "module" else "modules"
-      val aLabel = if (a == 1) "artifact" else "artifacts"
-      Some(f"Updating $m $mLabel, $a $aLabel, $mib%.1f MiB")
+      val label = if (n == 1) "file" else "files"
+      val elapsedMicros = math.max(0L, (System.nanoTime() - burstStartNanos.get()) / 1000L)
+      Some((f"Updating $n $label, $mib%.1f MiB", elapsedMicros))
     }
+}
+
+private[sbt] object ResolutionProgress {
+  // Checksum/signature companions go through the same cache callbacks as real files; counting
+  // them would roughly double the file count.
+  private val checksumLikeSuffixes = Seq(".sha1", ".sha256", ".sha512", ".md5", ".asc", ".sig")
+  private[coursierint] def isChecksumLike(url: String): Boolean = {
+    val lower = url.toLowerCase(java.util.Locale.ROOT)
+    checksumLikeSuffixes.exists(s => lower.endsWith(s))
+  }
 }
 
 /**
@@ -81,9 +104,9 @@ private[sbt] final class ResolutionProgress {
 private[sbt] final class ResolutionProgressLogger(sink: ResolutionProgress) extends CacheLogger {
   override def init(sizeHint: Option[Int]): Unit = sink.onInit()
   override def stop(): Unit = sink.onStop()
-  override def foundLocally(url: String): Unit = sink.onArtifact()
+  override def foundLocally(url: String): Unit = sink.onFile(url)
   override def downloadedArtifact(url: String, success: Boolean): Unit =
-    if (success) sink.onArtifact()
+    if (success) sink.onFile(url)
   override def downloadProgress(url: String, downloaded: Long): Unit =
     sink.onProgress(url, downloaded)
 }

--- a/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
+++ b/main/src/main/scala/sbt/coursierint/ResolutionProgress.scala
@@ -1,0 +1,89 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package coursierint
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
+import lmcoursier.definitions.CacheLogger
+
+/**
+ * Per-command running total of dependency-resolution progress.
+ *
+ * One instance is created per command in `MainLoop.next` (held under `Keys.resolutionProgress`, the
+ * same lifecycle as `Keys.taskProgress`). It is fed by [[ResolutionProgressLogger]] from coursier's
+ * download-pool threads and read by `TaskProgress` to render a single super-shell line. Because
+ * those callbacks run in parallel across modules, every field is atomic and byte accounting uses a
+ * monotonic per-url delta and so can never go backwards. There is no cross-command reset: the
+ * instance is born empty and discarded with the command.
+ */
+private[sbt] final class ResolutionProgress {
+  private val inFlight = new AtomicInteger(0)
+  private val modules = new AtomicInteger(0)
+  private val artifacts = new AtomicLong(0L)
+  private val bytes = new AtomicLong(0L)
+  private val seen = new ConcurrentHashMap[String, java.lang.Long]
+
+  def onInit(): Unit = {
+    inFlight.incrementAndGet()
+    modules.incrementAndGet()
+    ()
+  }
+
+  def onStop(): Unit = {
+    inFlight.updateAndGet(n => math.max(0, n - 1))
+    ()
+  }
+
+  def onArtifact(): Unit = {
+    artifacts.incrementAndGet()
+    ()
+  }
+
+  def onProgress(url: String, downloaded: Long): Unit = {
+    // compute keeps the read-compare-add atomic per url, so concurrent progress callbacks for the
+    // same url can neither double-count nor lose a byte delta; `seen` always holds the max seen.
+    seen.compute(
+      url,
+      (_: String, prev: java.lang.Long) => {
+        val p: Long = if (prev == null) 0L else prev.longValue
+        if (downloaded > p) bytes.addAndGet(downloaded - p)
+        java.lang.Long.valueOf(math.max(downloaded, p))
+      }
+    )
+    ()
+  }
+
+  /** A render string while at least one resolution is in flight, else None (the line disappears). */
+  def snapshot(): Option[String] =
+    if (inFlight.get() <= 0) None
+    else {
+      val m = modules.get()
+      val a = artifacts.get()
+      val mib = bytes.get().toDouble / (1024.0 * 1024.0)
+      val mLabel = if (m == 1) "module" else "modules"
+      val aLabel = if (a == 1) "artifact" else "artifacts"
+      Some(f"Updating $m $mLabel, $a $aLabel, $mib%.1f MiB")
+    }
+}
+
+/**
+ * A coursier `CacheLogger` that feeds a per-command [[ResolutionProgress]]. Supplying any logger to
+ * lm-coursier suppresses coursier's own per-module progress bar and lets resolution run in parallel
+ * across modules; the aggregate is rendered at the sbt task level instead.
+ */
+private[sbt] final class ResolutionProgressLogger(sink: ResolutionProgress) extends CacheLogger {
+  override def init(sizeHint: Option[Int]): Unit = sink.onInit()
+  override def stop(): Unit = sink.onStop()
+  override def foundLocally(url: String): Unit = sink.onArtifact()
+  override def downloadedArtifact(url: String, success: Boolean): Unit =
+    if (success) sink.onArtifact()
+  override def downloadProgress(url: String, downloaded: Long): Unit =
+    sink.onProgress(url, downloaded)
+}

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -18,6 +18,7 @@ import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.*
 import java.util.concurrent.{ ConcurrentHashMap, Executors, TimeoutException }
 import sbt.util.Logger
+import sbt.coursierint.ResolutionProgress
 
 /**
  * implements task progress display on the shell.
@@ -26,6 +27,7 @@ private[sbt] class TaskProgress(
     sleepDuration: FiniteDuration,
     threshold: FiniteDuration,
     logger: Logger,
+    resolutionProgress: ResolutionProgress,
     configNameToIdent: String => String = Scope.guessConfigIdent
 ) extends AbstractTaskExecuteProgress(configNameToIdent)
     with ExecuteProgress
@@ -180,6 +182,11 @@ private[sbt] class TaskProgress(
         toWrite.foreach { (task, elapsed) =>
           val name = taskName(task)
           distinct.put(name, ProgressItem(name, elapsed))
+        }
+        // Append one aggregate dependency-resolution line while `update` resolves in parallel,
+        // since coursier no longer renders its own per-module progress bars.
+        resolutionProgress.snapshot().foreach { line =>
+          distinct.put(line, ProgressItem(line, 0L))
         }
         ProgressEvent(
           "Info",

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -184,9 +184,10 @@ private[sbt] class TaskProgress(
           distinct.put(name, ProgressItem(name, elapsed))
         }
         // Append one aggregate dependency-resolution line while `update` resolves in parallel,
-        // since coursier no longer renders its own per-module progress bars.
-        resolutionProgress.snapshot().foreach { line =>
-          distinct.put(line, ProgressItem(line, 0L))
+        // since coursier no longer renders its own per-module progress bars. The burst elapsed
+        // renders as a live counter like any task's.
+        resolutionProgress.snapshot().foreach { (line, elapsed) =>
+          distinct.put(line, ProgressItem(line, elapsed))
         }
         ProgressEvent(
           "Info",

--- a/main/src/test/scala/sbt/coursierint/ResolutionProgressSpec.scala
+++ b/main/src/test/scala/sbt/coursierint/ResolutionProgressSpec.scala
@@ -17,7 +17,7 @@ object ResolutionProgressSpec extends BasicTestSuite:
     assert(p.snapshot().isEmpty)
   }
 
-  test("aggregates modules, artifacts, and monotonic bytes while resolving") {
+  test("aggregates distinct files and monotonic bytes while resolving") {
     val p = new ResolutionProgress
     val log = new ResolutionProgressLogger(p)
     log.init(None)
@@ -25,16 +25,49 @@ object ResolutionProgressSpec extends BasicTestSuite:
     log.downloadProgress("a.jar", 1000L)
     log.downloadProgress("a.jar", 4000L) // monotonic increase, total 4000
     log.downloadProgress("a.jar", 2000L) // out-of-order, must be ignored
-    log.foundLocally("b.jar") // counts as an artifact
-    log.downloadedArtifact("a.jar", success = true) // counts
+    log.foundLocally("b.jar")
+    log.downloadedArtifact("a.jar", success = true)
     log.downloadedArtifact("c.jar", success = false) // failed, must not count
-    val line = p.snapshot()
+    val line = p.snapshot().map(_._1)
     assert(line.isDefined, "expected a progress line while resolving")
-    assert(line.exists(_.contains("2 modules")), line.toString)
-    assert(line.exists(_.contains("2 artifacts")), line.toString)
+    assert(line.exists(_.contains("2 files")), line.toString)
     log.stop()
     log.stop()
     assert(p.snapshot().isEmpty)
+  }
+
+  test("per-configuration logger sessions do not inflate the file count") {
+    // coursier calls init/stop once per logger session — one per configuration resolution
+    // (compile, runtime, test, ...), plus retries — not once per module, and it re-checks the
+    // same urls in every session. Neither may inflate the count, and the line must not claim
+    // a module count it cannot know.
+    val p = new ResolutionProgress
+    val log = new ResolutionProgressLogger(p)
+    for (_ <- 1 to 3) { // e.g. compile, runtime, test sessions of one module's update
+      log.init(None)
+      log.foundLocally("x.pom")
+      log.foundLocally("x.jar")
+      log.stop()
+    }
+    log.init(None)
+    log.foundLocally("x.jar") // re-checked again in the artifacts run
+    val line = p.snapshot().map(_._1)
+    assert(line.exists(_.contains("2 files")), line.toString) // x.pom + x.jar, once each
+    assert(!line.exists(_.contains("module")), line.toString) // sessions are not modules
+    log.stop()
+  }
+
+  test("checksum and signature companions are not counted as files") {
+    val p = new ResolutionProgress
+    val log = new ResolutionProgressLogger(p)
+    log.init(None)
+    log.foundLocally("a.jar")
+    log.foundLocally("a.jar.sha1")
+    log.downloadedArtifact("a.jar.md5", success = true)
+    log.downloadedArtifact("a.pom.asc", success = true)
+    val line = p.snapshot().map(_._1)
+    assert(line.exists(_.contains("1 file,")), line.toString)
+    log.stop()
   }
 
   test("counts persist across the resolve and artifacts phases of one command") {
@@ -48,12 +81,17 @@ object ResolutionProgressSpec extends BasicTestSuite:
     // artifacts phase of the SAME command: counts accumulate, they do not reset
     log.init(None)
     log.downloadedArtifact("y.jar", success = true)
-    val line = p.snapshot()
-    assert(
-      line.exists(_.contains("2 modules")),
-      line.toString
-    ) // resolve + artifacts, not reset to 1
-    assert(line.exists(_.contains("2 artifacts")), line.toString) // x + y, not reset
+    val line = p.snapshot().map(_._1)
+    assert(line.exists(_.contains("2 files")), line.toString) // x + y, not reset
+    log.stop()
+  }
+
+  test("snapshot exposes a non-negative burst elapsed for the renderer") {
+    val p = new ResolutionProgress
+    val log = new ResolutionProgressLogger(p)
+    log.init(None)
+    val snap = p.snapshot()
+    assert(snap.exists(_._2 >= 0L), snap.toString)
     log.stop()
   }
 

--- a/main/src/test/scala/sbt/coursierint/ResolutionProgressSpec.scala
+++ b/main/src/test/scala/sbt/coursierint/ResolutionProgressSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.coursierint
+
+import verify.BasicTestSuite
+
+object ResolutionProgressSpec extends BasicTestSuite:
+
+  test("a fresh per-command instance starts with no line") {
+    val p = new ResolutionProgress
+    assert(p.snapshot().isEmpty)
+  }
+
+  test("aggregates modules, artifacts, and monotonic bytes while resolving") {
+    val p = new ResolutionProgress
+    val log = new ResolutionProgressLogger(p)
+    log.init(None)
+    log.init(None) // two resolutions in flight
+    log.downloadProgress("a.jar", 1000L)
+    log.downloadProgress("a.jar", 4000L) // monotonic increase, total 4000
+    log.downloadProgress("a.jar", 2000L) // out-of-order, must be ignored
+    log.foundLocally("b.jar") // counts as an artifact
+    log.downloadedArtifact("a.jar", success = true) // counts
+    log.downloadedArtifact("c.jar", success = false) // failed, must not count
+    val line = p.snapshot()
+    assert(line.isDefined, "expected a progress line while resolving")
+    assert(line.exists(_.contains("2 modules")), line.toString)
+    assert(line.exists(_.contains("2 artifacts")), line.toString)
+    log.stop()
+    log.stop()
+    assert(p.snapshot().isEmpty)
+  }
+
+  test("counts persist across the resolve and artifacts phases of one command") {
+    val p = new ResolutionProgress
+    val log = new ResolutionProgressLogger(p)
+    // resolve phase
+    log.init(None)
+    log.foundLocally("x.jar")
+    log.stop()
+    assert(p.snapshot().isEmpty) // idle between phases
+    // artifacts phase of the SAME command: counts accumulate, they do not reset
+    log.init(None)
+    log.downloadedArtifact("y.jar", success = true)
+    val line = p.snapshot()
+    assert(
+      line.exists(_.contains("2 modules")),
+      line.toString
+    ) // resolve + artifacts, not reset to 1
+    assert(line.exists(_.contains("2 artifacts")), line.toString) // x + y, not reset
+    log.stop()
+  }
+
+end ResolutionProgressSpec

--- a/notes/2.0.0/parallel-resolution-supershell.md
+++ b/notes/2.0.0/parallel-resolution-supershell.md
@@ -8,7 +8,7 @@ renders a single aggregate progress line at the task level instead, counting dis
 (metadata and artifacts) and bytes downloaded, e.g.:
 
 ```
-Updating 240 files, 31.0 MiB 12s
+downloading 240 files, 31.0 MiB 12s
 ```
 
 so resolution can run concurrently across modules. Setting `csrLogger := Some(...)` opts out: your

--- a/notes/2.0.0/parallel-resolution-supershell.md
+++ b/notes/2.0.0/parallel-resolution-supershell.md
@@ -1,0 +1,19 @@
+### `update` resolves in parallel under the super shell
+
+Building on #9270 (parallel dependency resolution for non-interactive runs), `update` now also
+resolves in parallel under the interactive super shell. Previously sbt let coursier draw its own
+per-module progress bars there, and those bars cannot be rendered from more than one module at
+once, so resolution was serialized one module at a time. sbt now suppresses coursier's bars and
+renders a single aggregate progress line at the task level instead, e.g.:
+
+```
+Updating 18 modules, 240 artifacts, 31.0 MiB
+```
+
+so resolution can run concurrently across modules. Setting `csrLogger := Some(...)` opts out: your
+logger is used instead, and coursier's behavior is unchanged.
+
+This is the first step of [#5627][i5627]. Per-module status lines (which would add a `status`
+field to `ProgressItem`) remain a possible follow-up.
+
+[i5627]: https://github.com/sbt/sbt/issues/5627

--- a/notes/2.0.0/parallel-resolution-supershell.md
+++ b/notes/2.0.0/parallel-resolution-supershell.md
@@ -4,10 +4,11 @@ Building on #9270 (parallel dependency resolution for non-interactive runs), `up
 resolves in parallel under the interactive super shell. Previously sbt let coursier draw its own
 per-module progress bars there, and those bars cannot be rendered from more than one module at
 once, so resolution was serialized one module at a time. sbt now suppresses coursier's bars and
-renders a single aggregate progress line at the task level instead, e.g.:
+renders a single aggregate progress line at the task level instead, counting distinct files
+(metadata and artifacts) and bytes downloaded, e.g.:
 
 ```
-Updating 18 modules, 240 artifacts, 31.0 MiB
+Updating 240 files, 31.0 MiB 12s
 ```
 
 so resolution can run concurrently across modules. Setting `csrLogger := Some(...)` opts out: your


### PR DESCRIPTION
## What

`update` now resolves dependencies **in parallel under the interactive super shell**, rendering one aggregate progress line instead of coursier's per-module bars. First step of #5627; builds on #9270.

## How

- `LMCoursier.coursierLoggerTask` now supplies a `CacheLogger` under the super shell instead of `None`. Supplying any logger (a) suppresses coursier's own per-module bar and (b) flips #9270's `progressBarActive` predicate to `false`, so resolution runs in parallel.
- Progress is a **per-command instance, not a global**: a `ResolutionProgress` is created in `MainLoop.next` alongside `Keys.taskProgress`, stored under an `AttributeKey` with the same lifecycle. `coursierLoggerTask` reads it from `State` and hands it to the `ResolutionProgressLogger` that coursier's download threads call; `TaskProgress` holds the same instance and appends one line at render time, e.g. `downloading 240 files, 31.0 MiB 12s` — distinct non-checksum urls (coursier reports logger sessions per *configuration*, not per module, so a module count isn't knowable here) plus a live burst elapsed. The instance is born empty per command and discarded with it — nothing leaks across commands, and the count never resets mid-`update`. Per-url byte accounting uses an atomic `compute` so concurrent download callbacks can't double-count.

## The call I made (redirect me if you'd rather)

v1 is a single aggregate line because it needs **no schema change**. Per-module status lines would require a `status` field on `ProgressItem` (and touch the logging codecs / BSP), so that's a follow-up. Happy to go straight to per-module if you'd prefer.

## One thing I want your call on

A single `update` does a resolve phase and a separate artifacts phase, so the per-command instance **accumulates across both** rather than resetting between them. Confirm that aggregate-across-phases is the behavior you want.

## Notes

- **`UpdateRun` lock deferred:** it only builds the report (no network), so the parallelism win is in `ResolutionRun`/`ArtifactsRun` (already unlocked by #9270). Follow-up.
- **Behavior change:** under the super shell, coursier's per-module bars are replaced by the aggregate line; `csrLogger := Some(...)` opts out (your logger is used, coursier unchanged).

## Testing

- Unit test (`ResolutionProgressSpec`, Verify): aggregation, monotonic bytes, counts-persist-across-phases, per-configuration-session dedup, and checksum-companion exclusion — each on a fresh instance.
- Parallelism follows from #9270's `progressBarActive` predicate (covered by `LockSpec`): supplying a logger ⇒ no lock.
- The super-shell *rendering* needs a real TTY, so it isn't deterministically CI-testable; the wiring was verified by tracing the `MainLoop` → `EvaluateTask` (`Keys.state`) → `coursierLoggerTask` path (the same threading that makes `streams.value` work in that task).

## Release note

`notes/2.0.0/parallel-resolution-supershell.md`.

re: #5627

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by me (scalafmt, compile, `ResolutionProgressSpec`, MiMa).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


