### PR TITLE
[2.x] fix: Fixes reboot from sbtn

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -159,7 +159,6 @@ private[sbt] object Server {
       }
 
       override def shutdown(): Unit = {
-        log.info("shutting down sbt server")
         if (portfile.exists) {
           IO.delete(portfile)
         }
@@ -171,6 +170,7 @@ private[sbt] object Server {
           case null =>
           case s    => s.close()
         }
+        log.info("shutting down sbt server")
       }
 
       private def writeTokenfile(): Unit = {

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -320,9 +320,9 @@ private[sbt] final class CommandExchange {
     }
     procFile = None
     fastTrackThread.close()
-    channels foreach (_.shutdown(true))
+    channels.foreach(c => Util.ignoreResult(Try(c.shutdown(true))))
     // interrupt and kill the thread
-    server.foreach(_.shutdown())
+    server.foreach(s => Util.ignoreResult(Try(s.shutdown())))
     server = None
     EvaluateTask.onShutdown()
   }

--- a/notes/2.0.0/reboot-reconnect.md
+++ b/notes/2.0.0/reboot-reconnect.md
@@ -1,0 +1,15 @@
+### `reboot` works from the thin client again
+
+Running `reboot` in the sbt shell dropped to the OS shell ("sbt server connection
+closed") instead of rebooting. The server's teardown began with a log line that
+throws when the terminal in scope is the rebooting client's already-closed
+virtual terminal, aborting teardown before the server socket was closed and the
+portfile deleted; the relaunched instance then mistook the leaked socket for
+another running sbt and never started its server, while the client latched onto
+the stale portfile. Server teardown now completes its state cleanup before
+logging, and one failing channel shutdown can no longer skip the rest of the
+exchange teardown. `reboot` returns to a working prompt.
+
+This addresses [#9095][i9095].
+
+[i9095]: https://github.com/sbt/sbt/issues/9095

--- a/server-test/src/test/scala/testpkg/AbstractServerTest.scala
+++ b/server-test/src/test/scala/testpkg/AbstractServerTest.scala
@@ -27,8 +27,15 @@ final class SbtServer(
     val baseDirectory: File,
     private val process: scala.sys.process.Process
 ) {
-  def close(): Unit =
-    session.shutdown(process.isAlive(), () => process.destroy()).get
+  def close(): Unit = {
+    val result = scala.util.Try(session.shutdown(process.isAlive(), () => process.destroy()).get)
+    if (process.isAlive()) process.destroy()
+    result match {
+      case scala.util.Failure(e) =>
+        System.err.println(s"server session shutdown failed (process destroyed): $e")
+      case _ =>
+    }
+  }
 }
 
 trait AbstractServerTest extends AnyFunSuite with BeforeAndAfterAll {

--- a/server-test/src/test/scala/testpkg/RebootTest.scala
+++ b/server-test/src/test/scala/testpkg/RebootTest.scala
@@ -1,0 +1,67 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package testpkg
+
+import java.io.{ InputStream, PrintStream }
+import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit, TimeoutException }
+import sbt.internal.client.NetworkClient
+import sbt.internal.util.Util
+
+/**
+ * Regression for https://github.com/sbt/sbt/issues/9095: `reboot` from a client must bring the
+ * server back and complete instead of leaving a zombie server that drops the client.
+ */
+class RebootTest extends AbstractServerTest {
+  override val testDirectory: String = "client"
+
+  private object BlockingInputStream extends InputStream {
+    override def read(): Int = {
+      try Thread.sleep(Long.MaxValue)
+      catch { case _: InterruptedException => }
+      -1
+    }
+  }
+  private val nullPrintStream = new PrintStream(_ => {}, false)
+
+  private def background[R](f: => R): R = {
+    val result = new LinkedBlockingQueue[Either[Throwable, R]]
+    val thread = new Thread("reboot-test-client") {
+      setDaemon(true)
+      override def run(): Unit =
+        try Util.ignoreResult(result.put(Right(f)))
+        catch { case e: Throwable => Util.ignoreResult(result.put(Left(e))) }
+    }
+    thread.start()
+    result.poll(3, TimeUnit.MINUTES) match {
+      case null =>
+        thread.interrupt()
+        thread.join(10000)
+        throw new TimeoutException("client did not complete within 3 minutes")
+      case Left(e)  => throw e
+      case Right(r) => r
+    }
+  }
+
+  private def client(args: String*): Int =
+    background(
+      NetworkClient.client(
+        testPath.toFile,
+        args.toArray,
+        BlockingInputStream,
+        nullPrintStream,
+        nullPrintStream,
+        false
+      )
+    )
+
+  test("reboot completes and the rebooted server serves the next command") {
+    assert(client("reboot") == 0, "reboot from a client must complete with exit 0")
+    assert(client("willSucceed") == 0, "the rebooted server must serve a new client connection")
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9095

## Problem

Running `reboot` in the sbt shell drops to the OS shell ("sbt server connection closed") instead of rebooting (#9095). The reboot protocol is intact on both ends: the server sends the reboot-flavored `Shutdown` notification, and the thin client's reconnect machinery (wait for the server, re-attach, replay) handles it. The break is in teardown. `Server.shutdown` opens with `log.info`, and during a client-initiated reboot the terminal in scope is that client's already-closed virtual terminal, so the log write throws `ClosedChannelException` through the terminal proxy. Teardown aborts before the portfile is deleted and the server socket closed, and the exception is swallowed by the shutdown hook, whose own error print goes to the same dead terminal.

The relaunched instance's startup probe then connects to the leaked socket, concludes another sbt is running, and never starts a server; the client's wait is satisfied by the stale portfile and it attaches to the zombie socket. Under sbtn the relaunched instance immediately self-shutdowns (`startedByRemoteClient` with no server), producing the reported "sbt server connection closed".

## Fix

- `Server.shutdown` completes its state cleanup (portfile, tokenfile, running flag, server socket) before logging, so teardown cannot be aborted by a logging failure.
- `CommandExchange.shutdown` wraps each channel shutdown and the server shutdown individually, so one failing step cannot skip the rest.

No protocol or client changes: the existing reconnect machinery works once teardown completes. (Two follow-up candidates, happy to file: the client's `blockUntilStart` treats a still-existing portfile as "server is back", which masked this; and shutdown-hook exceptions print to a possibly-dead terminal, which made the abort invisible.)

## Testing

- `RebootTest` (server-test) exercises the round trip with batch clients: `reboot` must complete with exit 0 (the client's reboot handler reconnects to the relaunched server and completes the exec), and a second client must then be served by the rebooted server. On develop the relaunched instance connects to the leaked socket, warns `Running multiple instances is unsupported`, and the follow-up client exits 1; with this change both exit 0, verified under 2-core CPU contention (3/3) as well as unconstrained.
- An interactive-stdin variant of the test was abandoned deliberately: it exposed a pre-existing input race in the thin client, unrelated to this fix (a `readSystemIn` request that arrives while the one-byte `RawInputThread` is exiting is silently dropped, permanently wedging session input; reproducible under CPU contention). Happy to file that separately with the capture logs.
- `commandProj`/`mainProj` compile, scalafmt, MiMa clean.

---

*Diagnosed with AI assistance (Claude Code): the failure was reproduced in the server-test harness, the `ClosedChannelException` captured with instrumentation, and the fix validated end-to-end before productionizing.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
