### PR TITLE
[2.x] Suppress multiple main classes warning when running tests

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1143,7 +1143,7 @@ object Defaults extends BuildCommon with DefExtra {
         // Suppress warning for run/test commands (user is actively running, warning is noise)
         def isRunOrTestCommand(s: String): Boolean = s match
           case "run" | "runMain" | "bgRun" | "bgRunMain" | "fgRun" | "fgRunMain" => true
-          case t if t.startsWith("test")                                         => true
+          case "test" | "testFull" | "testOnly" | "testQuick" | "testSelected"   => true
           case _                                                                 => false
         val logWarning = state.value.currentCommand.forall(!_.commandLine.split(" ").exists {
           case s if isRunOrTestCommand(s) => true

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1140,19 +1140,20 @@ object Defaults extends BuildCommon with DefExtra {
       selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
       run / mainClass := (run / selectMainClass).value,
       mainClass := Def.uncached {
-        // Suppress warning for run commands (user is actively running, warning is noise)
-        def isRunCommand(s: String): Boolean = s match
+        // Suppress warning for run/test commands (user is actively running, warning is noise)
+        def isRunOrTestCommand(s: String): Boolean = s match
           case "run" | "runMain" | "bgRun" | "bgRunMain" | "fgRun" | "fgRunMain" => true
+          case t if t.startsWith("test")                                         => true
           case _                                                                 => false
         val logWarning = state.value.currentCommand.forall(!_.commandLine.split(" ").exists {
-          case s if isRunCommand(s) => true
-          case r                    =>
+          case s if isRunOrTestCommand(s) => true
+          case r                          =>
             // Handle both "/" (new syntax like Test/run) and ":" (old syntax like test:run)
             r.split("[/:]") match {
               case Array(parts*) =>
                 parts.lastOption match {
-                  case Some(s) if isRunCommand(s) => true
-                  case _                          => false
+                  case Some(s) if isRunOrTestCommand(s) => true
+                  case _                                => false
                 }
             }
         })


### PR DESCRIPTION
In a project with multiple main classes, the "multiple main classes detected" warning is unwanted noise when running tests. This message is already suppressed for explicit run commands, now also suppress it for test commands.

Before:
```
> sbt
[info] server was not detected. starting an instance
[info] welcome to sbt 2.0.0 (Homebrew Java 25.0.1)
sbt:scarre> test
[warn] multiple main classes detected: run 'show discoveredMainClasses' to see the list
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testQuick
```

After:
```
> sbt
[info] server was not detected. starting an instance
[info] welcome to sbt 2.0.1-bin-SNAPSHOT (Homebrew Java 25.0.1)
sbt:scarre> test
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for Test / testQuick
```
