### PR TITLE
[2.x] fix: Fixes runner parsing build.properties with whitespaces

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -169,8 +169,10 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
     "sbt -v '++ 3' ci does not run native client for spaced sbt 1.x project",
     citestVariant = "citest",
     buildPropsContents = "sbt.version = 1.12.11\n",
+    stagedRunnerVersionOverride = "2.0.0",
   )("-v", "++ 3", "ci"): (out: List[String]) =>
     assert(!out.exists(_.contains("running native client")))
+    assert(out.exists(_.contains("sbt-launch.jar")))
     ()
 
   // Test for issue #4189: Improve -help and help commands

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -154,6 +154,25 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
     assertVersionOutput(out)
     ()
 
+  testOutput(
+    "sbt --version reports spaced sbt.version from project/build.properties (sbt 1.x)",
+    citestVariant = "citest",
+    buildPropsContents = "sbt.version = 1.12.11\n",
+  )("--version"): (out: List[String]) =>
+    val lines =
+      out.mkString(System.lineSeparator()).linesIterator.map(_.stripPrefix("[0J").trim).toList
+    assert(lines.exists(_.matches("^sbt version in this project: 1\\.12\\.11\\r?$")))
+    assert(lines.exists(_.matches("^sbt runner version: " + versionPattern + "\\r?$")))
+    ()
+
+  testOutput(
+    "sbt -v '++ 3' ci does not run native client for spaced sbt 1.x project",
+    citestVariant = "citest",
+    buildPropsContents = "sbt.version = 1.12.11\n",
+  )("-v", "++ 3", "ci"): (out: List[String]) =>
+    assert(!out.exists(_.contains("running native client")))
+    ()
+
   // Test for issue #4189: Improve -help and help commands
   testOutput(
     "sbt --help should show getting-started hints",

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -116,14 +116,20 @@ trait ShellScriptUtil extends BasicTestSuite {
 
           val envVars = scala.collection.mutable.Map[String, String]()
 
+          // Set up dist sbtopts if provided
+          // Note: sbt script derives sbt_home from script location, not SBT_HOME env var
+          // Copy the sbt staging directory to a temp location to avoid modifying the staging directory
           if (distSbtoptsContents.nonEmpty || stagedRunnerVersionOverride.nonEmpty) {
             val originalSbtHome = sbtScript.getParentFile.getParentFile
             val tempSbtHomeDir = Files.createTempDirectory("sbt-home-test").toFile
             tempSbtHome = Some(tempSbtHomeDir)
+            // Copy the entire sbt home directory structure
             retry(() => IO.copyDirectory(originalSbtHome, tempSbtHomeDir))
+            // Get the script from the copied directory
             val binDir = new File(tempSbtHomeDir, "bin")
             testSbtScript = new File(binDir, sbtScript.getName)
             if (distSbtoptsContents.nonEmpty) {
+              // Create dist sbtopts in the copied directory
               val distSbtoptsDir = new File(tempSbtHomeDir, "conf")
               distSbtoptsDir.mkdirs()
               IO.write(new File(distSbtoptsDir, "sbtopts"), distSbtoptsContents)
@@ -148,6 +154,7 @@ trait ShellScriptUtil extends BasicTestSuite {
               IO.write(testSbtScript, updated)
               if (!isBat) testSbtScript.setExecutable(true)
             }
+            // Store reference for cleanup
             sbtHome = Some(tempSbtHomeDir)
           }
 

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -40,6 +40,7 @@ trait ShellScriptUtil extends BasicTestSuite {
       machineSbtoptsContents: String = "",
       jvmoptsFileContents: String = "",
       buildPropsContents: String = "",
+      stagedRunnerVersionOverride: String = "",
       windowsSupport: Boolean = true,
       citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
@@ -115,24 +116,38 @@ trait ShellScriptUtil extends BasicTestSuite {
 
           val envVars = scala.collection.mutable.Map[String, String]()
 
-          // Set up dist sbtopts if provided
-          // Note: sbt script derives sbt_home from script location, not SBT_HOME env var
-          // Copy the sbt staging directory to a temp location to avoid modifying the staging directory
-          if (distSbtoptsContents.nonEmpty) {
+          if (distSbtoptsContents.nonEmpty || stagedRunnerVersionOverride.nonEmpty) {
             val originalSbtHome = sbtScript.getParentFile.getParentFile
             val tempSbtHomeDir = Files.createTempDirectory("sbt-home-test").toFile
             tempSbtHome = Some(tempSbtHomeDir)
-            // Copy the entire sbt home directory structure
             retry(() => IO.copyDirectory(originalSbtHome, tempSbtHomeDir))
-            // Get the script from the copied directory
             val binDir = new File(tempSbtHomeDir, "bin")
             testSbtScript = new File(binDir, sbtScript.getName)
-            // Create dist sbtopts in the copied directory
-            val distSbtoptsDir = new File(tempSbtHomeDir, "conf")
-            distSbtoptsDir.mkdirs()
-            val distSbtoptsFile = new File(distSbtoptsDir, "sbtopts")
-            IO.write(distSbtoptsFile, distSbtoptsContents)
-            // Store reference for cleanup
+            if (distSbtoptsContents.nonEmpty) {
+              val distSbtoptsDir = new File(tempSbtHomeDir, "conf")
+              distSbtoptsDir.mkdirs()
+              IO.write(new File(distSbtoptsDir, "sbtopts"), distSbtoptsContents)
+            }
+            if (stagedRunnerVersionOverride.nonEmpty) {
+              val isBat = testSbtScript.getName.endsWith(".bat")
+              val prefix =
+                if (isBat) "set init_sbt_version=" else "declare init_sbt_version="
+              val pattern =
+                if (isBat) "(?m)^set init_sbt_version=.*$"
+                else "(?m)^declare init_sbt_version=.*$"
+              val original = IO.read(testSbtScript)
+              val regex = pattern.r
+              assert(
+                regex.findFirstIn(original).nonEmpty,
+                s"init_sbt_version line not found in $testSbtScript"
+              )
+              val replacement =
+                java.util.regex.Matcher.quoteReplacement(prefix + stagedRunnerVersionOverride)
+              val updated = regex.replaceAllIn(original, replacement)
+              assert(updated.contains(prefix + stagedRunnerVersionOverride))
+              IO.write(testSbtScript, updated)
+              if (!isBat) testSbtScript.setExecutable(true)
+            }
             sbtHome = Some(tempSbtHomeDir)
           }
 

--- a/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
+++ b/launcher-package/integration-test/src/test/scala/ShellScriptUtil.scala
@@ -39,6 +39,7 @@ trait ShellScriptUtil extends BasicTestSuite {
       distSbtoptsContents: String = "",
       machineSbtoptsContents: String = "",
       jvmoptsFileContents: String = "",
+      buildPropsContents: String = "",
       windowsSupport: Boolean = true,
       citestVariant: String = "citest",
   )(args: String*)(f: List[String] => Any) =
@@ -104,6 +105,12 @@ trait ShellScriptUtil extends BasicTestSuite {
             } finally {
               jvmoptsWriter.close()
             }
+          }
+
+          if (buildPropsContents.nonEmpty) {
+            val projectDir = new File(workingDirectory, "project")
+            projectDir.mkdirs()
+            IO.write(new File(projectDir, "build.properties"), buildPropsContents)
           }
 
           val envVars = scala.collection.mutable.Map[String, String]()

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -96,8 +96,12 @@ if defined JAVA_HOMES (
 
 if exist "project\build.properties" (
   for /F "eol=# delims== tokens=1*" %%a in (project\build.properties) do (
-    if "%%a" == "sbt.version" if not "%%b" == "" (
-      set build_props_sbt_version=%%b
+    set "_prop_key="
+    set "_prop_val="
+    for /F "tokens=1 delims= " %%k in ("%%a") do set "_prop_key=%%k"
+    for /F "tokens=1 delims= " %%v in ("%%b") do set "_prop_val=%%v"
+    if "!_prop_key!" == "sbt.version" if not "!_prop_val!" == "" (
+      set "build_props_sbt_version=!_prop_val!"
     )
   )
 )

--- a/sbt
+++ b/sbt
@@ -870,6 +870,7 @@ appendSbtoptsFromFile() {
 
 loadPropFile() {
   while IFS='=' read -r k v; do
+    # trim key and value so as to be more forgiving with spaces around the '=':
     k=$(trimString "$k")
     v=$(trimString "$v")
     if [[ "$k" == "sbt.version" ]]; then

--- a/sbt
+++ b/sbt
@@ -869,10 +869,9 @@ appendSbtoptsFromFile() {
 }
 
 loadPropFile() {
-  # trim key and value so as to be more forgiving with spaces around the '=':
-  k=$(trimString $k)
-  v=$(trimString $v)
   while IFS='=' read -r k v; do
+    k=$(trimString "$k")
+    v=$(trimString "$v")
     if [[ "$k" == "sbt.version" ]]; then
       build_props_sbt_version="$v"
     fi


### PR DESCRIPTION
Fixes #9339

## Problem
When `build.properties` contains whitespaces like `sbt.version = 1.12.12`, parsing fails and the detected sbt version falls back to 2.0.0.

## Solution
Trim whitespaces in build.properties.