### PR TITLE
[2.x] Fix macro expand for HKT type arguments

### DIFF
--- a/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
+++ b/core-macros/src/main/scala/sbt/internal/util/appmacro/Convert.scala
@@ -64,6 +64,8 @@ trait Convert[C <: Quotes & Singleton] extends ContextUtil[C]:
                     report.errorAndAbort(message, position)
                   case _ =>
                     super.transformTerm(tree)(owner)
+              case _ =>
+                super.transformTerm(tree)(owner)
           case _ =>
             super.transformTerm(tree)(owner)
     end appTransformer

--- a/main-settings/src/test/scala/sbt/std/UsageTest.scala
+++ b/main-settings/src/test/scala/sbt/std/UsageTest.scala
@@ -29,6 +29,30 @@ object UseTask:
   }
 end UseTask
 
+// https://github.com/sbt/sbt/issues/9375
+object UseHktTypeArgument:
+  final class IO[A]
+
+  object Builder:
+    def apply[F[_]](value: String): String = value
+
+  val settingWithHktTypeArgument: Def.Initialize[String] = Def.setting {
+    Builder[IO]("setting")
+  }
+
+  val taskWithHktTypeArgument: Def.Initialize[Task[String]] = Def.task {
+    Builder[IO]("task")
+  }
+
+  val name = Def.settingKey[String]("name")
+  val key = Def.taskKey[String]("key")
+  val settings = Seq(
+    key := Def.uncached {
+      Builder[IO](name.value)
+    }
+  )
+end UseHktTypeArgument
+
 object Assign {
   import java.io.File
 


### PR DESCRIPTION
fix https://github.com/sbt/sbt/issues/9375

`Def.setting` and `Def.task` macro expansion looks for internal wrapper call generated for `.value`.

It visits all function calls in the macro. If the block contains functions call whose type parameter is HKT, macro expansion crashed.

For example:

```scala
final class IO[A]
object Builder {
  def apply[F[_]](value: String): String = value
}
Def.setting {
  Builder[IO](name.value)
}
```

Macro expansion tries to match `IO` against `'[a]`, and failed with `MatchError`.

This commit adds wildcard pattern, and leave unmatched type arguments unchanged.