### PR TITLE
[2.x] fix: Fixes console / javaOptions + console / fork := true

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1121,6 +1121,8 @@ object Defaults extends BuildCommon with DefExtra {
         Compiler.toConsoleScalacOptions(scalacOptions.value)
       },
       console / forkOptions := Def.uncached(Compiler.consoleForkOptions.value),
+      // fork when sbt is launched with --server
+      console / fork := true,
       collectAnalyses := Definition.collectAnalysesTask.map(_ => ()).value,
       consoleQuick := consoleQuickTask.value,
       consoleQuick / scalacOptions := Def.uncached {

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -616,12 +616,13 @@ object Compiler:
     }
 
   def consoleForkOptions: Def.Initialize[Task[ForkOptions]] = Def.task {
+    val jo = (Keys.console / Keys.javaOptions).value.toVector
     // Build environment variables for proper terminal handling
     val termEnv = sys.env.get("TERM").getOrElse("xterm-256color")
     ForkOptions()
       .withConnectInput(true)
       .withRunJVMOptions(
-        Vector(
+        jo ++ Vector(
           s"-Dorg.jline.terminal.type=$termEnv",
           "-Djline.terminal=auto",
         )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9320
Ref https://github.com/sbt/sbt/issues/9317 (Scala 3.9.0-RC1 uses JLine 4)

## Problem
console / javaOptions is ignored.

## Solution
1. This enables forked console even for `sbt --server` mode.
2. This includes console / javaOptions to the forkOptions.

## Test

```scala
scalaVersion := "3.9.0-RC1"
Compile / console / javaOptions += "-Dfoo=1"
```

```scala
sbt:consoletest> console
[info] running console (fork)
[info] running (fork) sbt.internal.worker1.WorkerMain @/..../target/bg-jobs/sbt_b091ebab/job-1/console-params.json
Welcome to Scala 3.9.0-RC1 (17.0.12, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> sys.props("foo")
val res0: String = "1"
```

This should behave the same for both sbtn (default) or `sbt --server`