### PR TITLE
[2.x] Add native client startup diagnostics regression test

### DIFF
--- a/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
@@ -162,6 +162,29 @@ object ExtendedRunnerTest extends BasicTestSuite:
     ()
   }
 
+  test("sbt --client reports server startup errors") {
+    if isWindows then ()
+    else
+      IO.withTemporaryDirectory: tmp =>
+        val projectDir = new File(tmp, "project")
+        IO.createDirectory(projectDir)
+        IO.write(new File(projectDir, "build.properties"), "sbt.version=2.0.0\n")
+        IO.write(new File(tmp, "build.sbt"), "name := \"startup-error\"\n")
+        IO.write(new File(tmp, "target"), "")
+
+        val output = new StringBuffer
+        def append(line: String): Unit =
+          output.append(line).append(System.lineSeparator())
+          ()
+        val exitCode = sbtProcessInDir(tmp)("--client", "--no-colors", "about")
+          .!(ProcessLogger(append, append))
+        val diagnostics = output.toString
+        assert(exitCode == 1, diagnostics)
+        assert(diagnostics.contains("Could not create directory"), diagnostics)
+        assert(diagnostics.contains("target/global-logging"), diagnostics)
+    ()
+  }
+
   // Test for issue #6485: Test `sbt --client` startup
   // https://github.com/sbt/sbt/issues/6485
   test("sbt --client startup time") {

--- a/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
@@ -185,34 +185,6 @@ object ExtendedRunnerTest extends BasicTestSuite:
     ()
   }
 
-  test("sbt --client honors -java-home when starting server") {
-    if isWindows then ()
-    else
-      IO.withTemporaryDirectory: tmp =>
-        val projectDir = new File(tmp, "project")
-        IO.createDirectory(projectDir)
-        IO.write(new File(projectDir, "build.properties"), "sbt.version=2.0.0\n")
-        IO.write(new File(tmp, "build.sbt"), "name := \"java-home\"\n")
-
-        val output = new StringBuffer
-        def append(line: String): Unit =
-          output.append(line).append(System.lineSeparator())
-          ()
-        val exitCode = sbtProcessInDir(tmp)(
-          "--client",
-          "--no-colors",
-          "-java-home",
-          sys.props("java.home"),
-          "about"
-        ).!(ProcessLogger(append, append))
-        val diagnostics = output.toString
-        try
-          assert(exitCode == 0, diagnostics)
-          assert(diagnostics.contains("This is sbt"), diagnostics)
-        finally sbtProcessInDir(tmp)("shutdown").!
-    ()
-  }
-
   // Test for issue #6485: Test `sbt --client` startup
   // https://github.com/sbt/sbt/issues/6485
   test("sbt --client startup time") {

--- a/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
@@ -185,6 +185,34 @@ object ExtendedRunnerTest extends BasicTestSuite:
     ()
   }
 
+  test("sbt --client honors -java-home when starting server") {
+    if isWindows then ()
+    else
+      IO.withTemporaryDirectory: tmp =>
+        val projectDir = new File(tmp, "project")
+        IO.createDirectory(projectDir)
+        IO.write(new File(projectDir, "build.properties"), "sbt.version=2.0.0\n")
+        IO.write(new File(tmp, "build.sbt"), "name := \"java-home\"\n")
+
+        val output = new StringBuffer
+        def append(line: String): Unit =
+          output.append(line).append(System.lineSeparator())
+          ()
+        val exitCode = sbtProcessInDir(tmp)(
+          "--client",
+          "--no-colors",
+          "-java-home",
+          sys.props("java.home"),
+          "about"
+        ).!(ProcessLogger(append, append))
+        val diagnostics = output.toString
+        try
+          assert(exitCode == 0, diagnostics)
+          assert(diagnostics.contains("This is sbt"), diagnostics)
+        finally sbtProcessInDir(tmp)("shutdown").!
+    ()
+  }
+
   // Test for issue #6485: Test `sbt --client` startup
   // https://github.com/sbt/sbt/issues/6485
   test("sbt --client startup time") {


### PR DESCRIPTION
Fix #9417

This is a regression test, issue does not reproduce anymore, the actual fix is #8816, and #9443