### PR TITLE
[2.x] Update Coursier to version 2.1.25-M26

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -121,7 +121,7 @@ object Dependencies {
 
   // lm-coursier dependencies
   val dataclassScalafixVersion = "0.3.0"
-  val coursierVersion = "2.1.25-M25"
+  val coursierVersion = "2.1.25-M26"
 
   val coursier = ("io.get-coursier" %% "coursier" % coursierVersion)
     .cross(CrossVersion.for3Use2_13)


### PR DESCRIPTION
This is forward port of https://github.com/sbt/sbt/pull/9382

Includes performance improvements.

https://github.com/coursier/coursier/compare/v2.1.25-M25...v2.1.25-M26