### PR TITLE
[2.0.x] bport: Fix packageDirectory zip publication race

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -10,7 +10,14 @@ package sbt.util
 
 import java.io.{ File, IOException, PrintWriter }
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, NoSuchFileException, Path, Paths, StandardCopyOption }
+import java.nio.file.{
+  AtomicMoveNotSupportedException,
+  Files,
+  NoSuchFileException,
+  Path,
+  Paths,
+  StandardCopyOption
+}
 import sbt.internal.util.{
   ActionCacheEvent,
   CacheEventLog,
@@ -334,6 +341,36 @@ object ActionCache:
 
   private val default2010Timestamp: Long = 1262304000000L
 
+  /**
+   * Publishes `builtZip` as `destZip` by staging next to the destination and renaming into place.
+   * Avoids races from a direct `Files.copy` into `destZip` under parallel task execution.
+   */
+  private def installPackagedZip(builtZip: Path, destZip: Path, fallbackStagingDir: Path): Unit =
+    val stagingDir = Option(destZip.getParent) match
+      case Some(parent) =>
+        Files.createDirectories(parent)
+        parent
+      case None => fallbackStagingDir
+
+    val staging = Files.createTempFile(
+      stagingDir,
+      destZip.getFileName.toString + ".",
+      dirZipExt + ".tmp",
+    )
+    try
+      Files.copy(builtZip, staging, StandardCopyOption.REPLACE_EXISTING)
+      try
+        Files.move(
+          staging,
+          destZip,
+          StandardCopyOption.REPLACE_EXISTING,
+          StandardCopyOption.ATOMIC_MOVE,
+        )
+      catch
+        case _: AtomicMoveNotSupportedException =>
+          Files.move(staging, destZip, StandardCopyOption.REPLACE_EXISTING)
+    finally Files.deleteIfExists(staging)
+
   def packageDirectory(
       dir: VirtualFileRef,
       conv: FileConverter,
@@ -375,7 +412,7 @@ object ActionCache:
         tempZipPath.toFile(),
         Some(default2010Timestamp)
       )
-      Files.copy(tempZipPath, zipPath, StandardCopyOption.REPLACE_EXISTING)
+      installPackagedZip(tempZipPath, zipPath, tempDir.toPath())
 
       conv.toVirtualFile(zipPath)
 

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -1,8 +1,10 @@
 package sbt.util
 
 import java.io.{ IOException, InputStream }
-import java.nio.file.NoSuchFileException
 import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
+import java.util.Optional
+import java.util.concurrent.{ CyclicBarrier, ExecutorService, Executors, TimeUnit }
 
 import sbt.internal.util.CacheEventLog
 import sbt.internal.util.StringVirtualFile1
@@ -11,18 +13,15 @@ import sbt.io.syntax.*
 import verify.BasicTestSuite
 import xsbti.{
   CompileFailed,
+  FileConverter,
   HashedVirtualFileRef,
   Problem,
   Position,
   Severity,
   VirtualFile,
-  FileConverter,
-  VirtualFileRef
+  VirtualFileRef,
 }
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.Files
-import java.util.Optional
+
 import ActionCache.InternalActionResult
 
 object ActionCacheTest extends BasicTestSuite:
@@ -312,6 +311,36 @@ object ActionCacheTest extends BasicTestSuite:
     val v2 = ActionCache.cache((), Digest.zero, Digest.zero, tags, config2)(action)
     assert(v2 == 42)
     assert(called == 2)
+
+  test("packageDirectory is safe when many threads package the same directory concurrently"):
+    IO.withTemporaryDirectory: tmp =>
+      val root = tmp.toPath
+      val classesDir = root.resolve("classes")
+      Files.createDirectories(classesDir)
+      Files.writeString(classesDir.resolve("A.class"), "compiled")
+      val classesPathStr = classesDir.toString
+      val dirRef = VirtualFileRef.of(classesPathStr)
+      val conv = new FileConverter:
+        override def toPath(ref: VirtualFileRef): Path = Paths.get(ref.id)
+        override def toVirtualFile(path: Path): VirtualFile =
+          val content =
+            if Files.isRegularFile(path) then
+              new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+            else ""
+          StringVirtualFile1(path.toString, content)
+      val threadCount = 64
+      val barrier = new CyclicBarrier(threadCount)
+      val pool: ExecutorService = Executors.newFixedThreadPool(threadCount)
+      try
+        val tasks =
+          for _ <- 1 to threadCount yield pool.submit: () =>
+            barrier.await(30, TimeUnit.SECONDS)
+            ActionCache.packageDirectory(dirRef, conv, root)
+        tasks.foreach(_.get(60, TimeUnit.SECONDS))
+        val zipPath = Paths.get(classesPathStr + ActionCache.dirZipExt)
+        assert(Files.isRegularFile(zipPath))
+        assert(Files.size(zipPath) > 0L)
+      finally pool.shutdown()
 
   test("Changing cacheVersion invalidates the cache"):
     withDiskCache(testCacheVersionInvalidation)


### PR DESCRIPTION
This is a 2.0.x backport of #9047.

Fix #9311