### PR TITLE
[2.x] fix: Probe for a live server before refusing to start

### DIFF
--- a/main-command/src/main/java/sbt/internal/BootServerSocket.java
+++ b/main-command/src/main/java/sbt/internal/BootServerSocket.java
@@ -123,12 +123,17 @@ public class BootServerSocket implements AutoCloseable {
                             bytes.put(b);
                             clientSocketReads.put(ClientSocket.this);
                           } else {
+                            // close() deregisters from clientSockets like the write
+                            // methods do; a dead entry left behind would block the
+                            // NO_BOOT_CLIENTS_CONNECTED signal in inputStream.read.
                             alive.set(false);
+                            close();
                           }
                         }
 
                       } catch (IOException e) {
                         alive.set(false);
+                        close();
                       }
                     }
                   } catch (final Exception ex) {

--- a/main-command/src/main/scala/sbt/internal/BootServerSocketProbe.scala
+++ b/main-command/src/main/scala/sbt/internal/BootServerSocketProbe.scala
@@ -1,0 +1,42 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import java.util.concurrent.atomic.AtomicBoolean
+import sbt.protocol.ClientSocket
+import scala.util.control.NonFatal
+
+private[sbt] object BootServerSocketProbe:
+  private val timeoutMillis = 2000L
+
+  /**
+   * True only if something answers on the boot socket at `location`. A live server answers
+   * immediately, so the connect runs on a daemon thread bounded by [[timeoutMillis]]: the
+   * underlying native connect has no timeout and blocks indefinitely against a bound socket whose
+   * listen backlog is saturated, which must never hang startup. LinkageError is caught alongside
+   * NonFatal because the connect may perform the JVM's first JNI/JNA load.
+   */
+  def liveServerDetected(location: String, useJni: Boolean): Boolean =
+    val answered = new AtomicBoolean(false)
+    val done = new CountDownLatch(1)
+    val t = new Thread(
+      () =>
+        try
+          ClientSocket.localSocket(location, useJni).close()
+          answered.set(true)
+        catch case NonFatal(_) | (_: LinkageError) => ()
+        finally done.countDown(),
+      "sbt-boot-socket-probe"
+    )
+    t.setDaemon(true)
+    t.start()
+    done.await(timeoutMillis, TimeUnit.MILLISECONDS)
+    answered.get()
+end BootServerSocketProbe

--- a/main-command/src/test/scala/sbt/internal/BootServerSocketSpec.scala
+++ b/main-command/src/test/scala/sbt/internal/BootServerSocketSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.nio.file.{ Files, Paths }
+import sbt.internal.util.Util
+import verify.BasicTestSuite
+
+object BootServerSocketSpec extends BasicTestSuite:
+
+  // the constructor only reads baseDirectory; provider is never touched
+  private def config(base: java.io.File): xsbti.AppConfiguration =
+    new xsbti.AppConfiguration {
+      override def arguments(): Array[String] = Array.empty
+      override def baseDirectory(): java.io.File = base
+      override def provider(): xsbti.AppProvider = null
+    }
+
+  private def useJni: Boolean =
+    BootServerSocket.requiresJNI() || sys.props.getOrElse("sbt.ipcsocket.jni", "false") == "true"
+
+  private def probe(location: String): Boolean =
+    BootServerSocketProbe.liveServerDetected(location, useJni)
+
+  private def freshBase(prefix: String): (java.io.File, Long) =
+    val base = Files.createTempDirectory(prefix).toRealPath().toFile
+    (base, base.getAbsolutePath.hashCode.toLong ^ System.nanoTime())
+
+  test("a live boot server is detected by the probe") {
+    val (base, token) = freshBase("boot-socket-live")
+    val location = BootServerSocket.socketLocation(base.toPath, token)
+    val server = new BootServerSocket(config(base), token)
+    val live =
+      try probe(location)
+      finally server.close()
+    assert(live)
+  }
+
+  test("the probe reports no live server when nothing is listening") {
+    val (base, token) = freshBase("boot-socket-none")
+    val location = BootServerSocket.socketLocation(base.toPath, token)
+    val live = probe(location)
+    assert(!live)
+  }
+
+  test("after close, the probe reports no live server") {
+    val (base, token) = freshBase("boot-socket-closed")
+    val location = BootServerSocket.socketLocation(base.toPath, token)
+    val server = new BootServerSocket(config(base), token)
+    server.close()
+    val live = probe(location)
+    assert(!live)
+  }
+
+  test("a stale socket file is not a live server and does not block a new socket") {
+    if (!Util.isWindows) {
+      val (base, token) = freshBase("boot-socket-stale")
+      val location = Paths.get(BootServerSocket.socketLocation(base.toPath, token))
+      Files.createDirectories(location.getParent)
+      Files.createFile(location) // leftover from a killed process
+      val staleLooksLive = probe(location.toString)
+      assert(!staleLooksLive)
+      val server = new BootServerSocket(config(base), token) // reclaims the path
+      val liveAfterReclaim =
+        try probe(location.toString)
+        finally server.close()
+      assert(liveAfterReclaim)
+    }
+  }
+
+end BootServerSocketSpec

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -152,29 +152,38 @@ private[sbt] object xMain:
   private def getSocketOrExit(
       configuration: xsbti.AppConfiguration
   ): (Option[BootServerSocket], Option[Exit]) = {
-    def printThrowable(e: Throwable): Unit = {
-      println("sbt thinks that server is already booting because of this exception:")
-      e.printStackTrace()
-    }
-
-    val target =
-      configuration.baseDirectory().toPath().toRealPath().resolve("project").resolve("target")
-    val hash = HashUtil.farmHash(target.toString().getBytes("UTF-8"));
+    val base = configuration.baseDirectory().toPath().toRealPath()
+    val target = base.resolve("project").resolve("target")
+    val hash = HashUtil.farmHash(target.toString().getBytes("UTF-8"))
+    // sbt runs fine without a boot socket (see the UnsatisfiedLinkError case below), so a
+    // creation failure only means "another sbt is booting" if something answers on it.
+    def liveServerDetected: Boolean =
+      BootServerSocketProbe.liveServerDetected(
+        BootServerSocket.socketLocation(base, hash),
+        BootServerSocket.requiresJNI() || SysProp.serverUseJni,
+      )
     try Some(new BootServerSocket(configuration, hash)) -> None
     catch {
-      case e: ServerAlreadyBootingException if hasConsole && !ITerminal.startedByRemoteClient =>
-        printThrowable(e)
+      // No live server and nothing the user can do about a socket failure, so proceed
+      // silently without the boot socket, as for UnsatisfiedLinkError below.
+      case _: ServerAlreadyBootingException if !liveServerDetected => (None, None)
+      case _: ServerAlreadyBootingException if hasConsole && !ITerminal.startedByRemoteClient =>
+        println("another sbt appears to be booting in this build.")
         println("Create a new server? y/n (default y)")
         val exit =
           if (ITerminal.get.withRawInput(System.in.read) == 'n'.toInt) Some(Exit(1))
           else None
         (None, exit)
-      case e: ServerAlreadyBootingException =>
+      case _: ServerAlreadyBootingException =>
         if (SysProp.forceServerStart) (None, None)
         else {
-          printThrowable(e)
+          println("another sbt appears to be booting in this build; exiting.")
+          println(
+            "wait for it to finish, attach to it with --client, or pass -Dsbt.server.forcestart=true to start anyway."
+          )
           (None, Some(Exit(2)))
         }
+      case _: IOException          => (None, None)
       case _: UnsatisfiedLinkError => (None, None)
     }
   }

--- a/notes/2.0.0/boot-socket-liveness.md
+++ b/notes/2.0.0/boot-socket-liveness.md
@@ -1,0 +1,16 @@
+### sbt no longer refuses to start when the boot socket cannot be created
+
+Failures to create the boot-time io socket used to be misreported: most were
+wrapped as "sbt thinks that server is already booting" with a stack trace, and
+non-interactive invocations exited with code 2, while failures to create the
+socket directory crashed startup outright. Permission or path-length problems
+with `XDG_RUNTIME_DIR` or the temp directory and Windows named-pipe access
+errors all hit one of these ([#6777][6777]).
+
+sbt now probes the socket first. Only a live server answering the probe is
+treated as another sbt booting in the build (the interactive prompt and
+non-interactive exit are unchanged, with a clearer message). Any other failure
+is no longer fatal: sbt continues without the boot socket, whose only job is
+forwarding boot-time io to early-connecting clients.
+
+  [6777]: https://github.com/sbt/sbt/issues/6777


### PR DESCRIPTION
## Problem

`sbt` refuses to start with a misleading error when the boot io socket cannot be
created (#6777, top-voted open bug):

    sbt thinks that server is already booting because of this exception:
    sbt.internal.ServerAlreadyBootingException: java.io.IOException: Could not create lock ...

Any `IOException` from creating the socket is wrapped as
`ServerAlreadyBootingException` and reported this way, and non-interactive
invocations exit with code 2. But a creation failure is rarely another sbt
booting: a stale socket reclaim race, permission or path-length problems with
`XDG_RUNTIME_DIR` or the temp directory, or a Windows named-pipe access error all
land here and block sbt entirely. Separately, `IOException` from the constructor
creating the socket *directory* was not caught at all and crashed startup.

## Fix

`xMain.getSocketOrExit` now connects to the socket to check whether a server is
actually listening before believing the exception:

- **Live server answers the probe** -> genuinely another sbt booting in this
  build: behavior is unchanged (interactive y/n prompt; non-interactive exit),
  with a concise actionable message instead of a stack trace.
- **Nothing answers** (or a raw constructor `IOException`) -> the failure is
  environmental; sbt continues without the boot socket, silently since nothing
  is actionable. This mirrors the grace sbt already extends on
  `UnsatisfiedLinkError`; the boot socket only forwards boot-time io to
  early-connecting clients.

The probe is extracted to `BootServerSocketProbe` so the test exercises the
production code path. It catches `LinkageError` as well as `NonFatal` (the
connect may perform the JVM's first JNI/JNA load, and an error escaping the
pattern guard would replace the original exception), and it runs on a daemon
thread bounded by a short timeout: the underlying native connect has no timeout
and would block indefinitely against a bound socket whose listen backlog is
saturated, so a hang-avoidance change must not itself be able to hang startup.

While here, `BootServerSocket`'s reader loop now deregisters a disconnected
client via `close()` the same way the write path already does, so a client (or
this probe) disconnecting during boot can't leave a dead entry that suppresses
the `NO_BOOT_CLIENTS_CONNECTED` signal. (A probe against a genuinely booting
server thus leaves at most a transient connection, reaped on that server's next
boot-input cycle.)

## Design notes

- `NetworkClient.waitForServer` already uses this exact connect as its liveness
  signal, so the probe is established practice, not a new mechanism.
- The probe can report a false negative in two narrow races (Windows pipe busy
  between accept instances; the booting server finishing and closing its boot
  socket between the bind failure and the probe). Both then degrade to
  "proceed without the socket", which is the same outcome `-Dsbt.server.forcestart=true`
  and the interactive prompt already allow, and the server-start portfile guard
  still arbitrates genuine duplicates. Failing open beats the old false-positive
  refusal for CI. On Linux the probe may be skipped-flaky (per the existing
  comment in `NetworkClient`), but a live server there almost never produces
  `ServerAlreadyBootingException` in the first place (the Unix path deletes and
  rebinds the socket).

## Testing

- New Verify suite `BootServerSocketSpec` (4 tests) pins the probe: live server
  detected, nothing-listening, after-close, and stale-socket-file reclaimed.
- `mainProj/compile`, `commandProj/Test`, `scalafmtCheck`, and
  `mimaReportBinaryIssues` on both modules green locally.

## Note

This targets 2.x; #6777 was originally filed on 1.x and the same misreport
exists there. Happy to port it to 1.x if you'd like.

Fixes #6777

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by
me (compile, unit tests, scalafmt, MiMa).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
