### PR TITLE
[2.0.x] bport: Fixes publishing platform-specific artifacts (like Scala Native)

### DIFF
--- a/lm-core/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/ArtifactExtra.scala
@@ -106,11 +106,7 @@ private[librarymanagement] abstract class ArtifactFunctions {
     val cross = CrossVersion(module.crossVersion, scalaVersion.full, scalaVersion.binary)
     val withPlatform = module.crossVersion match {
       case _: Disabled => artifact.name
-      case _           =>
-        module.platformOpt match {
-          case Some(p) if p.nonEmpty && p != Platform.jvm => s"${artifact.name}_$p"
-          case _                                          => artifact.name
-        }
+      case _           => CrossVersion.addPlatformSuffix(artifact.name, module.platformOpt, None)
     }
     val base = CrossVersion.applyCross(withPlatform, cross)
     base + "-" + module.revision + classifierStr + "." + artifact.extension

--- a/lm-core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -166,6 +166,20 @@ private[librarymanagement] abstract class CrossVersionFunctions {
   private[sbt] def crossName(name: String, cross: String): String =
     name + "_" + cross
 
+  /**
+   * Appends the platform suffix (e.g. `native0.5`, `sjs1`) to `name`, preferring an explicit
+   * `platformOpt` over the `projectPlatform`. `""` and `jvm` add no suffix. Keep in sync with
+   * `lmcoursier.FromSbt.addPlatformSuffix` (until lm-coursier moves under sbt).
+   */
+  private[sbt] def addPlatformSuffix(
+      name: String,
+      platformOpt: Option[String],
+      projectPlatform: Option[String]
+  ): String =
+    platformOpt.orElse(projectPlatform) match
+      case Some(p) if p.nonEmpty && p != Platform.jvm => crossName(name, p)
+      case _                                          => name
+
   /** Cross-versions `exclude` according to its `crossVersion`. */
   private[sbt] def substituteCross(
       exclude: ExclusionRule,

--- a/lm-coursier/src/main/scala/lmcoursier/FromSbt.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/FromSbt.scala
@@ -44,6 +44,8 @@ object FromSbt {
     }
   }
 
+  // Duplicate of sbt.librarymanagement.CrossVersion.addPlatformSuffix. Keep the two in sync
+  // until lm-coursier moves under sbt
   private def addPlatformSuffix(
       name: String,
       platformOpt: Option[String],

--- a/lm-ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/lm-ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -234,8 +234,18 @@ object IvyActions {
   }
   private def crossVersionMap(moduleSettings: ModuleSettings): Option[String => String] =
     moduleSettings match {
-      case i: InlineConfiguration => CrossVersion(i.module, i.scalaModuleInfo)
-      case _                      => None
+      case i: InlineConfiguration =>
+        // Platform suffix before cross suffix, matching the coordinate (sbt/sbt#9117).
+        CrossVersion(i.module, i.scalaModuleInfo).map { fn => (name: String) =>
+          fn(
+            CrossVersion.addPlatformSuffix(
+              name,
+              i.module.platformOpt,
+              i.scalaModuleInfo.flatMap(_.platform)
+            )
+          )
+        }
+      case _ => None
     }
   def mapArtifacts(
       module: ModuleDescriptor,

--- a/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
+++ b/main/src/main/scala/sbt/coursierint/CoursierArtifactsTasks.scala
@@ -31,6 +31,7 @@ object CoursierArtifactsTasks {
       val projId = sbt.Keys.projectID.value
       val sv = sbt.Keys.scalaVersion.value
       val sbv = sbt.Keys.scalaBinaryVersion.value
+      val projectPlatform = sbt.Keys.scalaModuleInfo.value.flatMap(_.platform)
       val ivyConfs = sbt.Keys.ivyConfigurations.value
       val extracted = Project.extract(s)
       import extracted.*
@@ -97,8 +98,13 @@ object CoursierArtifactsTasks {
 
       def artifactPublication(artifact: Artifact) = {
 
+        // Platform suffix before cross suffix, matching the coordinate
+        val base = projId.crossVersion match
+          case _: Disabled => artifact.name
+          case _           =>
+            CrossVersion.addPlatformSuffix(artifact.name, projId.platformOpt, projectPlatform)
         val name = CrossVersion(projId.crossVersion, sv, sbv)
-          .fold(artifact.name)(_(artifact.name))
+          .fold(base)(_(base))
 
         CPublication(
           name,

--- a/sbt-app/src/sbt-test/dependency-management/platform-publish/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/platform-publish/build.sbt
@@ -1,0 +1,48 @@
+// sbt/sbt#9117: published artifact names must carry the platform suffix, matching the
+// coordinate, on both publish backends. `platform` is set directly, as sbt-scala-native does.
+
+ThisBuild / organization := "com.example"
+ThisBuild / version := "0.1.0"
+ThisBuild / scalaVersion := "3.8.3"
+ThisBuild / csrCacheDirectory := (ThisBuild / baseDirectory).value / "coursier-cache"
+
+lazy val mavenRepo = settingKey[File]("shared local Maven repo for the consume round-trip")
+ThisBuild / mavenRepo := (ThisBuild / baseDirectory).value / "maven-repo"
+
+def expected(name: String) = s"${name}_native0.5_3"
+
+def producer(useIvyFlag: Boolean): Seq[Setting[?]] = Seq(
+  platform := "native0.5",
+  crossVersion := CrossVersion.binary,
+  useIvy := useIvyFlag,
+  publishMavenStyle := true,
+  ivyPaths := IvyPaths(baseDirectory.value.toString, Some((target.value / "ivy2").toString)),
+  publishTo := Some(MavenCache("platform-publish-local", (ThisBuild / mavenRepo).value))
+)
+
+// checkPomArtifactId only for ivyless: there the artifactId comes from PomGenerator (and
+// resolution does not validate POM content); the Ivy backend's is correct regardless.
+def ivyLayoutCheck(base: String, checkPomArtifactId: Boolean): Setting[?] =
+  TaskKey[Unit]("check") := {
+    val nm = expected(base)
+    val dir = target.value / "ivy2" / "local" / organization.value / nm / version.value
+    def req(f: File): Unit = assert(f.exists, s"expected $f to exist")
+    req(dir / "jars" / s"$nm.jar")
+    req(dir / "srcs" / s"$nm-sources.jar")
+    val pom = dir / "poms" / s"$nm.pom"
+    req(pom)
+    if (checkPomArtifactId)
+      assert(IO.read(pom).contains(s"<artifactId>$nm</artifactId>"), s"POM artifactId must be $nm: ${IO.read(pom)}")
+  }
+
+lazy val ivyfull = (project in file("ivyfull"))
+  .settings(name := "libivyfull", producer(true), ivyLayoutCheck("libivyfull", checkPomArtifactId = false))
+
+// Must not dependsOn the producers, so the coordinates resolve from the Maven repo rather
+// than inter-project - otherwise a suffix-dropped published name would not be caught.
+lazy val consumer = (project in file("consumer"))
+  .settings(
+    publish / skip := true,
+    resolvers += MavenCache("platform-publish-local", (ThisBuild / mavenRepo).value),
+    libraryDependencies += organization.value % expected("libivyfull") % version.value
+  )

--- a/sbt-app/src/sbt-test/dependency-management/platform-publish/ivyfull/src/main/scala/Lib.scala
+++ b/sbt-app/src/sbt-test/dependency-management/platform-publish/ivyfull/src/main/scala/Lib.scala
@@ -1,0 +1,4 @@
+package lib
+
+object Lib:
+  def greeting: String = "hi"

--- a/sbt-app/src/sbt-test/dependency-management/platform-publish/test
+++ b/sbt-app/src/sbt-test/dependency-management/platform-publish/test
@@ -1,0 +1,11 @@
+# sbt/sbt#9117: published artifact names must carry the platform suffix (_native0.5),
+# matching the coordinate, on both the ivyless and Ivy backends.
+
+# publishLocal (ivy layout): filenames + POM artifactId
+> ivyfull/publishLocal
+> ivyfull/check
+
+# publish to a local Maven repo, then resolve the artifacts back under their platform
+# coordinate
+> ivyfull/publish
+> consumer/update


### PR DESCRIPTION
This is a 2.0.x backport of https://github.com/sbt/sbt/pull/9293

## Problem
Platform suffix is absent in published artifacts.

## Solution
This fixes Ivy backend CrossVersion.substituteCross via IvyActions