### PR TITLE
[2.x] feat: Skip checksum generation for asc file, take 2

### DIFF
--- a/lm-ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
+++ b/lm-ivy/src/main/scala/sbt/internal/librarymanagement/ConvertResolver.scala
@@ -116,18 +116,13 @@ private[sbt] object ConvertResolver {
         checksum <- checksums
         if !ChecksumHelper.isKnownAlgorithm(checksum)
       } throw new IllegalArgumentException("Unknown checksum algorithm: " + checksum)
-      repository.put(artifact, src, dest, overwrite);
-      // Fix for sbt#1156 - Artifactory will auto-generate MD5/sha1 files, so
-      // we need to overwrite what it has.
-      if (!artifact.getName.endsWith(".asc")) {
-        for (checksum <- checksums) {
-          putChecksumMethod match {
+      repository.put(artifact, src, dest, overwrite)
+      if !dest.endsWith(".asc") then
+        for checksum <- checksums do
+          putChecksumMethod match
             case Some(method) =>
               method.invoke(this, artifact, src, dest, true: java.lang.Boolean, checksum)
             case None => // TODO - issue warning?
-          }
-        }
-      }
       if (signerName != null) {
         putSignatureMethod match {
           case None         => ()
@@ -219,15 +214,16 @@ private[sbt] object ConvertResolver {
         resolver
       }
       case repo: FileRepository => {
-        val resolver = new FileSystemResolver with DescriptorRequired {
-          // Workaround for #1156
-          // Temporarily in sbt 0.13.x we deprecate overwriting
-          // in local files for non-changing revisions.
-          // This will be fully enforced in sbt 1.0.
-          setRepository(new WarnOnOverwriteFileRepo())
-          override val managedChecksumsEnabled: Boolean = managedChecksums
-          override def getResource(resource: Resource, dest: File): Long = get(resource, dest)
-        }
+        val resolver =
+          new FileSystemResolver with ChecksumFriendlyURLResolver with DescriptorRequired {
+            // Workaround for #1156
+            // Temporarily in sbt 0.13.x we deprecate overwriting
+            // in local files for non-changing revisions.
+            // This will be fully enforced in sbt 1.0.
+            setRepository(new WarnOnOverwriteFileRepo())
+            override val managedChecksumsEnabled: Boolean = managedChecksums
+            override def getResource(resource: Resource, dest: File): Long = get(resource, dest)
+          }
         resolver.setName(repo.name)
         initializePatterns(resolver, repo.patterns, settings)
         import repo.configuration.{ isLocal, isTransactional }

--- a/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/build.sbt
+++ b/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/build.sbt
@@ -1,0 +1,25 @@
+// `signTask` stands in for sbt-pgp's signing task: it just writes a fake signature file
+// and publishes it as an extra artifact with an ".asc" extension.
+
+useIvy := true
+
+organization := "com.example"
+name := "foo"
+version := "1.0.0"
+scalaVersion := "2.12.21"
+autoScalaLibrary := false
+crossPaths := false
+Compile / packageDoc / publishArtifact := false
+Compile / packageSrc / publishArtifact := false
+publishTo := localStaging.value
+
+lazy val signTask = taskKey[HashedVirtualFileRef]("Emulates sbt-pgp's signing task")
+
+signTask := {
+  val conv = fileConverter.value
+  val out = target.value / "foo-1.0.0.jar.asc"
+  IO.write(out, "fake-signature")
+  conv.toVirtualFile(out.toPath)
+}
+
+addArtifact(Artifact("foo", "asc", "jar.asc"), signTask)

--- a/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/project/plugins.sbt
@@ -1,0 +1,5 @@
+libraryDependencies += Defaults.sbtPluginExtra(
+  "org.scala-sbt" % "sbt-ivy" % sbtVersion.value,
+  sbtVersion.value,
+  scalaVersion.value,
+)

--- a/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/test
+++ b/sbt-app/src/sbt-test/ivy/publish-asc-no-checksum/test
@@ -1,0 +1,16 @@
+# useIvy := true forces the Ivy-backed publisher (ConvertResolver), which is what generates
+# checksums via the ChecksumFriendlyURLResolver shim.
+> publish
+
+# ordinary artifacts and their checksums are published as usual
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar.md5
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar.sha1
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.pom
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.pom.md5
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.pom.sha1
+
+# the .asc signature artifact is published, but must NOT get its own checksum files
+$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar.asc
+-$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar.asc.md5
+-$ exists target/sona-staging/com/example/foo/1.0.0/foo-1.0.0.jar.asc.sha1


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8134

## Problem
Checksums are still generated for asc file.
1. localStaging is a file repo, which was not handled
2. It was checking Artifact name, not the file name

## Solution
This fixes both.
