### PR TITLE
[2.0.x] fix: Fixes cross build caching

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2267,7 +2267,9 @@ object Defaults extends BuildCommon {
         val dir = c.toPath(backendOutput.value).toFile
         result match
           case Result.Value(res) =>
-            val store = analysisStore(compileAnalysisFile.value.toPath(), c)
+            val af = compileAnalysisFile.value
+            val store = analysisStore(af.toPath(), c)
+            if !af.exists then sys.error(s"${af} is missing")
             val analysis = store.unsafeGet().getAnalysis()
             reporter.sendSuccessReport(analysis)
             bspTask.notifySuccess(analysis)
@@ -2454,6 +2456,7 @@ object Defaults extends BuildCommon {
           c.toVirtualFile(inputs.options.classesDirectory),
           c.toVirtualFile(inputs.setup.cacheFile.toPath),
           incrementalOptions,
+          scalaVersion.value,
         )
       },
       bspCompileTask :=

--- a/main/src/main/scala/sbt/internal/CompileInputs2.scala
+++ b/main/src/main/scala/sbt/internal/CompileInputs2.scala
@@ -13,6 +13,7 @@ case class CompileInputs2(
     outputPath: VirtualFileRef,
     cachePath: VirtualFileRef,
     incrementalOptions: Vector[(String, String)],
+    scalaVersion: String,
 )
 
 object CompileInputs2:
@@ -21,7 +22,8 @@ object CompileInputs2:
   given IsoLList.Aux[
     CompileInputs2,
     Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
-      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*: LNil
+      Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*:
+      String :*: LNil
   ] =
     LList.iso(
       { (v: CompileInputs2) =>
@@ -32,12 +34,13 @@ object CompileInputs2:
           ("outputPath", v.outputPath) :*:
           ("cachePath", v.cachePath) :*:
           ("incrementalOptions", v.incrementalOptions) :*:
+          ("scalaVersion", v.scalaVersion) :*:
           LNil
       },
       {
         (in: Vector[HashedVirtualFileRef] :*: Vector[HashedVirtualFileRef] :*: Vector[String] :*:
           Vector[String] :*: VirtualFileRef :*: VirtualFileRef :*: Vector[(String, String)] :*:
-          LNil) =>
+          String :*: LNil) =>
           CompileInputs2(
             in.head,
             in.tail.head,
@@ -46,6 +49,7 @@ object CompileInputs2:
             in.tail.tail.tail.tail.head,
             in.tail.tail.tail.tail.tail.head,
             in.tail.tail.tail.tail.tail.tail.head,
+            in.tail.tail.tail.tail.tail.tail.tail.head,
           )
       }
     )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9300
This is a 2.0.x backport of https://github.com/sbt/sbt/pull/9305

## Problem
We can get into a situation where CompileInputs2 become identical for Scala 3.x and 2.13, which breaks the recovery of Zinc analysis.

## Solution
This includes Scala version into CompileInput2 to workaround this issue.
