### PR TITLE
[2.x] fix: Don't re-extract a dirzip whose digest already matches

### DIFF
--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -312,9 +312,8 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
     // See https://github.com/sbt/sbt/issues/7656
     // On Windows, the program has be running under the Administrator privileges or the
     // user enable Developer Mode on Windows 10+ to create symbolic links.
-    def writeFileAndNotify(outPath: Path): Path =
-      Option(outPath.getParent()).foreach(parent => IO.createDirectory(parent.toFile()))
-      val result = Retry:
+    def linkOrCopy(outPath: Path): Path =
+      Retry:
         if Files.exists(outPath) then IO.delete(outPath.toFile())
         if symlinkSupported.get() && Files.exists(casFile) then
           try Files.createSymbolicLink(outPath, casFile)
@@ -333,6 +332,9 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
                 symlinkSupported.set(false)
               copyFile(outPath)
         else copyFile(outPath)
+    def writeFileAndNotify(outPath: Path): Path =
+      Option(outPath.getParent()).foreach(parent => IO.createDirectory(parent.toFile()))
+      val result = linkOrCopy(outPath)
       afterFileWrite(ref, result, outputDirectory)
       result
     val resolvedPath = converter.toPath(ref) match
@@ -344,11 +346,15 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
         writeFileAndNotify(p)
       case p =>
         try
-          // `!symlinkSupported` prevents unnecessary deletion of files and then copying them again
-          // in #writeFileAndNotify on machines that don't support symlinks.
-          if Digest.sameDigest(p, d) && (!symlinkSupported.get() || Files.isSymbolicLink(p)) then
-            afterFileUpToDate(ref, p, outputDirectory)
-            p
+          // A matching digest means the content is already the blob's, so a dirzip's extracted
+          // directory is in sync and must not be unpackaged again. Relink to the CAS to keep
+          // deduplication, but only where that isn't a needless delete-and-copy: on machines
+          // without symlink support the copy already there is what we would write back.
+          if Digest.sameDigest(p, d) then
+            val result =
+              if symlinkSupported.get() && !Files.isSymbolicLink(p) then linkOrCopy(p) else p
+            afterFileUpToDate(ref, result, outputDirectory)
+            result
           else
             // println(s"- syncFile: $p has different digest")
             IO.delete(p.toFile())

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -346,10 +346,6 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
         writeFileAndNotify(p)
       case p =>
         try
-          // A matching digest means the content is already the blob's, so a dirzip's extracted
-          // directory is in sync and must not be unpackaged again. Relink to the CAS to keep
-          // deduplication, but only where that isn't a needless delete-and-copy: on machines
-          // without symlink support the copy already there is what we would write back.
           if Digest.sameDigest(p, d) then
             val result =
               if symlinkSupported.get() && !Files.isSymbolicLink(p) then linkOrCopy(p) else p

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -114,6 +114,63 @@ object ActionCacheTest extends BasicTestSuite:
         assert((dir / "a.txt").exists, "a.txt not re-extracted after the directory was deleted")
         assert((dir / "b.txt").exists, "b.txt not re-extracted after the directory was deleted")
 
+  test("Disk cache does not re-extract a dirzip whose archive digest already matches"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+
+        // packageDirectory leaves a regular file whose digest already matches the blob, so the
+        // extracted tree is in sync by construction and syncing must not unpackage it again.
+        IO.write(dir / "a.txt", "diverged")
+        cache.syncBlobs(refs, outputDirectory)
+        assert(IO.read(dir / "a.txt") == "diverged")
+
+  test("Disk cache relinks a digest-matching dirzip to the CAS"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+        val zipPath = Paths.get(dir.toString + ActionCache.dirZipExt)
+        assert(!Files.isSymbolicLink(zipPath), "packageDirectory should leave a regular file")
+
+        cache.syncBlobs(refs, outputDirectory)
+        assert(Files.isSymbolicLink(zipPath), "digest-matching archive was not relinked to the CAS")
+
+  test("Disk cache re-extracts a dirzip whose archive digest differs"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+
+        IO.write(Paths.get(dir.toString + ActionCache.dirZipExt).toFile(), "not an archive")
+        IO.write(dir / "a.txt", "diverged")
+        IO.write(dir / "stray.txt", "stray")
+        cache.syncBlobs(refs, outputDirectory)
+        assert(IO.read(dir / "a.txt") == "contents A", "diverged file was not restored")
+        assert(!(dir / "stray.txt").exists, "stray file was not removed")
+
   test("In-memory cache can hold action value"):
     withInMemoryCache(testActionCacheBasic)
 


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes https://github.com/sbt/sbt/issues/9554

## Changes

Test the digest first. A matching digest already means the local content *is* the blob's, whether or not the path happens to be a symlink. Where the path is not yet a symlink and symlinks are supported, still relink it to the CAS so deduplication is kept, but reach `afterFileUpToDate` — one `isDirectory` stat — rather than `afterFileWrite`.

This makes the regular-file case behave like the symlink case, which already skipped re-extraction. The symlink-creation fallback, including the unsupported-symlink detection that clears `symlinkSupported`, is factored into `linkOrCopy` and shared with `writeFileAndNotify` rather than duplicated.

## Notes for review

**The behaviour given up.** A file inside the extracted directory that has diverged from the manifest is no longer silently restored while the archive digest still matches. On the write path the directory is the source the archive was just built from, so it is authoritative; on a cache hit with a differing digest the full unpackage runs as before; and a directory that is missing entirely is still recreated, which `afterFileUpToDate` already handles.

**Scope.** For outputs that are not dirzips, `afterFileWrite` and `afterFileUpToDate` are both no-ops, and that branch already did a delete-and-relink, so their behaviour is unchanged. The change is confined to dirzips.

## Verification

- `testFull` — no failures.
- `scripted cache/*` — 12/12, including `compile-classes-restore`, `declare-output-dir-restore` and `declare-output-loop`, which exercise exactly the restore paths this touches.
- `scripted remote-cache/basic` — `hitCount=9 missCount=0 remoteHitCount=9`.
- Three new tests in `ActionCacheTest`: syncing a freshly packaged archive leaves a diverged file in the extracted tree alone; a digest-matching regular file is still relinked to the CAS; and a differing digest still fully re-extracts, restoring a stale file and deleting a stray one. The first fails before this change, returning the archived content instead of the diverged content.
