### PR TITLE
[2.x] fix: Discard a cancelled task's output backlog on cancel

### DIFF
--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -92,6 +92,7 @@ final class NetworkChannel(
   private val pendingWrites = new LinkedBlockingQueue[(Array[Byte], Boolean)]()
   private val attached = new AtomicBoolean(false)
   private val alive = new AtomicBoolean(true)
+  private val isCanceled = new AtomicBoolean(false)
   private[sbt] def isInteractive = interactive.get
   private val interactive = new AtomicBoolean(false)
   private[sbt] def setInteractive(id: String, value: Boolean) = {
@@ -109,6 +110,10 @@ final class NetworkChannel(
   private[sbt] def prompt(): Unit = {
     interactive.set(true)
     jsonRpcNotify(promptChannel, "")
+  }
+  override def prompt(e: ConsolePromptEvent): Unit = {
+    isCanceled.set(false)
+    super.prompt(e)
   }
   private[sbt] def write(byte: Byte) = inputBuffer.add(byte.toInt)
 
@@ -533,6 +538,8 @@ final class NetworkChannel(
                 StandardMain.exchange.currentExec.exists(_.source.exists(_.channelName == name)))
             ) {
               runningEngine.cancelAndShutdown()
+              isCanceled.set(true)
+              discardPending()
 
               respondResult(
                 ExecStatusEvent(
@@ -626,16 +633,19 @@ final class NetworkChannel(
   }
 
   /** Notify to Language Server's client. */
-  private[sbt] def jsonRpcNotify[A: JsonFormat](method: String, params: A): Unit = {
-    val m =
-      JsonRpcNotificationMessage("2.0", method, Option(Converter.toJson[A](params).get))
-    if (method != Serialization.systemOut) {
-      forceFlush()
-      log.debug(s"jsonRpcNotify: $m")
+  private[sbt] def jsonRpcNotify[A: JsonFormat](method: String, params: A): Unit =
+    if (isCanceled.get && NetworkChannel.isCanceledOutput(method))
+      ()
+    else {
+      val m =
+        JsonRpcNotificationMessage("2.0", method, Option(Converter.toJson[A](params).get))
+      if (method != Serialization.systemOut) {
+        forceFlush()
+        log.debug(s"jsonRpcNotify: $m")
+      }
+      val bytes = Serialization.serializeNotificationMessage(m)
+      publishBytes(bytes)
     }
-    val bytes = Serialization.serializeNotificationMessage(m)
-    publishBytes(bytes)
-  }
 
   /** Notify to Language Server's client. */
   private[sbt] def jsonRpcRequest[A: JsonFormat](id: String, method: String, params: A): Unit = {
@@ -676,6 +686,11 @@ final class NetworkChannel(
 
   import scala.jdk.CollectionConverters.*
   private val outputBuffer = new LinkedBlockingQueue[Byte]
+  private def discardPending(): Unit = {
+    pendingWrites.clear()
+    outputBuffer.synchronized(outputBuffer.clear())
+  }
+
   // Batches writes to the client at most once per 20ms to cut terminal flicker (see
   // CoalescingFlusher). forceFlush drains now while leaving the timer live.
   private val flusher =
@@ -943,6 +958,9 @@ final class NetworkChannel(
 }
 
 object NetworkChannel {
+  private[server] def isCanceledOutput(method: String): Boolean =
+    method == Serialization.systemOut || method == Serialization.systemErr
+
   private[sbt] def cancel(
       execID: Option[String],
       id: String,

--- a/main/src/test/scala/sbt/internal/server/NetworkChannelSpec.scala
+++ b/main/src/test/scala/sbt/internal/server/NetworkChannelSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.server
+
+import sbt.protocol.Serialization
+import verify.BasicTestSuite
+
+object NetworkChannelSpec extends BasicTestSuite:
+
+  test("only systemOut and systemErr are dropped while canceling") {
+    assert(NetworkChannel.isCanceledOutput(Serialization.systemOut))
+    assert(NetworkChannel.isCanceledOutput(Serialization.systemErr))
+  }
+
+  test("control-plane and flush methods are never dropped while canceling") {
+    val kept = Seq(
+      Serialization.systemOutFlush,
+      Serialization.systemErrFlush,
+      Serialization.readSystemIn,
+      Serialization.promptChannel,
+      "build/logMessage",
+      "sbt/exec",
+      "window/logMessage",
+      sbt.BasicCommandStrings.Shutdown,
+    )
+    kept.foreach(m => assert(!NetworkChannel.isCanceledOutput(m), s"must not drop: $m"))
+  }
+
+end NetworkChannelSpec

--- a/notes/2.0.0/cancel-discards-output.md
+++ b/notes/2.0.0/cancel-discards-output.md
@@ -1,0 +1,8 @@
+### Cancelling a task discards its queued output
+
+Previously, cancelling a task that was producing a lot of output (Ctrl+C from the
+thin client) stopped the task, but the server kept draining the already-queued
+output to the client for several seconds, so the cancel appeared not to take
+effect. The cancelled task's buffered stdout/stderr is now discarded on cancel,
+so output stops promptly. Control-plane messages and the next command's output
+are unaffected.


### PR DESCRIPTION
## Problem

A task that floods stdout cannot be stopped promptly. Cancelling it (Ctrl+C from
`sbtn` / `sbt --client`) stops the task, but the server keeps draining the
already-queued output to the client for several seconds, so the cancel appears
not to take effect (#9373).

## Fix

`NetworkChannel.onCancellationRequest` now sets a per-channel `discarding` flag
and clears the queued frames and buffered stdout (`discardPending`). While the
flag is set, `jsonRpcNotify` drops the cancelled task's `systemOut`/`systemErr`
instead of delivering the backlog, so output stops promptly.

- Only those two data channels are gated. Control-plane replies (including the
  cancel ack, enqueued after the clear) and all other notifications flow normally.
  `NetworkChannel.isCancelledOutput` is a pure function so this contract is
  unit-tested.
- It is a flag, not a one-shot clear, because `cancelAndShutdown` only interrupts:
  a CPU-bound print loop keeps producing until it actually stops, and the flag
  gates that late output.
- The flag is reset at the next prompt (`prompt(ConsolePromptEvent)`, which fires
  per command), so the following command's output is delivered normally.

## Scope

This addresses the titled Ctrl+C symptom (the output backlog). The server-side
heap growth under a sustained flood (the ~6.6GB in the report) is a separate
follow-up: capping it needs back-pressure on the output buffers, which depends on
a separate fix to the output-flush coalescing that I am preparing independently.
Kept this change to the discard-on-cancel path so it stays surgical.

The object-level `NetworkChannel.cancel` path (server-side `shutdownall`) is
static with no channel handle, so it does not apply the discard; the interactive
Ctrl+C path (`onCancellationRequest`) is the one users hit.

## Testing

- `NetworkChannelSpec` (Verify): pins the control-plane-safety contract (only
  `systemOut`/`systemErr` are ever gated; responses, `Shutdown`, `build/logMessage`,
  flush markers, etc. are never dropped). A regression here would silently drop
  protocol replies.
- The discard and per-prompt reset behavior were verified with standalone
  concurrency harnesses (deadlock-free, frame-safe, reset-always-fires,
  cancel-ack-preserved); they are timing-dependent and kept out of the
  deterministic CI suite.
- `mainProj/scalafmtCheck`, `mainProj/Test/scalafmtCheck`,
  `mainProj/mimaReportBinaryIssues` green.

Refs #9373

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by me
(compile, unit test, scalafmt, MiMa, plus adversarial concurrency verification).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
