### PR TITLE
[2.x] ci: Fix warnings in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1185,8 +1185,8 @@ def customCommands: Seq[Setting[?]] = Seq(
     import extracted.*
     val sv = get(scalaVersion)
     val projs = structure.allProjectRefs
-    val ioOpt = projs find { case ProjectRef(_, id) => id == "ioRoot"; case _ => false }
-    val zincOpt = projs find { case ProjectRef(_, id) => id == "zincRoot"; case _ => false }
+    val ioOpt = projs find { case ProjectRef(_, id) => id == "ioRoot" }
+    val zincOpt = projs find { case ProjectRef(_, id) => id == "zincRoot" }
     (ioOpt map { case ProjectRef(build, _) => "{" + build.toString + "}/publishLocal" }).toList :::
       (zincOpt map { case ProjectRef(build, _) =>
         val zincSv = get((ProjectRef(build, "zinc") / scalaVersion))


### PR DESCRIPTION
```
-- [E121] Pattern Match Warning: /home/runner/work/sbt/sbt/build.sbt:1000:76 ---
1000 |    val ioOpt = projs find { case ProjectRef(_, id) => id == "ioRoot"; case _ => false }
     |                                                                            ^
     |Unreachable case except for null (if this is intentional, consider writing case null => instead).
-- [E121] Pattern Match Warning: /home/runner/work/sbt/sbt/build.sbt:1001:80 ---
1001 |    val zincOpt = projs find { case ProjectRef(_, id) => id == "zincRoot"; case _ => false }
     |                                                                                ^
     |Unreachable case except for null (if this is intentional, consider writing case null => instead).
```