### PR TITLE
[2.x] Make `clearCaches` clear the sbt 2 action cache

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -254,7 +254,13 @@ $AliasCommand name=
   def continuousBriefHelp: (String, String) =
     (ContinuousExecutePrefix + " <command>", continuousDetail)
   def ClearCaches: String = "clearCaches"
-  def ClearCachesDetailed: String = "Clears sbt's internal caches."
+  def ClearCachesDetailed: String =
+    "Clears sbt's internal in-memory caches (compiler cache, classloader cache, and file-cache stores), " +
+      "deletes the contents of the local disk action cache (its cas/ and ac/ directories), " +
+      "and removes action-cache references under the root output directory: " +
+      "the materialized task-value files in target/out/value and any symbolic links pointing into the deleted cache. " +
+      "Paths matching cleanKeepFiles or cleanKeepGlobs are preserved. " +
+      "Unlike cleanFull, build outputs, the command history (target/out/.history), and the sbt boot directory are not deleted."
 
   val CleanFull: String = "cleanFull"
   def cleanFullDetailed: String = "Clears sbt's local caches."

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -25,6 +25,7 @@ import sbt.nio.file.*
 import sbt.nio.file.syntax.pathToPathOps
 import sbt.nio.file.Glob.GlobOps
 import sbt.util.{ DiskActionCacheStore, Level }
+import sbt.internal.io.Retry
 import sbt.internal.util.complete.SizeParser
 import sjsonnew.JsonFormat
 import xsbti.{ PathBasedFile, VirtualFileRef }
@@ -205,10 +206,101 @@ private[sbt] object Clean {
     s.get(Keys.cacheStoreFactoryFactory).foreach(_.close())
     s.put(Keys.cacheStoreFactoryFactory, InMemoryCacheStore.factory(size))
 
+  private def actionCacheKeepFilter(s: State): Path => Boolean =
+    val extracted = Project.extract(s)
+    val refs = extracted.structure.allProjectRefs
+    val keepFiles =
+      refs.flatMap(ref => extracted.getOpt(ref / cleanKeepFiles).getOrElse(Nil)).distinct
+    val keepGlobs =
+      refs.flatMap(ref => extracted.getOpt(ref / cleanKeepGlobs).getOrElse(Nil)).distinct
+    val globs = keepFiles.map {
+      case f if f.isDirectory => Glob(f, AnyPath)
+      case f                  => f.toPath.toGlob
+    } ++ keepGlobs
+    (p: Path) => globs.exists(_.matches(p))
+
+  private def deleteStoreReferences(
+      dir: Path,
+      bases: Seq[Path],
+      exclude: Path => Boolean,
+      delete: Path => Unit
+  ): Unit = {
+    def loop(d: Path): Unit =
+      FileTreeView.default
+        .list(Glob(d, AnyPath))
+        .foreach {
+          // FileTreeView reports all-false attributes for dangling symlinks, so symlink
+          // detection must not rely on attrs.isSymbolicLink.
+          case (link, _) if Files.isSymbolicLink(link) =>
+            try {
+              val raw = Files.readSymbolicLink(link)
+              val resolved =
+                (if (raw.isAbsolute) raw
+                 else Option(link.getParent).fold(raw)(_.resolve(raw))).normalize()
+              if (bases.exists(resolved.startsWith(_)) && !exclude(link)) delete(link)
+            } catch { case _: IOException => () }
+          case (subdir, attrs) if attrs.isDirectory => loop(subdir)
+          case _                                    => ()
+        }
+    loop(dir)
+  }
+
+  private val clearActionCacheStores: State => State = (s: State) => {
+    val stores = s.get(BasicKeys.cacheStores).getOrElse(Nil).collect {
+      case d: DiskActionCacheStore => d
+    }
+    val bases = stores.map(_.base.toAbsolutePath.normalize).distinct
+    val exclude = actionCacheKeepFilter(s)
+    val failed = scala.collection.mutable.ListBuffer.empty[(Path, IOException)]
+    /* Deletion failures are collected and reported rather than swallowed. On
+     * Windows a delete can transiently fail with AccessDeniedException while a
+     * handle is briefly held, so retry (as DiskActionCacheStore#syncFile does for
+     * writes). Directories left non-empty by cleanKeepFiles / cleanKeepGlobs are
+     * expected to survive.
+     */
+    val delete: Path => Unit = path => {
+      try {
+        s.log.debug(s"clearCaches -- deleting $path")
+        Retry.io(Files.deleteIfExists(path), classOf[DirectoryNotEmptyException])
+        ()
+      } catch {
+        case _: DirectoryNotEmptyException => ()
+        case e: IOException                => failed += (path -> e)
+      }
+    }
+    /* Delete the target/out references (symlinks) before the cas blobs they point at. */
+    s.get(BasicKeys.rootOutputDirectory).foreach { rootOut =>
+      val valueDir = rootOut.resolve("value")
+      if (Files.exists(valueDir)) {
+        deleteContents(valueDir, exclude, FileTreeView.default, delete)
+        delete(valueDir)
+      }
+      if (Files.exists(rootOut) && bases.nonEmpty)
+        deleteStoreReferences(rootOut, bases, exclude, delete)
+    }
+    bases.filter(Files.exists(_)).foreach { base =>
+      deleteContents(base, exclude, FileTreeView.default, delete)
+    }
+    failed.foreach { case (p, e) => s.log.warn(s"clearCaches failed to delete $p: $e") }
+    if (bases.nonEmpty)
+      if (failed.isEmpty)
+        s.log.info(s"cleared action cache store(s): ${bases.mkString(", ")}")
+      else
+        s.log.warn(
+          s"partially cleared action cache store(s): ${bases.mkString(", ")} " +
+            s"(${failed.size} path(s) could not be deleted)"
+        )
+    s
+  }
+
+  /* Reset the in-memory caches before deleting the on-disk stores so that
+   * files the old caches may still reference (e.g. jars held open by cached
+   * classloaders) are released before their deletion is attempted. */
   private val clearCachesFun: State => State =
     registerCompilerCache
       .andThen(_.initializeClassLoaderCache)
       .andThen(addCacheStoreFactoryFactory)
+      .andThen(clearActionCacheStores)
 
   def clearCaches: Command =
     val help = Help.more(ClearCaches, ClearCachesDetailed)

--- a/sbt-app/src/sbt-test/cache/clear-caches/build.sbt
+++ b/sbt-app/src/sbt-test/cache/clear-caches/build.sbt
@@ -1,0 +1,59 @@
+import sbt.internal.util.StringVirtualFile1
+import sjsonnew.BasicJsonProtocol.*
+import sbt.nio.file.{ Glob, RecursiveGlob }
+
+val pure1 = taskKey[Unit]("")
+val checkCacheNonEmpty = taskKey[Unit]("")
+val checkCacheCleared = taskKey[Unit]("")
+val checkNoStoreLinks = taskKey[Unit]("")
+
+// The store directory name is unique to this test on purpose: scripted batch mode
+// shares one sandbox directory and one sbt JVM across the cache/* tests and silently
+// skips files it fails to delete between tests, so a Windows-locked blob left behind
+// by a preceding test using the shared "diskcache" name would otherwise show up in
+// this store and break checkCacheCleared.
+Global / localCacheDirectory := baseDirectory.value / "clear-caches-diskcache"
+Global / cleanKeepGlobs += Glob(baseDirectory.value / "clear-caches-diskcache" / "keep", RecursiveGlob)
+
+def storeEntries(base: File): Set[String] =
+  for {
+    dir <- Set("cas", "ac")
+    file <- Option((base / dir).listFiles).fold(Set.empty[String])(_.map(_.getName).toSet)
+  } yield s"$dir/$file"
+
+pure1 := {
+  val output = StringVirtualFile1("${OUT}/a.txt", "foo")
+  Def.declareOutput(output)
+  ()
+}
+
+checkCacheNonEmpty := Def.uncached {
+  assert(storeEntries(baseDirectory.value / "clear-caches-diskcache").nonEmpty, "no action cache entries present")
+}
+
+checkCacheCleared := Def.uncached {
+  val leftover = storeEntries(baseDirectory.value / "clear-caches-diskcache")
+  assert(leftover.isEmpty, s"entries survived clearCaches: ${leftover.mkString(", ")}")
+}
+
+checkNoStoreLinks := Def.uncached {
+  import java.nio.file.Files
+  val out = (baseDirectory.value / "target" / "out").toPath
+  val diskcache = (baseDirectory.value / "clear-caches-diskcache").toPath.toAbsolutePath.normalize
+  if (Files.exists(out)) {
+    val stream = Files.walk(out)
+    try {
+      val it = stream.iterator()
+      while (it.hasNext) {
+        val p = it.next()
+        if (Files.isSymbolicLink(p)) {
+          val raw = Files.readSymbolicLink(p)
+          val resolved =
+            (if (raw.isAbsolute) raw else Option(p.getParent).fold(raw)(_.resolve(raw)))
+              .normalize()
+          assert(!resolved.startsWith(diskcache), s"$p still points into $diskcache")
+        }
+      }
+    } finally stream.close()
+  }
+}

--- a/sbt-app/src/sbt-test/cache/clear-caches/test
+++ b/sbt-app/src/sbt-test/cache/clear-caches/test
@@ -1,0 +1,20 @@
+# Populate the action cache, then verify clearCaches empties the disk store and
+# removes the references under target/out, while preserving keep-globbed paths,
+# regular files, and everything else outside the cache.
+> startServer
+> pure1
+$ exists target/out/a.txt
+> checkCacheNonEmpty
+$ mkdir clear-caches-diskcache/keep
+$ touch clear-caches-diskcache/keep/marker.txt
+$ touch target/out/regular.txt
+> clearCaches
+> checkCacheCleared
+> checkNoStoreLinks
+$ absent target/out/value
+$ absent target/out/a.txt
+$ exists target/out/regular.txt
+$ exists clear-caches-diskcache/keep/marker.txt
+> pure1
+$ exists target/out/a.txt
+> checkCacheNonEmpty


### PR DESCRIPTION
It's a proposal to align the behavior of `clearCaches` with the newly added caching feature in sbt 2.

---
I found that `clearCaches` in sbt 2 works the same way as it does in sbt 1, so it doesn't clear the action caches introduced in sbt 2. This PR proposes updating it to clear the action caches when `clearCaches` is run. I've used Claude Code's Fable 5 to create comparison tables showing the differences between `clean`, `clearCaches`, and `cleanFull`.

To me, the most meaningful difference between the new behavior of `clearCaches` in this PR and `cleanFull` is that, unlike `cleanFull`, `clearCaches` doesn't delete the command history (`target/out/.history`). I think it makes sense for `cleanFull` to delete the history, as its name suggests, but in many cases, I just want to clear the caches while keeping the sbt console command history.

> [!NOTE]
> [This build failure](https://github.com/sbt/sbt/actions/runs/29886874422/job/88819114744?pr=9474) will be handled once #9485 is merged into the `develop` branch, and this branch is rebased onto `develop`.

***

# [2.x] Make `clearCaches` clear the sbt 2 action cache as well

## Problem

`clearCaches` predates the sbt 2 action cache and only resets in-memory state: the compiler cache, the classloader cache, and the file-cache store factory. The disk action cache (`cas/` and `ac/` under `localCacheDirectory`) survives it entirely. The only command that removes the action cache is `cleanFull`, which is much blunter: it unconditionally deletes all of `target/out` — including the command history at `target/out/.history` — plus the sbt boot directory, and it ignores `cleanKeepFiles` / `cleanKeepGlobs`.

There was no way to say "drop the action cache, keep my history and outputs".

## What this changes

`clearCaches` keeps doing everything it did before, and now also:

- deletes the contents of the `cas/` and `ac/` directories of every `DiskActionCacheStore` in `cacheStores` (remote stores are untouched, consistent with `cleanFull`),
- deletes the materialized task-value checkouts under `target/out/value`,
- removes symlinks under `target/out` that point into a cleared store — cached outputs are materialized as symlinks into `cas/`, so leaving them behind would leave dangling links for IDEs/tools that read `target/out` without running a task,
- respects `cleanKeepFiles` / `cleanKeepGlobs`, aggregated across all projects (unlike `cleanFull`).

What it still does **not** touch, unlike `cleanFull`: build outputs in `target/out`, the command history, and the boot directory.

## Implementation notes

- The in-memory resets run **before** the disk deletion so that jar handles held by cached classloaders are released before their blobs are deleted (this matters on Windows).
- Deletions are retried on transient `IOException`s, mirroring `DiskActionCacheStore#syncFile`'s write-side behavior; remaining failures are collected and reported as a warning rather than swallowed.
- An info line reports which store base directories were cleared (or a warning if only partially cleared).
- The help text for `clearCaches` is updated to describe the new behavior and the difference from `cleanFull`.

## Testing

New scripted test `cache/clear-caches`: populates the action cache via a cached task, runs `clearCaches`, and asserts that the disk store is completely empty, `target/out/value` and cache-pointing symlinks are gone, while keep-globbed paths, regular files under `target/out`, and re-caching after the clear all work.

⚠️ The test asserts strict behavior with no baseline/polling workarounds. On Windows it depends on the test-classloader/jar-handle leak fixes in #9485; the Windows scripted CI job is expected to fail until #9485 is merged and this branch is rebased onto it. Passes on Linux/macOS regardless (verified locally on macOS).

***

## Behavior before

Rows marked ⚠️ are the gaps this PR addresses.

| Location / state | `clean` (task) | `clearCaches` (command) | `cleanFull` (command) |
|---|---|---|---|
| `target/out/<platform>/scala-<V>/<module>/` — per-project target (classes, `streams/`, `src_managed/`, fileOutputs) | ✅ contents deleted, except `cleanKeepFiles`/`cleanKeepGlobs` matches | ❌ | ✅ deleted (whole `target/out` wiped, keep-filters ignored) |
| `target/out/.history` — command history | ❌ never visited and keep-globbed | ❌ | ✅ deleted (side effect of `target/out` wipe) |
| ⚠️ **`target/out/value/` (materialized task-value cache files)** | ❌ | ⚠️ **❌ left behind** | ✅ deleted |
| ⚠️ **Symlinks under `target/out` into the cache (materialized artifacts)** | ✅ only inside per-project targets | ⚠️ **❌ left dangling if the cache is removed** | ✅ deleted |
| Other files/dirs directly under `target/out/` | ❌ | ❌ | ✅ deleted |
| `target/global-logging/`, `target/task-temp-directory/`, `target/bg-jobs/`, `project/target/` | ❌ | ❌ | ❌ survive (outside `target/out`) |
| ⚠️ **Local disk action cache — `<localCacheDirectory>/cas/` + `/ac/` (default machine-global)** | ❌ | ⚠️ **❌ never cleared — the gap** | ✅ entire base dir deleted (no filters) |
| Remote cache stores (non-disk entries in `cacheStores`) | ❌ | ❌ | ❌ silently skipped |
| Launcher boot directory | ❌ | ❌ | ✅ deleted |
| In-memory: compiler cache, classloader cache, streams-cache wrapper | ❌ | ✅ all three reset | ✅ |
| JVM-global digest/stamp caches (`CacheImplicits`) | ❌ | ❌ | ❌ |

## Behavior after

Rows marked 🆕 are the behavior changes of this PR — everything else is identical to before.

| Location / state | `clean` (task) | `clearCaches` (after this PR) | `cleanFull` (command) |
|---|---|---|---|
| Per-project outputs `target/out/<platform>/scala-<V>/<module>/` (organic files: classes etc.) | ✅ contents deleted, except keep-filter matches | ❌ preserved (only symlinks into cleared bases removed) | ✅ deleted (whole `target/out`, no filters) |
| `target/out/.history` (command history) | ❌ preserved | ❌ preserved (regular file — never a candidate) | ✅ deleted (side effect) |
| 🆕 **`target/out/value/` (materialized task-value cache files)** | ❌ not visited | 🆕 **✅ deleted (keep-filter respected)** | ✅ deleted |
| 🆕 **Symlinks under `target/out` into cleared store bases (materialized artifacts)** | ✅ only inside per-project targets | 🆕 **✅ deleted everywhere under `target/out` (filtered); re-materialize on next run** | ✅ deleted |
| Other regular files/dirs under `target/out` | ❌ | ❌ preserved | ✅ deleted |
| `target/global-logging/`, `task-temp-directory/`, `bg-jobs/`, `project/target/` | ❌ | ❌ | ❌ |
| 🆕 **Local disk action cache `<localCacheDirectory>` (`cas/`+`ac/`, default machine-global)** | ❌ | 🆕 **✅ contents deleted (filtered; base dir kept; machine-wide effect)** | ✅ entire base dir deleted (no filters) |
| Remote cache stores | ❌ | ❌ untouched | ❌ silently skipped |
| Launcher boot directory | ❌ | ❌ preserved | ✅ deleted |
| In-memory: compiler / classloader / streams-cache wrapper | ❌ | ✅ reset (unchanged) | ✅ reset |
| JVM-global digest caches (`CacheImplicits`) | ❌ | ❌ | ❌ |
| 🆕 **Respects `cleanKeepFiles`/`cleanKeepGlobs`** | ✅ | 🆕 **✅ for all its disk deletions** (a protection even `cleanFull` lacks) | ❌ |

