### PR TITLE
[2.x] test: Sequence server start before publish in ivyless HTTP scripted tests

### DIFF
--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http-plugin/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http-plugin/build.sbt
@@ -38,11 +38,7 @@ stopPublishServer := {
 }
 
 val publishToHttp = taskKey[Unit]("Publish to HTTP server (start server, publish, stop server)")
-publishToHttp := {
-  startPublishServer.value
-  try publish.value
-  finally stopPublishServer.value
-}
+publishToHttp := Def.sequential(startPublishServer, publish, stopPublishServer).value
 
 val checkPublished = taskKey[Unit]("Check ivyless publish wrote the plugin cross-suffix PUT path")
 checkPublished := {

--- a/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/ivyless-publish-http/build.sbt
@@ -35,11 +35,7 @@ stopPublishServer := {
 }
 
 val publishToHttp = taskKey[Unit]("Publish to HTTP server (start server, publish, stop server)")
-publishToHttp := {
-  startPublishServer.value
-  try publish.value
-  finally stopPublishServer.value
-}
+publishToHttp := Def.sequential(startPublishServer, publish, stopPublishServer).value
 
 val checkIvylessPublish = taskKey[Unit]("Check that ivyless publish produced the expected files")
 checkIvylessPublish := {


### PR DESCRIPTION
## Problem

`dependency-management/ivyless-publish-http-plugin` (and its sibling `ivyless-publish-http`) started failing intermittently on the JDK-25 CI shard, turning `develop` red.

The failure is a task-ordering race in the test, not a product bug. `publishToHttp` was:

```scala
publishToHttp := {
  startPublishServer.value
  try publish.value
  finally stopPublishServer.value
}
```

`startPublishServer.value`, `publish.value`, and `stopPublishServer.value` are all task dependencies of `publishToHttp`, which sbt evaluates before the task body in an unspecified order (possibly in parallel). So `publish` can run before the HTTP server is listening and fail with `Connection refused`. On an idle machine the scheduler happens to order start -> publish -> stop; under CPU contention (the standard 2-vCPU runner) it loses the race. The sibling `ivyless-publish-maven-http` never hit this because it sequences the tasks as separate scripted commands.

## Fix

Use `Def.sequential(startPublishServer, publish, stopPublishServer)` to guarantee the ordering.

## Validation

Reproduced by pinning to 2 CPUs (`taskset -c 0,1`) under JDK 25 and running the ivyless-publish tests in parallel: about 1 in 3 rounds failed with `Connection refused` before the fix. After the fix, 10/10 constrained rounds pass, and the tests still pass in isolation. Note: the flake began around the sjson-new 0.15.1 bump (#9458), but that is a coincidence; it is a pure one-line version change and the tests pass on 0.15.1 in isolation. The trigger is CPU contention, not the bump.

---

*Diagnosed and fixed with AI assistance (Claude Code); reproduced and validated locally (2-CPU JDK-25 parallel repro, 10/10 green).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
