### PR TITLE
[2.0.x] bport: short-circuit --version from build.properties

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -12,11 +12,9 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
   private def assertVersionOutput(out: List[String]): Unit =
     val lines =
       out.mkString(System.lineSeparator()).linesIterator.map(_.stripPrefix("[0J").trim).toList
-    assert(
-      lines.exists(_.matches("^sbt version in this project: " + versionPattern + "\\r?$")) ||
-        lines.contains("sbtVersion")
-    )
+    assert(lines.exists(_.matches("^sbt version in this project: " + versionPattern + "\\r?$")))
     assert(lines.exists(_.matches("^sbt runner version: " + versionPattern + "\\r?$")))
+    assert(!lines.exists(_.contains("sbtVersion")))
     assert(!lines.exists(_.contains("failed to connect to server")))
 
   testOutput("sbt -no-colors")("compile", "-no-colors", "-v"): (out: List[String]) =>

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -754,8 +754,12 @@ if !sbt_args_print_sbt_version! equ 1 (
 
 if !sbt_args_print_version! equ 1 (
   if !is_this_dir_sbt! equ 1 (
-    call :set_sbt_version
-    echo sbt version in this project: !sbt_version!
+    if defined build_props_sbt_version (
+      call :set_sbt_version_from_build_props
+    ) else (
+      call :set_sbt_version
+    )
+    if defined sbt_version echo sbt version in this project: !sbt_version!
   )
   echo sbt runner version: !init_sbt_version!
   >&2 echo.
@@ -1181,6 +1185,16 @@ for /F "usebackq tokens=1,2 delims= " %%a in (`CALL "!_JAVACMD!" -jar "!sbt_jar!
   echo !_version_candidate!| findstr /R "^[0-9][0-9.]*[-+0-9A-Za-z._]*$" >nul && set "sbt_version=!_version_candidate!"
 )
 if not defined sbt_version if defined build_props_sbt_version set "sbt_version=!build_props_sbt_version!"
+exit /B 0
+
+:set_sbt_version_from_build_props
+set "sbt_version=!build_props_sbt_version!"
+for /F "tokens=* delims= " %%a in ("!sbt_version!") do set "sbt_version=%%a"
+:trim_version_end
+if "!sbt_version:~-1!" == " " (
+  set "sbt_version=!sbt_version:~0,-1!"
+  goto trim_version_end
+)
 exit /B 0
 
 :error

--- a/sbt
+++ b/sbt
@@ -587,7 +587,10 @@ run() {
     execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]//g'
   elif [[ $print_version ]]; then
     if [[ -n "$is_this_dir_sbt" ]]; then
-      execRunner "$java_cmd" -jar "$sbt_jar" "sbtVersion" | tail -1 | sed -e 's/\[info\]/sbt version in this project:/g'
+      local project_sbt_version
+      if project_sbt_version="$(projectSbtVersion)"; then
+        echo "sbt version in this project: $project_sbt_version"
+      fi
     fi
     echo "sbt runner version: $init_sbt_version"
     echoerr ""
@@ -808,6 +811,16 @@ loadPropFile() {
       build_props_sbt_version="$v"
     fi
   done <<< "$(cat "$1" | sed $'/^\#/d;s/\r$//')"
+}
+
+projectSbtVersion() {
+  local version
+  version="$(trimString "$build_props_sbt_version")"
+  if [[ -n "$version" ]]; then
+    echo "$version"
+    return 0
+  fi
+  return 1
 }
 
 detectNativeClient() {

--- a/sbtw/src/main/scala/sbtw/Main.scala
+++ b/sbtw/src/main/scala/sbtw/Main.scala
@@ -116,33 +116,37 @@ object Main:
     if opts.scriptVersion then
       println(LauncherOptions.initSbtVersion)
       return 0
-    val javaCmd = Runner.findJavaCmd(opts.javaHome)
-    val sbtJar = opts.sbtJar
-      .filter(p => new File(p).isFile)
-      .getOrElse(new File(sbtBinDir, "sbt-launch.jar").getAbsolutePath)
-    if !new File(sbtJar).isFile then
-      System.err.println("[error] Launcher jar not found for version check")
-      return 1
-    if opts.numericVersion then
-      try
-        val out = Process(Seq(javaCmd, "-jar", sbtJar, "sbtVersion")).!!
-        println(out.linesIterator.toSeq.lastOption.map(_.trim).getOrElse(""))
-        return 0
-      catch { case _: Exception => return 1 }
     if opts.version then
       if ConfigLoader.isSbtProjectDir(cwd) then
-        val out =
-          try Process(Seq(javaCmd, "-jar", sbtJar, "sbtVersion")).!!
-          catch { case _: Exception => "" }
-        val ver = out.linesIterator.toSeq.lastOption.map(_.trim).getOrElse("")
-        println("sbt version in this project: " + ver)
+        projectSbtVersion(cwd).foreach: version =>
+          println("sbt version in this project: " + version)
       println("sbt runner version: " + LauncherOptions.initSbtVersion)
       System.err.println("[info] sbt runner (sbtw) is a runner to run any declared version of sbt.")
       System.err.println(
         "[info] Actual version of sbt is declared using project\\build.properties for each build."
       )
       return 0
+    if opts.numericVersion then
+      val javaCmd = Runner.findJavaCmd(opts.javaHome)
+      val sbtJar = opts.sbtJar
+        .filter(p => new File(p).isFile)
+        .getOrElse(new File(sbtBinDir, "sbt-launch.jar").getAbsolutePath)
+      if !new File(sbtJar).isFile then
+        System.err.println("[error] Launcher jar not found for version check")
+        return 1
+      try
+        val out = Process(Seq(javaCmd, "-jar", sbtJar, "sbtVersion")).!!
+        println(out.linesIterator.toSeq.lastOption.map(_.trim).getOrElse(""))
+        return 0
+      catch { case _: Exception => return 1 }
     0
+
+  private def projectSbtVersion(cwd: File): Option[String] =
+    ConfigLoader.sbtVersionFromBuildProperties(cwd).flatMap(normalizeVersion)
+
+  private def normalizeVersion(version: String): Option[String] =
+    val trimmed = version.trim
+    if trimmed.nonEmpty then Some(trimmed) else None
 
   private def printUsage(): Int =
     println("""


### PR DESCRIPTION
This is a 2.0.x backport of #8822

Avoid launching sbt just to render --version by reading sbt.version directly from project/build.properties in the shell script, batch script, and sbtw wrapper. Tighten launcher integration assertions to verify version output no longer depends on the sbtVersion command output.
