### PR TITLE
[2.x] refactor: Separate file I/O from cache-write serialization

### DIFF
--- a/notes/2.0.0/cache-write-serialization-no-io.md
+++ b/notes/2.0.0/cache-write-serialization-no-io.md
@@ -1,0 +1,15 @@
+### Cache-write serialization no longer performs file I/O
+
+Serializing a task's result for the action cache re-read the size of every
+referenced file at write time, so a file vanishing between the task completing
+and the cache write (for example when two overlapping evaluations of the same
+task race the jar-to-CAS-symlink swap) made an otherwise successful task's
+cache write throw an intermittent `sjsonnew.SerializationException: error
+while writing the field outputFiles`. Each stored output reference is now
+materialized once, before its blob is stored, so the cache write succeeds even
+if the file vanishes afterwards, and I/O errors on an output file surface
+upfront at blob storage time rather than mid-serialization.
+
+This addresses [#9349][i9349].
+
+[i9349]: https://github.com/sbt/sbt/issues/9349

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -66,16 +66,20 @@ end ActionCacheStore
 
 trait AbstractActionCacheStore extends ActionCacheStore:
   def putBlobsIfNeeded(blobs: Seq[VirtualFile]): Seq[HashedVirtualFileRef] =
+    // Read each blob's hash and size once, up front, and return only these plain value refs:
+    // serializing the ActionResult afterwards does no file I/O, and nothing re-stats a blob
+    // after its CAS entry is written.
+    val materialized: Seq[(VirtualFile, HashedVirtualFileRef)] = blobs.map: blob =>
+      blob -> HashedVirtualFileRef.of(blob.id, blob.contentHashStr, blob.sizeBytes)
     val found = findBlobs(blobs).toSet
     val missing = blobs.flatMap: blob =>
       val ref: HashedVirtualFileRef = blob
       if found.contains(ref) then None
       else Some(blob)
     val combined = putBlobs(missing).toSet ++ found
-    blobs.flatMap: blob =>
+    materialized.flatMap: (blob, plain) =>
       val ref: HashedVirtualFileRef = blob
-      if combined.contains(ref) then Some(ref)
-      else None
+      if combined.contains(ref) then Some(plain) else None
 
   def notFound: Throwable =
     new RuntimeException("not found")

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -25,6 +25,8 @@ import xsbti.{
 import ActionCache.InternalActionResult
 
 object ActionCacheTest extends BasicTestSuite:
+  final case class Unserializable(n: Int)
+
   val tags = CacheLevelTag.all.toList
 
   test("findMissingFile extracts the path from a wrapped NoSuchFileException"):
@@ -347,6 +349,108 @@ object ActionCacheTest extends BasicTestSuite:
       val v2 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
       assert(v2 == 2)
       assert(called == 1, s"expected a success cache hit after the cure (called=$called)")
+
+  test("A file vanishing after its blob is stored no longer breaks the cache write"):
+    withDiskCache: cache =>
+      import sjsonnew.BasicJsonProtocol.*
+      var called = 0
+      IO.withTemporaryDirectory: tempDir =>
+        val config = getCacheConfig(cache, tempDir)
+        val goodHash = Digest.sha256Hash("hello".getBytes(StandardCharsets.UTF_8)).contentHashStr
+        val casFile = cache.toCasFile(Digest(s"$goodHash/5"))
+        // Models the reported race: the backing file vanishes the moment its blob reaches the
+        // CAS (the concurrent winner's syncFile swap), so any later stat throws.
+        val vanishing = new xsbti.BasicVirtualFileRef(s"$tempDir/out.jar") with VirtualFile:
+          private def maybeThrow[A](a: A): A =
+            if Files.exists(casFile) then throw new NoSuchFileException(id) else a
+          override def contentHash: Long = 0L
+          override def sizeBytes: Long = maybeThrow(5L)
+          override def contentHashStr: String = maybeThrow(goodHash)
+          override def input: java.io.InputStream =
+            new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8))
+        val action: ((Int, Int)) => InternalActionResult[Int] = { (a, b) =>
+          called += 1
+          InternalActionResult(a + b, Seq(vanishing))
+        }
+        val v1 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v1 == 2)
+        assert(called == 1)
+        val v2 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v2 == 2)
+        assert(called == 1, s"expected a cache hit: the write must have succeeded (called=$called)")
+
+  test("A file already missing at the cache write degrades to an uncached task"):
+    withDiskCache: cache =>
+      import sjsonnew.BasicJsonProtocol.*
+      var called = 0
+      IO.withTemporaryDirectory: tempDir =>
+        val config = getCacheConfig(cache, tempDir)
+        val gone = new xsbti.BasicVirtualFileRef(s"$tempDir/out.jar") with VirtualFile:
+          override def contentHash: Long = throw new NoSuchFileException(id)
+          override def sizeBytes: Long = throw new NoSuchFileException(id)
+          override def contentHashStr: String = throw new NoSuchFileException(id)
+          override def input: java.io.InputStream = throw new NoSuchFileException(id)
+        val action: ((Int, Int)) => InternalActionResult[Int] = { (a, b) =>
+          called += 1
+          InternalActionResult(a + b, Seq(gone))
+        }
+        val v1 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v1 == 2)
+        assert(called == 1)
+        val v2 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v2 == 2)
+        assert(called == 2, "a degraded cache write must mean a cache miss on the next run")
+
+  test("put materializes output refs so serialization does no file I/O"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        @volatile var vanished = false
+        val goodHash = Digest.sha256Hash("hello".getBytes(StandardCharsets.UTF_8)).contentHashStr
+        val ref = new xsbti.BasicVirtualFileRef(s"$tempDir/out.jar") with VirtualFile:
+          private def maybeThrow[A](a: A): A =
+            if vanished then throw new NoSuchFileException(id) else a
+          override def contentHash: Long = 0L
+          override def sizeBytes: Long = maybeThrow(5L)
+          override def contentHashStr: String = maybeThrow(goodHash)
+          override def input: java.io.InputStream =
+            new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8))
+        val stored =
+          cache.put(UpdateActionResultRequest(Digest.dummy(42L), Vector(ref), exitCode = 0)) match
+            case Right(r) => r.outputFiles.head
+            case Left(e)  => throw new AssertionError(s"put failed: $e", e)
+        vanished = true
+        assert(stored.id == ref.id)
+        assert(
+          stored.contentHashStr == goodHash && stored.sizeBytes == 5L,
+          "stored ref must not re-stat the file"
+        )
+
+  test("A successful task whose value fails to serialize returns it uncached"):
+    withDiskCache: cache =>
+      var called = 0
+      // Pins the value-serialization leg of the NonFatal recovery introduced in #9488, which
+      // had no test: a codec that always throws, standing in for any serialization failure
+      // during the cache write of a succeeded task.
+      given sjsonnew.JsonFormat[Unserializable] = new sjsonnew.JsonFormat[Unserializable]:
+        override def write[J](obj: Unserializable, builder: sjsonnew.Builder[J]): Unit =
+          sjsonnew.serializationError("Unserializable is unserializable")
+        override def read[J](
+            jsOpt: Option[J],
+            unbuilder: sjsonnew.Unbuilder[J]
+        ): Unserializable = Unserializable(0)
+      import sjsonnew.BasicJsonProtocol.*
+      val action: ((Int, Int)) => InternalActionResult[Unserializable] = { (a, b) =>
+        called += 1
+        InternalActionResult(Unserializable(a + b), Nil)
+      }
+      IO.withTemporaryDirectory: tempDir =>
+        val config = getCacheConfig(cache, tempDir)
+        val v1 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v1 == Unserializable(2))
+        assert(called == 1)
+        val v2 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, config)(action)
+        assert(v2 == Unserializable(2))
+        assert(called == 2, "a degraded cache write must mean a cache miss on the next run")
 
   test("Cache falls back to recompute when syncBlobs throws FileNotFoundException"):
     withDiskCache(testSyncBlobsThrowsFallback)


### PR DESCRIPTION
## Problem

The `HashedVirtualFileRef` codec does live file I/O at serialization time: it reads `contentHashStr` and `sizeBytes`, which for zinc's `MappedVirtualFile` is a plain `def` calling `Files.size` on every invocation. If a file referenced by a task's result vanishes between the task completing and its cache write, that stat throws mid-serialization, surfacing as the reporter's intermittent `SerializationException: error while writing the field outputFiles` (#9349).

The intermittency is a real race, recovered from the reporter's original CI log and reproduced locally under strace: a plugin using `Extracted.runTask` (sbt-buildinfo's task-typed keys) triggers a concurrent duplicate evaluation of the same `packageBin` action, since nested evaluations share no deduplication with the outer graph and the action cache has no per-digest single-flight. The winner's post-put `syncFile` swaps the freshly built jar for a CAS symlink via a non-atomic delete-then-link (a sub-millisecond hole measured under strace); the loser's serialization-time stat lands in the hole.

#9488 already stopped this from failing the build: `organicTask` now recovers from any `NonFatal` storage error and returns the task's value uncached. This PR removes the cause on the store side, so the write succeeds instead of being skipped.

## Fix

`putBlobsIfNeeded` (shared by the disk, in-memory, and remote gRPC stores) reads each blob's hash and size once, up front, and returns only plain `HashedVirtualFileRef.of(id, hash, size)` values. Serializing an `ActionResult` then performs no file I/O in any store, nothing re-stats a blob after its CAS entry is written, and I/O errors on an output file surface upfront at blob storage time rather than mid-serialization: a file vanishing once its blob is stored no longer prevents the cache write.

One live read remains outside this PR's reach: a task whose *value* itself contains file refs (e.g. `packageBin` returning its jar ref) serializes them before the put. A vanish there is covered by #9488's recovery.

## Testing

Unit (`ActionCacheTest`, 58/58):
- A file vanishing the moment its blob reaches the CAS: the write succeeds and the next run is a cache hit. Fails on develop, where the same sequence degrades and recomputes.
- A stored ref must not re-stat its file (the materialization pin). Fails on develop.
- A file already missing at the cache write: value returned uncached, next run recomputes.
- A value whose codec throws: value returned uncached, next run recomputes (pins the value-serialization leg of #9488's `NonFatal` recovery, which had no test).

Full `scripted cache/*` sweep green; scalafmt and MiMa clean.

Follow-up candidates deliberately not in this PR: an atomic symlink swap in `syncFile`, and per-digest single-flight for concurrent duplicate evaluations of the same action. Happy to file issues for either.

---

*Diagnosed and fixed with AI assistance (Claude Code); the race was pinned empirically (original CI log recovered, strace shows the unlink-to-symlink hole, disk cache held five action entries sharing one CAS blob) and the fix is discriminator-proven (the vanish-after-storage and materialization tests fail with the store change reverted).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
