### PR TITLE
[2.x] fix: Keep the client stdin reader alive so input requests are never dropped

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -173,9 +173,13 @@ class NetworkClient(
   private val sbtProcess = new AtomicReference[Process](null)
   private class ConnectionRefusedException(t: Throwable) extends Throwable(t)
   private class ServerFailedException extends Exception
-  private def startInputThread(): Unit = inputThread.get match {
-    case null => inputThread.set(new RawInputThread)
-    case _    =>
+  private val inputThreadLock = new Object
+  private def startInputThread(): Unit = inputThreadLock.synchronized {
+    inputThread.get match {
+      case null               => inputThread.set(new RawInputThread)
+      case t if t.stopped.get => inputThread.set(new RawInputThread)
+      case _                  => ()
+    }
   }
   private lazy val log: Logger = new Logger {
     def trace(t: => Throwable): Unit = ()
@@ -1130,18 +1134,21 @@ class NetworkClient(
 
   private class RawInputThread extends Thread("sbt-read-input-thread") with AutoCloseable {
     setDaemon(true)
-    start()
+    // stopped must be initialized before start(): run() reads it as soon as the thread runs.
     val stopped = new AtomicBoolean(false)
+    start()
     override final def run(): Unit = {
-      def read(): Unit = {
-        val b = inputStream.read
-        inLock.synchronized(stdinBytes.offer(b))
-        if (attached.get()) drain()
-      }
-      try read()
-      catch { case _: InterruptedException | NonFatal(_) => stopped.set(true) }
+      try {
+        var b = 0
+        while (!stopped.get && b != -1) {
+          b = inputStream.read
+          inLock.synchronized(stdinBytes.offer(b))
+          if (attached.get()) drain()
+        }
+      } catch { case _: InterruptedException | NonFatal(_) => () }
       finally {
-        inputThread.set(null)
+        stopped.set(true)
+        inputThreadLock.synchronized(Util.ignoreResult(inputThread.compareAndSet(this, null)))
       }
     }
 
@@ -1153,6 +1160,7 @@ class NetworkClient(
     }
 
     override def close(): Unit = {
+      stopped.set(true)
       RawInputThread.this.interrupt()
     }
   }

--- a/notes/2.0.0/stdin-wedge.md
+++ b/notes/2.0.0/stdin-wedge.md
@@ -1,0 +1,15 @@
+### Interactive client input no longer wedges permanently
+
+The thin client's stdin reader thread lived for exactly one byte, and the
+server's next per-byte input request could arrive while that thread was
+exiting, in which case the request was silently dropped: no thread ever read
+the next byte, the server's terminal read blocked forever, and the session
+stopped accepting all keyboard input until the client was killed. Under CPU
+load this raced frequently at typing and paste speed. The reader now lives
+until the server cancels input reading or stdin ends, and an input request
+that arrives while the reader is exiting starts a replacement instead of
+being dropped.
+
+This addresses [#9507][i9507].
+
+[i9507]: https://github.com/sbt/sbt/issues/9507


### PR DESCRIPTION
## Problem

The server requests interactive stdin one byte at a time via `readSystemIn` notifications. `RawInputThread.run()` read a single byte, forwarded it, and exited through `finally inputThread.set(null)`, while `startInputThread()` was a no-op whenever `inputThread` was non-null. A `readSystemIn` arriving in the window between the forward and the `finally` was silently dropped: no thread ever read the next byte, the server's pending terminal read blocked forever, and session input was dead. Typed bytes stopped echoing and executing, and only killing sbtn and re-attaching recovered. A byte read while `attached` was false during a reboot was likewise parked in `stdinBytes` with nothing left to drain it (#9507).

Reproduced through a real pseudo-terminal driving the actual client entry against a forked server: paste-speed input wedges 5 of 10 sessions pinned to 2 cores, and 3 of 4 sessions on an unpinned 12-core machine with background CPU load; jstack of a wedged client shows no `sbt-read-input-thread` alive.

## Fix

- The reader thread now lives until input reading is cancelled or stdin reaches EOF, reading in a loop, so there is no per-byte exit window to race.
- `close()` marks the thread stopped before interrupting, and `startInputThread()` replaces a stopped-but-not-yet-deregistered thread, with both sides synchronizing on the registration, so an input request that arrives while the reader is exiting starts a replacement instead of being dropped.
- The `stopped` flag is initialized before `start()`, since `run()` reads it immediately; the reproduction harness caught an NPE from the reverse order recreating the wedge.
- Bytes read while detached mid-reboot no longer strand, because the surviving reader drains them once re-attached. A command typed mid-reboot can still be lost to the dying server's connection, but the session now survives it; preserving type-ahead across reboot is offered as a follow-up.

Two consequences worth stating. After a cancel, a reader parked in a blocking `read` cannot be interrupted out of it; it reads at most one more byte, forwards it under the lock, and exits, so a cancel-then-request cycle has a brief bounded two-reader window whose worst case is a one-byte reorder, strictly dominated by the permanent wedge it replaces. And one `readSystemIn` now starts continuous streaming until cancelled, so paste bursts buffer in the server's unbounded input queue instead of the client's tty buffer; the consumers were audited and none assumes at-most-one-byte-per-request (the boot path already sent multi-byte batches).

## Testing

- Real-pty verification, same driver and configurations as the reproduction on the issue, with the client jar hash checked before each series to rule out stale bytecode. The race is scheduler-dependent, so rates vary by run: across two independent develop series, paste bursts wedged 5 of 10 pinned sessions in one and 0 of 15 in the other, while sessions on an unpinned 12-core machine with background CPU load wedged 3 of 4 and 5 of 6; every captured jstack shows the same signature (no `sbt-read-input-thread` alive). With this change, 0 of 31 sessions across all configurations wedge, and typing during `reboot` leaves a live session in 3 of 3 runs instead of a dead one. Driver and jstack dumps available on request.
- No in-repo interactive regression test ships with this PR, deliberately. An interactive test was written and passed everywhere locally, but on CI runners it consistently stalls in the server's per-keystroke terminal queries, a separate pre-existing unbounded-wait defect family in `NetworkChannel`/`VirtualTerminal` (the mechanism behind #6841 and #6840); a thread capture in the CI failure showed this fix's reader thread alive and waiting, which is the fixed behavior. Rather than merge a test that cannot run in CI, it was dropped; an interactive test becomes CI-viable once those waits are bounded.
- `commandProj` compile, scalafmt, MiMa clean.

---

*Diagnosed and fixed with AI assistance (Claude Code); the race was found by code reading during CI triage of #9497, confirmed with a real-pty reproduction against a forked server, and the fix stress-verified under CPU contention with the same driver.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
