### PR TITLE
[2.x] fix: sbt.bat fails to start client/server mode on Windows

### DIFF
--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -123,22 +123,22 @@ if not defined _JAVACMD (
 
 if not defined _JAVACMD set _JAVACMD=java
 
-rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config.
-if not defined _JAVA_OPTS if defined JAVA_OPTS set _JAVA_OPTS=%JAVA_OPTS%
+rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config. 
+if not defined _JAVA_OPTS if defined JAVA_OPTS set _JAVA_OPTS=%JAVA_OPTS% 
 
-rem users can set JAVA_OPTS via .jvmopts (sbt-extras style)
-if exist .jvmopts for /F %%A in (.jvmopts) do (
-  set _jvmopts_line=%%A
-  if not "!_jvmopts_line:~0,1!" == "#" (
-    if defined _JAVA_OPTS (
-      set _JAVA_OPTS=!_JAVA_OPTS! %%A
-    ) else (
-      set _JAVA_OPTS=%%A
-    )
-  )
-)
-
-rem If nothing is defined, use the defaults.
+rem users can set JAVA_OPTS via .jvmopts (sbt-extras style) 
+if exist .jvmopts for /F %%A in (.jvmopts) do ( 
+  set _jvmopts_line=%%A 
+  if not "!_jvmopts_line:~0,1!" == "#" ( 
+    if defined _JAVA_OPTS ( 
+      set _JAVA_OPTS=!_JAVA_OPTS! %%A 
+    ) else ( 
+      set _JAVA_OPTS=%%A 
+    ) 
+  ) 
+) 
+ 
+rem If nothing is defined, use the defaults. 
 if not defined _JAVA_OPTS if defined default_java_opts set _JAVA_OPTS=!default_java_opts!
 
 rem We use the value of the SBT_OPTS environment variable if defined, rather than the config.
@@ -1018,7 +1018,6 @@ for /F "delims=.-_ tokens=1-2" %%v in ("!sbtV!") do (
   set sbtBinaryV_1=%%v
   set sbtBinaryV_2=%%w
 )
-
 rem default to run_native_client=1 for sbt 2.x
 if !sbtBinaryV_1! geq 2 (
   if !sbt_args_jvm_client! equ 1 (

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -51,7 +51,7 @@ set sbt_args_allow_empty=
 set sbt_args_sbt_dir=
 set sbt_args_sbt_version=
 set sbt_args_mem=
-set sbt_args_client=
+set sbt_args_client=-1
 set sbt_args_jvm_client=
 set sbt_args_no_server=
 set sbt_args_experimental_execution_log=
@@ -123,22 +123,22 @@ if not defined _JAVACMD (
 
 if not defined _JAVACMD set _JAVACMD=java
 
-rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config. 
-if not defined _JAVA_OPTS if defined JAVA_OPTS set _JAVA_OPTS=%JAVA_OPTS% 
+rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config.
+if not defined _JAVA_OPTS if defined JAVA_OPTS set _JAVA_OPTS=%JAVA_OPTS%
 
-rem users can set JAVA_OPTS via .jvmopts (sbt-extras style) 
-if exist .jvmopts for /F %%A in (.jvmopts) do ( 
-  set _jvmopts_line=%%A 
-  if not "!_jvmopts_line:~0,1!" == "#" ( 
-    if defined _JAVA_OPTS ( 
-      set _JAVA_OPTS=!_JAVA_OPTS! %%A 
-    ) else ( 
-      set _JAVA_OPTS=%%A 
-    ) 
-  ) 
-) 
- 
-rem If nothing is defined, use the defaults. 
+rem users can set JAVA_OPTS via .jvmopts (sbt-extras style)
+if exist .jvmopts for /F %%A in (.jvmopts) do (
+  set _jvmopts_line=%%A
+  if not "!_jvmopts_line:~0,1!" == "#" (
+    if defined _JAVA_OPTS (
+      set _JAVA_OPTS=!_JAVA_OPTS! %%A
+    ) else (
+      set _JAVA_OPTS=%%A
+    )
+  )
+)
+
+rem If nothing is defined, use the defaults.
 if not defined _JAVA_OPTS if defined default_java_opts set _JAVA_OPTS=!default_java_opts!
 
 rem We use the value of the SBT_OPTS environment variable if defined, rather than the config.
@@ -198,6 +198,14 @@ if "%~0" == "--client" set _client_arg=true
 if defined _client_arg (
   set _client_arg=
   set sbt_args_client=1
+  goto args_loop
+)
+
+if "%~0" == "--server" set _server_arg=true
+
+if defined _server_arg (
+  set _server_arg=
+  set sbt_args_client=0
   goto args_loop
 )
 
@@ -800,7 +808,7 @@ if defined sbt_args_verbose (
   set "SBT_ARGS=-v !SBT_ARGS!"
 )
 
-set "SBT_SCRIPT=!SBT_BIN_DIR: =%%20!sbt.bat"
+for %%I in ("!SBT_BIN_DIR!sbt.bat") do set "SBT_SCRIPT=%%~sI"
 set "SBT_ARGS=--sbt-script=!SBT_SCRIPT! %SBT_ARGS%"
 
 rem Microsoft Visual C++ 2010 SP1 Redistributable Package (x64) is required
@@ -1010,6 +1018,7 @@ for /F "delims=.-_ tokens=1-2" %%v in ("!sbtV!") do (
   set sbtBinaryV_1=%%v
   set sbtBinaryV_2=%%w
 )
+
 rem default to run_native_client=1 for sbt 2.x
 if !sbtBinaryV_1! geq 2 (
   if !sbt_args_jvm_client! equ 1 (


### PR DESCRIPTION
## Problem

`sbt.bat` fails to start in client/server mode on Windows, falling back to running the full JVM in the foreground.

Three bugs in `sbt.bat` prevent the native client (`sbtn`) from being used, even though the bash script `sbt` handles all three correctly.

1. `sbt_args_client` defaults to empty string. The `:process` subroutine uses `if !sbt_args_client! equ 0` to check whether the user explicitly opted out of the native client. Windows batch treats empty as `0` in numeric comparisons, so the default (empty) and the explicit opt-out (`--server`/`bsp`) are indistinguishable. This causes `run_native_client` to always be cleared for sbt 2.x, meaning the native client is never launched.

2. When `sbtn` spawns the sbt server, it calls `sbt.bat --server`. Without an argument handler, `--server` falls through as a residual arg and `sbt.bat` launches `sbtn` again instead of running as a server.

3. `sbtn` uses `CreateProcess` to spawn the server process. The original `%%20` path encoding doesn't work in batch delayed expansion context, and the default install path `C:\Program Files (x86)` contains spaces that `CreateProcess` splits at.

## Fix

1. Initialize `sbt_args_client` to `-1` (sentinel for "not set") so the three states are numerically distinct: `-1` (unset) vs `0` (explicit opt-out) vs `1` (explicit opt-in).

2. Add a `--server` argument handler that sets `sbt_args_client=0`, matching the bash script at line 759: `--server) use_sbtn=0 && shift`.

3. Use `for %%I` with `%%~sI` to resolve the Windows short (8.3) path (`C:\PROGRA~2\sbt\bin\sbt.bat`), which has no spaces and works with `CreateProcess`.

## Testing

- Verified `sbt --verbose help` in a fresh sbt 2.0.3 project launches `sbtn` ("entering thin client") and connects to the server.
- Verified `sbtn --sbt-script=C:\PROGRA~2\sbt\bin\sbt.bat --server help` spawns the server successfully and returns output.
- Confirmed all 3 fixes are required as a chain: removing any one breaks client/server mode.

*Diagnosed and fixed with AI assistance.*