### PR TITLE
[2.x] Tweak server startup message

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -183,6 +183,11 @@ class NetworkClient(
     def log(level: Level.Value, message: => String): Unit = console.appendLog(level, message)
   }
   private val interactive = arguments.commandArguments.isEmpty
+  private val startupMessages: List[String] =
+    "entering thin client - BEEP WHIRR" ::
+      "starting sbt server in the background" ::
+      "use 'sbt shutdown' to shutdown the server" ::
+      " " :: Nil
 
   private[sbt] def connectOrStartServerAndConnect(
       promptCompleteUsers: Boolean,
@@ -359,8 +364,9 @@ class NetworkClient(
     var serverStderrFile: Option[File] = None
     val process = socket match {
       case None if startServer =>
-        if (log) console.appendLog(Level.Info, "server was not detected. starting an instance")
-
+        if log then
+          startupMessages.foreach: msg =>
+            console.appendLog(Level.Info, msg)
         val props =
           Seq(
             term.getWidth,
@@ -965,10 +971,8 @@ class NetworkClient(
           catch { case _: InterruptedException => }
           if (exitClean.get) 0 else 1
         }
-        if (interactive) {
-          console.appendLog(Level.Info, "terminate the server with `shutdown`")
-          block()
-        } else if (exit) 0
+        if interactive then block()
+        else if exit then 0
         else {
           batchMode.set(true)
           val res = batchExecute(userCommands.toList)

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -97,7 +97,7 @@ private[sbt] object Server {
                 case null =>
                 case s    => s.close()
               }
-              log.info(s"sbt server started at ${connection.shortName}")
+              log.debug(s"sbt server started at ${connection.shortName}")
               writePortfile()
               if (connection.bspEnabled) {
                 log.debug("Writing bsp connection file")

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -255,7 +255,7 @@ private[sbt] final class CommandExchange {
         case Some(Success(())) =>
           // remember to shutdown only when the server comes up
           server = Some(serverInstance)
-          s.log.info("started sbt server")
+          s.log.debug("started sbt server")
           // register this server in the shared proc directory
           try {
             val procDir = SysProp.globalLocalCache / "proc"


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9428

## Problem/Solution
sbt 2.x uses client-server by default.
This makes the message a bit more obvious when the build is using a client.