### PR TITLE
[2.0.x] fix: Fixes console / javaOptions

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1109,6 +1109,8 @@ object Defaults extends BuildCommon {
         Compiler.toConsoleScalacOptions(scalacOptions.value)
       },
       console / forkOptions := Def.uncached(Compiler.consoleForkOptions.value),
+      // fork when sbt is launched with --server
+      console / fork := true,
       collectAnalyses := Definition.collectAnalysesTask.map(_ => ()).value,
       consoleQuick := consoleQuickTask.value,
       consoleQuick / scalacOptions := Def.uncached {

--- a/main/src/main/scala/sbt/internal/Compiler.scala
+++ b/main/src/main/scala/sbt/internal/Compiler.scala
@@ -424,12 +424,13 @@ object Compiler:
     s"""{ "jsonrpc": "2.0", "method": "$method", "params": $params, "id": $id }"""
 
   def consoleForkOptions: Def.Initialize[Task[ForkOptions]] = Def.task {
+    val jo = (Keys.console / Keys.javaOptions).value.toVector
     // Build environment variables for proper terminal handling
     val termEnv = sys.env.get("TERM").getOrElse("xterm-256color")
     ForkOptions()
       .withConnectInput(true)
       .withRunJVMOptions(
-        Vector(
+        jo ++ Vector(
           s"-Dorg.jline.terminal.type=$termEnv",
           "-Djline.terminal=auto",
         )


### PR DESCRIPTION
This is a 2.0.x backport of #9322 

## Problem
console / javaOptions is ignored.

## Solution
1. This enables forked console even for sbt --server mode.
2. This includes console / javaOptions to the forkOptions.