### PR TITLE
[2.x] fix: Improves cache restoration when the expected outputs are missing

### DIFF
--- a/notes/2.0.0/dirzip-restore-on-hit.md
+++ b/notes/2.0.0/dirzip-restore-on-hit.md
@@ -1,0 +1,15 @@
+### Directories declared with `Def.declareOutputDirectory` are restored on cache hits
+
+A directory declared as a cached task's output is packaged as a `.sbtdir.zip`
+sibling of the directory. Deleting the directory leaves the sibling zip behind
+(an `rm -rf` of the directory or of `classes/` does exactly this), which left
+the cache convinced everything was in sync: on the next cache hit the task did not re-run, but the
+directory was never re-extracted either. For sbt's own `compile`, whose classes
+directory is declared this way, a deleted output directory plus a warm cache
+meant `run` failed with `ClassNotFoundException` and no recompile. The cache now
+re-extracts a declared directory when the directory itself is missing, at the
+cost of a single stat on the warm path.
+
+This addresses the directory-restoration half of [#9462][i9462].
+
+[i9462]: https://github.com/sbt/sbt/issues/9462

--- a/sbt-app/src/sbt-test/cache/compile-classes-restore/Main.scala
+++ b/sbt-app/src/sbt-test/cache/compile-classes-restore/Main.scala
@@ -1,0 +1,2 @@
+@main def main(args: String*) =
+  println("hello from probe")

--- a/sbt-app/src/sbt-test/cache/compile-classes-restore/build.sbt
+++ b/sbt-app/src/sbt-test/cache/compile-classes-restore/build.sbt
@@ -1,0 +1,53 @@
+import sbt.internal.util.CacheEventSummary
+
+val checkCompileHit = taskKey[Unit]("asserts the previous command took cache hits")
+val delClasses = taskKey[Unit]("deletes the classes directory")
+val delClassesZip = taskKey[Unit]("deletes the sibling classes.sbtdir.zip")
+val checkClasses = taskKey[Unit]("asserts .class files exist")
+val checkNoClasses = taskKey[Unit]("asserts no .class files exist")
+
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+// A distinct project id keeps this fixture's output paths from colliding with same-named
+// sibling fixtures in scripted's shared batch directory.
+lazy val compileClassesRestore = project
+  .in(file("."))
+  .settings(
+    scalaVersion := "3.8.4"
+  )
+
+delClasses := Def.uncached {
+  val dir = (Compile / classDirectory).value
+  IO.delete(dir)
+  streams.value.log.info(s"deleted $dir")
+}
+
+delClassesZip := Def.uncached {
+  val dir = (Compile / classDirectory).value
+  val zip = new java.io.File(dir.getParentFile, dir.getName + ".sbtdir.zip")
+  streams.value.log.info(s"deleting $zip (exists=${zip.exists})")
+  IO.delete(zip)
+}
+
+checkClasses := Def.uncached {
+  val dir = (Compile / classDirectory).value
+  val classes = (dir ** "*.class").get()
+  streams.value.log.info(s"classes under $dir: ${classes.mkString(", ")}")
+  assert(classes.nonEmpty, s"no class files under $dir")
+}
+
+checkNoClasses := Def.uncached {
+  val dir = (Compile / classDirectory).value
+  val classes = (dir ** "*.class").get()
+  streams.value.log.info(s"classes under $dir: ${classes.mkString(", ")}")
+  assert(classes.isEmpty, s"unexpected class files under $dir: ${classes.mkString(", ")}")
+}
+
+checkCompileHit := Def.uncached {
+  val config = Def.cacheConfiguration.value
+  val prev = config.cacheEventLog.previous match
+    case s: CacheEventSummary.Data => s
+    case _                         => sys.error("empty event log")
+  streams.value.log.info(s"prev hitCount=${prev.hitCount} missCount=${prev.missCount}")
+  assert(prev.hitCount >= 1, s"expected cache hits but hitCount=${prev.hitCount}")
+}

--- a/sbt-app/src/sbt-test/cache/compile-classes-restore/test
+++ b/sbt-app/src/sbt-test/cache/compile-classes-restore/test
@@ -1,0 +1,18 @@
+# Regression for #9462: compile's classes dir (declared via Def.declareOutputDirectory)
+# must be restored on a cache hit after the classes directory is deleted.
+> compile
+> checkClasses
+> run
+> delClasses
+> checkNoClasses
+> compile
+> checkCompileHit
+> checkClasses
+> run
+
+# restoration also works when the sibling classes.sbtdir.zip is gone too
+> delClasses
+> delClassesZip
+> compile
+> checkClasses
+> run

--- a/sbt-app/src/sbt-test/cache/declare-output-dir-restore/build.sbt
+++ b/sbt-app/src/sbt-test/cache/declare-output-dir-restore/build.sbt
@@ -1,0 +1,60 @@
+import sbt.internal.util.CacheEventSummary
+import xsbti.HashedVirtualFileRef
+
+val declareDir = taskKey[HashedVirtualFileRef]("writes 2 files into a dir and declares the dir")
+val checkFiles = taskKey[Unit]("asserts both files exist")
+val checkGone = taskKey[Unit]("asserts the dir has no files")
+val delDir = taskKey[Unit]("deletes the generated dir")
+val delZip = taskKey[Unit]("deletes the sibling .sbtdir.zip")
+val checkHit = taskKey[Unit]("asserts previous command was a pure cache hit")
+
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+lazy val declareOutputDirRestore = project.in(file("."))
+
+declareDir := {
+  val log = streams.value.log
+  val dir = target.value / "gen-dir"
+  IO.createDirectory(dir)
+  IO.write(dir / "a.txt", "contents A")
+  IO.write(dir / "b.txt", "contents B")
+  log.info(s"COMPUTED declareDir (cache miss)")
+  val vf = fileConverter.value.toVirtualFile(dir.toPath)
+  Def.declareOutputDirectory(vf)
+}
+
+checkFiles := Def.uncached {
+  val log = streams.value.log
+  val dir = target.value / "gen-dir"
+  val listing = if (dir.exists) (dir ** "*").get().mkString(", ") else "<dir missing>"
+  log.info(s"gen-dir listing: $listing")
+  assert((dir / "a.txt").exists, s"a.txt missing under $dir")
+  assert((dir / "b.txt").exists, s"b.txt missing under $dir")
+}
+
+checkGone := Def.uncached {
+  val dir = target.value / "gen-dir"
+  assert(!(dir / "a.txt").exists && !(dir / "b.txt").exists, s"files still present under $dir")
+}
+
+delDir := Def.uncached {
+  val dir = target.value / "gen-dir"
+  IO.delete(dir)
+  streams.value.log.info(s"deleted $dir")
+}
+
+delZip := Def.uncached {
+  val zip = new java.io.File(target.value, "gen-dir.sbtdir.zip")
+  streams.value.log.info(s"deleting $zip (exists=${zip.exists})")
+  IO.delete(zip)
+}
+
+checkHit := Def.uncached {
+  val config = Def.cacheConfiguration.value
+  val prev = config.cacheEventLog.previous match
+    case s: CacheEventSummary.Data => s
+    case _                         => sys.error("empty event log")
+  streams.value.log.info(s"prev hitCount=${prev.hitCount} missCount=${prev.missCount}")
+  assert(prev.missCount == 0, s"expected pure hit but missCount=${prev.missCount}")
+  assert(prev.hitCount >= 1, s"expected a hit but hitCount=${prev.hitCount}")
+}

--- a/sbt-app/src/sbt-test/cache/declare-output-dir-restore/test
+++ b/sbt-app/src/sbt-test/cache/declare-output-dir-restore/test
@@ -1,0 +1,16 @@
+# Regression for #9462: a Def.declareOutputDirectory dir must be restored on a cache hit
+# after the extracted directory is deleted (the sibling .sbtdir.zip survives an rm -rf).
+> declareDir
+> checkFiles
+> delDir
+> checkGone
+> declareDir
+> checkHit
+> checkFiles
+
+# restoration also works when the sibling zip itself is gone
+> delDir
+> delZip
+> declareDir
+> checkHit
+> checkFiles

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -339,7 +339,9 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
         try
           // `!symlinkSupported` prevents unnecessary deletion of files and then copying them again
           // in #writeFileAndNotify on machines that don't support symlinks.
-          if Digest.sameDigest(p, d) && (!symlinkSupported.get() || Files.isSymbolicLink(p)) then p
+          if Digest.sameDigest(p, d) && (!symlinkSupported.get() || Files.isSymbolicLink(p)) then
+            afterFileUpToDate(ref, p, outputDirectory)
+            p
           else
             // println(s"- syncFile: $p has different digest")
             IO.delete(p.toFile())
@@ -356,6 +358,16 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
   def afterFileWrite(ref: HashedVirtualFileRef, path: Path, outputDirectory: Path): Unit =
     if path.toString().endsWith(ActionCache.dirZipExt) then unpackageDirZip(path, outputDirectory)
     else ()
+
+  /** Re-extract a dirzip whose extracted directory is missing: one stat on the warm path. */
+  private def afterFileUpToDate(
+      ref: HashedVirtualFileRef,
+      path: Path,
+      outputDirectory: Path
+  ): Unit =
+    if path.toString().endsWith(ActionCache.dirZipExt) then
+      val dirPath = Paths.get(path.toString.dropRight(ActionCache.dirZipExt.size))
+      if !Files.isDirectory(dirPath) then Util.ignoreResult(unpackageDirZip(path, outputDirectory))
 
   /**
    * Given a dirzip, unzip it in a temp directory, and sync each items to the outputDirectory.

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -1,6 +1,6 @@
 package sbt.util
 
-import java.io.{ IOException, InputStream }
+import java.io.{ ByteArrayInputStream, IOException, InputStream }
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
 import java.util.Optional
@@ -87,6 +87,30 @@ object ActionCacheTest extends BasicTestSuite:
         val b = bytes(index) & 0xff
         index += 1
         b
+
+  test("Disk cache re-extracts a dirzip whose directory was deleted"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        IO.write(dir / "b.txt", "contents B")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+        assert(refs.size == 1)
+
+        cache.syncBlobs(refs, outputDirectory)
+        assert((dir / "a.txt").exists && (dir / "b.txt").exists)
+
+        IO.delete(dir)
+        assert(!dir.exists)
+        cache.syncBlobs(refs, outputDirectory)
+        assert((dir / "a.txt").exists, "a.txt not re-extracted after the directory was deleted")
+        assert((dir / "b.txt").exists, "b.txt not re-extracted after the directory was deleted")
 
   test("In-memory cache can hold action value"):
     withInMemoryCache(testActionCacheBasic)
@@ -506,6 +530,18 @@ object ActionCacheTest extends BasicTestSuite:
       CacheImplicits.defaultLocalDigestCacheByteSize,
       cacheVersion,
     )
+
+  // The String-based fileConverter mangles binary blobs (zips).
+  def binaryFileConverter = new FileConverter:
+    override def toPath(ref: VirtualFileRef): Path = Paths.get(ref.id)
+    override def toVirtualFile(path: Path): VirtualFile =
+      val bytes =
+        if Files.isRegularFile(path) then Files.readAllBytes(path) else Array.empty[Byte]
+      new xsbti.BasicVirtualFileRef(path.toString) with VirtualFile:
+        override def contentHash: Long = sbt.util.HashUtil.xxhash64(bytes)
+        override def sizeBytes: Long = bytes.length.toLong
+        override def contentHashStr: String = Digest.sha256Hash(bytes).contentHashStr
+        override def input: InputStream = new ByteArrayInputStream(bytes)
 
   def fileConverter = new FileConverter:
     override def toPath(ref: VirtualFileRef): Path = Paths.get(ref.id)


### PR DESCRIPTION
## Problem

A directory declared with `Def.declareOutputDirectory` is packaged as a sibling `<dir>.sbtdir.zip`. Deleting the directory (an `rm -rf` of `target/` or of the classes directory) leaves the zip behind, and on the next cache hit `syncFile`'s up-to-date short-circuit sees the zip in sync (same digest, already a CAS symlink) and returns without the unpack side effect, which only runs from the file-write path. The directory is never restored.

sbt's own `compile` declares its classes directory this way (`cachedCompileIncrementalTask`), so a warm cache plus a deleted output directory means `run` fails with `ClassNotFoundException` and no recompile — reported with a clean repro in #9462 (cases 3 and 6 of the reporter's repo). Only deleting the zip as well, or the whole cache, recovers.

## Fix

On the up-to-date branch, for dirzip refs, re-extract when the extracted directory itself is missing: a single stat on the warm path (per review discussion on #9462, in preference to a manifest-based per-file check). Partial deletions inside a still-existing directory are not repaired, consistent with treating `target/` contents as sbt-managed; the full unpack (which also repairs stale content by digest and removes extraneous files) still runs whenever the zip itself needs re-syncing.

## Semantics and cost, stated deliberately

- Files that exist but whose content was modified by hand are not repaired on the warm path (the warm path never verified extracted content, only the zip digest; repairing would mean hashing every file on every hit). The full unpack still repairs by digest whenever it runs.
- The warm fast path also skips the extraneous-file deletion pass; files not in the manifest are removed whenever a restore is actually triggered.
- A corrupt or unreadable zip now fails closed: the presence check returns false and the full unpack runs, which either repairs or fails loudly, rather than silently leaving the directory unrestored.

## Testing

- `ActionCacheTest` (unit): a dirzip synced, its extracted directory deleted, `syncBlobs` again re-extracts both files. (The test needed a byte-faithful `VirtualFile` converter; the existing String-based test converter corrupts binary zips.)
- `cache/declare-output-dir-restore` (scripted): a custom `Def.declareOutputDirectory` task; delete the dir; cache hit must restore it (also covered with the zip deleted too). Fails on develop, passes with this change.
- `cache/compile-classes-restore` (scripted): vanilla project; `compile`, delete the classes dir, `compile` + `run` again must restore the classes and run. Mirrors the reported `ClassNotFoundException` case exactly; fails on develop, passes with this change.
- Full `cache/*` scripted group green (11 tests); `utilCache` scalafmt, `scalafmtSbtCheck`, MiMa clean.

The `declareOutput`-in-a-loop half of #9462 is a separate macro-layer defect; a follow-up PR is prepared for it.

One test-infrastructure note: scripted batch mode runs a group's tests sequentially in one shared directory, and fixtures without an explicit root project id share output paths, so one fixture's leftover class files can let a later same-named fixture overwrite them through a read-only directory check (directory write permission only guards entry creation). The two new fixtures here define distinct root project ids for that reason; `cache/compile-io-failure` remains sensitive to same-path predecessors, which I can harden in a follow-up if you'd like.

---

*Diagnosed and fixed with AI assistance (Claude Code); root cause isolated with an empirical discriminator (deleting the sibling zip made the identical cache hit restore correctly) and validated locally as above.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

