### PR TITLE
[2.x] fix: Constrain job id parser to signed longs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,12 @@ After this you can set the sbt version within your own project in `project/build
 sbt.version=2.x.y-bin-SNAPSHOT
 ```
 
+If you are iterating on changes, you will need to wipe the local sbt cache between runs:
+
+```bash
+$ rm -fr ~/.sbt/boot/scala-3.*/org.scala-sbt/sbt/2.x.y-bin-SNAPSHOT/
+```
+
 See also [Development environment][02] and [Coding style and best practices][03].
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,12 @@ $ sbt
 > publishLocalBin
 ```
 
+After this you can set the sbt version within your own project in `project/build.properties` to use the locally-published snapshot version:
+
+```properties
+sbt.version=2.x.y-bin-SNAPSHOT
+```
+
 See also [Development environment][02] and [Coding style and best practices][03].
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,18 +104,6 @@ $ sbt
 > publishLocalBin
 ```
 
-After this you can set the sbt version within your own project in `project/build.properties` to use the locally-published snapshot version:
-
-```properties
-sbt.version=2.x.y-bin-SNAPSHOT
-```
-
-If you are iterating on changes, you will need to wipe the local sbt cache between runs:
-
-```bash
-$ rm -fr ~/.sbt/boot/scala-3.*/org.scala-sbt/sbt/2.x.y-bin-SNAPSHOT/
-```
-
 See also [Development environment][02] and [Coding style and best practices][03].
 
 
@@ -124,8 +112,8 @@ See also [Development environment][02] and [Coding style and best practices][03]
 sbt features a testing infrastructure encompassing multiple testing methodologies designed to ensure reliability and functionality across different integrations. The testing framework includes:
 
 - [Unit tests][04]
-- [scripted tests][05]
-- [Manual tests][06], using the locally baked sbt
+- [Scripted tests][05]
+- [Manual tests][06], which details how to run the locally baked sbt in your own project
 
 ### Tech stack
 

--- a/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parsers.scala
@@ -224,13 +224,18 @@ trait Parsers {
   lazy val Port = token(IntBasic, "<port>")
 
   /** Parses a signed integer. */
-  lazy val IntBasic = mapOrFail('-'.? ~ Digit.+)(Function.tupled(toInt))
+  lazy val IntBasic = parseSigned(_.toInt)
+
+  /** Parses a signed long. */
+  lazy val LongBasic = parseSigned(_.toLong)
 
   /** Parses an unsigned integer. */
   lazy val NatBasic = mapOrFail(Digit.+)(_.mkString.toInt)
 
-  private def toInt(neg: Option[Char], digits: Seq[Char]): Int =
-    (neg.toSeq ++ digits).mkString.toInt
+  private def parseSigned[A](f: String => A) =
+    mapOrFail('-'.? ~ Digit.+) { case (neg, digits) =>
+      f((neg.toSeq ++ digits).mkString)
+    }
 
   /** Parses the lower-case values `true` and `false` into their corresponding Boolean values. */
   lazy val Bool = ("true" ^^^ true) | ("false" ^^^ false)

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -96,12 +96,12 @@ object BackgroundJobService {
   private[sbt] def jobIdParser: (State, Seq[JobHandle]) => Parser[Seq[JobHandle]] = {
     import DefaultParsers.*
     (state, handles) => {
-      val stringIdParser: Parser[Seq[String]] = Space ~> token(
-        NotSpace.examples(handles.map(_.id.toString).toSet),
+      val idParser: Parser[Seq[Int]] = Space ~> token(
+        NatBasic.examples(handles.map(_.id.toString).toSet),
         description = "<job id>"
       ).+
-      stringIdParser.map { strings =>
-        strings.map(Integer.parseInt(_)).flatMap(id => handles.find(_.id == id))
+      idParser.map { ids =>
+        ids.flatMap(id => handles.find(_.id == id))
       }
     }
   }

--- a/main/src/main/scala/sbt/BackgroundJobService.scala
+++ b/main/src/main/scala/sbt/BackgroundJobService.scala
@@ -96,8 +96,8 @@ object BackgroundJobService {
   private[sbt] def jobIdParser: (State, Seq[JobHandle]) => Parser[Seq[JobHandle]] = {
     import DefaultParsers.*
     (state, handles) => {
-      val idParser: Parser[Seq[Int]] = Space ~> token(
-        NatBasic.examples(handles.map(_.id.toString).toSet),
+      val idParser: Parser[Seq[Long]] = Space ~> token(
+        LongBasic.examples(handles.map(_.id.toString).toSet),
         description = "<job id>"
       ).+
       idParser.map { ids =>


### PR DESCRIPTION
Job ids are`long`. The job id parser currently uses `NotSpace` to parse the ids, which fails with a `NumberFormatException` for short non-numeric values and OOMs SBT for long non-numeric values:

Before:
```
SBT_OPTS="-Xmx384m" sbt
[info] welcome to sbt 2.0.0 (Homebrew Java 25.0.1)
sbt:mdfm> bgStop foo
java.lang.NumberFormatException: For input string: "foo"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
        ...
sbt:mdfm> bgStop foooooooooooooooooooooooooooooooooooooooooo
[error] sbt server disconnected
```

After:
```
SBT_OPTS="-Xmx384m" sbt
[info] welcome to sbt 2.0.1-bin-SNAPSHOT (Homebrew Java 25.0.1)
sbt:mdfm> bgStop foooooooooooooooooooooooooooooooooooooooooo
[error] Expected whitespace character
[error] Expected '/'
[error] Expected digit
[error] bgStop foooooooooooooooooooooooooooooooooooooooooo
[error]        ^
```

Testing:
```
sbt
[info] welcome to sbt 2.0.1-bin-SNAPSHOT (Homebrew Java 25.0.1)
sbt:mdfm> bgRunMain org.merlin.hello
[info] [root] compiling 1 Scala source to /Users/merlin/sbt-test/target/out/jvm/scala-3.8.4/mdfm/classes ...
[info] running org.merlin.hello
[success] elapsed time: 4 s, cache 55%, 11 disk cache hits, 9 onsite tasks
Hello, world!
1
2
sbt:mdfm> show bgList
[info] * JobHandle(1, bgRunMain, ProjectRef(uri("file:/Users/merlin/sbt-test/"), "root") / Compile / bgRunMain)
[success] elapsed time: 0 s
3
4
sbt:mdfm> bgStop 1
Exception in thread "sbt-bg-threads-1" java.lang.InterruptedException: sleep interrupted
[success] elapsed time: 0 s
	at java.base/java.lang.Thread.sleepNanos0(Native Method)
sbt:mdfm> show bgList
[info] *
[success] elapsed time: 0 s
```