### PR TITLE
[2.0.x] bport: Keep the output-flush timer alive across forceFlush

### DIFF
--- a/main/src/main/scala/sbt/internal/server/CoalescingFlusher.scala
+++ b/main/src/main/scala/sbt/internal/server/CoalescingFlusher.scala
@@ -1,0 +1,57 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package server
+
+import java.util.concurrent.{ Executors, Future, RejectedExecutionException, TimeUnit }
+import java.util.concurrent.atomic.AtomicReference
+import sbt.internal.util.Util
+
+/**
+ * Coalesces calls to a `drain` callback so it runs at most once per `delayMillis` window, on one
+ * dedicated thread. This batches remote-client writes to cut terminal flicker and byte volume.
+ *
+ * [[forceFlush]] runs the drain immediately (e.g. to order buffered stdout before a control-plane
+ * message) and leaves the timer live, so coalescing keeps working; a pending coalesced drain
+ * harmlessly drains the remainder when it fires. Only [[close]] shuts the thread down.
+ */
+private[server] final class CoalescingFlusher(
+    threadName: String,
+    delayMillis: Long,
+    drain: () => Unit
+) extends AutoCloseable:
+  private val executor = Executors.newSingleThreadScheduledExecutor(r => new Thread(r, threadName))
+  private val pending = new AtomicReference[Future[?]]
+
+  /**
+   * Schedule a coalesced drain if none is already pending; drain inline if the timer is closed.
+   * Not safe for concurrent callers (the check-then-schedule on `pending` is not atomic); the sole
+   * caller serializes its writes upstream.
+   */
+  def flush(): Unit =
+    pending.get match
+      case null =>
+        try
+          pending.set(
+            executor.schedule(
+              (() => { pending.set(null); drain() }): Runnable,
+              delayMillis,
+              TimeUnit.MILLISECONDS
+            )
+          )
+        catch case _: RejectedExecutionException => drain()
+      case _ => ()
+
+  /** Drain now, leaving the timer intact so subsequent [[flush]] calls still coalesce. */
+  def forceFlush(): Unit = drain()
+
+  def close(): Unit = Util.ignoreResult(executor.shutdownNow())
+
+end CoalescingFlusher

--- a/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
+++ b/main/src/main/scala/sbt/internal/server/NetworkChannel.scala
@@ -12,13 +12,7 @@ package server
 
 import java.io.{ IOException, InputStream, OutputStream }
 import java.net.{ Socket, SocketTimeoutException }
-import java.util.concurrent.{
-  ConcurrentHashMap,
-  Executors,
-  LinkedBlockingQueue,
-  RejectedExecutionException,
-  TimeUnit
-}
+import java.util.concurrent.{ ConcurrentHashMap, LinkedBlockingQueue }
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import sbt.BasicCommandStrings.{ Shutdown, TerminateAction }
@@ -586,6 +580,7 @@ final class NetworkChannel(
       remainingCommands: Option[(String, String)]
   ): Unit = {
     doFlush()
+    flusher.close()
     terminal.close()
     StandardMain.exchange.removeChannel(this)
     super.shutdown(logShutdown)
@@ -680,15 +675,18 @@ final class NetworkChannel(
 
   import scala.jdk.CollectionConverters.*
   private val outputBuffer = new LinkedBlockingQueue[Byte]
-  private val flushExecutor = Executors.newSingleThreadScheduledExecutor(r =>
-    new Thread(r, s"$name-output-buffer-timer-thread")
-  )
+  // Batches writes to the client at most once per 20ms to cut terminal flicker (see
+  // CoalescingFlusher). forceFlush drains now while leaving the timer live.
+  private val flusher =
+    new CoalescingFlusher(s"$name-output-buffer-timer-thread", 20L, () => doFlush())
 
-  private def forceFlush(): Unit =
-    Util.ignoreResult(flushExecutor.shutdownNow())
-    doFlush()
+  private def forceFlush(): Unit = flusher.forceFlush()
 
-  private def doFlush() = {
+  // Serializes an inline forceFlush drain against the timer's drain across BOTH the drain and the
+  // publish, so two stdout batches can't reach the client out of order (publishBytes is a queue
+  // put, so it can't deadlock under this lock).
+  private val flushLock = new AnyRef
+  private def doFlush(): Unit = flushLock.synchronized {
     val list = new java.util.ArrayList[Byte]
     outputBuffer.synchronized(outputBuffer.drainTo(list))
     if (!list.isEmpty) jsonRpcNotify(Serialization.systemOut, list.asScala.toSeq)
@@ -696,42 +694,13 @@ final class NetworkChannel(
 
   private lazy val outputStream: OutputStream & AutoCloseable = new OutputStream
     with AutoCloseable {
-    /*
-     * We buffer calls to flush to the remote client so that it is called at most
-     * once every 20 milliseconds. This is done because many terminals seem to flicker
-     * and display ghost characters if we flush to the remote client too often. The
-     * json protocol is a bit bulky so this will also reduce the total number of
-     * bytes that are written to the named pipe or unix domain socket. The buffer
-     * period of 20 milliseconds was arbitrarily chosen and could be tuned in the future.
-     * The thinking is that writes tend to be bursty so a twenty millisecond window is
-     * probably long enough to catch each burst but short enough to not introduce
-     * noticeable latency.
-     */
-    private val flushFuture = new AtomicReference[java.util.concurrent.Future[?]]
     override def close(): Unit = {
       forceFlush()
     }
     override def write(b: Int): Unit = outputBuffer.synchronized {
       outputBuffer.put(b.toByte)
     }
-    override def flush(): Unit = {
-      flushFuture.get match {
-        case null =>
-          try {
-            flushFuture.set(
-              flushExecutor.schedule(
-                (() => {
-                  flushFuture.set(null)
-                  doFlush()
-                }): Runnable,
-                20,
-                TimeUnit.MILLISECONDS
-              )
-            )
-          } catch { case _: RejectedExecutionException => doFlush() }
-        case f =>
-      }
-    }
+    override def flush(): Unit = flusher.flush()
     override def write(b: Array[Byte]): Unit = outputBuffer.synchronized {
       b.foreach(outputBuffer.put)
     }

--- a/main/src/test/scala/sbt/internal/server/CoalescingFlusherSpec.scala
+++ b/main/src/test/scala/sbt/internal/server/CoalescingFlusherSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.server
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import verify.BasicTestSuite
+
+object CoalescingFlusherSpec extends BasicTestSuite:
+
+  private def newFlusher(count: AtomicInteger, delayMillis: Long = 20L): CoalescingFlusher =
+    new CoalescingFlusher("test-flusher", delayMillis, () => { count.incrementAndGet(); () })
+
+  private def awaitAtLeast(count: AtomicInteger, n: Int): Unit =
+    val deadline = System.nanoTime + TimeUnit.SECONDS.toNanos(5)
+    while (count.get < n && System.nanoTime < deadline) Thread.sleep(2)
+
+  test("repeated flush calls within the window coalesce into a single drain") {
+    val drains = new AtomicInteger(0)
+    val flusher = newFlusher(drains)
+    try {
+      (1 to 50).foreach(_ => flusher.flush())
+      awaitAtLeast(drains, 1)
+      assert(drains.get == 1, s"expected 1 coalesced drain, got ${drains.get}")
+    } finally flusher.close()
+  }
+
+  // The regression this fixes: forceFlush used to shut the timer executor down, so all later
+  // flushes stopped coalescing (and, in the bad state, stopped draining). It must drain now and
+  // leave the timer live.
+  test("forceFlush drains immediately and does not disable coalescing") {
+    val drains = new AtomicInteger(0)
+    val flusher = newFlusher(drains)
+    try {
+      flusher.forceFlush() // 1 immediate drain
+      assert(drains.get == 1)
+      (1 to 50).foreach(_ => flusher.flush()) // must still coalesce into 1 scheduled drain
+      awaitAtLeast(drains, 2)
+      // exactly 2: if forceFlush had torn down the executor, each flush would fall back to an
+      // inline drain instead of coalescing, giving 51.
+      assert(drains.get == 2, s"expected 2 drains, got ${drains.get}")
+    } finally flusher.close()
+  }
+
+  test("flush after close drains inline") {
+    val drains = new AtomicInteger(0)
+    val flusher = newFlusher(drains)
+    flusher.close()
+    flusher.flush()
+    assert(drains.get == 1, s"expected inline drain after close, got ${drains.get}")
+  }
+
+end CoalescingFlusherSpec

--- a/notes/2.0.0/output-flush-coalescing.md
+++ b/notes/2.0.0/output-flush-coalescing.md
@@ -1,0 +1,6 @@
+### Server output flushing no longer disables its own coalescing
+
+The server batches a task's stdout/stderr to the client about once every 20ms to
+reduce terminal flicker. Ordering buffered output ahead of a control-plane message
+used to shut that timer down, so subsequent output was flushed per write instead
+of batched for the rest of the connection. The timer now stays alive.


### PR DESCRIPTION
This is 2.0.x backport of #9414

NetworkChannel batches writes to the client at most once per 20ms to reduce terminal flicker and byte volume. forceFlush(), used to order buffered stdout ahead of a control-plane message, called flushExecutor.shutdownNow() -- the only place the executor was ever shut down. Once it ran during active output it tore the executor down (and, if a coalesced flush was pending, cancelled its future without resetting flushFuture, leaving the slot stuck), so the 20ms coalescing was gone for the rest of the connection: stdout was then flushed per write via the inline fallback instead of batched. Output still reaches the client, so the effect is extra flushes rather than lost output, but shutting the shared executor down on the first forceFlush is clearly unintended.

Extract the flush state machine into CoalescingFlusher. forceFlush now drains immediately and leaves the timer live (a pending coalesced drain harmlessly drains the remainder when it fires); the executor is shut down once, at channel teardown, so it no longer leaks. doFlush now holds a lock across both the drain and the publish so an inline forceFlush and the timer's drain can't deliver two stdout batches out of order.

Fixes #9415