### PR TITLE
[2.x] fix: Fixes sbtn not propagating -java-home

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -376,33 +376,19 @@ class NetworkClient(
             term.isSupershellEnabled
           ).mkString(",")
 
-        val cmd = arguments.sbtLaunchJar match {
-          case Some(lj) =>
-            if (log) {
-              val sbtScript = if (Properties.isWin) "sbt.bat" else "sbt"
-              console.appendLog(Level.Warn, s"server is started using sbt-launch jar directly")
-              console.appendLog(
-                Level.Warn,
-                "this is not the recommended way: .sbtopts and .jvmopts files are not loaded and SBT_OPTS is ignored"
-              )
-              console.appendLog(
-                Level.Warn,
-                s"either upgrade $sbtScript to its latest version or make sure it is accessible from $$PATH, and run 'sbt bspConfig'"
-              )
-            }
-            val java = Option(Properties.javaHome)
-              .map { javaHome =>
-                s"$javaHome/bin/java"
-              }
-              .getOrElse("java")
-            List(java) ++ arguments.sbtArguments.filterNot(
-              NetworkClient.emptyBuildFlags.contains
-            ) ++
-              List("-jar", lj, DashDashDetachStdio, DashDashServer)
-          case _ =>
-            List(arguments.sbtScript) ++ arguments.sbtArguments ++
-              List(DashDashDetachStdio, DashDashServer)
+        if (log && arguments.sbtLaunchJar.isDefined) {
+          val sbtScript = if (Properties.isWin) "sbt.bat" else "sbt"
+          console.appendLog(Level.Warn, s"server is started using sbt-launch jar directly")
+          console.appendLog(
+            Level.Warn,
+            "this is not the recommended way: .sbtopts and .jvmopts files are not loaded and SBT_OPTS is ignored"
+          )
+          console.appendLog(
+            Level.Warn,
+            s"either upgrade $sbtScript to its latest version or make sure it is accessible from $$PATH, and run 'sbt bspConfig'"
+          )
         }
+        val cmd = NetworkClient.serverCommand(arguments)
 
         // https://github.com/sbt/sbt/issues/6271
         val nohup =
@@ -1204,6 +1190,7 @@ object NetworkClient {
       val sbtScript: String,
       val bsp: Boolean,
       val sbtLaunchJar: Option[String],
+      val launcherValueArgs: Seq[String] = Nil,
   ) {
     def withBaseDirectory(file: File): Arguments =
       new Arguments(
@@ -1214,8 +1201,20 @@ object NetworkClient {
         sbtScript,
         bsp,
         sbtLaunchJar,
+        launcherValueArgs,
       )
   }
+  private[client] def serverCommand(arguments: Arguments): List[String] =
+    arguments.sbtLaunchJar match {
+      case Some(lj) =>
+        val java =
+          Option(Properties.javaHome).map(javaHome => s"$javaHome/bin/java").getOrElse("java")
+        List(java) ++ arguments.sbtArguments.filterNot(emptyBuildFlags.contains) ++
+          List("-jar", lj, DashDashDetachStdio, DashDashServer)
+      case _ =>
+        List(arguments.sbtScript) ++ arguments.launcherValueArgs ++ arguments.sbtArguments ++
+          List(DashDashDetachStdio, DashDashServer)
+    }
   private[client] val completions = "--completions"
   private[client] val noTab = "--no-tab"
   private[client] val noStdErr = "--no-stderr"
@@ -1293,6 +1292,8 @@ object NetworkClient {
     "--autostart=",
     "-autostart=",
   )
+  private[client] val launcherValueEqPrefixes: Seq[String] =
+    launcherValueFlags.toSeq.map(_ + "=")
   private[client] def parseArgs(args: Array[String]): Arguments = {
     val defaultSbtScript = if (Properties.isWin) "sbt.bat" else "sbt"
     var sbtScript = Properties.propOrNone("sbt.script")
@@ -1301,10 +1302,32 @@ object NetworkClient {
     val commandArgs = new mutable.ArrayBuffer[String]
     val sbtArguments = new mutable.ArrayBuffer[String]
     val completionArguments = new mutable.ArrayBuffer[String]
+    val launcherValueArgs = new mutable.ArrayBuffer[String]
     val SysProp = "-D([^=]+)=(.*)".r
-    val sanitized = args.flatMap {
-      case a if a.startsWith("\"") => Array(a)
-      case a                       => a.split(" ")
+    val sanitized = new mutable.ArrayBuffer[String]
+    val splitFromPrev = new mutable.ArrayBuffer[Boolean]
+    args.foreach {
+      case a if a.startsWith("\"") =>
+        sanitized += a
+        splitFromPrev += false
+      case a =>
+        var first = true
+        a.split(" ").foreach { part =>
+          if (part.nonEmpty) {
+            sanitized += part
+            splitFromPrev += !first
+            first = false
+          }
+        }
+    }
+    def valueFrom(start: Int): (String, Int) = {
+      var last = start
+      val sb = new StringBuilder(sanitized(start))
+      while (last + 1 < sanitized.length && splitFromPrev(last + 1)) {
+        last += 1
+        sb.append(" ").append(sanitized(last))
+      }
+      (sb.toString, last)
     }
     var i = 0
     while (i < sanitized.length) {
@@ -1339,7 +1362,20 @@ object NetworkClient {
         case a if a.startsWith("-autostart=") =>
           System.setProperty("sbt.server.autostart", a.stripPrefix("-autostart="))
         case a if launcherValueFlags.contains(a) =>
-          if (i + 1 < sanitized.length) i += 1
+          if (i + 1 < sanitized.length) {
+            launcherValueArgs += a
+            val (value, last) = valueFrom(i + 1)
+            launcherValueArgs += value
+            i = last
+          }
+        case a if launcherValueEqPrefixes.exists(p => a.startsWith(p)) =>
+          val (full, last) = valueFrom(i)
+          i = last
+          val eq = full.indexOf('=')
+          if (eq < full.length - 1) {
+            launcherValueArgs += full.substring(0, eq)
+            launcherValueArgs += full.substring(eq + 1)
+          }
         case a if launcherNoValueFlags.contains(a)                => ()
         case a if launcherEqPrefixes.exists(p => a.startsWith(p)) => ()
         case a if a.startsWith("-J")                              => ()
@@ -1366,6 +1402,7 @@ object NetworkClient {
       sbtScript.getOrElse(defaultSbtScript).replace("%20", " "),
       bsp,
       launchJar,
+      launcherValueArgs.toSeq,
     )
   }
 

--- a/main-command/src/test/scala/sbt/internal/client/NetworkClientParseArgsTest.scala
+++ b/main-command/src/test/scala/sbt/internal/client/NetworkClientParseArgsTest.scala
@@ -184,6 +184,7 @@ object NetworkClientParseArgsTest extends BasicTestSuite:
     assert(!result.sbtArguments.contains("-mem"))
     assert(!result.sbtArguments.contains("10000"))
     assert(result.sbtArguments.exists(_.contains("-Dfoo=bar")))
+    assert(result.launcherValueArgs == Seq("-mem", "10000"))
     assert(result.commandArguments.contains("compile"))
     assert(result.commandArguments.contains("test"))
 
@@ -196,7 +197,71 @@ object NetworkClientParseArgsTest extends BasicTestSuite:
     assert(!result.sbtArguments.contains("/jdk"))
     assert(!result.sbtArguments.exists(_.contains("color=never")))
     assert(result.sbtArguments.exists(_.contains("-Dfoo=bar")))
+    assert(result.launcherValueArgs == Seq("-java-home", "/jdk"))
     assert(result.commandArguments.contains("compile"))
     assert(result.commandArguments.size == 1)
+
+  // -- Launcher value flags are captured for a forked server (#9418) --
+
+  test("-java-home /path is captured in launcherValueArgs for propagation"):
+    val result = parse("-java-home", "/path/to/jdk", "compile")
+    assert(result.launcherValueArgs == Seq("-java-home", "/path/to/jdk"))
+
+  test("--java-home=/path is consumed, not forwarded, and captured as flag + value"):
+    val result = parse("--java-home=/path/to/jdk", "compile")
+    assert(!result.sbtArguments.exists(_.contains("java-home")))
+    assert(!result.commandArguments.exists(_.contains("java-home")))
+    assert(result.launcherValueArgs == Seq("--java-home", "/path/to/jdk"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("--java-home=/path does not leak a bare -- into forwarded args"):
+    val result = parse("--java-home=/usr/lib/jvm/java-17", "scalafmtCheckAll")
+    assert(!result.sbtArguments.exists(_.startsWith("--java-home")))
+    assert(result.commandArguments == Seq("scalafmtCheckAll"))
+
+  test("-mem=10000 eq-form is consumed and captured as flag + value"):
+    val result = parse("-mem=10000", "compile")
+    assert(!result.sbtArguments.exists(_.contains("mem")))
+    assert(result.launcherValueArgs == Seq("-mem", "10000"))
+    assert(result.commandArguments.contains("compile"))
+
+  test("--java-home= with an empty value is consumed but not propagated"):
+    val result = parse("--java-home=", "compile")
+    assert(!result.sbtArguments.exists(_.contains("java-home")))
+    assert(result.launcherValueArgs.isEmpty)
+    assert(result.commandArguments == Seq("compile"))
+
+  test("-java-home with a spaced path keeps the path intact"):
+    val result = parse("-java-home", "C:\\Program Files\\Java\\jdk-17", "compile")
+    assert(result.launcherValueArgs == Seq("-java-home", "C:\\Program Files\\Java\\jdk-17"))
+    assert(result.commandArguments == Seq("compile"))
+
+  test("--java-home= with a spaced path keeps the path intact"):
+    val result = parse("--java-home=C:\\Program Files\\Java\\jdk-17", "compile")
+    assert(result.launcherValueArgs == Seq("--java-home", "C:\\Program Files\\Java\\jdk-17"))
+    assert(result.commandArguments == Seq("compile"))
+
+  test("a single arg joining a flag and its value is still split and captured"):
+    val result = parse("-mem 10000", "compile")
+    assert(result.launcherValueArgs == Seq("-mem", "10000"))
+    assert(result.commandArguments == Seq("compile"))
+
+  test("serverCommand propagates -java-home to the forked server before --server"):
+    val args = parse("-java-home", "/opt/jdk17", "compile")
+    val cmd = NetworkClient.serverCommand(args)
+    val jh = cmd.indexOf("-java-home")
+    assert(jh >= 0, cmd.toString)
+    assert(cmd(jh + 1) == "/opt/jdk17", cmd.toString)
+    assert(jh < cmd.indexOf("--server"), cmd.toString)
+
+  test("a value flag with no value is dropped, not propagated as a dangling flag"):
+    val result = parse("-java-home")
+    assert(result.launcherValueArgs.isEmpty)
+    assert(result.commandArguments.isEmpty)
+
+  test("extra whitespace in a value does not leave a stray leading space"):
+    val result = parse("-mem", " 10000", "compile")
+    assert(result.launcherValueArgs == Seq("-mem", "10000"))
+    assert(result.commandArguments == Seq("compile"))
 
 end NetworkClientParseArgsTest

--- a/notes/2.0.0/thin-client-java-home.md
+++ b/notes/2.0.0/thin-client-java-home.md
@@ -1,0 +1,11 @@
+### The thin client honors `-java-home` when it starts a server
+
+Launcher value flags such as `-java-home` were parsed by the thin client but then
+dropped: the `=` form (`--java-home=/path`) was forwarded to the server verbatim
+and rejected as a command (`Not a valid command: --`), and the space form
+(`-java-home /path`) was silently discarded when the client had to start a server,
+so that server came up under the default JVM. Both forms are now consumed by the
+client and re-passed to a server it starts, so the server runs under the requested
+JVM, including values that contain spaces such as a Windows path
+(`C:\Program Files\Java\...`). This also applies to the other launcher value flags
+(`-mem`, `-jvm-debug`, `-sbt-dir`, ...), which were dropped the same way.


### PR DESCRIPTION
## Problem

The sbt 2.x thin client (sbtn) mishandles `-java-home` (#9418):

- `sbt --java-home=/path <cmd>` → `[error] Not a valid command: --`. The `=` form of a launcher value flag isn't recognized by `parseArgs`, so it falls through to the residual arguments and is forwarded to the server as a command.
- `sbt -java-home /path <cmd>` with no server running → `[error] failed to connect to server`. The space form *is* recognized, but it's consumed and discarded; when the client starts a server it re-invokes the `sbt` launcher without it, so the server comes up under the default JVM. In CI where the intended JDK is only reachable via `-java-home`, that server fails to start/connect.

`--server` works because in server mode the `sbt` launcher runs the server itself and applies `-java-home` directly; only the thin-client cold-start path drops it.

## Fix

`NetworkClient.parseArgs` now captures the launcher value flags it consumes (both `flag value` and `flag=value`, normalized to a `flag`/`value` pair) into a new `Arguments.launcherValueArgs`, and the cold-start server fork re-passes them to the `sbt` launcher (which parses `-java-home <path>` etc.). This covers all the launcher value flags (`-mem`, `-jvm-debug`, `-sbt-dir`, ...), which were dropped the same way.

- The `=` form is no longer forwarded to the server, so the `Not a valid command: --` error is gone.
- An empty `flag=` value is consumed but not propagated (the launcher's `require_arg` would otherwise fail the fork).
- The `sbt-launch-jar` path (already warned as unsupported) is unchanged: it invokes `java -jar` directly, so there is no launcher to interpret `-java-home` and the JVM is already chosen.

`Arguments` is `private[client]`; no public API change (MiMa clean).

## Testing

- `NetworkClientParseArgsTest` (Verify): pins that both forms are consumed (not leaked to the server), that `launcherValueArgs` holds the normalized flag/value pair for propagation, that the `=` form no longer leaks a bare `--`, and that an empty `flag=` is dropped. Existing parse tests unchanged and green (32 total).
- `commandProj/scalafmtCheckAll`, `commandProj/Test/scalafmtCheckAll`, `commandProj/mimaReportBinaryIssues` green.
- Release note: `notes/2.0.0/thin-client-java-home.md`.

The parse/capture contract and the launcher's space-form handling (`sbt` script `-java-home|--java-home) require_arg path`) are verified directly. I did not reproduce the reporter's CI end to end (it needs a second JDK on the box), but the fix targets the exact mechanism: the consumed flag never reaching the forked launcher.

The generic "failed to connect to server" with no detail (independent of `-java-home`) is tracked separately in #9417.

---

*Implemented with AI assistance (Claude Code); reviewed and verified locally by me (unit tests, scalafmt, MiMa).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
