### PR TITLE
[2.0.x] bport: Fixes dependency tree rendering on some libraries

### DIFF
--- a/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
@@ -235,6 +235,7 @@ private[internal] object SbtUpdateReport {
         .withConfiguration(Configuration.empty)
         .withMinimizedExclusions(MinimizedExclusions.zero)
         .withOptional(false)
+        .clearOverrides
 
     def lookupProject(mv: coursier.core.Resolution.ModuleVersion): Option[Project] =
       res.projectCache.get(mv) match {

--- a/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
+++ b/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
@@ -322,4 +322,38 @@ final class ResolutionSpec extends AnyPropSpec with Matchers {
     val compress = componentConfig.modules.find(_.module.name == "commons-compress").get
     compress.licenses should have size 1
   }
+
+  property(
+    "transitive caller lookup is not broken by inherited management overrides (sbt/sbt#9348)"
+  ) {
+    val dependencies =
+      Vector("org.apache.tika" % "tika-core" % "3.3.1" % "compile")
+    val coursierModule = module(lmEngine, stubModule, dependencies, Some("2.12.4"))
+    val resolution =
+      lmEngine.update(coursierModule, UpdateConfiguration(), UnresolvedWarningConfiguration(), log)
+
+    assert(resolution.isRight)
+    val compileConfig =
+      resolution.toOption.get.configurations.find(_.configuration == Compile.toConfigRef).get
+    val tikaCaller = "org.apache.tika:tika-core:3.3.1"
+
+    def callerOf(name: String): ModuleReport = {
+      val reports = compileConfig.modules.filter(_.module.name == name)
+      withClue(s"$name not found in: ${compileConfig.modules.map(_.module.name).mkString(", ")}") {
+        reports should have size 1
+      }
+      reports.head
+    }
+
+    def coord(m: sbt.librarymanagement.ModuleID): String =
+      s"${m.organization}:${m.name}:${m.revision}"
+
+    for (transitive <- Seq("commons-io", "slf4j-api")) {
+      val report = callerOf(transitive)
+      val callerCoords = report.callers.map(c => coord(c.caller)).toSet
+      withClue(s"$transitive callers: $callerCoords") {
+        callerCoords should contain(tikaCaller)
+      }
+    }
+  }
 }

--- a/sbt-app/src/sbt-test/dependency-graph/ignoreScalaLibrary/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-graph/ignoreScalaLibrary/build.sbt
@@ -15,28 +15,18 @@ TaskKey[Unit]("check") := {
     .map(_.trim)
     .mkString("\n")
 
-/*
-Started to return:
-
-ch.qos.logback:logback-core:1.0.7
-default:sbt_8ae1da13_2.12:0.1.0-SNAPSHOT [S]
-  +-ch.qos.logback:logback-classic:1.0.7
-  | +-org.slf4j:slf4j-api:1.6.6 (evicted by: 1.7.2)
-  |
-  +-org.slf4j:slf4j-api:1.7.2
-*/
-
   val expectedGraph =
     """foo:foo_2.12:0.1.0-SNAPSHOT [S]
       |  +-ch.qos.logback:logback-classic:1.0.7
+      |  | +-ch.qos.logback:logback-core:1.0.7
       |  | +-org.slf4j:slf4j-api:1.6.6 (evicted by: 1.7.2)
+      |  | +-org.slf4j:slf4j-api:1.7.2
       |  |
       |  +-org.slf4j:slf4j-api:1.7.2
       |  """.stripMargin
 
-
   // IO.writeLines(file("/tmp/blib"), sanitize(graph).split("\n"))
   // IO.writeLines(file("/tmp/blub"), sanitize(expectedGraph).split("\n"))
-  require(sanitize(graph) == sanitize(expectedGraph), "Graph for report %s was '\n%s' but should have been '\n%s'" format (report, sanitize(graph), sanitize(expectedGraph)))
+  assert(sanitize(graph) == sanitize(expectedGraph), s"Graph was '\n$graph' but should have been '\n$expectedGraph'")
   ()
 }


### PR DESCRIPTION
This is a 2.0.x backport of #9371

For the purposes of matching resolved dependencies to reverse-dependency entries, do not use dependency overrides to check equality.
