### PR TITLE
[2.x] fix: Fixes ByteStream timeout

### DIFF
--- a/sbt-remote-cache/src/main/scala/sbt/internal/GrpcActionCacheStore.scala
+++ b/sbt-remote-cache/src/main/scala/sbt/internal/GrpcActionCacheStore.scala
@@ -151,12 +151,16 @@ class GrpcActionCacheStore(
     case _       => casStub0
   lazy val byteStreamStub0 = ByteStreamGrpc.newStub(channel)
   lazy val byteStreamStub = remoteHeaders match
-    case x :: xs =>
-      byteStreamStub0
-        .withCallCredentials(creds)
-        .withDeadlineAfter(remoteTimeoutInSec, TimeUnit.SECONDS)
-    case _ =>
-      byteStreamStub0.withDeadlineAfter(remoteTimeoutInSec, TimeUnit.SECONDS)
+    case x :: xs => byteStreamStub0.withCallCredentials(creds)
+    case _       => byteStreamStub0
+
+  // The deadline must be attached per call, not on the memoized stub above.
+  // withDeadlineAfter computes an absolute deadline at the moment it is called, so a stub
+  // stored in a (session-lived) lazy val would expire remoteTimeoutInSec after first use and
+  // then reject every later call with DEADLINE_EXCEEDED. Deriving a fresh stub per RPC gives
+  // each call its own relative timeout.
+  private[internal] def byteStreamStubWithDeadline =
+    byteStreamStub.withDeadlineAfter(remoteTimeoutInSec, TimeUnit.SECONDS)
 
   override def storeName: String = "remote"
 
@@ -279,7 +283,7 @@ class GrpcActionCacheStore(
   def uploadBlob(blob: VirtualFile): Future[HashedVirtualFileRef] =
     val d = Digest(blob)
     withSingleResponse[ByteStreamProto.WriteResponse, HashedVirtualFileRef]: (p, resObs) =>
-      val reqObs = byteStreamStub.write(resObs)
+      val reqObs = byteStreamStubWithDeadline.write(resObs)
       val un = uploadName(d, UUID.randomUUID())
       var off: Long = 0L
       try
@@ -327,7 +331,7 @@ class GrpcActionCacheStore(
     b.setResourceName(dn)
     b.setReadOffset(0L)
     val req = b.build()
-    byteStreamStub.read(req, resObs)
+    byteStreamStubWithDeadline.read(req, resObs)
     p.future
 
   // helper function for many-to-one gRPC streaming

--- a/sbt-remote-cache/src/test/scala/sbt/internal/GrpcActionCacheStoreTest.scala
+++ b/sbt-remote-cache/src/test/scala/sbt/internal/GrpcActionCacheStoreTest.scala
@@ -1,6 +1,11 @@
 package sbt
 package internal
 
+import java.net.URI
+import java.nio.file.Files
+import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.util.DiskActionCacheStore
+
 object GrpcActionCacheStoreTest extends verify.BasicTestSuite:
   test("chunkBytes"):
     val actual = GrpcActionCacheStore.chunkBytes(0L)
@@ -15,4 +20,26 @@ object GrpcActionCacheStoreTest extends verify.BasicTestSuite:
 
     val actual4 = GrpcActionCacheStore.chunkBytes(meg + 1)
     assert(actual4 == List(meg, 1L))
+
+  // Regression test: the ByteStream deadline must be applied per RPC, not baked into the
+  // memoized stub. A deadline on the (session-lived) stub is absolute and expires
+  // remoteTimeoutInSec after first use, after which every later blob transfer fails with
+  // DEADLINE_EXCEEDED for the rest of the sbt server's life.
+  test("byteStream deadline is per-call, not on the memoized stub"):
+    val store = newStore()
+    assert(store.byteStreamStub.getCallOptions.getDeadline == null)
+
+    val deadline1 = store.byteStreamStubWithDeadline.getCallOptions.getDeadline
+    val deadline2 = store.byteStreamStubWithDeadline.getCallOptions.getDeadline
+    assert(deadline1 != null)
+    assert(deadline2 != null)
+    // Distinct Deadline instances derived at call time, not a single shared frozen one.
+    assert(!deadline1.eq(deadline2))
+
+  private def newStore(): GrpcActionCacheStore =
+    val base = Files.createTempDirectory("grpc-action-cache-test")
+    val disk = DiskActionCacheStore(base, PlainVirtualFileConverter.converter)
+    // A plaintext URI is enough to build the stubs; no connection is opened by reading
+    // CallOptions, so no server is required.
+    GrpcActionCacheStore(new URI("grpc://localhost:1"), None, None, None, Nil, disk)
 end GrpcActionCacheStoreTest


### PR DESCRIPTION
## Problem

Since upgrading to sbt 2.x, we see a lot of errors in CI like this one:

```
com.eed3si9n.remoteapis.shaded.io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: ClientCall started after CallOptions deadline was exceeded -6.675555649 seconds ago. Name resolution delay 0.000000000      
  seconds.                                                                                                                                                                                                      
        at com.eed3si9n.remoteapis.shaded.io.grpc.Status.asRuntimeException(Status.java:533)                                                                                                                    
        at com.eed3si9n.remoteapis.shaded.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:481)                                                                            
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:574)                                                                                                
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:72)                                                                                                    
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:742)                                                           
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:723)                                                          
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)                                                                                                         
        at com.eed3si9n.remoteapis.shaded.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)                                                                                                
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)                                                                                                            
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)                                                                                                            
        at java.base/java.lang.Thread.run(Thread.java:1474)
```

If you check the deadlines, they all point to a single point in time. That seems to be due to the deadline being accidentally cached as an absolute point in time inside a `lazy val`, namely `GrpcActionCacheStore.byteStreamStub`'s `withDeadlineAfter`:

```scala
lazy val byteStreamStub = remoteHeaders match
  case x :: xs =>
    byteStreamStub0
      .withCallCredentials(creds)
      .withDeadlineAfter(remoteTimeoutInSec, TimeUnit.SECONDS)
  case _ =>
    byteStreamStub0.withDeadlineAfter(remoteTimeoutInSec, TimeUnit.SECONDS)
```

`withDeadlineAfter` computes an **absolute** `Deadline` (now + 60s) at the moment it is evaluated. 

### Impact

Only the ByteStream stub carries the deadline (`acStub`/`casStub` don't), and ByteStream is used only for blobs larger than `chunkSizeBytes` (1 MiB) — i.e. real module artifacts. So after the first 60s of the session:

- **Uploads fail** → the cache is never populated (even the seeding build only uploads for its first 60s).
- **Downloads fail** → `getActionResult` still succeeds, so sbt finds a remote hit, then can't fetch the output and falls back to local execution.

The failures are swallowed as `NonFatal` (build stays green), so this surfaces only as noisy stack traces and a remote cache that provides no speedup.

## Fix

Extract the application of the timeout/deadline into a `def`, keep the rest of options inside the `lazy val`.

## Test

Added a regression test asserting the memoized stub carries no deadline while per-call derivations each produce a distinct `Deadline`.


AI (Claude Opus 4.8) has been used to investigate and fix, everything has been manually reviewed and tested.
