### PR TITLE
[1.x] fix: Delegate JDK platform classes to the platform loader in console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       if: ${{ matrix.jobtype == 2 }}
       shell: bash
       run: |
-        ./sbt -v "scripted actions/* apiinfo/* compiler-project/* ivy-deps-management/* reporter/* tests/* watch/* classloader-cache/* package/*"
+        ./sbt -v "scripted actions/* apiinfo/* compiler-project/* console/* ivy-deps-management/* reporter/* tests/* watch/* classloader-cache/* package/*"
     - name: Build and test (3)
       if: ${{ matrix.jobtype == 3 }}
       shell: bash

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2185,6 +2185,28 @@ object Defaults extends BuildCommon {
 
   def consoleTask: Initialize[Task[Unit]] = consoleTask(fullClasspath, console)
   def consoleQuickTask = consoleTask(externalDependencyClasspath, consoleQuick)
+
+  // The ScalaInstance loader chain bottoms out at the launcher's loader, which does not
+  // delegate to the JDK platform classloader. None on JDK 8 (no platform loader).
+  private[this] lazy val platformLoader: Option[ClassLoader] =
+    try {
+      Option(
+        classOf[ClassLoader]
+          .getMethod("getPlatformClassLoader")
+          .invoke(null)
+          .asInstanceOf[ClassLoader]
+      )
+    } catch { case NonFatal(_) => None }
+
+  private[this] def platformFallbackLoader(parent: ClassLoader): ClassLoader =
+    platformLoader match {
+      case Some(platform) =>
+        new ClassLoader(parent) {
+          override def findClass(name: String): Class[_] = platform.loadClass(name)
+        }
+      case None => parent
+    }
+
   def consoleTask(classpath: TaskKey[Classpath], task: TaskKey[_]): Initialize[Task[Unit]] =
     Def.task {
       val si = (task / scalaInstance).value
@@ -2192,7 +2214,8 @@ object Defaults extends BuildCommon {
       val cpFiles = data((task / classpath).value)
       val fullcp = (cpFiles ++ si.allJars).distinct
       val tempDir = IO.createUniqueDirectory((task / taskTemporaryDirectory).value).toPath
-      val loader = ClasspathUtil.makeLoader(fullcp.map(_.toPath), si, tempDir)
+      val loader =
+        platformFallbackLoader(ClasspathUtil.makeLoader(fullcp.map(_.toPath), si, tempDir))
       val compiler =
         (task / compilers).value.scalac match {
           case ac: AnalyzingCompiler => ac.onArgs(exported(s, "scala"))

--- a/sbt-app/src/sbt-test/console/jdk-platform-classes/build.sbt
+++ b/sbt-app/src/sbt-test/console/jdk-platform-classes/build.sbt
@@ -1,0 +1,19 @@
+scalaVersion := "2.13.12"
+
+lazy val markerFile = settingKey[java.io.File]("marker file written by the console REPL when JDK platform classes load")
+
+markerFile := target.value / "console-jdk-platform-ok"
+
+console / initialCommands := {
+  val path = markerFile.value.getAbsolutePath.replace("\\", "\\\\")
+  // java.sql lives in a JDK platform module. Loading it through the console REPL's
+  // classloader chain threw SecurityException("Prohibited package name: java.sql")
+  // before the platform-loader fallback (#4328): `ts` covers the top-down request,
+  // `mts` covers supertype resolution for a class defined from the project classpath.
+  // The REPL traps exceptions, so the assertion is a marker file: it is only written
+  // if both classes actually load.
+  s"""val ts = new java.sql.Timestamp(0L)
+     |val mts = new MyTimestamp
+     |java.nio.file.Files.write(java.nio.file.Paths.get("$path"), (ts.getClass.getName + " " + mts.getClass.getName).getBytes("UTF-8"))
+     |""".stripMargin
+}

--- a/sbt-app/src/sbt-test/console/jdk-platform-classes/src/main/scala/MyTimestamp.scala
+++ b/sbt-app/src/sbt-test/console/jdk-platform-classes/src/main/scala/MyTimestamp.scala
@@ -1,0 +1,5 @@
+// Linkage through the defining loader: resolving the java.sql.Timestamp supertype of a
+// project-classpath class exercises the classpath loader's parent chain, not a top-down
+// REPL request. This is the shape of sbt/sbt#4328's original repro (a JDBC driver
+// implementing java.sql.Driver).
+class MyTimestamp extends java.sql.Timestamp(0L)

--- a/sbt-app/src/sbt-test/console/jdk-platform-classes/test
+++ b/sbt-app/src/sbt-test/console/jdk-platform-classes/test
@@ -1,0 +1,2 @@
+> console
+$ exists target/console-jdk-platform-ok


### PR DESCRIPTION
## Problem

`sbt console` (and `consoleQuick`) on JDK 9+ cannot touch JDK platform-module
classes (`java.sql.*`, `java.scripting.*`, ...):

    java.lang.SecurityException: Prohibited package name: java.sql

Reproducible on 1.11.7. #4328 was filed for this in 2018 and was recently closed
referencing sbt/zinc#1706, but the 1.x failure is on a different path, so it is
still live there.

## Cause

For a top-down REPL reference, `ClasspathFilter`'s post-check rejects classes
whose code source is a `jrt:` URL, so the platform class never resolves through
the chain sbt passes to the REPL. The REPL's own classloader then finds the
bytes in the runner-generated `~/.sbt/1.0/java9-rt-ext-<jvm>/rt.jar` (put on the
REPL classpath via `scala.ext.dirs` for scalac on JDK 9+) and `defineClass` on a
`java.*` name is forbidden.

Linkage through the classpath loader was already sound: the launcher's
`topLoader` delegates to the platform loader on JDK 9+, so a project class
extending a `java.sql` type (e.g. a JDBC driver) links fine. Only the top-down
path through the filter was broken.

## Fix

`consoleTask` wraps the REPL parent loader with a platform-loader fallback that
is consulted only when the existing chain misses: platform classes resolve from
the JDK instead of being redefined, and classes served by the project classpath
are unaffected (the fallback is last). `getPlatformClassLoader` is looked up
reflectively and the wrapper is skipped on JDK 8 (no platform loader, no rt-ext
jar, no bug).

## Verification

Against the original report's repro on a real launcher (sbt 1.11.7 unpatched vs
a locally published 1.12.3-SNAPSHOT with this change):

|                                                        | 1.11.7            | patched |
| ------------------------------------------------------ | ----------------- | ------- |
| `new java.sql.Timestamp(0L)`                            | SecurityException | ok      |
| project class extending `java.sql.Timestamp`           | ok                | ok      |
| `Class.forName("org.postgresql.Driver")`                | ok                | ok      |
| `DriverManager.getConnection` (postgresql driver)       | SecurityException | reaches the network layer (`PSQLException: Connection refused`) |

- New scripted test `console/jdk-platform-classes` covers both the top-down
  reference and the linkage case via marker file (the REPL traps exceptions).
  Fails without the change, passes with it.
- The `console/*` scripted group is added to a CI glob; it was not in any, so
  neither this test nor the pre-existing `console/project-compiler-bridge`
  ever ran on CI.
- `consoleProject` is not affected (verified on 1.11.7): it runs on sbt's
  application loader chain, which reaches the platform loader.
- sbt 2.x is not affected: the Scala 3 REPL's own classloader chain reaches the
  platform loader.
- `mainProj/scalafmtCheck` and `mainProj/mimaReportBinaryIssues` green.

Fixes #4328 (closed via sbt/zinc#1706, but that change covers the 2.x path
only; still reproducible on 1.11.7 before this change).

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by
me (repro on 1.11.7 and on a patched real launcher, scripted both directions,
scalafmt, MiMa).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
