### PR TITLE
[2.x] preserve --allow-empty and --sbt-create in sbtArguments

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -389,7 +389,9 @@ class NetworkClient(
                 s"$javaHome/bin/java"
               }
               .getOrElse("java")
-            List(java) ++ arguments.sbtArguments ++
+            List(java) ++ arguments.sbtArguments.filterNot(
+              NetworkClient.emptyBuildFlags.contains
+            ) ++
               List("-jar", lj, DashDashDetachStdio, DashDashServer)
           case _ =>
             List(arguments.sbtScript) ++ arguments.sbtArguments ++
@@ -1270,11 +1272,13 @@ object NetworkClient {
     "--no-share",
     "-no-global",
     "--no-global",
+    "shutdownall"
+  )
+  private[client] val emptyBuildFlags: Set[String] = Set(
     "-allow-empty",
     "--allow-empty",
     "-sbt-create",
     "--sbt-create",
-    "shutdownall",
   )
   // Prefixes for launcher flags using = syntax
   private[client] val launcherEqPrefixes: Seq[String] = Seq(
@@ -1301,8 +1305,10 @@ object NetworkClient {
     var i = 0
     while (i < sanitized.length) {
       sanitized(i) match {
-        case a if completionArguments.nonEmpty => completionArguments += a
-        case a if commandArgs.nonEmpty         => commandArgs += a
+        case a if completionArguments.nonEmpty                        => completionArguments += a
+        case a if commandArgs.nonEmpty && emptyBuildFlags.contains(a) =>
+          sbtArguments += a
+        case a if commandArgs.nonEmpty                                     => commandArgs += a
         case a if a == noStdErr || a == noTab || a.startsWith(completions) =>
           completionArguments += a
         case a if a.startsWith("--sbt-script=") =>

--- a/main-command/src/test/scala/sbt/internal/client/NetworkClientParseArgsTest.scala
+++ b/main-command/src/test/scala/sbt/internal/client/NetworkClientParseArgsTest.scala
@@ -77,10 +77,34 @@ object NetworkClientParseArgsTest extends BasicTestSuite:
     assert(!result.sbtArguments.contains("-batch"))
     assert(result.commandArguments.contains("compile"))
 
-  test("-allow-empty is dropped"):
+  test("-allow-empty remains in sbtArguments and is not a sbt command"):
     val result = parse("-allow-empty", "compile")
-    assert(!result.sbtArguments.contains("-allow-empty"))
+    assert(result.sbtArguments.contains("-allow-empty"))
     assert(!result.commandArguments.contains("-allow-empty"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("--allow-empty remains in sbtArguments and is not a sbt command"):
+    val result = parse("--allow-empty", "compile")
+    assert(result.sbtArguments.contains("--allow-empty"))
+    assert(!result.commandArguments.contains("--allow-empty"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("-sbt-create remains in sbtArguments and is not a sbt command"):
+    val result = parse("-sbt-create", "compile")
+    assert(result.sbtArguments.contains("-sbt-create"))
+    assert(!result.commandArguments.contains("-sbt-create"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("--sbt-create remains in sbtArguments and is not a sbt command"):
+    val result = parse("--sbt-create", "compile")
+    assert(result.sbtArguments.contains("--sbt-create"))
+    assert(!result.commandArguments.contains("--sbt-create"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("compile --allow-empty keeps --allow-empty in sbtArguments"):
+    val result = parse("compile", "--allow-empty")
+    assert(result.sbtArguments.contains("--allow-empty"))
+    assert(!result.commandArguments.contains("--allow-empty"))
     assert(result.commandArguments.contains("compile"))
 
   // -- Eq-syntax flags and -J* --


### PR DESCRIPTION
Fix #9358

Fix the native client to make sure `--allow-empty` and legacy `--sbt-create` are propagated to the sbt server through the launcher script correctly. Drop those arguments only when explicitly passed launcher jar.