### PR TITLE
[2.x] fix: Fixes a/build.sbt leakage

### DIFF
--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -1129,7 +1129,9 @@ private[sbt] object Load {
       val newProjects = rest ++ discovered ++ projectLevelExtra
       val newAcc = acc :+ finalRoot
       val newGenerated = generated ++ generatedConfigClassFiles
-      loadTransitive1(newProjects, newAcc, newGenerated, finalRoot.commonSettings)
+      // only root-level settings are build-wide; a submodule's own settings must not leak to siblings (#9517).
+      val cs = if isRootPath(p.base, buildBase) then finalRoot.commonSettings else commonSettings
+      loadTransitive1(newProjects, newAcc, newGenerated, cs)
     }
 
     // Load all config files AND process the project at the root directory, if it exists.

--- a/sbt-app/src/sbt-test/project/common-settings/build.sbt
+++ b/sbt-app/src/sbt-test/project/common-settings/build.sbt
@@ -1,3 +1,4 @@
+@transient
 lazy val check = taskKey[Unit]("")
 
 def scala212 = "2.12.21"
@@ -5,8 +6,8 @@ scalaVersion := scala212
 val o = "com.example"
 organization := o
 
-lazy val root = (project in file("."))
-  .aggregate(foo, bar, baz)
+lazy val root = rootProject
+  .autoAggregate
 
 lazy val foo = project
 lazy val bar = project
@@ -16,12 +17,14 @@ lazy val bar = project
   )
 
 lazy val baz = project
+lazy val qux = project
 
-check := {
+LocalRootProject / check := {
   assert((root / scalaVersion).value == scala212)
   assert((foo / scalaVersion).value == scala212)
   assert((bar / scalaVersion).value == scala212)
   assert((baz / scalaVersion).value == scala212)
+  assert((qux / scalaVersion).value == scala212)
 
   assert((root / organization).value == o, s"(root / organization).value: ${(root / organization).value}")
   assert((foo / organization).value == o, s"(foo / organization).value: ${(foo / organization).value}")
@@ -29,5 +32,7 @@ check := {
   assert((bar / organization).value == "com.example.bar")
   // Test that baz/build.sbt bare settings get loaded
   assert((baz / organization).value == "com.example.baz")
+  // Test that baz/build.sbt settings don't leak onto qux, processed right after it (#9517)
+  assert((qux / organization).value == o, s"(qux / organization).value: ${(qux / organization).value}")
 }
 check / aggregate := false


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9517

## Problem
subproject build.sbt like a/build.sbt leaks to siblings.

## Solution
Don't forward freshly computed common settings unless the `build.sbt` is at root.
