### PR TITLE
[2.x] fix: Fixes common settings with a plugin with extraProjects

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1129,7 +1129,7 @@ private[sbt] object Load {
       val newProjects = rest ++ discovered ++ projectLevelExtra
       val newAcc = acc :+ finalRoot
       val newGenerated = generated ++ generatedConfigClassFiles
-      loadTransitive1(newProjects, newAcc, newGenerated, commonSettings)
+      loadTransitive1(newProjects, newAcc, newGenerated, finalRoot.commonSettings)
     }
 
     // Load all config files AND process the project at the root directory, if it exists.

--- a/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/build.sbt
+++ b/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/build.sbt
@@ -6,11 +6,32 @@
  * Licensed under Apache License 2.0 (see LICENSE)
  */
 
-val check = taskKey[Unit]("Repro for #4947: task at root when extraProjects creates auto root")
+@transient
+val check4947 = taskKey[Unit]("")
+
+@transient
+val check5661 = taskKey[Unit]("")
+
+@transient
+val check9493 = taskKey[Unit]("")
+
+organization := "com.example"
 
 val a = project
 val p = project
   .settings(
     name := "p",
-    check := ()
+    // subproject-level task
+    check4947 := {},
+
+    check9493 := {
+      val o = organization.value
+      assert(o == "com.example", s"actual: $o")
+    }
   )
+
+LocalProject("mc") / cantTouchThis := "foo"
+LocalRootProject / check5661 := {
+  val actual = (LocalProject("mc") / cantTouchThis).value
+  assert(actual == "foo", s"actual: $actual")
+}

--- a/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/project/ExtraPlugin.scala
+++ b/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/project/ExtraPlugin.scala
@@ -6,10 +6,18 @@
  * Licensed under Apache License 2.0 (see LICENSE)
  */
 
-import sbt._, Keys._
+import sbt.*, Keys.*
 
-object ExtraPlugin extends AutoPlugin {
+object ExtraPlugin extends AutoPlugin:
+  object autoImport:
+    val cantTouchThis = settingKey[String]("")
+  end autoImport
+  import autoImport.*
+
   override def trigger = allRequirements
   override def extraProjects: Seq[Project] =
-    Seq(Project("z", file("z")).settings(name := "z"))
-}
+    Seq(Project("mc", file("mc")).settings(
+      name := "mc",
+      cantTouchThis := "can't touch this",  
+    ))
+end ExtraPlugin

--- a/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/test
+++ b/sbt-app/src/sbt-test/project/extra-projects-key-aggregate/test
@@ -1,1 +1,5 @@
-> check
+> check4947
+
+> check5661
+
+> p/check9493


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9493
Fixes #5661  

## Problem
The presence of extraProjects broke common settings.

## Solution
This fixes it by passing finalRoot.commonSettings.