### PR TITLE
[2.x] ci: Fix publishLocalBin

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -22,8 +22,6 @@ jobs:
           java-version: "17"
           cache: sbt
       - uses: sbt/setup-sbt@v1
-        with:
-          disk-cache: false
       - name: Set bazel-remote version
         id: bazel-remote-version
         run: echo "version=2.6.2" >> "$GITHUB_OUTPUT"

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -4,6 +4,7 @@ import java.nio.file.{ FileAlreadyExistsException, Files }
 
 import sbt.Keys.*
 import sbt.util.CacheImplicits.given
+import sbt.librarymanagement.LibraryManagementCodec.given
 import sbt.internal.librarymanagement.IvyXml
 
 /** This local plugin provides ways of publishing just the binary jar. */
@@ -53,12 +54,15 @@ object PublishBinPlugin extends AutoPlugin {
         .value
     ),
     dummyDoc := {
-      val dummyFile = streams.value.cacheDirectory / "doc.jar"
+      val _ = projectID.value
+      val dummyFile = target.value / "dummy-doc" / "doc.jar"
       try {
         Files.createDirectories(dummyFile.toPath.getParent)
         Files.createFile(dummyFile.toPath)
       } catch { case _: FileAlreadyExistsException => }
-      fileConverter.value.toVirtualFile(dummyFile.toPath)
+      val out = fileConverter.value.toVirtualFile(dummyFile.toPath)
+      Def.declareOutput(out)
+      (out: HashedVirtualFileRef)
     },
     dummyDoc / packagedArtifact := Def.uncached(
       (Compile / packageDoc / artifact).value -> dummyDoc.value


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9504

## Problem/Solution
dummyDoc was not cached properly.