### PR TITLE
[2.x] fix: Fixes inMemoryAnalysisCache limit

### DIFF
--- a/main/src/main/scala/sbt/internal/BuildDef.scala
+++ b/main/src/main/scala/sbt/internal/BuildDef.scala
@@ -9,7 +9,7 @@
 package sbt
 package internal
 
-import com.github.benmanes.caffeine.cache.{ Cache as CCache, Caffeine, Weigher }
+import com.github.benmanes.caffeine.cache.{ Cache as CCache, Caffeine }
 import java.io.File
 import java.nio.file.{ Files, NoSuchFileException, Path as NioPath }
 import java.nio.file.attribute.BasicFileAttributes
@@ -92,16 +92,10 @@ private[sbt] object BuildDef:
   ): Seq[xsbti.compile.CompileAnalysis] =
     in.flatMap(a => extractAnalysis(a.metadata, converter))
 
-  private[sbt] final val localAnalysisCacheByteSize = 100 * 1024L * 1024L
-  private val weigher: Weigher[String, (Option[AnalysisContents], Long, Long)] = {
-    case (_, (_, _, sizeBytes)) => sizeBytes.toInt
-  }
   private val inMemoryAnalysisCache: CCache[String, (Option[AnalysisContents], Long, Long)] =
-    Caffeine
-      .newBuilder()
-      .maximumWeight(localAnalysisCacheByteSize)
-      .weigher(weigher)
-      .build()
+    val maxCount = SysProp.analysisCacheMaxCount
+    val builder = Caffeine.newBuilder()
+    (if maxCount == 0 then builder else builder.maximumSize(maxCount.toLong)).build()
   private def getOrElseUpdate(ref: VirtualFileRef, lastModified: Long, sizeBytes: Long)(
       value: => Option[AnalysisContents]
   ): Option[AnalysisContents] =

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -123,6 +123,8 @@ object SysProp:
   @deprecated("Resident compilation is no longer supported", "1.4.0")
   def residentLimit: Int = int("sbt.resident.limit", 0)
 
+  def analysisCacheMaxCount: Int = int("sbt.local_cache.analysis_count", 8)
+
   /**
    * Indicates whether formatting has been disabled in environment variables.
    * 1. -Dsbt.log.noformat=true means no formatting.


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/9477

## Problem
The in-memory Analysis cache is currently weighted by on-disk size, but according to the user report it expands out 50x, so 100MB size limit doesn't hit.

## Solution
This set maxCount instead, default 8 and configurable by system property `sbt.local_cache.analysis_count`.