### PR TITLE
[2.x] fix: Add MiMa filter for ContextUtil.Output member removals from #9473

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -675,6 +675,10 @@ lazy val coreMacrosProj = (project in file("core-macros"))
     SettingKey[Boolean]("exportPipelining") := false,
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
+      // macro-expansion internals; Output's per-call-site var codegen members were removed
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sbt.internal.util.appmacro.ContextUtil#Output.*"
+      ),
     ),
   )
 


### PR DESCRIPTION
## Problem

[#9473](https://github.com/sbt/sbt/pull/9473) (fix/9462-dirzip-restore) removed the per-call-site var codegen members from `ContextUtil.Output` (toVarDef, toAssign, toRef, isFile, name, parent) when replacing them with a `ListBuffer`-based accumulator. The code changes and the `cache/declare-output-loop` scripted fixture landed with [#9473](https://github.com/sbt/sbt/pull/9473), but the corresponding MiMa exclusion filter was inadvertently excluded from the squash.

## Fix

Add the MiMa binary compatibility filter for the removed `ContextUtil.Output.*` members.

## Testing

- `coreMacrosProj/mimaReportBinaryIssues` green
- `mainProj/compile` green (re-expands every internal `Def.cachedTask` through the new codegen)
- `scalafmtSbtCheck` green

Fixes #9462

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)