### PR TITLE
[2.x] fix dependency parsing for bsp

### DIFF
--- a/main/src/main/scala/sbt/internal/InternalDependencies.scala
+++ b/main/src/main/scala/sbt/internal/InternalDependencies.scala
@@ -22,9 +22,9 @@ private[sbt] object InternalDependencies {
     ((ref -> allConfigs) +:
       projectDependencies.flatMap { case ClasspathDep.ResolvedClasspathDependency(p, rawConfigs) =>
         val configs = rawConfigs.getOrElse("*->compile").split(";").flatMap { config =>
-          config.split("->") match {
-            case Array(n, c) if applicableConfigs.contains(n) => Some(c)
-            case Array(n) if applicableConfigs.contains(n)    =>
+          config.split("->", 2).map(_.trim) match {
+            case Array(n, c) if c.nonEmpty && applicableConfigs.contains(n) => Some(c)
+            case Array(n) if applicableConfigs.contains(n)                  =>
               // "test" is equivalent to "compile->test"
               Some("compile")
             case _ => None

--- a/sbt-app/src/sbt-test/project/bsp-internal-dependency-configs/build.sbt
+++ b/sbt-app/src/sbt-test/project/bsp-internal-dependency-configs/build.sbt
@@ -4,6 +4,10 @@ lazy val b = project.in(file("b")).dependsOn(c)
 
 lazy val c = project.in(file("c"))
 
+lazy val d = project.in(file("d")).dependsOn(b % "test -> test")
+
+lazy val e = project.in(file("e")).dependsOn(b % "test ->")
+
 def getConfigs(key: SettingKey[Seq[(ProjectRef, Set[ConfigKey])]]):
   Def.Initialize[Map[String, Set[String]]] =
     Def.setting(key.value.map { case (p, c) => p.project -> c.map(_.name) }.toMap)
@@ -16,4 +20,16 @@ TaskKey[Unit]("check") := {
     "c" -> Set("compile")
   )
   assert(testDeps == expected)
+
+  val spacedTestDeps = getConfigs(d / Test / bspInternalDependencyConfigurations).value
+  val spacedExpected = Map(
+    "d" -> Set("compile", "test"),
+    "b" -> Set("compile", "test"),
+    "c" -> Set("compile")
+  )
+  assert(spacedTestDeps == spacedExpected, spacedTestDeps)
+
+  val emptyTargetDeps = getConfigs(e / Test / bspInternalDependencyConfigurations).value
+  val emptyTargetExpected = Map("e" -> Set("compile", "test"))
+  assert(emptyTargetDeps == emptyTargetExpected, emptyTargetDeps)
 }


### PR DESCRIPTION
Fix #9378 for sbt 2

Do parsing for bsp the same way as done for compilation: https://github.com/sbt/sbt/blob/2d2d5136efdae62cbd971546781081e7ad582cc3/main/src/main/scala/sbt/internal/ClasspathImpl.scala#L422