### PR TITLE
[2.x] feat: Add work-stealing to forked test execution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -475,7 +475,12 @@ lazy val workerProj = (project in file("worker"))
     libraryDependencies ++= Seq(gson, testInterface),
     libraryDependencies += "org.scala-lang" %% "scala3-library" % scalaVersion.value % Test,
     // run / fork := false,
-    Test / fork := true,
+    // Not forked. This project's own classes shadow WorkerMain on a forked worker's classpath, so a
+    // forked run pairs this worker with the older React of the sbt building us; that React drops
+    // every group notification, and a failing test here ends in `[success]` with no results at all.
+    // Note that WorkerMain.process calls System.exit on a request with no "jsonrpc" field, which
+    // unforked would take the sbt server with it, so tests here must only send well-formed requests.
+    Test / fork := false,
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
     ),

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -8,20 +8,23 @@
 
 package sbt
 
-import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser, JsonSyntaxException }
+import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser }
 import testing.{ Logger as _, Task as _, * }
 import java.io.*
-import java.util.ArrayList
+import java.util.{ ArrayList, Set as JSet }
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 import Tests.{ Output as TestOutput, * }
 import sbt.util.Logger
 import sbt.ConcurrentRestrictions.Tag
 import sbt.protocol.testing.*
-import sbt.internal.{ WorkerExchange, WorkerResponseListener }
+import sbt.internal.{ TestQueue, WorkerExchange, WorkerProxy, WorkerResponseListener }
 import sbt.internal.util.Util.*
 import sbt.internal.util.{ MessageOnlyException, Terminal as UTerminal }
 import sbt.internal.worker1.*
 import xsbti.{ FileConverter, HashedVirtualFileRef }
 import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration.Duration
 import scala.util.Random
@@ -37,6 +40,9 @@ import sbt.internal.WorkerConnection
 private[sbt] object ForkTests:
   val r = Random()
 
+  /** Gson instances are thread-safe, so one serves every session. */
+  private[sbt] val gson = WorkerMain.mkGson()
+
   /**
    * virtualClasspath can be controlled by setting
    * Test / classLoaderLayeringStrategy to ClassLoaderLayeringStrategy.Raw.
@@ -49,8 +55,11 @@ private[sbt] object ForkTests:
       converter: FileConverter,
       fork: ForkOptions,
       log: Logger,
+      forkedParallel: Boolean,
       parallelism: Option[Int],
       virtualClasspath: Boolean,
+      frameworks: Map[TestFramework, Framework],
+      maxWorkers: Int,
       tags: (Tag, Int)*
   ): Task[TestOutput] = {
     import std.TaskExtra.*
@@ -58,107 +67,264 @@ private[sbt] object ForkTests:
       this.getClass.getClassLoader // can't provide the loader for test classes, which is in another jvm
     def all(work: Seq[ClassLoader => Unit]) = work.fork(f => f(dummyLoader))
 
+    // The worker sends indices into testRunners, so the queue's framework indexing shares this order.
+    val runnerSeq = runners.toSeq
+    lazy val units = byFramework(runnerSeq, frameworks, opts.tests)
+    // `parallelExecution`'s question, not `testForkedParallel`'s: that one governs only what a
+    // worker does with the classes it holds, so turning it off is a reason to spread, not to pin.
+    val n = workerCount(maxWorkers, config.parallel, units, log)
+    // What each worker then does with the classes it holds. ANDed, so `parallelExecution := false` still
+    // means one at a time inside the single JVM it leaves.
+    val workerParallel = config.parallel && forkedParallel
+
+    // Identical for every worker: queue mode is group-wide (n > 1 iff a queue exists).
+    lazy val request = testRequestJson(
+      runnerSeq,
+      opts,
+      classpath,
+      converter,
+      workerParallel,
+      parallelism,
+      virtualClasspath,
+      queueMode = n > 1
+    )
+    lazy val extraCp =
+      if virtualClasspath then Nil else classpath.map(vf => converter.toPath(vf).toFile())
+    lazy val testNames = opts.tests.map(_.name)
+
+    // A group's first JVM runs ahead of ordinary tasks, the ones that only spread its queue wider
+    // behind them by index, so a freed slot goes to a group with no JVM before a second JVM for a
+    // group that has one. Only orders what a CompletionService is already holding back -- `submit`
+    // runs a task as soon as its tags validate -- so it governs freed slots, not idle ones. Mill's
+    // schedule: `priority = if (processIndex == 0) -1 else processIndex`.
+    def worker(queue: Option[TestQueue], index: Int) =
+      std.TaskExtra
+        .task(
+          queue match
+            // Skip the ~1s JVM spawn when earlier workers already drained the queue.
+            case Some(q) if !q.hasWork =>
+              TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty)
+            case q =>
+              runWorker(request, testNames, opts.testListeners, extraCp, fork, log, q)
+        )
+        .withPriority(if index == 0 then -1 else index)
+        .tagw(config.tags*)
+        .tagw(tags*)
+
     val main =
       if opts.tests.isEmpty then
         constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
       else
-        mainTestTask(
-          runners = runners,
-          opts = opts,
-          classpath = classpath,
-          converter = converter,
-          fork = fork,
-          log = log,
-          parallel = config.parallel,
-          parallelism = parallelism,
-          virtualClasspath = virtualClasspath,
-        ).tagw(config.tags*)
-    main.tagw(tags*).dependsOn(all(opts.setup)*) flatMap { results =>
+        val queue = if n == 1 then None else Some(TestQueue(units))
+        val listeners = testsListeners(opts)
+        // doInit/doComplete fire once per group. Only the workers are tagged, so a Tags.limit on
+        // ForkedTestGroup counts JVMs without counting the group twice.
+        std.TaskExtra
+          .task(listeners.foreach(_.doInit()))
+          .flatMap: _ =>
+            Tests
+              .foldTasks(
+                queue.fold(Seq(worker(None, 0)))(_ => (0 until n).map(i => worker(queue, i))),
+                true
+              )
+              .map: out =>
+                queue
+                  .flatMap(q => undrainedQueue(q.remaining))
+                  .foreach: why =>
+                    throw MessageOnlyException(why)
+                listeners.foreach(_.doComplete(out.overall))
+                out
+    main.dependsOn(all(opts.setup)*) flatMap { results =>
       all(opts.cleanup).join.map(_ => results)
     }
   }
 
-  private def mainTestTask(
-      runners: Map[TestFramework, Runner],
+  /**
+   * How many forked JVMs a group may spread over. `units` is by-name because the default path never
+   * needs it, and matching fingerprints for a group that will not spread is wasted work.
+   */
+  private[sbt] def workerCount(
+      maxWorkers: Int,
+      parallel: Boolean,
+      units: => Vector[Vector[Int]],
+      log: Logger
+  ): Int =
+    if maxWorkers <= 1 then 1
+    else if !parallel then
+      log.debug(
+        "testForkedWorkStealing is on, but parallel test execution is off for this group, so it " +
+          "will run in one JVM."
+      )
+      1
+    else if !spreadable(units) then
+      log.info(
+        "Not spreading this test group over several forked JVMs: some of its classes match more " +
+          "than one test framework, and the two runs of such a class would overlap. Running the " +
+          "group in one JVM instead."
+      )
+      1
+    else
+      val unitCount = units.map(_.size).sum
+      val workers = math.max(1, math.min(maxWorkers, unitCount))
+      if workers > 1 then
+        log.info(s"Spreading $unitCount test classes over up to $workers forked JVMs.")
+      workers
+
+  /**
+   * Whether a group's classes may be spread over several JVMs: false when any class matches more
+   * than one framework, since its two runs could then overlap and put two writers on one
+   * `TEST-<suite>.xml`.
+   */
+  private[sbt] def spreadable(units: Vector[Vector[Int]]): Boolean =
+    val flat = units.flatten
+    flat.distinct.size == flat.size
+
+  private def testsListeners(opts: ProcessedOptions): Vector[TestsListener] =
+    opts.testListeners.flatMap:
+      case tl: TestsListener => tl.some
+      case _                 => none[TestsListener]
+
+  /**
+   * For each framework index, the `taskDefs` indices that framework matches. A relation, not a
+   * partition: a class matching two frameworks appears in both and runs under each.
+   */
+  private[sbt] def byFramework(
+      runnerSeq: Seq[(TestFramework, Runner)],
+      frameworks: Map[TestFramework, Framework],
+      tests: Vector[TestDefinition]
+  ): Vector[Vector[Int]] =
+    runnerSeq.toVector.map: (tf, _) =>
+      val prints = frameworks.get(tf).map(TestFramework.getFingerprints).getOrElse(Nil)
+      tests.zipWithIndex.collect {
+        case (t, i) if prints.exists(p => TestFramework.matches(p, t.fingerprint)) => i
+      }
+
+  private[sbt] def testRequestJson(
+      runnerSeq: Seq[(TestFramework, Runner)],
       opts: ProcessedOptions,
       classpath: Seq[HashedVirtualFileRef],
       converter: FileConverter,
-      fork: ForkOptions,
-      log: Logger,
       parallel: Boolean,
       parallelism: Option[Int],
       virtualClasspath: Boolean,
-  ): Task[TestOutput] =
-    std.TaskExtra.task {
-      val testListeners = opts.testListeners.flatMap:
-        case tl: TestsListener => tl.some
-        case _                 => none[TestsListener]
-      val resultsAcc = mutable.Map.empty[String, SuiteResult]
-      val randomId = r.nextLong()
-      def testOutputResult =
-        TestOutput(
-          overall(resultsAcc.values.map(_.result)),
-          resultsAcc.toMap,
-          Iterable.empty
-        )
-      val taskdefs = opts.tests.map: t =>
-        new TaskDef(
-          t.name,
-          forkFingerprint(t.fingerprint),
-          t.explicitlySpecified,
-          t.selectors
-        )
-      val testRunners = runners.toSeq.map: (testFramework, mainRunner) =>
-        TestInfo.TestRunner(
-          ArrayList(testFramework.implClassNames.asJava),
-          ArrayList(mainRunner.args().toList.asJava),
-          ArrayList(mainRunner.remoteArgs().toList.asJava)
-        )
-      val g = WorkerMain.mkGson()
-      val cpList = ArrayList[FilePath](
-        (classpath
-          .map: vf =>
-            FilePath(converter.toPath(vf).toUri(), vf.contentHashStr()))
-          .asJava
+      queueMode: Boolean
+  ): String =
+    val taskdefs = opts.tests.map: t =>
+      new TaskDef(
+        t.name,
+        forkFingerprint(t.fingerprint),
+        t.explicitlySpecified,
+        t.selectors
       )
-      val cpFiles =
-        classpath.map: vf =>
-          converter.toPath(vf).toFile()
-      val param = TestInfo(
-        true, /* jvm */
-        RunInfo.JvmRunInfo(
-          ArrayList(),
-          if virtualClasspath then cpList else ArrayList(),
-          "",
-          false /*connectInput*/,
-        ),
-        null,
-        UTerminal.isAnsiSupported,
-        parallel,
-        parallelism.map(Integer.valueOf).orNull,
-        ArrayList(taskdefs.asJava),
-        ArrayList(testRunners.asJava),
+    val testRunners = runnerSeq.map: (testFramework, mainRunner) =>
+      TestInfo.TestRunner(
+        ArrayList(testFramework.implClassNames.asJava),
+        ArrayList(mainRunner.args().toList.asJava),
+        ArrayList(mainRunner.remoteArgs().toList.asJava)
       )
-      testListeners.foreach(_.doInit())
-      val result =
-        val ct = WorkerConnection.Tcp
-        val w = WorkerExchange.startWorker(fork, if virtualClasspath then Nil else cpFiles, ct)
-        val wl = React(randomId, log, opts.testListeners, resultsAcc, w.process)
-        try
-          WorkerExchange.registerListener(wl)
-          val paramJson = g.toJson(param, param.getClass)
-          val json = jsonRpcRequest(randomId, "test", paramJson)
-          w.println(json)
-          if wl.blockForResponse() != 0 then
-            throw MessageOnlyException("Forked test harness failed")
-          testOutputResult
-        finally WorkerExchange.unregisterListener(wl)
-      testListeners.foreach(_.doComplete(result.overall))
-      result
-    } // end task
+    val cpList =
+      if virtualClasspath then
+        ArrayList[FilePath](
+          (classpath
+            .map: vf =>
+              FilePath(converter.toPath(vf).toUri(), vf.contentHashStr()))
+            .asJava
+        )
+      else ArrayList[FilePath]()
+    val param = TestInfo(
+      true, /* jvm */
+      RunInfo.JvmRunInfo(
+        ArrayList(),
+        cpList,
+        "",
+        false /*connectInput*/,
+      ),
+      null,
+      UTerminal.isAnsiSupported,
+      parallel,
+      parallelism.map(Integer.valueOf).orNull,
+      ArrayList(taskdefs.asJava),
+      ArrayList(testRunners.asJava),
+      queueMode,
+    )
+    gson.toJson(param, param.getClass)
+
+  private def runWorker(
+      request: String,
+      testNames: Vector[String],
+      listeners: Seq[TestReportListener],
+      extraCp: Seq[File],
+      fork: ForkOptions,
+      log: Logger,
+      queue: Option[TestQueue]
+  ): TestOutput = {
+    // Two threads record into it: the reader thread as groups end, and the watch thread
+    // synthesising results for a dying worker.
+    val resultsAcc = TrieMap.empty[String, SuiteResult]
+    val randomId = r.nextLong()
+    val w = WorkerExchange.startWorker(fork, extraCp, WorkerConnection.Tcp)
+    val wl = React(randomId, log, listeners, resultsAcc, w, queue, testNames)
+    try
+      // Both, in this order: the registry carries exits; bind routes this connection's lines here.
+      WorkerExchange.registerListener(wl)
+      w.bind(wl)
+      // An exit can be broadcast before this listener exists to hear it.
+      if !w.process.isAlive() then wl.notifyExit(w.process)
+      w.println(jsonRpcRequest(randomId, "test", request))
+      if wl.blockForResponse() != 0 then throw MessageOnlyException("Forked test harness failed")
+      incompleteRun(wl.unacknowledgedLeases, wl.unrecordedFailure).foreach: why =>
+        // The others are still leasing from a group that is about to fail.
+        queue.foreach(_.poison())
+        throw MessageOnlyException(why)
+      TestOutput(overall(resultsAcc.values.map(_.result)), resultsAcc.toMap, Iterable.empty)
+    finally
+      WorkerExchange.unregisterListener(wl)
+      w.close()
+  } // end runWorker
+
+  /**
+   * Why a group's queue was left with work in it, if it was. The workers of a group all end without
+   * failing only when each found the queue empty, so units still in it mean classes nobody ran.
+   */
+  private[sbt] def undrainedQueue(remaining: Int): Option[String] =
+    if remaining > 0 then
+      Some(s"$remaining test classes were never run because the forked test workers exited early")
+    else None
+
+  /**
+   * Why a worker's report cannot be trusted, if it cannot. Both would otherwise read as a pass: an
+   * unrun class leaves no trace, and an unrecorded result leaves its suite absent.
+   */
+  private[sbt] def incompleteRun(
+      unrun: Vector[String],
+      unrecorded: Option[String]
+  ): Option[String] =
+    if unrun.nonEmpty then
+      // A worker can exit cleanly without running a leased class: the framework failed to load, or
+      // the runner threw. The queue still counts the class as handed out.
+      Some(s"A forked test worker exited without running ${unrun.distinct.sorted.mkString(", ")}")
+    else
+      unrecorded.map: why =>
+        s"A forked test worker reported test results sbt could not record, so this run is " +
+          s"incomplete: $why"
 
   private def jsonRpcRequest(id: Long, method: String, params: String): String =
     s"""{ "jsonrpc": "2.0", "method": "$method", "params": $params, "id": $id }"""
+
+  /**
+   * The kinds of line a worker sends. Dispatching on `method` first keeps a worker's `nextTest`
+   * request from being mistaken for the session response.
+   */
+  private[sbt] enum Shape:
+    case Request, Notification, Response, Unknown
+
+  private[sbt] def shapeOf(o: JsonObject): Shape =
+    if o.has("method") then
+      if o.has("id") then Shape.Request
+      else if o.has("re") then Shape.Notification
+      else Shape.Unknown
+    else if o.has("id") then Shape.Response
+    else Shape.Unknown
 
   private def forkFingerprint(f: Fingerprint): Fingerprint & Serializable =
     f match
@@ -167,44 +333,182 @@ private[sbt] object ForkTests:
       case _                       => sys.error("Unknown fingerprint type: " + f.getClass)
 end ForkTests
 
-private class React(
+private[sbt] class React(
     id: Long,
     log: Logger,
     listeners: Seq[TestReportListener],
     results: mutable.Map[String, SuiteResult],
-    process: Process
+    proxy: WorkerProxy,
+    queue: Option[TestQueue],
+    testNames: Vector[String]
 ) extends WorkerResponseListener:
-  val g = WorkerMain.mkGson()
+  private val process: Process = proxy.process
+
+  /** Suites started but not yet finished, so a dying worker can report what it was running. */
+  private val startedGroups: JSet[String] = ConcurrentHashMap.newKeySet[String]()
+
+  /**
+   * Leases this worker has not acknowledged finishing. Keyed by (framework index, `taskDefs` index)
+   * rather than class name: a class matching two frameworks is leased once per framework.
+   */
+  private val outstandingLeases: JSet[(Int, Int)] =
+    ConcurrentHashMap.newKeySet[(Int, Int)]()
+
+  /**
+   * The class a lease stands for. An index this session cannot name still names something: dropping
+   * it would turn a class nobody ran into a run with nothing owed, which reads as a pass.
+   */
+  private def nameOf(index: Int): String =
+    if index >= 0 && index < testNames.length then testNames(index)
+    else s"an unidentified test class at index $index"
+
+  /** The first thing this session could not record, which makes the run's report incomplete. */
+  private val unrecorded = AtomicReference[String](null)
+  def unrecordedFailure: Option[String] = Option(unrecorded.get())
+
+  /**
+   * Notified one by one, so a listener that throws costs neither the others nor the record. At error,
+   * as `TestFramework.safeForeach` does in-process: a throw here has lost that suite's report.
+   */
+  private def tell(group: String)(f: TestReportListener => Unit): Unit =
+    listeners.foreach: l =>
+      try f(l)
+      catch
+        case NonFatal(e) =>
+          log.trace(e)
+          log.error(s"Listener ${l.getClass.getName} could not record $group: $e")
+
+  private val g = ForkTests.gson
   val promise: Promise[Int] = Promise()
 
-  /** Events per test group, accumulated for [[SuiteResult]] (listeners get each event immediately). */
+  /** Events per group, for [[SuiteResult]]. Touched only by this connection's reader thread. */
   private val progressEvents = mutable.Map.empty[String, mutable.ArrayBuffer[testing.Event]]
   override def apply(line: String): Unit =
-    try
-      val o = JsonParser.parseString(line).getAsJsonObject()
-      if o.has("id") then
-        val resId = o.getAsJsonPrimitive("id").getAsLong()
-        if resId == id then
-          if promise.isCompleted then ()
-          else if o.has("error") then promise.failure(new RuntimeException(line))
-          else promise.success(0)
-        else ()
-      // per JSON-PRC notifications do not have "id" field, so we use "re"
-      else if o.has("re") && o.has("method") then
-        val resId = o.getAsJsonPrimitive("re").getAsLong()
-        if resId == id then processNotification(o)
-        else ()
-      else ()
-    catch
-      case _: JsonSyntaxException => log.info(line)
-      case NonFatal(_)            => ()
+    // Workers print ordinary output down this connection too.
+    messageOf(line) match
+      case None    => log.info(line)
+      case Some(o) =>
+        try dispatch(o, line)
+        catch case NonFatal(e) => cannotAccountFor(s"$e")
 
+  /**
+   * Notes that a worker reported something this session could not act on. Dropped in silence, sbt
+   * cannot tell a worker that found nothing from one whose results it threw away.
+   */
+  private def cannotAccountFor(what: String): Unit =
+    log.error(s"Could not record what a forked test worker reported: $what")
+    unrecorded.compareAndSet(null, what)
+    ()
+
+  /**
+   * A result-bearing notification whose envelope named this session but whose payload named another.
+   * A worker writes both from one id, so they disagree only if the two sides of the protocol do.
+   */
+  private def foreignPayload(method: String, payloadId: Long): Unit =
+    cannotAccountFor(s"a $method naming session $payloadId arrived on session $id's channel")
+
+  private def messageOf(line: String): Option[JsonObject] =
+    try Some(JsonParser.parseString(line).getAsJsonObject())
+    catch case NonFatal(_) => None
+
+  private def dispatch(o: JsonObject, line: String): Unit =
+    ForkTests.shapeOf(o) match
+      case ForkTests.Shape.Request      => serveRequest(o)
+      case ForkTests.Shape.Notification =>
+        if o.getAsJsonPrimitive("re").getAsLong() == id then processNotification(o)
+        else ()
+      case ForkTests.Shape.Response =>
+        if o.getAsJsonPrimitive("id").getAsLong() == id then
+          if o.has("error") then promise.tryFailure(new RuntimeException(line))
+          else promise.trySuccess(0)
+          ()
+        else ()
+      case ForkTests.Shape.Unknown => ()
+
+  private def serveRequest(o: JsonObject): Unit =
+    val method = o.getAsJsonPrimitive("method").getAsString()
+    val reqId = o.getAsJsonPrimitive("id").getAsLong()
+    val params = o.getAsJsonObject("params")
+    if params == null || !params.has("id") then ()
+    else if params.getAsJsonPrimitive("id").getAsLong() != id then ()
+    else
+      method match
+        case "nextTest" =>
+          val framework = params.getAsJsonPrimitive("framework").getAsInt()
+          completeLease(framework, params)
+          val result = leaseFor(framework).fold("null")(_.toString)
+          proxy.println(s"""{ "jsonrpc": "2.0", "result": $result, "id": $reqId }""")
+        // The worker blocks on the reply, so silence here stalls it until its ten-minute rpc
+        // timeout. Naming the method says which side of the protocol the two disagree on.
+        case other => cannotAccountFor(s"a request sbt does not serve: $other")
+
+  /**
+   * Ticks off the class reported in `done`. Only the worker knows a lease is finished: a framework
+   * may produce no task at all for a class it matched.
+   */
+  private def completeLease(framework: Int, params: JsonObject): Unit =
+    val done = params.get("done")
+    if done != null && done.isJsonPrimitive() then
+      outstandingLeases.remove((framework, done.getAsInt()))
+      ()
+
+  private def leaseFor(framework: Int): Option[Int] =
+    val leased = queue.flatMap(_.lease(framework))
+    leased.foreach(i => outstandingLeases.add((framework, i)))
+    leased
+
+  def unacknowledgedLeases: Vector[String] =
+    outstandingLeases.asScala.toVector.map((_, i) => nameOf(i))
+
+  /** Reports the suites still in flight when the process died; unrecorded they read as a pass. */
+  private def synthesizeErrorsForInFlight(exitCode: Int): Unit =
+    val inFlight = startedGroups.toArray(Array.empty[String]).toVector
+    inFlight.foreach: group =>
+      log.error(
+        s"Test suite $group was interrupted: the forked test JVM exited with code $exitCode"
+      )
+      results += group -> SuiteResult.Error
+      tell(group)(_.endGroup(group, TestResult.Error))
+      startedGroups.remove(group)
+      ()
+
+  /**
+   * Judges a dead worker, at most once, and only its own: exits are broadcast, so `p` filters out
+   * other workers' deaths. `synchronized` because the watch thread and `runWorker`'s re-check can
+   * arrive together; [[apply]] must stay free of the monitor, since `awaitStreamEnd` waits for the
+   * thread that calls it.
+   */
   override def notifyExit(p: Process): Unit =
-    if !process.isAlive() && !promise.isCompleted then
-      val exitCode = process.exitValue()
-      if exitCode != 0 then
-        promise.failure(new RuntimeException(s"Forked test process exited with code $exitCode"))
-      else promise.success(exitCode)
+    if p eq process then
+      synchronized:
+        if !process.isAlive() && !promise.isCompleted then
+          // Suites can still be buffered in the socket; judging before they drain would misreport
+          // a healthy run.
+          proxy.awaitStreamEnd()
+          if !promise.isCompleted then
+            val exitCode = process.exitValue()
+            val inFlight = !startedGroups.isEmpty()
+            // Completing the promise releases blockForResponse; reporting must never prevent it.
+            val failure: Option[String] =
+              if exitCode != 0 then Some(s"Forked test process exited with code $exitCode")
+              else if inFlight then
+                // The worker ends every suite it starts, so a clean exit with one open means a
+                // test called System.exit.
+                Some(
+                  "Forked test process exited cleanly while test suites were still running, " +
+                    "which usually means a test called System.exit"
+                )
+              else None
+            try
+              if failure.isDefined then
+                queue.foreach(_.poison())
+                synthesizeErrorsForInFlight(exitCode)
+            catch case NonFatal(e) => log.trace(e)
+            finally
+              failure match
+                case Some(msg) => promise.tryFailure(new RuntimeException(msg))
+                case None      => promise.trySuccess(exitCode)
+              ()
 
   def processNotification(o: JsonObject): Unit =
     val method = o.getAsJsonPrimitive("method").getAsString()
@@ -226,8 +530,9 @@ private class React(
           g.fromJson[ForkTestMain.ForkGroupStart](params, classOf[ForkTestMain.ForkGroupStart])
         if info.id == id then
           progressEvents(info.group) = mutable.ArrayBuffer.empty
-          listeners.foreach(_.startGroup(info.group))
-        else ()
+          startedGroups.add(info.group)
+          tell(info.group)(_.startGroup(info.group))
+        else foreignPayload("startTestGroup", info.id)
       case "testProgress" =>
         val params = o.getAsJsonObject("params")
         val info =
@@ -236,8 +541,8 @@ private class React(
           val buf = progressEvents.getOrElseUpdate(info.group, mutable.ArrayBuffer.empty)
           for e <- info.events.asScala do
             buf += e
-            listeners.foreach(_.testEvent(TestEvent(Seq(e))))
-        else ()
+            tell(info.group)(_.testEvent(TestEvent(Seq(e))))
+        else foreignPayload("testProgress", info.id)
       case "endTestGroup" =>
         val params = o.getAsJsonObject("params")
         val info =
@@ -245,18 +550,22 @@ private class React(
         if info.id == id then
           val events = progressEvents.remove(info.group).getOrElse(mutable.ArrayBuffer.empty).toSeq
           val suiteResult = SuiteResult(events)
-          results += info.group -> suiteResult
-          listeners.foreach(_.endGroup(info.group, suiteResult.result))
-        else ()
+          // Added to, never replacing: a class matching two frameworks runs once per framework in the
+          // one JVM `spreadable` keeps it in, and replacing would keep only the last verdict.
+          results += info.group -> results.get(info.group).fold(suiteResult)(_ + suiteResult)
+          startedGroups.remove(info.group)
+          tell(info.group)(_.endGroup(info.group, suiteResult.result))
+        else foreignPayload("endTestGroup", info.id)
       case "forkError" =>
         val params = o.getAsJsonObject("params")
         val info =
           g.fromJson[ForkTestMain.ForkErrorInfo](params, classOf[ForkTestMain.ForkErrorInfo])
         if info.id == id then
           log.trace(info.error)
-          promise.failure(info.error)
-        else ()
-      case _ => ()
+          promise.tryFailure(info.error)
+          ()
+        else foreignPayload("forkError", info.id)
+      case other => cannotAccountFor(s"a notification sbt does not handle: $other")
 
   def blockForResponse(): Int =
     Await.result(promise.future, Duration.Inf)

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -485,6 +485,16 @@ object Tests {
       case TestResult.Failed                    => 1
       case TestResult.Error                     => 2
 
+  // Shares one project's forked-test-JVM budget across the groups that will actually fork.
+  private[sbt] def workersPerGroup(
+      budget: Int,
+      groups: Seq[Group],
+      processed: Map[Group, ProcessedOptions]
+  ): Int =
+    val forking = groups.count: g =>
+      g.runPolicy.isInstanceOf[SubProcess] && processed.get(g).exists(_.tests.nonEmpty)
+    math.max(1, budget / math.max(1, forking))
+
   def foldTasks(results: Seq[Task[Output]], parallel: Boolean): Task[Output] =
     if (results.isEmpty) {
       task { Output(TestResult.Passed, Map.empty, Nil) }

--- a/main-actions/src/main/scala/sbt/internal/TestQueue.scala
+++ b/main-actions/src/main/scala/sbt/internal/TestQueue.scala
@@ -1,0 +1,44 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+
+/**
+ * A queue of test-class work units shared by the forked workers of one test group. Thread-safe.
+ *
+ * Each element of `perFramework` indexes the `taskDefs` vector sent to every worker, one sub-queue
+ * per framework: a worker runs frameworks sequentially and must never be handed a class belonging
+ * to a framework it is not currently running.
+ */
+private[sbt] final class TestQueue(perFramework: Vector[Vector[Int]]):
+  private val cursors: Vector[AtomicInteger] = perFramework.map(_ => AtomicInteger(0))
+  private val poisoned: AtomicBoolean = AtomicBoolean(false)
+
+  def hasWork: Boolean = !poisoned.get() && remaining > 0
+
+  /** Each index goes to at most one caller. */
+  def lease(framework: Int): Option[Int] =
+    if poisoned.get() || framework < 0 || framework >= perFramework.length then None
+    else
+      val units = perFramework(framework)
+      val i = cursors(framework).getAndIncrement()
+      if i < units.length then Some(units(i))
+      else None
+
+  /** Stops serving new work; units already leased are unaffected. */
+  def poison(): Unit = poisoned.set(true)
+
+  /** Units never leased; non-zero at the end of a run means classes nobody ran. */
+  def remaining: Int =
+    perFramework.indices.map { f =>
+      math.max(0, perFramework(f).length - cursors(f).get())
+    }.sum
+end TestQueue

--- a/main-actions/src/main/scala/sbt/internal/WorkerExchange.scala
+++ b/main-actions/src/main/scala/sbt/internal/WorkerExchange.scala
@@ -13,6 +13,7 @@ import org.scalasbt.shadedgson.com.google.gson.Gson
 import java.io.*
 import java.net.{ InetAddress, ServerSocket }
 import java.util.Scanner
+import java.util.concurrent.atomic.AtomicReference
 import sbt.io.IO
 import sbt.internal.io.Retry
 import sbt.internal.worker1.*
@@ -20,11 +21,13 @@ import sbt.testing.Framework
 import scala.sys.process.{ BasicIO, Process, ProcessIO }
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration.*
+import scala.util.control.NonFatal
 
 object WorkerExchange:
   val listeners: mutable.ListBuffer[WorkerResponseListener] = ListBuffer.empty
+
   private val loopback = InetAddress.getByName(null)
 
   /**
@@ -42,14 +45,34 @@ object WorkerExchange:
       IO.classLocationPath(classOf[Gson]).toFile,
     )
     val inputRef = Promise[OutputStream]()
+    // Completed once everything the worker sent has been handed to the listeners.
+    val streamEnd = Promise[Unit]()
+    val bound = AtomicReference[WorkerResponseListener](null)
+    def deliver(line: String): Unit =
+      bound.get() match
+        case null => notifyListeners(line)
+        case wl   => wl(line)
     val socketOpt = connectionType match
       case WorkerConnection.Tcp =>
         val serverSocket = Retry(ServerSocket(0, 1, loopback))
         val accepter = Thread(() => {
-          val socket = serverSocket.accept()
-          inputRef.success(socket.getOutputStream())
-          val scanner = Scanner(socket.getInputStream(), "UTF-8")
-          while scanner.hasNextLine() do notifyListeners(scanner.nextLine())
+          try
+            // Quiet on purpose: this throws when startWorker gives up on a worker that never
+            // connected, and the caller is already reporting why the fork failed.
+            val accepted =
+              try Some(serverSocket.accept())
+              catch case NonFatal(_) => None
+            accepted.foreach: socket =>
+              try
+                inputRef.success(socket.getOutputStream())
+                val scanner = Scanner(socket.getInputStream(), "UTF-8")
+                while scanner.hasNextLine() do deliver(scanner.nextLine())
+              finally
+                // Closing the ServerSocket does not close what it accepted.
+                socket.close()
+          finally
+            streamEnd.trySuccess(())
+            ()
         })
         accepter.setName("sbt-fork-test-response-reader")
         accepter.setPriority(Thread.NORM_PRIORITY + 1)
@@ -65,39 +88,60 @@ object WorkerExchange:
         case Some(s) => Seq("--tcp", s.getLocalPort().toString())
         case _       => Nil)
     val onStdoutLine: String => Unit = connectionType match
-      case WorkerConnection.Stdio => notifyListeners
+      case WorkerConnection.Stdio => deliver
       case _                      => (line) => scala.Console.out.println(line)
+    val readStdout = BasicIO.processFully(onStdoutLine)
     val processIo = ProcessIO(
       in = (input) =>
         (connectionType match
           case WorkerConnection.Stdio => inputRef.success(input)
           case _                      => ()
         ),
-      out = BasicIO.processFully(onStdoutLine),
+      // Over Stdio the notifications arrive on stdout; over Tcp the accepter thread owns the signal.
+      out = connectionType match
+        case WorkerConnection.Stdio =>
+          (stream) =>
+            try readStdout(stream)
+            finally
+              streamEnd.trySuccess(())
+              ()
+        case _ => readStdout,
       err = BasicIO.processFully((line) => scala.Console.err.println(line)),
     )
     val forkWithIo = fo.withOutputStrategy(OutputStrategy.CustomInputOutput(processIo))
     val p = Fork.java.fork(forkWithIo, options)
     val forkTimeout = fo.connectionTimeout.getOrElse(30.seconds)
-    val input = Await.result(inputRef.future, forkTimeout)
-    WorkerProxy(input, p, options, socketOpt)
+    val input =
+      try Await.result(inputRef.future, forkTimeout)
+      catch
+        case NonFatal(e) =>
+          // No WorkerProxy exists yet to close these.
+          socketOpt.foreach(_.close())
+          p.destroy()
+          throw e
+    WorkerProxy(input, p, options, socketOpt, streamEnd.future, bound)
 
   def registerListener(listener: WorkerResponseListener): Unit =
     synchronized:
       listeners.append(listener)
+      ()
 
   def unregisterListener(listener: WorkerResponseListener): Unit =
     synchronized:
       if listeners.contains(listener) then listeners.remove(listeners.indexOf(listener))
-      else ()
+      ()
 
-  /**
-   * Unified worker output handler.
-   */
+  // Snapshot under the lock, call listeners outside it.
+  private def snapshot(): Vector[WorkerResponseListener] = synchronized(listeners.toVector)
+
+  /** Broadcast handler for connections no listener has claimed — see [[WorkerProxy.bind]]. */
   def notifyListeners(line: String): Unit =
-    synchronized:
-      listeners.foreach: wl =>
-        wl(line)
+    snapshot().foreach: wl =>
+      wl(line)
+
+  def notifyExit(p: Process): Unit =
+    snapshot().foreach: wl =>
+      wl.notifyExit(p)
 end WorkerExchange
 
 class WorkerProxy(
@@ -105,7 +149,43 @@ class WorkerProxy(
     val process: Process,
     val options: Seq[String],
     serverSocket: Option[ServerSocket],
+    // Completes when the stream carrying this worker's notifications reaches its end, which is the
+    // only point at which everything the worker sent has been handed to the listeners.
+    streamEnd: Future[Unit],
+    // Where [[bind]] records this connection's owner, shared with the thread that reads it.
+    boundListener: AtomicReference[WorkerResponseListener],
 ) extends AutoCloseable:
+  def this(
+      input: OutputStream,
+      process: Process,
+      options: Seq[String],
+      serverSocket: Option[ServerSocket],
+  ) =
+    this(
+      input,
+      process,
+      options,
+      serverSocket,
+      Future.unit,
+      AtomicReference[WorkerResponseListener](null)
+    )
+
+  /**
+   * Claims this connection, so its lines and its process exit go only to `wl` instead of being
+   * broadcast. Call before the request that makes the worker start writing.
+   */
+  private[sbt] def bind(wl: WorkerResponseListener): Unit = boundListener.set(wl)
+
+  /**
+   * Blocks until every notification this worker sent has reached the listeners, which anything
+   * judging a dead worker's state has to do first. The bound is a backstop, not a deadline.
+   */
+  private[sbt] def awaitStreamEnd(): Unit =
+    try
+      Await.ready(streamEnd, 30.seconds)
+      ()
+    catch case NonFatal(_) => ()
+
   lazy val inputStream = PrintStream(input)
   def close(): Unit =
     input.close()
@@ -121,7 +201,10 @@ class WorkerProxy(
 
   val watch = Thread(() => {
     while process.isAlive() do Thread.sleep(100)
-    WorkerExchange.listeners.foreach(_.notifyExit(process))
+    // Exits go to the owner once bound; broadcast covers an exit before any bind.
+    boundListener.get() match
+      case null => WorkerExchange.notifyExit(process)
+      case wl   => wl.notifyExit(process)
   })
   watch.start()
 end WorkerProxy

--- a/main-actions/src/test/scala/sbt/WorkersPerGroupTest.scala
+++ b/main-actions/src/test/scala/sbt/WorkersPerGroupTest.scala
@@ -1,0 +1,86 @@
+package sbt
+
+import hedgehog.*
+import hedgehog.runner.*
+import hedgehog.core.Result
+import _root_.sbt.testing.{ Fingerprint, Selector, SubclassFingerprint }
+
+/**
+ * Pins [[Tests.workersPerGroup]].
+ *
+ * The forked-JVM ceiling is a budget for a project's test run, and every group gets its own queue
+ * and its own fan-out, so handing each the whole number multiplies JVM launches by the group count
+ * rather than the concurrency, which the `ForkedTestGroup` rule caps either way.
+ */
+object WorkersPerGroupTest extends Properties:
+
+  override lazy val tests: List[Test] = List(
+    example("one group gets the whole budget", exOneGroup),
+    example("the budget is shared, not handed to each group", exShared),
+    example("more groups than budget still leaves every group a worker", exNeverZero),
+    example("groups that will not fork are not charged a share", exInProcessNotCharged),
+    example("groups left empty by filtering are not charged a share", exEmptyNotCharged),
+    example("a budget of one is one per group, whatever the grouping", exDefaultUnchanged),
+  )
+
+  private val print: SubclassFingerprint =
+    new SubclassFingerprint:
+      def isModule(): Boolean = false
+      def superclassName(): String = "junit.framework.TestCase"
+      def requireNoArgConstructor(): Boolean = false
+
+  private def defn(nm: String): TestDefinition =
+    new TestDefinition(nm, print: Fingerprint, false, Array.empty[Selector])
+
+  private def group(nm: String, forked: Boolean, n: Int): Tests.Group =
+    new Tests.Group(
+      nm,
+      (0 until n).map(i => defn(s"$nm$i")),
+      if forked then Tests.SubProcess(ForkOptions()) else Tests.InProcess
+    )
+
+  /** As `allTestGroupsTask` builds it: each group mapped to the tests left after filtering. */
+  private def processed(gs: Seq[Tests.Group]): Map[Tests.Group, Tests.ProcessedOptions] =
+    gs.map(g =>
+      g -> Tests.ProcessedOptions(g.tests.toVector, Vector.empty, Vector.empty, Vector.empty)
+    ).toMap
+
+  private def workers(budget: Int, gs: Seq[Tests.Group]): Int =
+    Tests.workersPerGroup(budget, gs, processed(gs))
+
+  def exOneGroup: Result =
+    val gs = Seq(group("g0", forked = true, 20))
+    Result.assert(workers(4, gs) == 4).log(s"got ${workers(4, gs)}")
+
+  def exShared: Result =
+    val two = Seq(group("g0", true, 10), group("g1", true, 10))
+    val four = (0 until 4).map(i => group(s"g$i", true, 5))
+    Result
+      .assert(workers(4, two) == 2)
+      .and(Result.assert(workers(4, four) == 1))
+      // The product is what matters: budget × 1 group and (budget/n) × n groups are the same total.
+      .and(Result.assert(workers(4, two) * 2 == 4))
+      .and(Result.assert(workers(4, four) * 4 == 4))
+      .log(s"two=${workers(4, two)} four=${workers(4, four)}")
+
+  def exNeverZero: Result =
+    val eight = (0 until 8).map(i => group(s"g$i", true, 2))
+    // 4/8 truncates to 0, which would build no worker tasks and run nothing at all.
+    Result.assert(workers(4, eight) == 1).log(s"got ${workers(4, eight)}")
+
+  def exInProcessNotCharged: Result =
+    val mixed = Seq(group("g0", forked = true, 10), group("g1", forked = false, 10))
+    Result.assert(workers(4, mixed) == 4).log(s"got ${workers(4, mixed)}")
+
+  def exEmptyNotCharged: Result =
+    // What `testOnly` against one group of four produces: the other three fork nothing, so charging
+    // them a share would leave the one group with work a quarter of the budget.
+    val gs = Seq(group("g0", true, 5), group("g1", true, 0), group("g2", true, 0))
+    Result.assert(workers(4, gs) == 4).log(s"got ${workers(4, gs)}")
+
+  def exDefaultUnchanged: Result =
+    // A budget of one is one JVM per group however the project is grouped, which is what sbt has
+    // always done — so the default cannot change how an existing build runs its tests.
+    val counts = Seq(1, 2, 4, 16).map(n => workers(1, (0 until n).map(i => group(s"g$i", true, 5))))
+    Result.assert(counts.forall(_ == 1)).log(s"got $counts")
+end WorkersPerGroupTest

--- a/main-actions/src/test/scala/sbt/internal/ForkTestsFrameworkTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/ForkTestsFrameworkTest.scala
@@ -1,0 +1,256 @@
+package sbt
+package internal
+
+import hedgehog.*
+import hedgehog.runner.*
+import hedgehog.core.Result
+import org.scalasbt.shadedgson.com.google.gson.JsonParser
+import java.util.concurrent.atomic.AtomicInteger
+// `_root_` because `import hedgehog.*` brings a `hedgehog.sbt` into scope, which would otherwise
+// shadow this package. `Task` is aliased because sbt's own task type has the same name here.
+import _root_.sbt.util.Logger
+import _root_.sbt.testing.{
+  Fingerprint,
+  Framework,
+  Runner,
+  Selector,
+  SubclassFingerprint,
+  Task as STask,
+  TaskDef
+}
+
+/**
+ * Pins the index space that `ForkTests.byFramework` produces.
+ *
+ * A scripted test cannot reach this: a single-class project never enters the queue path, and a
+ * single-framework project gives an identity index mapping, so confusing the full `taskDefs` index
+ * space with a per-framework filtered one would go unnoticed.
+ */
+object ForkTestsFrameworkTest extends Properties:
+
+  override lazy val tests: List[Test] = List(
+    example(
+      "indices address the full taskDefs vector, not a per-framework subset",
+      exFullIndexSpace
+    ),
+    example("a class matching two frameworks appears in both sub-queues", exRelationNotPartition),
+    example("a framework matching nothing gets an empty sub-queue", exNoMatches),
+    example("sub-queue order follows the runner sequence", exOrderFollowsRunners),
+    example("disjoint sub-queues may be spread", exDisjointSpreads),
+    example("a class in two sub-queues stops the group spreading", exOverlapDoesNotSpread),
+    example("degenerate shapes are spreadable rather than special-cased", exSpreadableEdges),
+    example("one worker, or none allowed, means one JVM", exWorkerCountFloor),
+    example("a group that cannot spread never matches fingerprints", exWorkerCountSkipsMatching),
+    example("a group that cannot run in parallel keeps to one JVM", exWorkerCountSerial),
+    example("a group with an overlapping class keeps to one JVM", exWorkerCountOverlap),
+    example("the JVM count is capped by the classes there are to run", exWorkerCountByUnits),
+    example("a run that reported everything it was given is complete", exRunComplete),
+    example("a class leased and never run makes the run incomplete", exRunLostClass),
+    example("a result sbt could not record makes the run incomplete", exRunUnrecorded),
+    example("a queue left with work in it fails the group", exUndrainedQueue),
+    example("the test request names every class and how to run them", exRequestBody),
+  )
+
+  def exRequestBody: Result =
+    // One string goes to every worker of a group, so a field missing from it changes the plan in
+    // silence: no taskDefs and the worker runs nothing at all and exits 0, which sbt's batch path has
+    // no lease accounting to notice; no parallelism and each JVM runs one class at a time whatever
+    // the build asked for; and queueMode is what decides whether the worker leases from sbt or just
+    // runs the batch it was handed.
+    val opts = new Tests.ProcessedOptions(interleaved, Vector.empty, Vector.empty, Vector.empty)
+    val json = ForkTests.testRequestJson(
+      Seq(junitTf -> noRunner),
+      opts,
+      // Empty, which is the only reason a null converter is safe here: it is consulted per entry.
+      Nil,
+      null,
+      parallel = true,
+      parallelism = Some(3),
+      virtualClasspath = false,
+      queueMode = true
+    )
+    val o = JsonParser.parseString(json).getAsJsonObject()
+    Result
+      .assert(o.getAsJsonArray("taskDefs").size == interleaved.size)
+      .and(Result.assert(interleaved.forall(t => json.contains(t.name))))
+      .and(Result.assert(o.getAsJsonPrimitive("parallelism").getAsInt == 3))
+      .and(Result.assert(o.getAsJsonPrimitive("queueMode").getAsBoolean))
+      .and(Result.assert(o.getAsJsonArray("testRunners").size == 1))
+      .log(json)
+
+  def exUndrainedQueue: Result =
+    // The last thing standing between a class nobody leased and a group that reports a pass.
+    Result
+      .assert(ForkTests.undrainedQueue(0).isEmpty)
+      .and(Result.assert(ForkTests.undrainedQueue(3).exists(_.contains("3 test classes"))))
+      .and(Result.assert(ForkTests.undrainedQueue(-1).isEmpty))
+      .log(s"three=${ForkTests.undrainedQueue(3)}")
+
+  def exRunComplete: Result =
+    Result.assert(ForkTests.incompleteRun(Vector.empty, None).isEmpty)
+
+  def exRunLostClass: Result =
+    // Named, and deduplicated: a class matching two frameworks is leased once per framework, and
+    // reporting it twice would read as two missing classes.
+    val why = ForkTests.incompleteRun(Vector("B", "A", "A"), None)
+    Result
+      .assert(why.isDefined)
+      .and(Result.assert(why.exists(_.endsWith("A, B"))))
+      // "A, A, B" would also contain "A, B", so the repeat has to be ruled out on its own.
+      .and(Result.assert(!why.exists(_.contains("A, A"))))
+      .log(s"why=$why")
+
+  def exRunUnrecorded: Result =
+    // Nothing else fails this run: the worker exited cleanly and every lease came back, so without
+    // this the group reports a pass with a suite missing from it.
+    val why = ForkTests.incompleteRun(Vector.empty, Some("boom"))
+    Result
+      .assert(why.exists(_.contains("boom")))
+      .and(Result.assert(why.exists(_.contains("could not record"))))
+      .log(s"why=$why")
+
+  private val twoUnits = Vector(Vector(0, 1, 2, 3), Vector(4, 5))
+  private val overlapping = Vector(Vector(0, 1), Vector(1))
+
+  def exWorkerCountFloor: Result =
+    // The default. Nothing may talk a group with no budget into forking twice.
+    Result
+      .assert(ForkTests.workerCount(1, true, twoUnits, Logger.Null) == 1)
+      .and(Result.assert(ForkTests.workerCount(0, true, twoUnits, Logger.Null) == 1))
+      .and(Result.assert(ForkTests.workerCount(-1, true, twoUnits, Logger.Null) == 1))
+
+  def exWorkerCountSkipsMatching: Result =
+    // `units` is by-name, and the budget is checked before anything else, so a group that cannot
+    // spread never builds the queue's index map — which means matching every class against every
+    // framework's fingerprints. That is every build leaving testForkedWorkStealing alone, so the
+    // early return is the whole reason the default path costs nothing.
+    val forced = AtomicInteger(0)
+    val workers =
+      ForkTests.workerCount(1, true, { forced.incrementAndGet(); twoUnits }, Logger.Null)
+    Result
+      .assert(workers == 1)
+      .and(Result.assert(forced.get() == 0))
+      .log(s"workers=$workers forced=${forced.get()}")
+
+  def exWorkerCountSerial: Result =
+    // Spreading a group is parallel execution however the threads inside each JVM are configured, so
+    // a build that turned parallel execution off must not get it by another name.
+    Result.assert(ForkTests.workerCount(4, false, twoUnits, Logger.Null) == 1)
+
+  def exWorkerCountOverlap: Result =
+    Result
+      .assert(ForkTests.workerCount(4, true, overlapping, Logger.Null) == 1)
+      .and(Result.assert(ForkTests.workerCount(4, true, twoUnits, Logger.Null) == 4))
+
+  def exWorkerCountByUnits: Result =
+    // Six work units and a budget of four is four JVMs; two units and a budget of four is two, since
+    // a JVM with nothing to lease only costs a fork.
+    Result
+      .assert(ForkTests.workerCount(4, true, twoUnits, Logger.Null) == 4)
+      .and(Result.assert(ForkTests.workerCount(8, true, twoUnits, Logger.Null) == 6))
+      .and(Result.assert(ForkTests.workerCount(4, true, Vector(Vector(0, 1)), Logger.Null) == 2))
+      .and(Result.assert(ForkTests.workerCount(4, true, Vector(Vector.empty), Logger.Null) == 1))
+
+  // Otherwise the two runs of a class matching two frameworks could overlap in different JVMs, and
+  // two writers land on one TEST-<suite>.xml.
+  def exDisjointSpreads: Result =
+    Result
+      .assert(ForkTests.spreadable(Vector(Vector(0, 2, 4), Vector(1, 3))))
+      .and(Result.assert(ForkTests.spreadable(Vector(Vector(0, 1, 2)))))
+
+  def exOverlapDoesNotSpread: Result =
+    Result
+      .assert(!ForkTests.spreadable(Vector(Vector(0, 1, 2, 3, 4), Vector(1, 3))))
+      // One shared class out of many is still enough: the queue's unit is a (framework, class) pair
+      // and nothing can pin two of them to the same worker.
+      .and(Result.assert(!ForkTests.spreadable(Vector(Vector(0, 1, 2, 3), Vector(3)))))
+
+  def exSpreadableEdges: Result =
+    Result
+      .assert(ForkTests.spreadable(Vector.empty))
+      .and(Result.assert(ForkTests.spreadable(Vector(Vector.empty))))
+      // A framework matching nothing cannot overlap with anything.
+      .and(Result.assert(ForkTests.spreadable(Vector(Vector(0, 1), Vector.empty))))
+
+  private def print(superclass: String): SubclassFingerprint =
+    new SubclassFingerprint:
+      def isModule(): Boolean = false
+      def superclassName(): String = superclass
+      def requireNoArgConstructor(): Boolean = false
+
+  private val junitPrint = print("junit.framework.TestCase")
+  private val specsPrint = print("org.specs2.Specification")
+
+  private def framework(nm: String, prints: Fingerprint*): Framework =
+    new Framework:
+      def name(): String = nm
+      def fingerprints(): Array[Fingerprint] = prints.toArray
+      def runner(args: Array[String], remoteArgs: Array[String], cl: ClassLoader): Runner =
+        sys.error("not used")
+
+  private val noRunner: Runner =
+    new Runner:
+      def args(): Array[String] = Array.empty
+      def remoteArgs(): Array[String] = Array.empty
+      def tasks(defs: Array[TaskDef]): Array[STask] = Array.empty[STask]
+      def done(): String = ""
+
+  private def defn(nm: String, print: Fingerprint): TestDefinition =
+    new TestDefinition(nm, print, false, Array.empty[Selector])
+
+  private val junitTf = TestFramework("junit.Framework")
+  private val specsTf = TestFramework("specs.Framework")
+
+  /** junit and specs2 suites interleaved, so neither framework's indices are contiguous. */
+  private val interleaved: Vector[TestDefinition] = Vector(
+    defn("A", junitPrint),
+    defn("B", specsPrint),
+    defn("C", junitPrint),
+    defn("D", specsPrint),
+    defn("E", junitPrint),
+  )
+
+  def exFullIndexSpace: Result =
+    val runnerSeq = Seq(junitTf -> noRunner, specsTf -> noRunner)
+    val frameworks = Map(
+      junitTf -> framework("junit", junitPrint),
+      specsTf -> framework("specs2", specsPrint),
+    )
+    val queues = ForkTests.byFramework(runnerSeq, frameworks, interleaved)
+    Result
+      .assert(queues.length == 2)
+      .and(Result.assert(queues(0) == Vector(0, 2, 4)))
+      .and(Result.assert(queues(1) == Vector(1, 3)))
+      .log(s"queues=$queues")
+
+  def exRelationNotPartition: Result =
+    val both = framework("both", junitPrint, specsPrint)
+    val runnerSeq = Seq(junitTf -> noRunner, specsTf -> noRunner)
+    val frameworks = Map(junitTf -> both, specsTf -> framework("specs2", specsPrint))
+    val queues = ForkTests.byFramework(runnerSeq, frameworks, interleaved)
+    Result
+      .assert(queues(0) == Vector(0, 1, 2, 3, 4))
+      .and(Result.assert(queues(1) == Vector(1, 3)))
+      .and(Result.assert(queues(0).intersect(queues(1)) == Vector(1, 3)))
+      .log(s"queues=$queues")
+
+  def exNoMatches: Result =
+    val other = framework("other", print("nothing.Matches"))
+    val runnerSeq = Seq(junitTf -> noRunner)
+    val queues = ForkTests.byFramework(runnerSeq, Map(junitTf -> other), interleaved)
+    Result.assert(queues == Vector(Vector.empty)).log(s"queues=$queues")
+
+  def exOrderFollowsRunners: Result =
+    val frameworks = Map(
+      junitTf -> framework("junit", junitPrint),
+      specsTf -> framework("specs2", specsPrint),
+    )
+    val forward =
+      ForkTests.byFramework(Seq(junitTf -> noRunner, specsTf -> noRunner), frameworks, interleaved)
+    val reversed =
+      ForkTests.byFramework(Seq(specsTf -> noRunner, junitTf -> noRunner), frameworks, interleaved)
+    Result
+      .assert(forward == Vector(Vector(0, 2, 4), Vector(1, 3)))
+      .and(Result.assert(reversed == Vector(Vector(1, 3), Vector(0, 2, 4))))
+      .log(s"forward=$forward reversed=$reversed")
+end ForkTestsFrameworkTest

--- a/main-actions/src/test/scala/sbt/internal/ReactTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/ReactTest.scala
@@ -1,0 +1,629 @@
+package sbt
+package internal
+
+import hedgehog.*
+import hedgehog.runner.*
+import hedgehog.core.Result
+// `_root_` because `import hedgehog.*` brings a `hedgehog.sbt` into scope, which would otherwise
+// shadow this package.
+import _root_.sbt.util.{ Level, Logger }
+import _root_.sbt.protocol.testing.TestResult
+import org.scalasbt.shadedgson.com.google.gson.JsonParser
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.{ Callable, CountDownLatch, Executors }
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicReference }
+import scala.collection.mutable
+import scala.concurrent.{ Future, Promise }
+import scala.sys.process.Process
+
+/**
+ * Pins how [[React]] accounts for the test classes a worker leases.
+ *
+ * `TestQueue.remaining` only knows whether a unit was handed out, so a class the worker takes and
+ * then never runs is invisible to it, and with several workers the others report normally and the
+ * missing class reads as a pass. Asserted here rather than in a scripted test, which cannot make a
+ * framework fail to load only inside the fork.
+ */
+object ReactTest extends Properties:
+
+  override lazy val tests: List[Test] = List(
+    example("a class leased and never acknowledged is reported", exLeaseWithoutAck),
+    example("a lease this session cannot name is still reported", exLeaseWithoutAName),
+    example("acknowledging every leased class leaves nothing owed", exFullRun),
+    example("a class that produced no test task still counts as run", exNoTasksProduced),
+    example("the two leases of a class matching two frameworks are tracked apart", exTwoFrameworks),
+    example("a request carrying another session's id leases nothing", exForeignSession),
+    example("a clean exit with a suite still open fails the run", exCleanExitMidSuite),
+    example("a clean exit with every suite finished passes", exCleanExitAfterSuites),
+    example("an exit is not judged until the notifications have arrived", exWaitsForTheStream),
+    example("an exit reaching two threads at once is judged once", exExitJudgedOnce),
+    example("another worker's exit is not this session's to judge", exForeignExit),
+    example(
+      "requests arriving at once lease each class to exactly one of them",
+      exConcurrentRequests
+    ),
+    example("a listener that throws does not hide the crash from the others", exListenerThrows),
+    example("an error response to the test request fails the run", exErrorResponse),
+    example("a late error response cannot turn a finished run red", exFirstCompletionWins),
+    example("a worker that exits non-zero fails the run", exNonZeroExit),
+    example("a dying worker stops the queue serving the others", exDeathPoisonsTheQueue),
+    example("another session's notifications are not recorded here", exForeignNotification),
+    example("another session's response cannot finish this run", exForeignResponse),
+    example("a worker's own output reaches the log at the level it asked for", exLogLevels),
+    example("the events of a suite become its result", exProgressBecomesResult),
+    example("a class run under two frameworks reports both runs", exOneClassTwoFrameworks),
+    example("a suite's events are taken when it ends, not copied", exEventsConsumedOnEnd),
+    example("a request sbt does not serve is reported, not ignored", exUnservedRequest),
+    example("a suite sbt cannot record is reported, not dropped", exUnrecordableSuite),
+    example("a result sbt cannot attribute is reported, not dropped", exUnattributableResult),
+    example("a notification sbt has no case for is reported, not dropped", exUnhandledMethod),
+    example("ordinary worker output is logged, not treated as a lost result", exPlainOutput),
+    example("a line of no recognised shape neither records nor ends the run", exUnknownShape),
+  )
+
+  private val id = 42L
+  private val names = Vector("A", "B", "C")
+
+  private def reply(result: String, reqId: Int): String =
+    s"""{ "jsonrpc": "2.0", "result": $result, "id": $reqId }"""
+
+  private class Fixture(
+      queue: Option[TestQueue],
+      listeners: Seq[TestReportListener] = Nil,
+      streamEnd: Future[Unit] = Future.unit,
+      exitCode: Int = 0,
+      log: Logger = Logger.Null
+  ):
+    private val out = ByteArrayOutputStream()
+
+    // isAlive is false so WorkerProxy's watch thread finishes at once rather than outliving the
+    // test JVM. The one notifyExit it broadcasts is harmless: this React is never registered.
+    private val process: Process = new Process:
+      def isAlive(): Boolean = false
+      def exitValue(): Int = exitCode
+      def destroy(): Unit = ()
+
+    val results: mutable.Map[String, SuiteResult] = mutable.Map.empty
+    val proxy: WorkerProxy =
+      WorkerProxy(out, process, Nil, None, streamEnd, AtomicReference[WorkerResponseListener](null))
+    val react: React =
+      React(
+        id,
+        log,
+        listeners,
+        results,
+        proxy,
+        queue,
+        names
+      )
+
+    /** The exit notification the process watch thread would deliver. */
+    def notifyExit(): Unit = react.notifyExit(process)
+
+    /** An exit broadcast for some other worker, which reaches this listener too. */
+    def notifyForeignExit(): Unit = react.notifyExit(Fixture.deadStranger)
+
+    /** One steal request: `done` is the index the requesting thread has just finished, if any. */
+    def nextTest(reqId: Int, done: String = "null", session: Long = id, framework: Int = 0): Unit =
+      val params = s"""{"id": $session, "framework": $framework, "done": $done}"""
+      react(s"""{ "jsonrpc": "2.0", "method": "nextTest", "params": $params, "id": $reqId }""")
+
+    def startGroup(group: String): Unit = send("startTestGroup", group)
+    def endGroup(group: String): Unit = send("endTestGroup", group)
+
+    /** An event whose throwable the worker never set, which SuiteResult cannot read. */
+    def brokenProgress(group: String): Unit =
+      val event = s"""{"fullyQualifiedName": "$group",
+                     |"selector": {"type": "SuiteSelector"}, "status": "Success"}""".stripMargin
+      val params = s"""{"id": $id, "group": "$group", "events": [$event]}"""
+      react(s"""{ "jsonrpc": "2.0", "method": "testProgress", "params": $params, "re": $id }""")
+
+    /** One test event for `group`, as the worker reports it while the suite runs. */
+    def testProgress(group: String, status: String): Unit =
+      val event =
+        s"""{"fullyQualifiedName": "$group",
+            |"fingerprint": {"type": "SubclassFingerscan", "isModule": false,
+            |  "superclassName": "junit.framework.TestCase", "requireNoArgConstructor": false},
+            |"selector": {"type": "SuiteSelector"},
+            |"status": "$status", "throwable": {}, "duration": 1}""".stripMargin
+      val params = s"""{"id": $id, "group": "$group", "events": [$event]}"""
+      react(s"""{ "jsonrpc": "2.0", "method": "testProgress", "params": $params, "re": $id }""")
+
+    /** One log line, as the worker forwards everything its test loggers are given. */
+    def testLog(tag: String, message: String, session: Long = id, re: Long = id): Unit =
+      val params = s"""{"id": $session, "tag": "$tag", "message": "$message"}"""
+      react(s"""{ "jsonrpc": "2.0", "method": "testLog", "params": $params, "re": $re }""")
+
+    /** The response that ends the session, as the worker sends it when its run is over. */
+    def sessionResponse(error: Boolean = false, session: Long = id): Unit =
+      val body = if error then """"error": {"code": 1}""" else """"result": 0"""
+      react(s"""{ "jsonrpc": "2.0", $body, "id": $session }""")
+
+    private def send(method: String, group: String): Unit =
+      val params = s"""{"id": $id, "group": "$group"}"""
+      react(s"""{ "jsonrpc": "2.0", "method": "$method", "params": $params, "re": $id }""")
+
+    def replies: List[String] = out.toString("UTF-8").linesIterator.toList
+  end Fixture
+
+  private object Fixture:
+    /** Stands in for a sibling worker that has died, so only identity distinguishes it. */
+    val deadStranger: Process = new Process:
+      def isAlive(): Boolean = false
+      def exitValue(): Int = 1
+      def destroy(): Unit = ()
+
+  def exLeaseWithoutAck: Result =
+    val f = Fixture(Some(TestQueue(Vector(Vector(0, 1)))))
+    f.nextTest(reqId = 7)
+    f.nextTest(reqId = 8, done = "0")
+    Result
+      .assert(f.react.unacknowledgedLeases == Vector("B"))
+      .and(Result.assert(f.replies == List(reply("0", 7), reply("1", 8))))
+      .log(s"owed=${f.react.unacknowledgedLeases} replies=${f.replies}")
+
+  def exLeaseWithoutAName: Result =
+    // The queue and the name vector are built from one `opts.tests`, so an index outside it means
+    // the two drifted apart. Naming it vaguely still fails the run; dropping it would report a
+    // worker that lost a class as one that owed nothing, which is the pass this whole guard exists
+    // to prevent.
+    val f = Fixture(Some(TestQueue(Vector(Vector(0, 5)))))
+    f.nextTest(reqId = 7)
+    f.nextTest(reqId = 8, done = "0")
+    val owed = f.react.unacknowledgedLeases
+    Result
+      .assert(owed.size == 1)
+      .and(Result.assert(owed.exists(_.contains("5"))))
+      .and(Result.assert(ForkTests.incompleteRun(owed, None).isDefined))
+      .log(s"owed=$owed")
+
+  def exFullRun: Result =
+    val f = Fixture(Some(TestQueue(Vector(Vector(0, 1)))))
+    f.nextTest(reqId = 7)
+    f.startGroup("A")
+    f.endGroup("A")
+    f.nextTest(reqId = 8, done = "0")
+    f.startGroup("B")
+    f.endGroup("B")
+    f.nextTest(reqId = 9, done = "1")
+    Result
+      .assert(f.react.unacknowledgedLeases.isEmpty)
+      .and(Result.assert(f.replies.last == reply("null", 9)))
+      .and(Result.assert(f.results.keySet == Set("A", "B")))
+      .log(s"replies=${f.replies} results=${f.results.keySet}")
+
+  def exNoTasksProduced: Result =
+    // A framework may match a class and then produce no task for it, so no group is ever reported.
+    // The worker still acknowledges the lease, and that must not be read as a lost class.
+    val f = Fixture(Some(TestQueue(Vector(Vector(0)))))
+    f.nextTest(reqId = 7)
+    f.nextTest(reqId = 8, done = "0")
+    Result
+      .assert(f.react.unacknowledgedLeases.isEmpty)
+      .and(Result.assert(f.results.isEmpty))
+      .log(s"owed=${f.react.unacknowledgedLeases} results=${f.results.keySet}")
+
+  def exTwoFrameworks: Result =
+    // A worker runs its frameworks sequentially, so today the two leases of such a class never
+    // overlap — but the accounting must not depend on that, or a later change would lose classes.
+    val f = Fixture(Some(TestQueue(Vector(Vector(0), Vector(0)))))
+    f.nextTest(reqId = 7, framework = 0)
+    f.nextTest(reqId = 8, framework = 1)
+    val bothOwed = f.react.unacknowledgedLeases
+    f.nextTest(reqId = 9, done = "0", framework = 0)
+    Result
+      .assert(bothOwed == Vector("A", "A"))
+      .and(Result.assert(f.react.unacknowledgedLeases == Vector("A")))
+      .and(Result.assert(f.replies == List(reply("0", 7), reply("0", 8), reply("null", 9))))
+      .log(s"bothOwed=$bothOwed owed=${f.react.unacknowledgedLeases} replies=${f.replies}")
+
+  def exForeignSession: Result =
+    val queue = TestQueue(Vector(Vector(0, 1)))
+    val f = Fixture(Some(queue))
+    f.nextTest(reqId = 7, session = id + 1)
+    Result
+      .assert(f.react.unacknowledgedLeases.isEmpty)
+      .and(Result.assert(f.replies.isEmpty))
+      .and(Result.assert(queue.remaining == 2))
+      .log(s"replies=${f.replies} remaining=${queue.remaining}")
+
+  def exCleanExitMidSuite: Result =
+    // A test calling System.exit(0) leaves its suite started and never ended, while the exit code
+    // says nothing is wrong. No queue here, so this is the single-worker path.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.notifyExit()
+    val outcome = f.react.promise.future.value
+    Result
+      .assert(outcome.exists(_.isFailure))
+      .and(Result.assert(f.results.get("A").contains(SuiteResult.Error)))
+      .log(s"outcome=$outcome results=${f.results}")
+
+  def exWaitsForTheStream: Result =
+    // The watch thread polls, so it can see the process exit while the socket still holds lines
+    // nobody has read, and judging then would call a healthy run a System.exit. The suite's end
+    // arrives only after the exit is observed, which is what a buffered socket looks like.
+    val drained = Promise[Unit]()
+    val f = Fixture(None, streamEnd = drained.future)
+    f.startGroup("A")
+    val reader = Thread(() => {
+      f.endGroup("A")
+      drained.success(())
+      ()
+    })
+    reader.start()
+    f.notifyExit()
+    reader.join()
+    val outcome = f.react.promise.future.value
+    Result
+      .assert(outcome.contains(scala.util.Success(0)))
+      .log(s"outcome=$outcome results=${f.results}")
+
+  def exExitJudgedOnce: Result =
+    // Three callers can reach notifyExit for the same worker: its own watch thread, runWorker's
+    // re-check after registering, and the watch thread of any other worker that dies. Two arriving
+    // together must not both synthesize a result for the same in-flight suite, or JUnit XML gets
+    // two <testsuite> elements for one class.
+    val ends = AtomicInteger(0)
+    // Holds the first thread inside the report so a second one is caught rather than raced past.
+    // The count, not the wait, is what is asserted.
+    val arrived = CountDownLatch(2)
+    val counting = new TestReportListener:
+      def startGroup(name: String): Unit = ()
+      def testEvent(event: TestEvent): Unit = ()
+      def endGroup(name: String, t: Throwable): Unit = ()
+      def endGroup(name: String, result: TestResult): Unit =
+        ends.incrementAndGet()
+        arrived.countDown()
+        arrived.await(2, TimeUnit.SECONDS)
+        ()
+    val f = Fixture(None, listeners = Seq(counting))
+    f.startGroup("A")
+    val second = Thread(() => f.notifyExit())
+    second.start()
+    f.notifyExit()
+    second.join()
+    Result
+      .assert(ends.get() == 1)
+      .and(Result.assert(f.react.promise.future.value.exists(_.isFailure)))
+      .log(s"endGroup fired ${ends.get()} times")
+
+  def exForeignExit: Result =
+    // Exits are broadcast, so a session whose own worker is already dead hears about every other
+    // worker's death too, and acting on those re-runs the judgement. Both processes here report
+    // isAlive false, so only identity distinguishes them.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.notifyForeignExit()
+    val afterForeign = f.react.promise.future.value
+    f.notifyExit()
+    Result
+      .assert(afterForeign.isEmpty)
+      .and(Result.assert(f.react.promise.future.value.exists(_.isFailure)))
+      .log(s"afterForeign=$afterForeign afterOwn=${f.react.promise.future.value}")
+
+  def exConcurrentRequests: Result =
+    // One reader thread serves a session's requests today, so this cannot happen in production — but
+    // the accounting must not be what keeps a class from running twice. The queue's cursor is what
+    // does: losing its atomicity hands one index to two callers, and the group reports a pass with
+    // one class run twice and another not at all.
+    val callers = 8
+    val f = Fixture(Some(TestQueue(Vector(Vector(0, 1, 2)))))
+    val pool = Executors.newFixedThreadPool(callers)
+    // A spin gate rather than a barrier: leaving a barrier is serialised by the barrier's own lock,
+    // so the requests would not really overlap.
+    val go = AtomicBoolean(false)
+    val leased =
+      try
+        val jobs: Seq[Callable[Unit]] = (0 until callers).map: c =>
+          new Callable[Unit]:
+            def call(): Unit =
+              while !go.get() do Thread.onSpinWait()
+              f.nextTest(reqId = c)
+        val futures = jobs.map(pool.submit)
+        go.set(true)
+        futures.foreach(_.get())
+        f.replies.flatMap: line =>
+          JsonParser.parseString(line).getAsJsonObject().get("result") match
+            case r if r.isJsonNull() => None
+            case r                   => Some(r.getAsInt())
+      finally
+        pool.shutdown()
+        pool.awaitTermination(30, TimeUnit.SECONDS)
+        ()
+    Result
+      .assert(leased.sorted == List(0, 1, 2))
+      .and(Result.assert(leased.distinct.size == leased.size))
+      .and(Result.assert(f.replies.size == callers))
+      // Every class handed out is owed by the worker, whichever caller took it.
+      .and(Result.assert(f.react.unacknowledgedLeases.sorted == Vector("A", "B", "C")))
+      .log(s"leased=$leased replies=${f.replies.size} owed=${f.react.unacknowledgedLeases}")
+
+  def exListenerThrows: Result =
+    // Ending a suite the worker left open runs on the process watch thread, not the one that ran it,
+    // and a listener is free to object to that. Without the per-listener guard the first throw would
+    // deprive every later listener of the crash, and the run would report an interrupted suite as a
+    // pass.
+    val seen = mutable.ListBuffer.empty[String]
+    val throwing = new TestReportListener:
+      def startGroup(name: String): Unit = ()
+      def testEvent(event: TestEvent): Unit = ()
+      def endGroup(name: String, t: Throwable): Unit = ()
+      def endGroup(name: String, result: TestResult): Unit =
+        throw RuntimeException("this listener keeps state on another thread")
+    val recording = new TestReportListener:
+      def startGroup(name: String): Unit = ()
+      def testEvent(event: TestEvent): Unit = ()
+      def endGroup(name: String, t: Throwable): Unit = ()
+      def endGroup(name: String, result: TestResult): Unit =
+        seen += s"$name=$result"
+        ()
+    val f = Fixture(None, listeners = Seq(throwing, recording))
+    f.startGroup("A")
+    f.notifyExit()
+    Result
+      .assert(seen.toList == List(s"A=${TestResult.Error}"))
+      .and(Result.assert(f.results.get("A").contains(SuiteResult.Error)))
+      // Nothing a listener does may stop the promise completing: blockForResponse waits on it.
+      .and(Result.assert(f.react.promise.future.value.exists(_.isFailure)))
+      .log(s"seen=$seen results=${f.results} outcome=${f.react.promise.future.value}")
+
+  def exErrorResponse: Result =
+    // The one line that says the run itself could not be done, rather than that some test failed.
+    // Read as a success it settles the session with 0 and the group reports no results at all --
+    // which is exactly what a group whose every suite passed looks like from here.
+    val f = Fixture(None)
+    f.sessionResponse(error = true)
+    val outcome = f.react.promise.future.value
+    Result
+      .assert(outcome.exists(_.isFailure))
+      // Carrying the worker's own line, since nothing else says what it objected to.
+      .and(Result.assert(outcome.exists(_.failed.get.getMessage.contains("error"))))
+      .log(s"outcome=$outcome")
+
+  def exFirstCompletionWins: Result =
+    // A worker writes its response once, but exits are broadcast and notifications keep arriving, so
+    // more than one thing can try to settle the session. The first outcome is the run's outcome.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.endGroup("A")
+    f.sessionResponse()
+    val afterResponse = f.react.promise.future.value
+    f.sessionResponse(error = true)
+    f.notifyExit()
+    Result
+      .assert(afterResponse.contains(scala.util.Success(0)))
+      .and(Result.assert(f.react.promise.future.value.contains(scala.util.Success(0))))
+      .log(s"afterResponse=$afterResponse final=${f.react.promise.future.value}")
+
+  def exNonZeroExit: Result =
+    // Nothing else covers the exit code itself: a worker killed by the OOM killer or by a bad JVM
+    // option finishes no suite, so only the code says the run is not a pass.
+    val f = Fixture(None, exitCode = 3)
+    f.notifyExit()
+    val outcome = f.react.promise.future.value
+    Result
+      .assert(outcome.exists(_.isFailure))
+      .and(Result.assert(outcome.exists(_.failed.get.getMessage.contains("3"))))
+      .log(s"outcome=$outcome")
+
+  def exDeathPoisonsTheQueue: Result =
+    // The other workers of the group are still leasing. Left serving, they would pick up the classes
+    // of a group that has already failed and report them into a run that is going to be thrown away.
+    val queue = TestQueue(Vector(Vector(0, 1, 2)))
+    val f = Fixture(Some(queue), exitCode = 1)
+    f.nextTest(reqId = 7)
+    val servingBefore = queue.hasWork
+    f.notifyExit()
+    Result
+      .assert(servingBefore)
+      .and(Result.assert(!queue.hasWork))
+      .and(Result.assert(queue.lease(0).isEmpty))
+      // The units are still counted as unrun, which is what fails the group.
+      .and(Result.assert(queue.remaining == 2))
+      .log(s"before=$servingBefore after=${queue.hasWork} remaining=${queue.remaining}")
+
+  def exForeignNotification: Result =
+    // Several workers share the registry, so until a connection is bound a sibling's notifications
+    // reach this listener too. Recording them would credit this session with another's suites, and
+    // it has to be a silent drop: a sibling is not a protocol disagreement, so treating one as
+    // something this session could not account for would fail a run over another worker's traffic.
+    val f = Fixture(None)
+    val params = s"""{"id": ${id + 1}, "group": "A"}"""
+    def foreign(method: String, body: String = params): Unit =
+      f.react(s"""{ "jsonrpc": "2.0", "method": "$method", "params": $body, "re": ${id + 1} }""")
+    foreign("startTestGroup")
+    foreign("endTestGroup")
+    foreign("forkError", s"""{"id": ${id + 1}, "error": {"message": "not ours"}}""")
+    Result
+      .assert(f.results.isEmpty)
+      .and(Result.assert(f.react.unrecordedFailure.isEmpty))
+      // A sibling's forkError must not fail this session either.
+      .and(Result.assert(f.react.promise.future.value.isEmpty))
+      .log(
+        s"results=${f.results.keySet} unrecorded=${f.react.unrecordedFailure} " +
+          s"promise=${f.react.promise.future.value}"
+      )
+
+  def exForeignResponse: Result =
+    // Nothing stops a sibling's response reaching this listener, and taking it would end this session
+    // before its own worker had run anything, reporting a group of missing classes as a pass.
+    val f = Fixture(None)
+    f.sessionResponse(session = id + 1)
+    val afterForeign = f.react.promise.future.value
+    f.sessionResponse()
+    Result
+      .assert(afterForeign.isEmpty)
+      .and(Result.assert(f.react.promise.future.value.contains(scala.util.Success(0))))
+      .log(s"afterForeign=$afterForeign final=${f.react.promise.future.value}")
+
+  def exLogLevels: Result =
+    // Everything a test prints, and every reason a framework gives for failing, reaches the user
+    // through these lines alone. A level dropped or downgraded loses that silently.
+    val seen = mutable.ListBuffer.empty[(Level.Value, String)]
+    val capture = new Logger:
+      def trace(t: => Throwable): Unit = ()
+      def success(message: => String): Unit = ()
+      def log(level: Level.Value, message: => String): Unit =
+        seen.append(level -> message)
+    val f = Fixture(None, log = capture)
+    f.testLog("Error", "boom")
+    f.testLog("Warn", "careful")
+    f.testLog("Info", "running")
+    f.testLog("Debug", "detail")
+    // A sibling's line, filtered by the id inside the notification rather than by the envelope.
+    f.testLog("Error", "someone else's", session = id + 1)
+    Result
+      .assert(
+        seen.toList == List(
+          Level.Error -> "boom",
+          Level.Warn -> "careful",
+          Level.Info -> "running",
+          Level.Debug -> "detail",
+        )
+      )
+      .log(s"seen=${seen.toList}")
+
+  def exProgressBecomesResult: Result =
+    // A suite's events are what its SuiteResult is made of, so dropping them turns a suite full of
+    // failures into an empty pass.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.testProgress("A", "Failure")
+    f.testProgress("A", "Success")
+    f.endGroup("A")
+    val result = f.results.get("A")
+    Result
+      .assert(result.exists(_.result == TestResult.Failed))
+      .and(Result.assert(result.exists(_.failureCount == 1)))
+      .and(Result.assert(result.exists(_.passedCount == 1)))
+      .log(s"result=${result.map(r => (r.result, r.failureCount, r.passedCount))}")
+
+  def exOneClassTwoFrameworks: Result =
+    // Why `spreadable` keeps such a group in one JVM: the class runs once per framework, and that
+    // one JVM reports a start/end pair per run under the one name. Both verdicts have to survive —
+    // keeping the last would let a pass under the second framework bury a failure under the first.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.testProgress("A", "Failure")
+    f.endGroup("A")
+    val afterFirst = f.results.get("A").map(_.result)
+    f.startGroup("A")
+    f.testProgress("A", "Success")
+    f.endGroup("A")
+    val result = f.results.get("A")
+    Result
+      .assert(afterFirst.contains(TestResult.Failed))
+      .and(Result.assert(result.exists(_.result == TestResult.Failed)))
+      .and(Result.assert(result.exists(_.failureCount == 1)))
+      .and(Result.assert(result.exists(_.passedCount == 1)))
+      .log(s"afterFirst=$afterFirst result=${result.map(r => (r.result, r.failureCount))}")
+
+  def exEventsConsumedOnEnd: Result =
+    // Taken from the buffer, not copied out of it. What is left behind is counted again by the next
+    // end for that name, and held for as long as the run lasts — an event keeps its throwable, and a
+    // throwable keeps the test class loader and its open jars alive.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.testProgress("A", "Failure")
+    f.endGroup("A")
+    // A late event with no start of its own, which a framework reporting after its suite closed
+    // produces. It must stand alone rather than joining the events already counted.
+    f.testProgress("A", "Success")
+    f.endGroup("A")
+    val result = f.results.get("A")
+    Result
+      .assert(result.exists(_.failureCount == 1))
+      .and(Result.assert(result.exists(_.passedCount == 1)))
+      .log(s"result=${result.map(r => (r.failureCount, r.passedCount))}")
+
+  def exUnknownShape: Result =
+    // Valid JSON that is none of the three shapes: no method, so not a request or notification, and
+    // no id, so not this session's response. It carries nothing to record, and above all it must not
+    // be mistaken for the response — completing the promise here would end the run at whatever had
+    // been reported so far and call that the group's result.
+    val f = Fixture(None)
+    f.react("""{ "jsonrpc": "2.0" }""")
+    f.react("""{ "jsonrpc": "2.0", "method": "startTestGroup" }""")
+    Result
+      .assert(f.react.promise.future.value.isEmpty)
+      .and(Result.assert(f.results.isEmpty))
+      .and(Result.assert(f.react.unrecordedFailure.isEmpty))
+      .log(s"promise=${f.react.promise.future.value} results=${f.results.keySet}")
+
+  def exUnservedRequest: Result =
+    // The worker blocks on the reply, so silence here is a ten-minute stall ending in "Lost contact
+    // with sbt". sbt gave this worker its session id, so a method it has no case for means the two
+    // sides disagree on the protocol, and the run cannot be vouched for either way.
+    val f = Fixture(None)
+    f.react(s"""{ "jsonrpc": "2.0", "method": "nextSuite", "params": {"id": $id}, "id": 7 }""")
+    Result
+      .assert(f.react.unrecordedFailure.exists(_.contains("nextSuite")))
+      .and(Result.assert(f.replies == Nil))
+      .log(s"unrecorded=${f.react.unrecordedFailure} replies=${f.replies}")
+
+  def exUnrecordableSuite: Result =
+    // The event's throwable is unset, which SuiteResult dereferences.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.brokenProgress("A")
+    f.endGroup("A")
+    Result
+      .assert(f.results.get("A").isEmpty)
+      .and(Result.assert(f.react.unrecordedFailure.isDefined))
+      .log(s"results=${f.results.keySet} unrecorded=${f.react.unrecordedFailure}")
+
+  def exUnattributableResult: Result =
+    // How a whole run disappears: every filter here used to drop in silence, so a worker whose
+    // suites sbt could not attribute reported nothing at all and the group passed with no tests run.
+    // The envelope names this session and the payload names another, which one worker cannot do.
+    val f = Fixture(None)
+    val params = s"""{"id": ${id + 1}, "group": "A"}"""
+    f.react(s"""{ "jsonrpc": "2.0", "method": "startTestGroup", "params": $params, "re": $id }""")
+    Result
+      .assert(f.results.isEmpty)
+      .and(Result.assert(f.react.unrecordedFailure.isDefined))
+      .and(Result.assert(f.react.unrecordedFailure.exists(_.contains("startTestGroup"))))
+      .log(s"unrecorded=${f.react.unrecordedFailure}")
+
+  def exUnhandledMethod: Result =
+    // A worker sending something this sbt has no case for means the two disagree about the protocol.
+    // Ignoring it cannot be safe: the notification may be the one carrying a suite's results.
+    val f = Fixture(None)
+    val params = s"""{"id": $id, "group": "A"}"""
+    f.react(s"""{ "jsonrpc": "2.0", "method": "somethingNewer", "params": $params, "re": $id }""")
+    Result
+      .assert(f.react.unrecordedFailure.exists(_.contains("somethingNewer")))
+      .log(s"unrecorded=${f.react.unrecordedFailure}")
+
+  def exPlainOutput: Result =
+    // A line this cannot parse is the only way anything the protocol does not carry reaches the
+    // user, so it has to be logged — not quietly reshaped into a message of no recognised shape and
+    // dropped. Asserting only that nothing was recorded let exactly that through.
+    val seen = mutable.ListBuffer.empty[(Level.Value, String)]
+    val capture = new Logger:
+      def trace(t: => Throwable): Unit = ()
+      def success(message: => String): Unit = ()
+      def log(level: Level.Value, message: => String): Unit =
+        seen.append(level -> message)
+    val f = Fixture(None, log = capture)
+    f.react("Downloading some dependency...")
+    f.react("")
+    Result
+      .assert(seen.contains(Level.Info -> "Downloading some dependency..."))
+      .and(Result.assert(f.react.unrecordedFailure.isEmpty))
+      .and(Result.assert(f.results.isEmpty))
+      .log(s"seen=$seen unrecorded=${f.react.unrecordedFailure}")
+
+  def exCleanExitAfterSuites: Result =
+    // The other side of the same check: an ordinary run ends with every suite closed.
+    val f = Fixture(None)
+    f.startGroup("A")
+    f.endGroup("A")
+    f.notifyExit()
+    val outcome = f.react.promise.future.value
+    Result
+      .assert(outcome.contains(scala.util.Success(0)))
+      .log(s"outcome=$outcome")
+end ReactTest

--- a/main-actions/src/test/scala/sbt/internal/TestQueueTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/TestQueueTest.scala
@@ -1,0 +1,163 @@
+package sbt
+package internal
+
+import hedgehog.*
+import hedgehog.runner.*
+import hedgehog.core.Result
+import java.util.concurrent.{ Callable, Executors, TimeUnit }
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.jdk.CollectionConverters.*
+
+object TestQueueTest extends Properties:
+
+  override lazy val tests: List[Test] = List(
+    property("single leaser drains exactly the input", propDrainsExactly),
+    property("concurrent leasers partition the input", propConcurrentPartition),
+    property("poison stops serving", propPoison),
+    example("empty queue leases nothing", exEmpty),
+    example("frameworks are independent", exIndependentFrameworks),
+    example("out of range framework leases nothing", exOutOfRange),
+    example("hasWork follows both the units and the poison", exHasWork),
+    example("leasers released together still never share a unit", exSimultaneousLeases),
+  )
+
+  private def genSizes: Gen[List[Int]] =
+    Gen.int(Range.linear(0, 12)).list(Range.linear(1, 4))
+
+  private def queueOf(sizes: List[Int]): (TestQueue, Vector[Vector[Int]]) =
+    var next = 0
+    val per = sizes.toVector.map: n =>
+      val v = Vector.range(next, next + n)
+      next += n
+      v
+    (TestQueue(per), per)
+
+  private def drainAll(q: TestQueue, frameworks: Int): Vector[Int] =
+    (0 until frameworks).toVector.flatMap: f =>
+      Iterator.continually(q.lease(f)).takeWhile(_.isDefined).flatten.toVector
+
+  def propDrainsExactly: Property =
+    for sizes <- genSizes.forAll
+    yield
+      val (q, per) = queueOf(sizes)
+      val drained = drainAll(q, per.length)
+      Result
+        .assert(drained.sorted == per.flatten.sorted)
+        .and(Result.assert(q.remaining == 0))
+        .log(s"drained=$drained expected=${per.flatten}")
+
+  def propConcurrentPartition: Property =
+    for
+      sizes <- genSizes.forAll
+      threads <- Gen.int(Range.linear(2, 8)).forAll
+    yield
+      val (q, per) = queueOf(sizes)
+      val pool = Executors.newFixedThreadPool(threads)
+      try
+        val jobs = (1 to threads).map: _ =>
+          new Callable[Vector[Int]]:
+            def call(): Vector[Int] = drainAll(q, per.length)
+        val results = pool.invokeAll(jobs.asJava).asScala.toVector.map(_.get)
+        val all = results.flatten
+        Result
+          .assert(all.sorted == per.flatten.sorted)
+          .and(Result.assert(all.distinct.length == all.length))
+          .and(Result.assert(q.remaining == 0))
+          .log(s"perThread=${results.map(_.length)} total=${all.length}")
+      finally
+        pool.shutdown()
+        pool.awaitTermination(30, TimeUnit.SECONDS)
+        ()
+
+  def propPoison: Property =
+    for sizes <- genSizes.filter(_.sum > 0).forAll
+    yield
+      val (q, per) = queueOf(sizes)
+      val servedBefore = q.hasWork
+      q.poison()
+      val leased = drainAll(q, per.length)
+      Result
+        .assert(leased.isEmpty)
+        .and(Result.assert(servedBefore))
+        .and(Result.assert(!q.hasWork))
+        .and(Result.assert(q.remaining == per.flatten.length))
+        .log(s"leased=$leased remaining=${q.remaining}")
+
+  def exEmpty: Result =
+    val q = TestQueue(Vector(Vector.empty, Vector.empty))
+    Result
+      .assert(q.lease(0).isEmpty)
+      .and(Result.assert(q.lease(1).isEmpty))
+      .and(Result.assert(q.remaining == 0))
+      .and(Result.assert(!q.hasWork))
+
+  def exIndependentFrameworks: Result =
+    val q = TestQueue(Vector(Vector(0, 1), Vector(2)))
+    val a = q.lease(0)
+    val b = q.lease(1)
+    val c = q.lease(0)
+    val d = q.lease(0)
+    Result
+      .assert(Set(a, c) == Set(Some(0), Some(1)))
+      .and(Result.assert(b == Some(2)))
+      .and(Result.assert(d.isEmpty))
+      .and(Result.assert(q.lease(1).isEmpty))
+
+  def exSimultaneousLeases: Result =
+    // Threads running at the same time are not the same as threads colliding: the window between
+    // reading the cursor and storing it back is nanoseconds wide, so a lease that lost its
+    // atomicity survives `propConcurrentPartition` (whose runs lease a dozen units) most of the
+    // time. What finds it is a long unsynchronised hammer on one cursor — hence the spin gate
+    // rather than a barrier, since leaving a barrier is serialised by the barrier's own lock.
+    val threads = math.max(4, Runtime.getRuntime().availableProcessors())
+    val total = 20000
+    val q = TestQueue(Vector(Vector.range(0, total)))
+    val go = AtomicBoolean(false)
+    val pool = Executors.newFixedThreadPool(threads)
+    val leased =
+      try
+        val jobs: Seq[Callable[Vector[Int]]] = (0 until threads).map: _ =>
+          new Callable[Vector[Int]]:
+            def call(): Vector[Int] =
+              while !go.get() do Thread.onSpinWait()
+              Iterator.continually(q.lease(0)).takeWhile(_.isDefined).flatten.toVector
+        val futures = jobs.map(pool.submit)
+        go.set(true)
+        futures.toVector.flatMap(_.get())
+      finally
+        pool.shutdown()
+        pool.awaitTermination(30, TimeUnit.SECONDS)
+        ()
+    Result
+      .assert(leased.size == total)
+      .and(Result.assert(leased.distinct.size == leased.size))
+      .and(Result.assert(q.remaining == 0))
+      .log(s"threads=$threads leased=${leased.size} distinct=${leased.distinct.size}")
+
+  def exHasWork: Result =
+    // What decides whether a worker task forks a JVM at all, so it has to answer for a queue that is
+    // drained and for one that still holds units but has stopped serving them.
+    val q = TestQueue(Vector(Vector(0), Vector(1)))
+    val atStart = q.hasWork
+    q.lease(0)
+    val partlyDrained = q.hasWork
+    q.lease(1)
+    val drained = q.hasWork
+    val poisoned = TestQueue(Vector(Vector(0, 1)))
+    poisoned.poison()
+    Result
+      .assert(atStart)
+      .and(Result.assert(partlyDrained))
+      .and(Result.assert(!drained))
+      // Units remain, but a poisoned queue will not serve them, so spawning for them is waste.
+      .and(Result.assert(poisoned.remaining == 2))
+      .and(Result.assert(!poisoned.hasWork))
+      .log(s"atStart=$atStart partly=$partlyDrained drained=$drained")
+
+  def exOutOfRange: Result =
+    val q = TestQueue(Vector(Vector(0)))
+    Result
+      .assert(q.lease(-1).isEmpty)
+      .and(Result.assert(q.lease(5).isEmpty))
+      .and(Result.assert(q.lease(0) == Some(0)))
+end TestQueueTest

--- a/main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala
+++ b/main-actions/src/test/scala/sbt/internal/WorkerExchangeTest.scala
@@ -5,7 +5,14 @@ import hedgehog.*
 import hedgehog.runner.*
 import hedgehog.core.{ ShrinkLimit, SuccessCount }
 import hedgehog.core.Result
+import org.scalasbt.shadedgson.com.google.gson.JsonParser
+import java.net.{ InetAddress, InetSocketAddress, ServerSocket }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicReference }
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration.*
 import scala.sys.process.Process
+import scala.util.control.NonFatal
 
 object WorkerExchangeTest extends Properties:
   given Gen[WorkerConnection] =
@@ -16,7 +23,237 @@ object WorkerExchangeTest extends Properties:
   override lazy val tests: List[Test] = List(
     propertyN("non-jsonrpc should return exit code 1", propBadInput, 10),
     propertyN("bye should return response json with a result", propBye, 10),
+    propertyN("a line for one session is ignored by another session's listener", propDemux, 10),
+    propertyN("a request from the worker is not mistaken for the session response", propShape, 10),
+    propertyN("a bound connection delivers only to its owner", propBind, 10),
+    example("a session registering does not disturb a broadcast in flight", exRegistryChurn),
+    example("a broadcast is not held up by what a listener does with it", exBroadcastOutsideLock),
+    example("a bound worker's exit reaches its owner and nobody else", exBoundExitGoesToOwner),
+    example("closing a worker gives back the port it was listening on", exCloseFreesThePort),
+    example("a fork that never connects fails instead of waiting for ever", exForkNeverConnects),
+    example("a blank line is a request the worker cannot parse, not a goodbye", exBlankLine),
+    example("unregistering a listener that is not registered is a no-op", exUnregisterTwice),
+    example("closing a worker stops the JVM waiting on its request", exCloseStopsTheWorker),
+    example("the end of a worker's stream is signalled, not waited out", exStreamEndSignalled),
   )
+
+  def exStreamEndSignalled: Result =
+    // awaitStreamEnd is what stops a dead worker being judged before its suites have drained, and it
+    // gives up after 30 seconds. That bound is a backstop, not the normal path: the thread reading a
+    // worker has to signal the end however it finishes, or judging every dead worker pays the full
+    // 30 seconds — once per worker, and a spread group forks several.
+    val w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    w.println("""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": 1}""")
+    val exitCode = w.blockForExitCode()
+    val startedAt = System.nanoTime()
+    w.awaitStreamEnd()
+    val elapsed = (System.nanoTime() - startedAt).nanos
+    w.close()
+    Result
+      .assert(exitCode == 0)
+      // Nowhere near the bound, so a signal that never comes cannot be mistaken for a slow one.
+      .and(Result.assert(elapsed < 15.seconds))
+      .log(s"exitCode=$exitCode elapsed=$elapsed")
+
+  def exCloseStopsTheWorker: Result =
+    // A worker that has connected sits blocked on the one request sbt is going to send it. Closing
+    // has to close the connection, not only the listening socket: closing a ServerSocket leaves what
+    // it accepted open, so the JVM would wait for a request that never comes and outlive the build —
+    // once per worker, and work stealing forks several per group.
+    val w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    w.close()
+    // A bound, not a timing assertion: the wait can only run out if the close left it connected.
+    val deadline = System.currentTimeMillis() + 30000L
+    while w.process.isAlive() && System.currentTimeMillis() < deadline do Thread.sleep(50)
+    val stopped = !w.process.isAlive()
+    // Otherwise this test would leave a stray JVM behind for the rest of the run.
+    if !stopped then w.process.destroy()
+    Result.assert(stopped).log(s"stopped=$stopped")
+
+  def exUnregisterTwice: Result =
+    // runWorker unregisters in a finally, so this runs on the failure paths too. Removing without
+    // checking membership takes an index of -1 and throws, which would replace whatever the run was
+    // already failing with.
+    val stranger = new WorkerResponseListener:
+      def apply(line: String): Unit = ()
+      def notifyExit(p: Process): Unit = ()
+    WorkerExchange.registerListener(stranger)
+    val first = scala.util.Try(WorkerExchange.unregisterListener(stranger))
+    val second = scala.util.Try(WorkerExchange.unregisterListener(stranger))
+    Result
+      .assert(first.isSuccess)
+      .and(Result.assert(second.isSuccess))
+      .and(Result.assert(!WorkerExchange.listeners.contains(stranger)))
+      .log(s"first=$first second=$second")
+
+  def exBlankLine: Result =
+    // The worker parks on one request handed over by its reader thread, and tells a real request
+    // from the reader's end-of-stream signal by comparing against an empty String *by reference*.
+    // Matching by value instead would read a blank line as the end of the stream: the worker would
+    // stop before running anything and exit 0, and a forked group that ran nothing and exited
+    // cleanly is a group sbt reports as passed.
+    val w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    w.println("")
+    val exitCode = w.blockForExitCode()
+    w.close()
+    Result.assert(exitCode != 0).log(s"exitCode=$exitCode")
+
+  def exForkNeverConnects: Result =
+    // A bad JVM option kills the fork before it dials back.
+    val fo = ForkOptions()
+      .withRunJVMOptions(Vector("-XX:ThisOptionDoesNotExist"))
+      .withConnectionTimeout(3.seconds)
+    val startedAt = System.nanoTime()
+    val outcome =
+      try
+        WorkerExchange.startWorker(fo, Nil, WorkerConnection.Tcp)
+        None
+      catch case NonFatal(e) => Some(e)
+    val elapsed = (System.nanoTime() - startedAt).nanos
+    Result
+      .assert(outcome.isDefined)
+      // Well inside the 30s default, so a build that asked to give up sooner really does.
+      .and(Result.assert(elapsed < 20.seconds))
+      .log(s"outcome=$outcome elapsed=$elapsed")
+
+  /**
+   * Calling the listeners with the registry lock held deadlocks sbt: [[React.notifyExit]] waits for
+   * the thread that reads the worker's socket before judging a dead worker, and that reader delivers
+   * through `notifyListeners`. The exit would hold the monitor the reader needs to make progress.
+   */
+  def exBroadcastOutsideLock: Result =
+    val insideNotifyExit = CountDownLatch(1)
+    val broadcast = CountDownLatch(1)
+    val delivered = AtomicBoolean(false)
+    val waiting = new WorkerResponseListener:
+      def apply(line: String): Unit = ()
+      def notifyExit(p: Process): Unit =
+        insideNotifyExit.countDown()
+        delivered.set(broadcast.await(10, TimeUnit.SECONDS))
+        ()
+    val reader = Thread(() => {
+      insideNotifyExit.await(10, TimeUnit.SECONDS)
+      WorkerExchange.notifyListeners("""{ "jsonrpc": "2.0" }""")
+      broadcast.countDown()
+    })
+    try
+      WorkerExchange.registerListener(waiting)
+      reader.start()
+      WorkerExchange.notifyExit(deadProcess)
+      reader.join(30000L)
+      Result
+        .assert(delivered.get())
+        .log(s"delivered=${delivered.get()}")
+    finally WorkerExchange.unregisterListener(waiting)
+
+  def exBoundExitGoesToOwner: Result =
+    // blockForResponse waits on a promise only the exit completes, so an exit that misses its owner
+    // hangs the build; one handed to every session instead lets a sibling judge a worker it knows
+    // nothing about. Both listeners count only this worker's exit, since the watch thread of a
+    // worker from an earlier test may still be on its way.
+    val w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    val owner = ExitListener(w.process)
+    val bystander = ExitListener(w.process)
+    try
+      WorkerExchange.registerListener(bystander)
+      w.bind(owner)
+      w.println("""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": 1}""")
+      val exitCode = w.blockForExitCode()
+      owner.awaitExit()
+      Result
+        .assert(exitCode == 0)
+        .and(Result.assert(owner.exits.get() == 1))
+        .and(Result.assert(bystander.exits.get() == 0))
+        .log(s"owner=${owner.exits.get()} bystander=${bystander.exits.get()}")
+    finally
+      WorkerExchange.unregisterListener(bystander)
+      w.close()
+
+  def exCloseFreesThePort: Result =
+    // One listening socket per forked test group, and closing the proxy is the only thing that hands
+    // it back. A build with many groups would otherwise run the sbt process out of descriptors.
+    val w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    val port = w.options.dropWhile(_ != "--tcp").drop(1).head.toInt
+    w.println("""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": 1}""")
+    w.blockForExitCode()
+    w.close()
+    val rebound =
+      val probe = ServerSocket()
+      // So a lingering connection cannot be mistaken for a socket still listening.
+      probe.setReuseAddress(true)
+      try
+        probe.bind(InetSocketAddress(InetAddress.getByName(null), port), 1)
+        true
+      catch case NonFatal(_) => false
+      finally probe.close()
+    Result.assert(rebound).log(s"port=$port")
+
+  private class ExitListener(target: Process) extends WorkerResponseListener:
+    val exits: AtomicInteger = AtomicInteger(0)
+    private val latch = CountDownLatch(1)
+    def apply(line: String): Unit = ()
+    def notifyExit(p: Process): Unit =
+      if p eq target then
+        exits.incrementAndGet()
+        latch.countDown()
+    def awaitExit(): Unit =
+      latch.await(30, TimeUnit.SECONDS)
+      ()
+
+  private val deadProcess: Process = new Process:
+    def isAlive(): Boolean = false
+    def exitValue(): Int = 0
+    def destroy(): Unit = ()
+
+  /**
+   * Broadcasts iterate a snapshot taken under the lock. Iterating the buffer itself throws
+   * ConcurrentModificationException as another worker's session registers, which on the reader thread
+   * of a healthy worker would abandon the rest of its notifications.
+   */
+  def exRegistryChurn: Result =
+    val rounds = 2000
+    val failure = AtomicReference[Throwable](null)
+    def record(t: Throwable): Unit =
+      failure.compareAndSet(null, t)
+      ()
+    val churn = Thread(() => {
+      try
+        for _ <- 0 until rounds do
+          val l = ConcreteListener()
+          WorkerExchange.registerListener(l)
+          WorkerExchange.unregisterListener(l)
+      catch case t: Throwable => record(t)
+    })
+    churn.start()
+    try for i <- 0 until rounds do WorkerExchange.notifyListeners(s"""{"round": $i}""")
+    catch case t: Throwable => record(t)
+    churn.join(30000L)
+    Result
+      .assert(failure.get() == null)
+      .log(s"failure=${failure.get()}")
+
+  /**
+   * Unbound, every line goes to every registered listener and each parses it to find out whether it
+   * is theirs. A registered listener seeing nothing here is the point.
+   */
+  def propBind: Property =
+    for
+      i <- intGen.forAll
+      w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    yield
+      val owner = ConcreteListener()
+      w.bind(owner)
+      withListener: bystander =>
+        w.println(s"""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": $i}""")
+        val exitCode = w.blockForExitCode()
+        owner.awaitResponse()
+        Result
+          .assert(exitCode == 0)
+          .and(
+            Result.assert(owner.sb.toString() == s"""{ "jsonrpc": "2.0", "result": 0, "id": $i }""")
+          )
+          .and(Result.assert(bystander.sb.isEmpty))
+          .log(s"owner=\"${owner.sb}\" bystander=\"${bystander.sb}\"")
 
   def propertyN(name: String, result: => Property, n: Int): Test =
     Test(name, result)
@@ -46,6 +283,63 @@ object WorkerExchangeTest extends Properties:
         .assert(exitCode == 0)
         .and(Result.assert(l.sb.toString() == s"""{ "jsonrpc": "2.0", "result": 0, "id": $i }"""))
         .log(s"\"${l.sb.toString()}\"")
+
+  def propShape: Property =
+    for i <- intGen.forAll
+    yield
+      val session = s"""{ "jsonrpc": "2.0", "result": 0, "id": $i }"""
+      val errorResponse = s"""{ "jsonrpc": "2.0", "error": {"code": 1}, "id": $i }"""
+      val notification =
+        s"""{ "jsonrpc": "2.0", "method": "testLog", "params": {}, "re": $i }"""
+      val request =
+        s"""{ "jsonrpc": "2.0", "method": "nextTest", "params": {"id": $i, "framework": 0}, "id": 7 }"""
+      def shape(line: String) = ForkTests.shapeOf(JsonParser.parseString(line).getAsJsonObject())
+      Result
+        .assert(shape(session) == ForkTests.Shape.Response)
+        .and(Result.assert(shape(errorResponse) == ForkTests.Shape.Response))
+        .and(Result.assert(shape(notification) == ForkTests.Shape.Notification))
+        .and(Result.assert(shape(request) == ForkTests.Shape.Request))
+        .and(Result.assert(shape("""{ "jsonrpc": "2.0" }""") == ForkTests.Shape.Unknown))
+
+  def propDemux: Property =
+    for
+      idA <- intGen.forAll
+      w = WorkerExchange.startWorker(ForkOptions(), Nil, WorkerConnection.Tcp)
+    yield
+      val idB = idA + 1
+      val a = IdListener(idA)
+      val b = IdListener(idB)
+      try
+        WorkerExchange.registerListener(a)
+        WorkerExchange.registerListener(b)
+        w.println(s"""{"jsonrpc": "2.0", "method": "bye", "params": {}, "id": $idA}""")
+        val exitCode = w.blockForExitCode()
+        a.awaitResponse()
+        Result
+          .assert(exitCode == 0)
+          .and(Result.assert(a.accepted.size == 1))
+          .and(Result.assert(b.accepted.isEmpty))
+          .log(s"a=${a.accepted.toList} b=${b.accepted.toList}")
+      finally
+        WorkerExchange.unregisterListener(a)
+        WorkerExchange.unregisterListener(b)
+
+  class IdListener(id: Long) extends WorkerResponseListener:
+    val accepted: ListBuffer[String] = ListBuffer.empty
+    private val latch = CountDownLatch(1)
+    def notifyExit(p: Process): Unit = ()
+    def apply(line: String): Unit =
+      val o = JsonParser.parseString(line).getAsJsonObject()
+      val lineId =
+        if o.has("id") then Some(o.getAsJsonPrimitive("id").getAsLong())
+        else if o.has("re") then Some(o.getAsJsonPrimitive("re").getAsLong())
+        else None
+      if lineId.contains(id) then
+        accepted += line
+        latch.countDown()
+    def awaitResponse(): Unit =
+      latch.await(30, TimeUnit.SECONDS)
+      ()
 
   def withListener[A1](f: ConcreteListener => A1) =
     val l = ConcreteListener()

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -195,6 +195,7 @@ object Defaults extends BuildCommon with DefExtra {
       javaHomes :== ListMap.empty,
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
       testForkedParallel :== true,
+      testForkedWorkStealing :== false,
       testForkedParallelism :== None,
       javaOptions :== Nil,
       sbtPlugin :== false,
@@ -1243,6 +1244,10 @@ object Defaults extends BuildCommon with DefExtra {
     executeTests := Def.uncached(Def.taskDyn {
       import sbt.TupleSyntax.*
       val fpm = testForkedParallelism.value
+      // Unscoped, matching how the engine reads it (EvaluateTask.getSetting: current project,
+      // delegating project -> build -> global). `Global / concurrentRestrictions` delegates only to
+      // itself, so a limit raised at ThisBuild would be missed and stealing silently do nothing.
+      val mfw = stealingWorkers(testForkedWorkStealing.value, concurrentRestrictions.value)
       (
         test / streams,
         loadedTestFrameworks,
@@ -1268,7 +1273,8 @@ object Defaults extends BuildCommon with DefExtra {
           jo,
           clls,
           s"${Util.quoteIfNotScalaId(thisProj.id)} / ",
-          c
+          c,
+          mfw
         )
       }
     }.value),
@@ -1443,6 +1449,22 @@ object Defaults extends BuildCommon with DefExtra {
       )
     }
 
+  /**
+   * The most forked JVMs one test group may spread over: however many concurrent forked test groups
+   * `concurrentRestrictions` admits, or one when stealing is off.
+   */
+  private[sbt] def stealingWorkers(stealing: Boolean, rules: Seq[Tags.Rule]): Int =
+    if !stealing then 1
+    else
+      // Read off the rules rather than the core count, since a build that raised Tags.limitAll past
+      // it asked for that concurrency. Rules admitting even the ceiling name no total limit at all,
+      // so those fall back to the core count instead of a JVM per test class.
+      val admitted = Tags.maxAllowed(rules, Tags.ForkedTestGroup, forkedTestProbeCeiling)
+      if admitted >= forkedTestProbeCeiling then EvaluateTask.SystemProcessors else admitted
+
+  /** Where probing `concurrentRestrictions` for the forked test JVM ceiling gives up. */
+  private val forkedTestProbeCeiling = 1024
+
   def inputTests(key: InputKey[?]): Initialize[InputTask[TestResult]] =
     inputTests0.mapReferenced(Def.mapScope((s) => s.rescope(key.key)))
 
@@ -1486,6 +1508,8 @@ object Defaults extends BuildCommon with DefExtra {
         classLoaderLayeringStrategy.value,
         projectId = s"${Util.quoteIfNotScalaId(thisProject.value.id)} / ",
         converter = fileConverter.value,
+        // Unscoped for the same reason as in `executeTests` above.
+        maxWorkers = stealingWorkers(testForkedWorkStealing.value, concurrentRestrictions.value),
       )
       val taskName = display.show(resolvedScoped.value)
       val trl = testResultLogger.value
@@ -1605,6 +1629,7 @@ object Defaults extends BuildCommon with DefExtra {
     )
   }
 
+  // Kept for binary compatibility; the older overloads delegate through this arity.
   private[sbt] def allTestGroupsTask(
       s: TaskStreams,
       frameworks: Map[TestFramework, Framework],
@@ -1618,6 +1643,38 @@ object Defaults extends BuildCommon with DefExtra {
       strategy: ClassLoaderLayeringStrategy,
       projectId: String,
       converter: FileConverter,
+  ): Task[Tests.Output] = {
+    allTestGroupsTask(
+      s,
+      frameworks,
+      loader,
+      groups,
+      config,
+      cp,
+      forkedParallelExecution,
+      forkedParallelism,
+      javaOptions,
+      strategy,
+      projectId,
+      converter,
+      maxWorkers = 1,
+    )
+  }
+
+  private[sbt] def allTestGroupsTask(
+      s: TaskStreams,
+      frameworks: Map[TestFramework, Framework],
+      loader: ClassLoader,
+      groups: Seq[Tests.Group],
+      config: Tests.Execution,
+      cp: Classpath,
+      forkedParallelExecution: Boolean,
+      forkedParallelism: Option[Int],
+      javaOptions: Seq[String],
+      strategy: ClassLoaderLayeringStrategy,
+      projectId: String,
+      converter: FileConverter,
+      maxWorkers: Int,
   ): Task[Tests.Output] = {
     val processedOptions: Map[Tests.Group, Tests.ProcessedOptions] =
       groups
@@ -1637,24 +1694,30 @@ object Defaults extends BuildCommon with DefExtra {
 
     val runners = createTestRunners(filteredFrameworks, loader, config)
 
+    val groupWorkers = Tests.workersPerGroup(maxWorkers, groups, processedOptions)
+
     val groupTasks = groups map { group =>
       group.runPolicy match {
         case Tests.SubProcess(opts) =>
           s.log.debug(s"javaOptions: ${opts.runJVMOptions}")
-          val forkedConfig = config.copy(parallel = config.parallel && forkedParallelExecution)
           s.log.debug(
-            s"Forking tests - parallelism = ${forkedConfig.parallel}, threads = ${forkedParallelism.getOrElse("auto")}"
+            s"Forking tests - parallelism = ${config.parallel && forkedParallelExecution}, threads = ${forkedParallelism.getOrElse("auto")}"
           )
+          // `config` un-ANDed: ForkTests needs `parallelExecution` alone to size the JVM count, and
+          // ANDs `forkedParallelExecution` in only for what each JVM does with the classes it holds.
           ForkTests(
             runners,
             processedOptions(group),
-            forkedConfig,
+            config,
             data(cp),
             converter,
             opts,
             s.log,
+            forkedParallelExecution,
             forkedParallelism,
             strategy != ClassLoaderLayeringStrategy.Raw,
+            filteredFrameworks,
+            groupWorkers,
             (Tags.ForkedTestGroup, 1) +: group.tags*
           )
         case Tests.InProcess =>

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -400,7 +400,8 @@ object Keys {
   @transient
   val testListeners = taskKey[Seq[TestReportListener]]("Defines test listeners.").withRank(DTask)
   val testForkedParallel = settingKey[Boolean]("Whether forked tests should be executed in parallel").withRank(CTask)
-  val testForkedParallelism = settingKey[Option[Int]]("Maximum number of parallel test threads when using testForkedParallel. Defaults to the number of available processors.").withRank(CTask)
+  val testForkedParallelism = settingKey[Option[Int]]("Maximum number of parallel test threads when using testForkedParallel. Defaults to the number of available processors, or to one for a group that testForkedWorkStealing spreads over several JVMs, since the JVM count is then the parallelism dial.").withRank(CTask)
+  val testForkedWorkStealing = settingKey[Boolean]("Spread a forked test group's classes over several JVMs, which lease them one at a time from a queue sbt serves. Off by default. Read at the test task's own scope, so a build can enable it globally and a project whose suites clobber shared external state can opt out with `Test / testForkedWorkStealing := false`. A group may use as many JVMs as concurrentRestrictions admits concurrent forked test groups: one by default, raised by replacing the default rule seq, since += only tightens.").withRank(CTask)
   val testExecution = taskKey[Tests.Execution]("Settings controlling test execution").withRank(DTask)
   val testFilter = taskKey[Seq[String] => Seq[String => Boolean]]("Filter controlling whether the test is executed").withRank(DTask)
   @transient

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -96,6 +96,17 @@ object Tags {
   /** Returns a Rule that limits the maximum number of concurrent executing tasks tagged with `tag` to `max`. */
   def limit(tag: Tag, max: Int): Rule = new Single(tag, max)
 
+  /**
+   * The largest number of concurrently running tasks tagged `tag` that `rules` admits, up to
+   * `bound`. Rules are opaque, so the limit is found by probing [[predicate]].
+   */
+  private[sbt] def maxAllowed(rules: Seq[Rule], tag: Tag, bound: Int): Int =
+    val allows = predicate(rules)
+    (1 to math.max(1, bound))
+      .takeWhile(n => allows(Map(tag -> n, All -> n)))
+      .lastOption
+      .getOrElse(1)
+
   def limitSum(max: Int, tags: Tag*): Rule = new Sum(tags, max)
 
   /** Ensure that a task with the given tag always executes in isolation. */

--- a/main/src/test/scala/StealingWorkersTest.scala
+++ b/main/src/test/scala/StealingWorkersTest.scala
@@ -1,0 +1,88 @@
+package sbt
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+
+/**
+ * Pins [[Defaults.stealingWorkers]] and [[Tags.maxAllowed]].
+ *
+ * How far a group may spread is not a setting — it is read off the `concurrentRestrictions` in
+ * force, so the rule that governs the forked test JVMs also sizes the fan-out and the two cannot
+ * disagree.
+ */
+object StealingWorkersTest extends Properties("stealingWorkers") {
+
+  private val cores = EvaluateTask.SystemProcessors
+
+  private def rules(forkedLimit: Int): Seq[Tags.Rule] =
+    Seq(
+      Tags.limitAll(cores),
+      Tags.limit(Tags.ForkedTestGroup, forkedLimit),
+      Tags.exclusiveGroup(Tags.Clean)
+    )
+
+  property("off means one JVM, whatever the rules allow") = forAll(Gen.choose(1, 64)) { (n: Int) =>
+    Defaults.stealingWorkers(stealing = false, rules(n)) == 1
+  }
+
+  property("on means however many the rules admit") = forAll(Gen.choose(1, 64)) { (n: Int) =>
+    Defaults.stealingWorkers(stealing = true, rules(n)) == math.min(n, cores)
+  }
+
+  property("sbt's own default rule set gives one") = {
+    // Tags.limit(ForkedTestGroup, 1) is what defaultRestrictions has always carried, so a build
+    // that leaves concurrentRestrictions alone never spreads a group however the flag is set.
+    Prop(Defaults.stealingWorkers(stealing = true, rules(1)) == 1)
+  }
+
+  property("a rule that admits nothing still leaves one JVM") = {
+    // Rather than zero workers, which would build no tasks and run no tests. Tags.limit refuses a
+    // max below one (`checkMax`), so reaching this needs a custom rule.
+    Prop(Defaults.stealingWorkers(stealing = true, Seq(Tags.customLimit(_ => false))) == 1)
+  }
+
+  property("the tighter of two rules on the tag wins") = forAll(Gen.choose(1, 32)) { (n: Int) =>
+    // Which is why `+=` cannot raise the limit: rules are anded together.
+    val anded = rules(1) :+ Tags.limit(Tags.ForkedTestGroup, n)
+    Defaults.stealingWorkers(stealing = true, anded) == 1
+  }
+
+  property("limitAll caps it too, since tagged tasks are also tasks") = {
+    val generous = Seq(Tags.limitAll(2), Tags.limit(Tags.ForkedTestGroup, 64))
+    Prop(Defaults.stealingWorkers(stealing = true, generous) == 2)
+  }
+
+  property("a limitAll above the core count is honoured, not clamped to it") = {
+    // The rules are what govern the JVMs, so a build deliberately oversubscribing its cores — an
+    // IO-bound suite, say — gets the fan-out it asked for rather than one per core.
+    val oversubscribed =
+      Seq(Tags.limitAll(cores * 4), Tags.limit(Tags.ForkedTestGroup, cores * 2))
+    Prop(Defaults.stealingWorkers(stealing = true, oversubscribed) == cores * 2)
+  }
+
+  property("a rule making forked test groups exclusive gives one") = {
+    // Not the same rule as exclusiveGroup: this one admits a second task only if it is untagged, so
+    // a group that spread would break the isolation the build asked for.
+    Prop(Defaults.stealingWorkers(stealing = true, Seq(Tags.exclusive(Tags.ForkedTestGroup))) == 1)
+  }
+
+  property("a limit with a hole in it stops at the hole") = {
+    // The engine reaches n by running n-1 first, so a count is only usable when every count below it
+    // is admitted too. Taking the largest admitted anywhere would spread through a level the rules
+    // forbid — the probe has to stop at the first refusal, not look past it.
+    val holed = Tags.customLimit(_.getOrElse(Tags.ForkedTestGroup, 0) != 3)
+    Prop(Tags.maxAllowed(Seq(holed), Tags.ForkedTestGroup, 64) == 2)
+  }
+
+  property("rules naming no total limit fall back to the core count") = {
+    // Probing cannot tell an unbounded rule set from a very large one, and the alternative is a
+    // forked JVM per test class.
+    Prop(Defaults.stealingWorkers(stealing = true, Nil) == cores)
+      .&&(
+        Prop(
+          Defaults.stealingWorkers(stealing = true, Seq(Tags.exclusiveGroup(Tags.Clean)))
+            == cores
+        )
+      )
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-parallel-limit/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-parallel-limit/build.sbt
@@ -1,0 +1,44 @@
+// Eight forked test groups, and an assertion about how many of them overlap: that raising the
+// ForkedTestGroup limit genuinely lets that many groups run together, which is also the number work
+// stealing reads as its fan-out ceiling. The serialising direction is covered by
+// tests/fork-test-group-parallel, whose groups collide on a lock directory.
+ThisBuild / scalaVersion := "2.12.21"
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
+Test / fork := true
+
+// Eight groups but only this many are expected to overlap, so the assertion holds on a small
+// machine: sbt's task pool and Tags.limitAll are both sized by the processor count, and no rule can
+// raise them.
+val expectedPeak = settingKey[Int]("How many forked test groups should be seen running at once")
+expectedPeak := math.min(4, java.lang.Runtime.getRuntime.availableProcessors)
+
+Test / javaOptions += s"-Dexpect.peak=${expectedPeak.value}"
+
+// One group per test class.
+Test / testGrouping := Def.uncached {
+  val base = baseDirectory.value
+  val opts = (Test / javaOptions).value
+  (Test / definedTests).value.map { t =>
+    new Tests.Group(
+      t.name,
+      Seq(t),
+      Tests.SubProcess(ForkOptions().withWorkingDirectory(Some(base)).withRunJVMOptions(opts.toVector))
+    )
+  }
+}
+
+val checkPeak = taskKey[Unit]("Every group arrived; the barrier in the tests is what proved the overlap")
+
+checkPeak := Def.uncached {
+  // The overlap is proved inside the run, not here: Barrier.arrive fails its class unless it can see
+  // `expect.peak` arrivals, and the marks are append-only, so the Nth arrival means those N are all
+  // still sitting in the barrier. There is nothing left for this task to check about the peak -- the
+  // markers carry no times. What it adds is that no group was skipped, which would otherwise surface
+  // as a puzzling barrier timeout in whichever groups did run rather than as a missing group.
+  val arrived = IO.listFiles(baseDirectory.value / "arrivals").map(_.getName).toSet
+  val missing = (0 until 8).map("G" + _).toSet -- arrived
+  if (missing.nonEmpty) sys.error(s"groups that never ran: ${missing.toSeq.sorted}")
+  streams.value.log.info(
+    s"all 8 forked test groups ran, ${expectedPeak.value} of them in the barrier together"
+  )
+}

--- a/sbt-app/src/sbt-test/tests/fork-parallel-limit/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-parallel-limit/src/test/scala/tests.scala
@@ -1,0 +1,35 @@
+import java.io.File
+
+/**
+ * Proves that N forked test groups really overlap, without sampling.
+ *
+ * Each class marks its arrival and then blocks until it can see `expect.peak` arrivals. The marks
+ * are append-only, so once the Nth arrives every one of those N is still sitting in the barrier —
+ * which makes "N ran at the same time" a fact rather than an inference from timing. If fewer than N
+ * groups may run at once, the first wave waits out the deadline and fails.
+ */
+object Barrier {
+  private val arrivals = new File("arrivals")
+
+  def arrive(name: String): Unit = {
+    val want = System.getProperty("expect.peak").toInt
+    arrivals.mkdirs()
+    new File(arrivals, name).createNewFile()
+    def seen: Int = Option(arrivals.list()).map(_.length).getOrElse(0)
+    val deadline = System.currentTimeMillis() + 90000L
+    while (seen < want && System.currentTimeMillis() < deadline) Thread.sleep(25)
+    if (seen < want)
+      throw new AssertionError(
+        s"expected $want forked test groups to run at once, only ever saw $seen"
+      )
+  }
+}
+
+class G0 { @org.junit.Test def t(): Unit = Barrier.arrive("G0") }
+class G1 { @org.junit.Test def t(): Unit = Barrier.arrive("G1") }
+class G2 { @org.junit.Test def t(): Unit = Barrier.arrive("G2") }
+class G3 { @org.junit.Test def t(): Unit = Barrier.arrive("G3") }
+class G4 { @org.junit.Test def t(): Unit = Barrier.arrive("G4") }
+class G5 { @org.junit.Test def t(): Unit = Barrier.arrive("G5") }
+class G6 { @org.junit.Test def t(): Unit = Barrier.arrive("G6") }
+class G7 { @org.junit.Test def t(): Unit = Barrier.arrive("G7") }

--- a/sbt-app/src/sbt-test/tests/fork-parallel-limit/test
+++ b/sbt-app/src/sbt-test/tests/fork-parallel-limit/test
@@ -1,0 +1,12 @@
+# Raising the ForkedTestGroup limit really does let that many forked groups overlap, which is the
+# same number work stealing uses as its fan-out ceiling. The barrier only passes if that many are
+# sitting in it together, so this is a fact about concurrency rather than about elapsed time.
+> set Global / concurrentRestrictions := Seq(Tags.limitAll(16), Tags.limit(Tags.ForkedTestGroup, 4))
+> testFull
+> checkPeak
+$ delete arrivals
+# And the same with work stealing on, which reads the ceiling from that rule rather than from a
+# setting.
+> set Global / testForkedWorkStealing := true
+> testFull
+> checkPeak

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/PoolRecord.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/PoolRecord.java
@@ -1,0 +1,24 @@
+package example;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Records the window a forked JVM spent on one class, tagged with the project and the JVM's pid. */
+public final class PoolRecord {
+  public static void mark() throws IOException, InterruptedException {
+    String dir = System.getProperty("records.dir");
+    String proj = System.getProperty("proj");
+    Files.createDirectories(Paths.get(dir));
+    long pid = ProcessHandle.current().pid();
+    long start = System.currentTimeMillis();
+    Thread.sleep(1500);
+    long end = System.currentTimeMillis();
+    synchronized (PoolRecord.class) {
+      try (FileWriter w = new FileWriter(dir + "/" + proj + "-" + pid + ".records", true)) {
+        w.write(proj + " " + pid + " " + start + " " + end + "\n");
+      }
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T1.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T1.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T1 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T2.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T2.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T2 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T3.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T3.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T3 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T4.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/a/src/test/java/example/T4.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T4 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/PoolRecord.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/PoolRecord.java
@@ -1,0 +1,24 @@
+package example;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Records the window a forked JVM spent on one class, tagged with the project and the JVM's pid. */
+public final class PoolRecord {
+  public static void mark() throws IOException, InterruptedException {
+    String dir = System.getProperty("records.dir");
+    String proj = System.getProperty("proj");
+    Files.createDirectories(Paths.get(dir));
+    long pid = ProcessHandle.current().pid();
+    long start = System.currentTimeMillis();
+    Thread.sleep(1500);
+    long end = System.currentTimeMillis();
+    synchronized (PoolRecord.class) {
+      try (FileWriter w = new FileWriter(dir + "/" + proj + "-" + pid + ".records", true)) {
+        w.write(proj + " " + pid + " " + start + " " + end + "\n");
+      }
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T1.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T1.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T1 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T2.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T2.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T2 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T3.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T3.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T3 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T4.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/b/src/test/java/example/T4.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T4 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/build.sbt
@@ -1,0 +1,94 @@
+// Five projects of four test classes each against a TWO-JVM pool, so the pool is scarce and the projects
+// must compete for it. Each is a group that could fill the pool alone; the run is correct only if the two
+// JVMs go to the first workers of two DIFFERENT projects, leaving no project holding both while another has
+// none. Deliberately more projects than JVMs and more classes per project than JVMs: with a pool as wide as
+// either number, both schedules look alike and the test would pass on any build.
+
+ThisBuild / scalaVersion := "2.12.21"
+
+Global / testForkedWorkStealing := true
+
+// Replacing the Seq rather than appending, since += only tightens.
+Global / concurrentRestrictions := Seq(
+  Tags.limitAll(java.lang.Runtime.getRuntime.availableProcessors),
+  Tags.limit(Tags.ForkedTestGroup, 2),
+  Tags.exclusiveGroup(Tags.Clean)
+)
+
+val recordsDir = settingKey[File]("Where each forked JVM records the window it spent on a class")
+ThisBuild / recordsDir := (ThisBuild / baseDirectory).value / "records"
+
+lazy val commonSettings = Seq(
+  libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+  Test / fork := true,
+  // One class at a time per JVM, the integration-test posture: a project spreads by taking MORE JVMs, which
+  // is exactly the competition under test.
+  Test / testForkedParallel := false,
+  Test / javaOptions ++= Seq(
+    s"-Drecords.dir=${(ThisBuild / recordsDir).value}",
+    s"-Dproj=${name.value}"
+  )
+)
+
+lazy val a = project.settings(commonSettings)
+lazy val b = project.settings(commonSettings)
+lazy val c = project.settings(commonSettings)
+lazy val d = project.settings(commonSettings)
+lazy val e = project.settings(commonSettings)
+
+val check = taskKey[Unit]("the pool is shared BETWEEN projects, not taken whole by one at a time")
+
+lazy val root = (project in file("."))
+  .aggregate(a, b, c, d, e)
+  .settings(
+    check := {
+      val log = streams.value.log
+      val recs = IO.listFiles((ThisBuild / recordsDir).value).toSeq.flatMap { f =>
+        IO.read(f).linesIterator.filter(_.trim.nonEmpty).map { line =>
+          val Array(proj, pid, s, e) = line.trim.split(" ")
+          (proj, pid, s.toLong, e.toLong)
+        }
+      }
+      if (recs.isEmpty) sys.error("no classes recorded a window")
+      val projects = recs.map(_._1).distinct.sorted
+      if (projects.size != 5) sys.error(s"expected all five projects to run, saw ${projects.mkString(",")}")
+
+      // Did two DIFFERENT projects ever hold a JVM at the same moment?
+      val crossOverlap = recs.combinations(2).exists {
+        case Seq((p1, _, s1, e1), (p2, _, s2, e2)) => p1 != p2 && math.min(e1, e2) - math.max(s1, s2) > 0
+        case _                                     => false
+      }
+      // The widest a single project spread: how many of its own JVMs were live at once.
+      val widest = recs.groupBy(_._1).map { case (p, rs) =>
+        p -> rs.map { case (_, _, s, _) => rs.count { case (_, _, s2, e2) => s2 <= s && s < e2 } }.max
+      }
+      if (!crossOverlap)
+        sys.error(
+          "no two projects ever held a JVM at the same time; the pool went to one project at a time " +
+            s"(widest spread per project: ${widest.toSeq.sorted.mkString(", ")})"
+        )
+      // Spreading is not banned -- it is what a group should do once nothing else wants the slots, so a
+      // project that is the only one left with work may hold both. What must not happen is EVERY project
+      // taking the whole pool in turn, which is the un-shared schedule this guards against.
+      //
+      // Deliberately no tighter than that. Priority only orders what a CompletionService is already
+      // holding back: `submit` starts a task the moment its tags validate, so a project whose two workers
+      // are submitted while the pool still has room takes both slots without priority being consulted at
+      // all, and which project that is comes down to whichever reaches its test task first. A project
+      // that is last to finish can spread for the legitimate reason too. Counting spreaders more strictly
+      // than "not all of them" measures that scheduling luck rather than the sharing -- over five runs
+      // here the single spreader was a, b, c or d depending on the run.
+      val spreaders = widest.collect { case (p, n) if n > 1 => p }.toSeq.sorted
+      if (spreaders.size == projects.size)
+        sys.error(
+          "every project held both JVMs at some point, so the pool went to one project at a time " +
+            s"rather than being shared (widest per project: ${widest.toSeq.sorted.mkString(", ")})"
+        )
+      // widest is logged either way, so a schedule that drifts towards monopolising the pool is visible
+      // in a passing run rather than only once it trips the assertion.
+      log.info(
+        s"pool shared across projects; ${if (spreaders.isEmpty) "no project" else spreaders.mkString(", ")}" +
+          s" spread to both JVMs, widest per project ${widest.toSeq.sorted.mkString(", ")} (${recs.size} classes)"
+      )
+    }
+  )

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/PoolRecord.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/PoolRecord.java
@@ -1,0 +1,24 @@
+package example;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Records the window a forked JVM spent on one class, tagged with the project and the JVM's pid. */
+public final class PoolRecord {
+  public static void mark() throws IOException, InterruptedException {
+    String dir = System.getProperty("records.dir");
+    String proj = System.getProperty("proj");
+    Files.createDirectories(Paths.get(dir));
+    long pid = ProcessHandle.current().pid();
+    long start = System.currentTimeMillis();
+    Thread.sleep(1500);
+    long end = System.currentTimeMillis();
+    synchronized (PoolRecord.class) {
+      try (FileWriter w = new FileWriter(dir + "/" + proj + "-" + pid + ".records", true)) {
+        w.write(proj + " " + pid + " " + start + " " + end + "\n");
+      }
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T1.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T1.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T1 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T2.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T2.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T2 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T3.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T3.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T3 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T4.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/c/src/test/java/example/T4.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T4 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/PoolRecord.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/PoolRecord.java
@@ -1,0 +1,24 @@
+package example;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Records the window a forked JVM spent on one class, tagged with the project and the JVM's pid. */
+public final class PoolRecord {
+  public static void mark() throws IOException, InterruptedException {
+    String dir = System.getProperty("records.dir");
+    String proj = System.getProperty("proj");
+    Files.createDirectories(Paths.get(dir));
+    long pid = ProcessHandle.current().pid();
+    long start = System.currentTimeMillis();
+    Thread.sleep(1500);
+    long end = System.currentTimeMillis();
+    synchronized (PoolRecord.class) {
+      try (FileWriter w = new FileWriter(dir + "/" + proj + "-" + pid + ".records", true)) {
+        w.write(proj + " " + pid + " " + start + " " + end + "\n");
+      }
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T1.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T1.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T1 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T2.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T2.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T2 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T3.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T3.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T3 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T4.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/d/src/test/java/example/T4.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T4 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/PoolRecord.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/PoolRecord.java
@@ -1,0 +1,24 @@
+package example;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Records the window a forked JVM spent on one class, tagged with the project and the JVM's pid. */
+public final class PoolRecord {
+  public static void mark() throws IOException, InterruptedException {
+    String dir = System.getProperty("records.dir");
+    String proj = System.getProperty("proj");
+    Files.createDirectories(Paths.get(dir));
+    long pid = ProcessHandle.current().pid();
+    long start = System.currentTimeMillis();
+    Thread.sleep(1500);
+    long end = System.currentTimeMillis();
+    synchronized (PoolRecord.class) {
+      try (FileWriter w = new FileWriter(dir + "/" + proj + "-" + pid + ".records", true)) {
+        w.write(proj + " " + pid + " " + start + " " + end + "\n");
+      }
+    }
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T1.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T1.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T1 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T2.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T2.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T2 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T3.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T3.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T3 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T4.java
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/e/src/test/java/example/T4.java
@@ -1,0 +1,7 @@
+package example;
+
+import org.junit.Test;
+
+public class T4 {
+  @Test public void t() throws Exception { PoolRecord.mark(); }
+}

--- a/sbt-app/src/sbt-test/tests/fork-pool-sharing/test
+++ b/sbt-app/src/sbt-test/tests/fork-pool-sharing/test
@@ -1,0 +1,5 @@
+# Five projects, four classes each, against a two-JVM pool. The two JVMs must go to the first workers of two
+# different projects; a project that takes both while four others have none fails the check. testFull rather
+# than test: test is testQuick and would skip on a warm cache.
+> testFull
+> check

--- a/sbt-app/src/sbt-test/tests/fork-test-group-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-test-group-parallel/build.sbt
@@ -28,3 +28,21 @@ inConfig(Test)(Seq(
     ()
   }
 ))
+
+// No setting names how many forked test groups may run at once, so this asserts on the rule set.
+// Def.uncached because sbt 2.x wants a JsonFormat for a cached task's inputs, and Tags.Rule has
+// none.
+val checkForkLimit = inputKey[Unit]("The rule set permits exactly the given number of forked groups")
+
+checkForkLimit := Def.uncached {
+  val want = Def.spaceDelimited("<n>").parsed.head.toInt
+  // Capped by the processor count because Tags.limitAll is, and no rule can raise it.
+  val cores = java.lang.Runtime.getRuntime.availableProcessors
+  val n = math.min(want, cores)
+  val permits = Tags.predicate((Global / concurrentRestrictions).value)
+  def allows(k: Int): Boolean = permits(Map(Tags.ForkedTestGroup -> k, Tags.All -> k))
+  if (!allows(n)) sys.error(s"expected $n concurrent forked test groups to be permitted, and they are not")
+  if (n < cores && allows(n + 1))
+    sys.error(s"expected at most $n concurrent forked test groups, but ${n + 1} is permitted")
+  streams.value.log.info(s"the rule set permits $n concurrent forked test group(s)")
+}

--- a/sbt-app/src/sbt-test/tests/fork-test-group-parallel/test
+++ b/sbt-app/src/sbt-test/tests/fork-test-group-parallel/test
@@ -1,3 +1,25 @@
 > testFailure
 > set Global / concurrentRestrictions += Tags.limit(Tags.ForkedTestGroup, 1)
 > testFull
+
+# The defaults still serialize forked test groups, as they always have: defaultRestrictions yields
+# Tags.limit(ForkedTestGroup, 1), so restoring them keeps these groups off each other's lock
+# directory.
+> set Global / concurrentRestrictions := Defaults.defaultRestrictions.value
+> testFull
+
+# Asserted on the rules rather than on a collision, so it holds on a one-core box too.
+> checkForkLimit 1
+
+# The upgrade case: a build that raised the ForkedTestGroup limit itself must keep it. Raising it
+# takes replacing the Seq, since += yields min(1, 4) — see the last scenario. These groups collide
+# on a lock directory when they overlap, so the failure below is the proof of overlap.
+> set Global / concurrentRestrictions := Seq(Tags.limitAll(4), Tags.limit(Tags.ForkedTestGroup, 4))
+> checkForkLimit 4
+-> testFull
+
+# And += on top of the defaults is still one at a time, exactly as it was.
+> set Global / concurrentRestrictions := Defaults.defaultRestrictions.value
+> set Global / concurrentRestrictions += Tags.limit(Tags.ForkedTestGroup, 4)
+> checkForkLimit 1
+> testFull

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/a/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/a/src/test/scala/tests.scala
@@ -1,0 +1,78 @@
+import java.io.File
+import org.junit.Test
+
+/**
+ * Records which JVM ran which class, and holds every class until this project holds the whole pool.
+ *
+ * No timestamps: every assertion in build.sbt is about which class ran in which process.
+ */
+object Rec {
+  private val dir = new File(System.getProperty("pids.dir"))
+  private val proj = System.getProperty("proj")
+
+  private def pid: String = {
+    val vm = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
+    vm.takeWhile(_ != '@')
+  }
+
+  def record(suite: String): Unit = {
+    dir.mkdirs()
+    new File(dir, s"$proj.$suite.$pid").createNewFile()
+    ()
+  }
+
+  private def myPids: Set[String] = {
+    val files = Option(dir.listFiles()).getOrElse(Array.empty[File])
+    files.map(_.getName).filter(_.startsWith(proj + ".")).map(_.split('.')(2)).toSet
+  }
+
+  /**
+   * Blocks until this project holds the whole pool.
+   *
+   * Every class calls this, which is load-bearing: a worker runs one class at a time, so a class
+   * waiting here pins its whole JVM, and if every class waits no worker can drain the queue before
+   * the pool is full. Whichever worker is admitted into a slot b, c or d released therefore still
+   * finds work.
+   *
+   * Having only the first class wait is not enough: a second worker admitted early would drain the
+   * other nineteen while the first sits here, so every later worker finds the queue empty.
+   *
+   * The bound is a backstop, not a timing assertion: b, c and d have one trivial class each and
+   * none of them waits on a's pool, so the slots a needs are always released.
+   */
+  def awaitPool(): Unit = {
+    val want = System.getProperty("expect.jvms").toInt
+    val deadline = System.currentTimeMillis() + 120000L
+    while (myPids.size < want && System.currentTimeMillis() < deadline) Thread.sleep(50)
+    if (myPids.size < want)
+      throw new AssertionError(
+        s"expected $want JVMs working on $proj, saw ${myPids.size}: ${myPids.toSeq.sorted}"
+      )
+  }
+
+  def run(suite: String): Unit = {
+    record(suite)
+    awaitPool()
+  }
+}
+
+class A00 { @Test def t(): Unit = Rec.run("A00") }
+class A01 { @Test def t(): Unit = Rec.run("A01") }
+class A02 { @Test def t(): Unit = Rec.run("A02") }
+class A03 { @Test def t(): Unit = Rec.run("A03") }
+class A04 { @Test def t(): Unit = Rec.run("A04") }
+class A05 { @Test def t(): Unit = Rec.run("A05") }
+class A06 { @Test def t(): Unit = Rec.run("A06") }
+class A07 { @Test def t(): Unit = Rec.run("A07") }
+class A08 { @Test def t(): Unit = Rec.run("A08") }
+class A09 { @Test def t(): Unit = Rec.run("A09") }
+class A10 { @Test def t(): Unit = Rec.run("A10") }
+class A11 { @Test def t(): Unit = Rec.run("A11") }
+class A12 { @Test def t(): Unit = Rec.run("A12") }
+class A13 { @Test def t(): Unit = Rec.run("A13") }
+class A14 { @Test def t(): Unit = Rec.run("A14") }
+class A15 { @Test def t(): Unit = Rec.run("A15") }
+class A16 { @Test def t(): Unit = Rec.run("A16") }
+class A17 { @Test def t(): Unit = Rec.run("A17") }
+class A18 { @Test def t(): Unit = Rec.run("A18") }
+class A19 { @Test def t(): Unit = Rec.run("A19") }

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/b/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/b/src/test/scala/tests.scala
@@ -1,0 +1,45 @@
+import java.io.File
+import org.junit.Test
+
+/** One class only, so this project cannot spread and must occupy exactly one JVM. */
+object Rec {
+  private val dir = new File(System.getProperty("pids.dir"))
+  private val proj = System.getProperty("proj")
+
+  private def pid: String = {
+    val vm = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
+    vm.takeWhile(_ != '@')
+  }
+
+  def record(suite: String): Unit = {
+    dir.mkdirs()
+    new File(dir, s"$proj.$suite.$pid").createNewFile()
+    ()
+  }
+
+  /**
+   * Waits until project a has started testing, which biases the run towards the interleaved case
+   * where a and b test at once.
+   *
+   * It does not *guarantee* the interleaving: the marker stays on disk after a's JVM exits, so a
+   * run that gave a the whole pool first would satisfy it from history. What proves the late
+   * forking is the JVM count in build.sbt.
+   *
+   * Only b waits, not c and d: two waiters could occupy every slot on a machine with fewer
+   * processors than the pool size, leaving nothing for a to be admitted into.
+   */
+  def awaitPeer(): Unit = {
+    val deadline = System.currentTimeMillis() + 120000L
+    def aRunning: Boolean =
+      Option(dir.listFiles()).getOrElse(Array.empty[File]).exists(_.getName.startsWith("a."))
+    while (!aRunning && System.currentTimeMillis() < deadline) Thread.sleep(50)
+    if (!aRunning) throw new AssertionError("project a never started, so the pool was never shared")
+  }
+}
+
+class bTest {
+  @Test def t(): Unit = {
+    Rec.record("bTest")
+    Rec.awaitPeer()
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/build.sbt
@@ -1,0 +1,85 @@
+// Four projects sharing one pool of four forked test JVMs.
+//
+// b, c and d have a single test class each, so each takes one JVM and cannot spread. a has twenty.
+// The point is what happens when b, c and d finish: their JVMs exit, sbt admits more of a's worker
+// tasks, and each forks a *new* JVM that steals from a's queue, so a ends the run holding the whole
+// pool. a's classes all block until that has happened — see Rec.awaitPool.
+
+ThisBuild / scalaVersion := "2.12.21"
+
+Global / testForkedWorkStealing := true
+
+// Four slots: one each for b, c and d at the start, and all four for a once they are done. This one
+// rule does both jobs, capping the concurrent forked test JVMs and sizing how far a group may
+// spread. Replacing the Seq rather than appending, since += only tightens.
+Global / concurrentRestrictions := Seq(
+  Tags.limitAll(java.lang.Runtime.getRuntime.availableProcessors),
+  Tags.limit(Tags.ForkedTestGroup, 4),
+  Tags.exclusiveGroup(Tags.Clean)
+)
+
+val pidsDir = settingKey[File]("Where forked test JVMs record which classes they ran")
+ThisBuild / pidsDir := (ThisBuild / baseDirectory).value / "pids"
+
+// Capped by the processor count because Tags.limitAll is, so the expectation holds on a two-core CI
+// box as well as a large one, where it degrades to a trivially true assertion.
+val expectedJvms = settingKey[Int]("How many JVMs project a should end up holding")
+ThisBuild / expectedJvms := math.min(4, java.lang.Runtime.getRuntime.availableProcessors)
+
+lazy val commonSettings = Seq(
+  libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+  Test / fork := true,
+  Test / javaOptions ++= Seq(
+    s"-Dpids.dir=${(ThisBuild / pidsDir).value}",
+    s"-Dproj=${name.value}",
+    s"-Dexpect.jvms=${(ThisBuild / expectedJvms).value}"
+  )
+)
+
+lazy val a = project.settings(commonSettings)
+lazy val b = project.settings(commonSettings)
+lazy val c = project.settings(commonSettings)
+lazy val d = project.settings(commonSettings)
+
+val check = taskKey[Unit]("A holds the whole pool once b, c and d have released it")
+
+lazy val root = (project in file("."))
+  .aggregate(a, b, c, d)
+  .settings(
+    check := {
+      val want = (ThisBuild / expectedJvms).value
+      val log = streams.value.log
+      // Each marker is `<project>.<suite>.<pid>`, so these are plain facts about what ran where.
+      val runs = IO.listFiles((ThisBuild / pidsDir).value).toSeq.map { f =>
+        val parts = f.getName.split('.')
+        (parts(0), parts(1), parts(2))
+      }
+      val byProject = runs.groupBy(_._1)
+
+      Seq("a", "b", "c", "d").foreach { p =>
+        if (!byProject.contains(p)) sys.error(s"project $p never ran any tests")
+      }
+
+      // b, c and d have one class each, so a project that cannot spread must not have spread.
+      Seq("b", "c", "d").foreach { p =>
+        val pids = byProject(p).map(_._3).distinct
+        if (pids.size != 1)
+          sys.error(s"$p has a single test class and must use one JVM, saw ${pids.size}: $pids")
+      }
+
+      val aPids = byProject("a").map(_._3).distinct
+      if (aPids.size != want)
+        sys.error(s"expected project a to end up with $want JVMs, saw ${aPids.size}: $aPids")
+
+      val aSuites = byProject("a").map(_._2).distinct
+      if (aSuites.size != 20)
+        sys.error(s"expected all 20 of a's classes to run, saw ${aSuites.size}")
+
+      // The proof of late forking: at most four JVMs may run at once, so more than four distinct
+      // JVMs over the run means the surplus was forked into slots earlier JVMs had released.
+      val total = runs.map(_._3).distinct.size
+      if (want > 1 && total <= 4)
+        sys.error(s"expected more than 4 distinct JVMs over the run, saw $total: no slot was reused")
+      log.info(s"a used ${aPids.size} JVMs, $total forked in total across the four projects")
+    }
+  )

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/c/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/c/src/test/scala/tests.scala
@@ -1,0 +1,21 @@
+import java.io.File
+import org.junit.Test
+
+/** One class only, so this project cannot spread and must occupy exactly one JVM. */
+object Rec {
+  private val dir = new File(System.getProperty("pids.dir"))
+  private val proj = System.getProperty("proj")
+
+  private def pid: String = {
+    val vm = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
+    vm.takeWhile(_ != '@')
+  }
+
+  def record(suite: String): Unit = {
+    dir.mkdirs()
+    new File(dir, s"$proj.$suite.$pid").createNewFile()
+    ()
+  }
+}
+
+class cTest { @Test def t(): Unit = Rec.record("cTest") }

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/d/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/d/src/test/scala/tests.scala
@@ -1,0 +1,21 @@
+import java.io.File
+import org.junit.Test
+
+/** One class only, so this project cannot spread and must occupy exactly one JVM. */
+object Rec {
+  private val dir = new File(System.getProperty("pids.dir"))
+  private val proj = System.getProperty("proj")
+
+  private def pid: String = {
+    val vm = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
+    vm.takeWhile(_ != '@')
+  }
+
+  def record(suite: String): Unit = {
+    dir.mkdirs()
+    new File(dir, s"$proj.$suite.$pid").createNewFile()
+    ()
+  }
+}
+
+class dTest { @Test def t(): Unit = Rec.record("dTest") }

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/test
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing-multi/test
@@ -1,0 +1,8 @@
+# Four projects, one pool of four forked test JVMs, work stealing on build-wide. b, c and d have one
+# test class each so they cannot spread; a has twenty, and every one of them blocks until a holds
+# the whole pool. A worker runs one class at a time, so those barriers pin a's JVMs without draining
+# a's queue, and the pool can only fill the intended way: b, c and d finish, their JVMs exit, and
+# sbt admits a's remaining worker tasks, each forking a new JVM that steals from a's queue. testFull
+# rather than test: test is testQuick and would skip on a warm cache.
+> testFull
+> check

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing/build.sbt
@@ -1,0 +1,208 @@
+ThisBuild / scalaVersion := "2.12.21"
+
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
+
+Test / fork := true
+
+// Capped by the processor count because Tags.limitAll is, so the expectation holds on a one-core
+// container as well as a large machine, where it degrades to a trivially true assertion.
+val expectedJvms = settingKey[Int]("How many JVMs the group should spread over")
+expectedJvms := math.min(2, java.lang.Runtime.getRuntime.availableProcessors)
+
+Test / javaOptions += s"-Dexpect.jvms=${expectedJvms.value}"
+
+// Global is where a build turns stealing on for every project. It is read at the test task's own
+// scope, so this delegates down to each project unless one overrides it — scenario 5 below.
+Global / testForkedWorkStealing := true
+
+// The fan-out ceiling is however many concurrent forked test groups this admits. Two, to keep the
+// assertions below machine-independent. Replacing the Seq rather than appending, because += cannot
+// raise a limit: rules are anded together and the default already says one.
+Global / concurrentRestrictions := Seq(
+  Tags.limitAll(java.lang.Runtime.getRuntime.availableProcessors),
+  Tags.limit(Tags.ForkedTestGroup, 2),
+  Tags.exclusiveGroup(Tags.Clean)
+)
+
+// A second framework, defined in this project's test sources. The queue keeps one sub-queue per
+// framework, so this exercises indices addressing the whole class list rather than one framework's
+// slice.
+Test / testFrameworks += TestFramework("MarkedFramework")
+
+// Records every endGroup, so the crash scenario can assert that the suite whose JVM died is
+// reported.
+Test / testListeners += {
+  val dir = baseDirectory.value / "reported"
+  new TestReportListener {
+    private def record(name: String, outcome: String): Unit = {
+      dir.mkdirs()
+      IO.write(dir / name, outcome)
+    }
+    def startGroup(name: String): Unit = ()
+    def testEvent(event: TestEvent): Unit = ()
+    def endGroup(name: String, t: Throwable): Unit = record(name, "throwable")
+    def endGroup(name: String, result: TestResult): Unit = record(name, result.toString)
+  }
+}
+
+// Records doInit and doComplete. Each call writes its own file, so counting is not a race even when
+// the calls come from several worker threads at once, which is the bug being guarded against.
+Test / testListeners += {
+  val dir = baseDirectory.value / "lifecycle"
+  val seq = new java.util.concurrent.atomic.AtomicInteger(0)
+  // Tagged with this listener's identity as well as a counter: testListeners is a task key, so each
+  // evaluation gets a fresh counter while the directory persists, and without the tag a second run
+  // would overwrite the first's files.
+  val tag = Integer.toHexString(System.identityHashCode(seq))
+  new TestsListener {
+    private def mark(kind: String): Unit = {
+      dir.mkdirs()
+      IO.touch(dir / s"$kind-$tag-${seq.getAndIncrement()}")
+    }
+    def doInit(): Unit = mark("init")
+    def doComplete(finalResult: TestResult): Unit = mark("complete")
+    def startGroup(name: String): Unit = ()
+    def testEvent(event: TestEvent): Unit = ()
+    def endGroup(name: String, t: Throwable): Unit = ()
+    def endGroup(name: String, result: TestResult): Unit = ()
+  }
+}
+
+// A to D are junit classes, E and F belong to the second framework.
+val allSuites = ('A' to 'F').map(_.toString).toSet
+
+val check = taskKey[Unit]("Every class is leased exactly once and runs within the JVM ceiling")
+
+check := {
+  val base = baseDirectory.value
+  // doInit and doComplete are once per test group, not once per worker JVM.
+  val lifecycle = IO.listFiles(base / "lifecycle").toSeq.map(_.getName.takeWhile(_ != '-'))
+  val counts = lifecycle.groupBy(identity).map { case (k, v) => k -> v.size }
+  if (counts != Map("init" -> 1, "complete" -> 1))
+    sys.error(s"expected one doInit and one doComplete for the group, got: $counts")
+  // Each marker is `<suite>.<pid>`, so these are plain facts about what ran where, with no timing.
+  val runs = IO.listFiles(base / "pids").toSeq.map { f =>
+    val n = f.getName
+    val i = n.lastIndexOf('.')
+    (n.substring(0, i), n.substring(i + 1))
+  }
+  val bySuite = runs.groupBy(_._1)
+  val missing = allSuites -- bySuite.keySet
+  if (missing.nonEmpty) sys.error(s"suites that never ran: $missing")
+  val dup = bySuite.filter(_._2.size > 1)
+  if (dup.nonEmpty)
+    sys.error(s"suites handed out more than once: ${dup.map { case (s, r) => s -> r.map(_._2) }}")
+  val pids = runs.map(_._2).distinct
+  val want = expectedJvms.value
+  // Exactly this many, not at most: the ceiling caps it above, and suite A refuses to finish until
+  // that many JVMs have recorded work, so a run that used fewer has already failed by here.
+  if (pids.size != want) sys.error(s"expected exactly $want test JVMs, saw ${pids.size}: $pids")
+  // One JUnit report per class, holding one test case: a worker runs the classes it leases
+  // concurrently and sbt hands every one of their events to the listeners on the single thread
+  // reading that worker's connection, so a listener keying the open suite by thread wrote one
+  // report for the whole group, named after whichever class started last.
+  val reportDir = (Test / testReportsDirectory).value
+  val cases = allSuites.toSeq.sorted.map { s =>
+    val f = reportDir / s"TEST-$s.xml"
+    s -> (if (f.exists) IO.read(f).sliding("<testcase".length).count(_ == "<testcase") else -1)
+  }
+  if (cases.exists(_._2 != 1))
+    sys.error(s"each class must have its own report with only its own test case, got: $cases")
+  streams.value.log.info(s"${runs.size} suites ran exactly once across ${pids.size} JVMs")
+}
+
+val checkThreads = taskKey[Unit]("Turning on stealing does not change testForkedParallelism")
+
+checkThreads := {
+  // The thread count is decided per group, inside ForkTests, so it cannot leak into a build-wide
+  // setting: a derived testForkedParallelism could only read the Global flag.
+  val p = (Test / testForkedParallelism).value
+  if (p != None)
+    sys.error(s"testForkedParallelism must stay at its own default with stealing on, got: $p")
+  streams.value.log.info("testForkedParallelism is untouched by testForkedWorkStealing")
+}
+
+val checkSerial = taskKey[Unit]("parallelExecution := false pins the whole group to one JVM")
+
+checkSerial := {
+  // No timing here: the JVM count is decided before anything forks, so a group that is not spread
+  // forks exactly one JVM and every marker carries its pid. Seeing one means the group was never
+  // spread, which is what disabling parallel execution has to mean.
+  val runs = IO.listFiles(baseDirectory.value / "pids").toSeq.map(_.getName)
+  val suites = runs.map(n => n.substring(0, n.lastIndexOf('.'))).toSet
+  val pids = runs.map(n => n.substring(n.lastIndexOf('.') + 1)).distinct
+  if (suites != allSuites) sys.error(s"expected every suite to run, got: $suites")
+  if (pids.size != 1)
+    sys.error(s"parallelExecution is off, so the group must run in one JVM, saw ${pids.size}: $pids")
+  streams.value.log.info(s"serial run used ${pids.size} JVM")
+}
+
+val checkSpread = taskKey[Unit]("testForkedParallel off still lets the group be leased across JVMs")
+
+checkSpread := {
+  // No timing here either: suite A refuses to finish until `expectedJvms` JVMs have recorded work, so a run
+  // that used fewer has already failed before this task.
+  val runs = IO.listFiles(baseDirectory.value / "pids").toSeq.map(_.getName)
+  val suites = runs.map(n => n.substring(0, n.lastIndexOf('.'))).toSet
+  val pids = runs.map(n => n.substring(n.lastIndexOf('.') + 1)).distinct
+  val want = expectedJvms.value
+  if (suites != allSuites) sys.error(s"expected every suite to run, got: $suites")
+  if (pids.size != want)
+    sys.error(
+      s"testForkedParallel governs the threads inside a worker, not how many workers a group gets: " +
+        s"expected $want test JVMs, saw ${pids.size}: $pids"
+    )
+  streams.value.log.info(s"group spread over ${pids.size} JVMs with testForkedParallel off")
+}
+
+val checkOptOut = taskKey[Unit]("A project may turn stealing off at its own scope while Global has it on")
+
+checkOptOut := {
+  // A project whose suites clobber shared external state has to keep them out of each other's way
+  // even though the build steals build-wide. Turning the flag off in this project's Test scope must
+  // leave the group unspread: one JVM, every suite in it. No timing — the JVM count is fixed before
+  // anything forks, so one pid means the queue never served a second worker.
+  val runs = IO.listFiles(baseDirectory.value / "pids").toSeq.map(_.getName)
+  val suites = runs.map(n => n.substring(0, n.lastIndexOf('.'))).toSet
+  val pids = runs.map(n => n.substring(n.lastIndexOf('.') + 1)).distinct
+  if (suites != allSuites) sys.error(s"expected every suite to run, got: $suites")
+  if (pids.size != 1)
+    sys.error(
+      s"Test / testForkedWorkStealing := false must override the Global flag and keep the group " +
+        s"in one JVM, saw ${pids.size}: $pids"
+    )
+  streams.value.log.info(s"the project opted out of stealing and used ${pids.size} JVM")
+}
+
+val checkOverlap = taskKey[Unit]("A class matching two frameworks keeps the whole group in one JVM")
+
+checkOverlap := {
+  // No timing here either: the JVM count is decided before anything forks, so seeing one pid means
+  // the group was never spread.
+  val runs = IO.listFiles(baseDirectory.value / "pids").toSeq.map(_.getName)
+  val suites = runs.map(n => n.substring(0, n.lastIndexOf('.'))).toSet
+  val pids = runs.map(n => n.substring(n.lastIndexOf('.') + 1)).distinct
+  if (suites != allSuites) sys.error(s"expected every suite to run, got: $suites")
+  if (pids.size != 1)
+    sys.error(
+      s"E and F match two frameworks, so the group must stay in one JVM, saw ${pids.size}: $pids"
+    )
+  streams.value.log.info(s"overlapping fingerprints kept the group in ${pids.size} JVM")
+}
+
+val checkCrash = taskKey[Unit]("A worker that dies mid-suite reports that suite as an error")
+
+checkCrash := {
+  val reported =
+    IO.listFiles(baseDirectory.value / "reported").map(f => f.getName -> IO.read(f).trim).toMap
+  // Only A is asserted: killing a worker poisons the shared queue, so classes not yet leased are
+  // legitimately skipped and asserting on them would be a race.
+  reported.get("A") match {
+    case None =>
+      sys.error(s"the crashed suite A was never reported; reported: ${reported.keySet}")
+    case Some(outcome) if !outcome.toLowerCase.contains("error") =>
+      sys.error(s"the crashed suite A should be reported as an error, got: $outcome")
+    case Some(outcome) =>
+      streams.value.log.info(s"crashed suite reported as $outcome")
+  }
+}

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing/src/test/scala/tests.scala
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing/src/test/scala/tests.scala
@@ -1,0 +1,177 @@
+
+import java.io.File
+import org.junit.Test
+import sbt.testing.{
+  Event,
+  EventHandler,
+  Fingerprint,
+  Framework,
+  Logger,
+  OptionalThrowable,
+  Runner,
+  Selector,
+  Status,
+  SubclassFingerprint,
+  SuiteSelector,
+  Task,
+  TaskDef
+}
+
+/**
+ * Each suite records the JVM it ran in by creating an empty file named `<suite>.<pid>`.
+ *
+ * No sleeps and no timestamps: every assertion in build.sbt is about which suite ran in which
+ * process, which the queue fixes rather than a race.
+ */
+object Recorder {
+  private def pid: String = {
+    val vm = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
+    vm.takeWhile(_ != '@')
+  }
+
+  def record(suite: String): Unit = {
+    val dir = new File("pids")
+    dir.mkdirs()
+    new File(dir, s"$suite.$pid").createNewFile()
+    ()
+  }
+
+  private def recordedNames: Array[String] =
+    Option(new File("pids").listFiles()).getOrElse(Array.empty[File]).map(_.getName)
+
+  private def recordedPids: Set[String] =
+    recordedNames.map(n => n.substring(n.lastIndexOf('.') + 1)).toSet
+
+  /**
+   * Waits for a second class to be running in this same JVM, where the scenario asked a worker for
+   * more than one thread.
+   *
+   * Every other scenario leaves `testForkedParallelism` at None, which is one class at a time per
+   * JVM, so this is the only place a group has several suites open on one connection's reader thread
+   * -- what keying the listener's open suites by name is for. A worker that ran them one at a time
+   * would satisfy every other assertion here.
+   *
+   * Neither class can leave until both have arrived, so the second arrival proves they overlapped
+   * rather than merely both having happened. Later classes in the same JVM pass at once on the
+   * earlier markers, which is fine: the first pair is the proof. The bound is a backstop -- both
+   * threads hold a lease while they wait, so the sibling is already running.
+   */
+  def awaitSibling(): Unit =
+    if (new File("expect-threads").exists) {
+      def mine: Int = recordedNames.count(_.endsWith("." + pid))
+      val deadline = System.currentTimeMillis() + 60000L
+      while (mine < 2 && System.currentTimeMillis() < deadline) Thread.sleep(50)
+      if (mine < 2)
+        throw new AssertionError(
+          s"expected this JVM ($pid) to be running two classes at once, saw only ${mine}: " +
+            recordedNames.mkString(", ")
+        )
+    }
+
+  /**
+   * Waits for a peer JVM to record work, in the scenarios that expect the group to be spread.
+   *
+   * Without this the whole project passes with work stealing disabled: one JVM running all six
+   * classes satisfies every other assertion here. Holding this class also pins its JVM without
+   * draining the queue — a worker runs one class at a time — so the peer sbt admits still has
+   * something to claim.
+   *
+   * The bound is a backstop, not a timing assertion: this class blocks holding its lease while the
+   * queue still has work, so the peer's marker is at most one fork's startup away.
+   */
+  def awaitSpread(): Unit =
+    if (new File("expect-spread").exists) {
+      val want = System.getProperty("expect.jvms").toInt
+      val deadline = System.currentTimeMillis() + 60000L
+      while (recordedPids.size < want && System.currentTimeMillis() < deadline) Thread.sleep(50)
+      if (recordedPids.size < want)
+        throw new AssertionError(
+          s"expected this group to be spread over $want JVMs, but only $recordedPids recorded anything"
+        )
+    }
+}
+
+class A {
+  @Test def t(): Unit = {
+    Recorder.record("A")
+    // Kills this worker only in the crash scenario, after the record above is on disk and the
+    // startTestGroup notification is written.
+    if (new File("mode-crash").exists) System.exit(1)
+    Recorder.awaitSibling()
+    Recorder.awaitSpread()
+  }
+}
+
+// awaitSibling on every class, not just A: which classes share a JVM is up to the queue, so any of
+// them may be one of the pair that has to overlap.
+class B { @Test def t(): Unit = { Recorder.record("B"); Recorder.awaitSibling() } }
+class C { @Test def t(): Unit = { Recorder.record("C"); Recorder.awaitSibling() } }
+class D { @Test def t(): Unit = { Recorder.record("D"); Recorder.awaitSibling() } }
+
+/**
+ * A second, deliberately minimal framework.
+ *
+ * Two frameworks give the queue two sub-queues, so the indices it hands out have to address the
+ * full class list rather than one framework's slice of it. Hand-written rather than resolved, since
+ * a real second framework would cost a dependency resolution for what these few classes cover.
+ */
+trait Marked
+
+final class MarkedFramework extends Framework {
+  def name(): String = "marked"
+  def fingerprints(): Array[Fingerprint] = Array(
+    new SubclassFingerprint {
+      def isModule(): Boolean = false
+      def superclassName(): String = "Marked"
+      def requireNoArgConstructor(): Boolean = true
+    }
+  )
+  def runner(args: Array[String], remoteArgs: Array[String], cl: ClassLoader): Runner =
+    new MarkedRunner
+}
+
+/**
+ * A third framework carrying the *same* fingerprint as MarkedFramework, so E and F match two
+ * frameworks at once and become two work units each. Only the overlap scenario adds it, with `set`.
+ */
+final class MarkedFramework2 extends Framework {
+  def name(): String = "marked2"
+  def fingerprints(): Array[Fingerprint] = Array(
+    new SubclassFingerprint {
+      def isModule(): Boolean = false
+      def superclassName(): String = "Marked"
+      def requireNoArgConstructor(): Boolean = true
+    }
+  )
+  def runner(args: Array[String], remoteArgs: Array[String], cl: ClassLoader): Runner =
+    new MarkedRunner
+}
+
+final class MarkedRunner extends Runner {
+  def args(): Array[String] = Array.empty
+  def remoteArgs(): Array[String] = Array.empty
+  def done(): String = ""
+  def tasks(defs: Array[TaskDef]): Array[Task] = defs.map(d => new MarkedTask(d): Task)
+}
+
+final class MarkedTask(d: TaskDef) extends Task {
+  def taskDef(): TaskDef = d
+  def tags(): Array[String] = Array.empty
+  def execute(handler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+    val suite = d.fullyQualifiedName()
+    Recorder.record(suite)
+    Recorder.awaitSibling()
+    handler.handle(new Event {
+      def fullyQualifiedName(): String = suite
+      def fingerprint(): Fingerprint = d.fingerprint()
+      def selector(): Selector = new SuiteSelector
+      def status(): Status = Status.Success
+      def throwable(): OptionalThrowable = new OptionalThrowable
+      def duration(): Long = 0L
+    })
+    Array.empty
+  }
+}
+
+class E extends Marked
+class F extends Marked

--- a/sbt-app/src/sbt-test/tests/fork-work-stealing/test
+++ b/sbt-app/src/sbt-test/tests/fork-work-stealing/test
@@ -1,0 +1,94 @@
+# Eight scenarios in one sbt session, since launching sbt dominates a scripted test's runtime. The
+# queue logic, framework index mapping and protocol shapes are covered by unit tests in
+# main-actions; this covers what those cannot, that a real worker issues nextTest and runs the class
+# it leased. testFull rather than test: test is testQuick and would skip on a warm cache.
+
+# 1. six classes, at most two JVMs: classes are leased from sbt's queue one at a time.
+# expect-spread makes suite A fail unless a second JVM really did record work, so this scenario
+# cannot pass with work stealing disabled.
+> checkThreads
+$ touch expect-spread
+> testFull
+> check
+
+# 2. a worker killed mid-suite must report that suite instead of dropping it.
+# Clear the recorded outcomes first so the assertion cannot pass on scenario 1's leftovers.
+$ delete expect-spread
+$ delete reported
+$ touch mode-crash
+-> testFull
+> checkCrash
+
+# 3. spreading a group is parallel execution, so a build that turned parallel execution off must
+# keep getting one JVM however many the rules would otherwise allow.
+$ delete mode-crash
+$ delete pids
+> set Test / parallelExecution := false
+> testFull
+> checkSerial
+
+# 4. testForkedParallel says whether a worker runs the classes it holds at the same time; it says nothing
+# about how many workers the group gets. Turning it off is a build asking for one class at a time per JVM,
+# which is a reason to spread rather than a reason not to, so the group must still be leased across JVMs.
+# expect-spread makes suite A fail unless a second JVM really recorded work.
+$ delete pids
+$ touch expect-spread
+> set Test / parallelExecution := true
+> set Test / testForkedParallel := false
+> testFull
+> checkSpread
+$ delete expect-spread
+> set Test / testForkedParallel := true
+
+# 5. the flag is read at the test task's own scope, so a project whose suites clobber shared external
+# state can opt out while the build keeps stealing on globally. One JVM, every suite in it.
+$ delete pids
+> set Test / testForkedWorkStealing := false
+> testFull
+> checkOptOut
+> set Test / testForkedWorkStealing := true
+
+# 6. the fan-out ceiling has to come from the same concurrentRestrictions the task engine honours.
+# The engine looks that setting up at the current project and delegates project -> build -> global,
+# so a build that raises the ForkedTestGroup limit at ThisBuild scope really does get that many
+# concurrent forked groups. Global is Zero on every axis and delegates only to itself, so reading the
+# ceiling there saw past a ThisBuild definition to the default's limit of one -- and stealing became a
+# silent no-op for a build that had configured it the way the setting's own documentation describes.
+# Global is put back to the default first, so this fails unless the ThisBuild definition is the one
+# being read.
+$ delete pids
+$ touch expect-spread
+> set Global / concurrentRestrictions := Defaults.defaultRestrictions.value
+> set ThisBuild / concurrentRestrictions := Seq(Tags.limitAll(java.lang.Runtime.getRuntime.availableProcessors), Tags.limit(Tags.ForkedTestGroup, 2), Tags.exclusiveGroup(Tags.Clean))
+> testFull
+> check
+$ delete expect-spread
+
+# 7. stealing on together with a worker running more than one class at a time. testForkedParallel is
+# on -- its default, so every scenario above already had it on -- but on its own that changes nothing
+# in queue mode: the thread count comes from testForkedParallelism, which defaults to None and means
+# one class at a time per JVM. Setting it is the only way both settings are doing something at once,
+# and the only time a group has several suites open on one connection's reader thread, which is what
+# keying the listener's open suites by name is for. expect-threads fails a class unless a sibling is
+# running in its own JVM, so this cannot pass on one-at-a-time behaviour, and check still requires one
+# report per class -- several suites open on one thread is exactly what used to collapse them into one.
+$ delete pids
+$ touch expect-threads
+$ touch expect-spread
+> set Test / parallelExecution := true
+> set Test / testForkedParallel := true
+> set Test / testForkedParallelism := Some(2)
+> testFull
+> check
+$ delete expect-threads
+$ delete expect-spread
+> set Test / testForkedParallelism := None
+
+# 8. a class matching two frameworks is two work units, and spreading them would let one class's two
+# runs overlap in different JVMs — two writers on one TEST-<suite>.xml. MarkedFramework2 carries the
+# same fingerprint as MarkedFramework, so E and F match both and the whole group stays in one JVM.
+# Last, because it leaves a framework registered that keeps the group unspreadable.
+$ delete pids
+> set Test / testFrameworks += TestFramework("MarkedFramework2")
+> testFull
+> checkOverlap

--- a/tasks-standard/src/main/scala/sbt/Task.scala
+++ b/tasks-standard/src/main/scala/sbt/Task.scala
@@ -36,6 +36,11 @@ final class Task[A](
   def postTransform(f: (A, AttributeMap) => AttributeMap): Task[A] =
     new Task(attributes, a => f(a, post(a)), work)
 
+  override def priority: Int = getOrElse(Task.Priority, 0)
+
+  /** See [[TaskId.priority]]. */
+  private[sbt] def withPriority(priority: Int): Task[A] = set(Task.Priority, priority)
+
   def tag(tags: Tag*): Task[A] = tagw(tags.map(t => (t, 1))*)
   def tagw(tags: (Tag, Int)*): Task[A] =
     val tgs: TagMap = get(tagsKey).getOrElse(TagMap.empty)
@@ -57,6 +62,7 @@ object Task:
 
   val Name = AttributeKey[String]("name")
   val Description = AttributeKey[String]("description")
+  private[sbt] val Priority = AttributeKey[Int]("priority")
   val defaultAttributeMap = const(AttributeMap.empty)
 
   given taskMonad: Monad[Task] with

--- a/tasks-standard/src/test/scala/CompletionServicePriority.scala
+++ b/tasks-standard/src/test/scala/CompletionServicePriority.scala
@@ -1,0 +1,96 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import java.util.concurrent.{ ConcurrentLinkedQueue, CountDownLatch, TimeUnit }
+
+import org.scalacheck.*
+import Prop.*
+
+import scala.jdk.CollectionConverters.*
+
+object CompletionServicePrioritySpec extends Properties("CompletionServicePriority") {
+
+  private val Timeout = 60
+
+  // A single slot, so every task after the first is held back and the order the service lets them
+  // out in is the only thing the property can be measuring.
+  private def oneSlot = ConcurrentRestrictions.tagged { m =>
+    m.getOrElse(ConcurrentRestrictions.All, 0) <= 1
+  }
+
+  property("the next free slot goes to the task with the lowest priority number") = {
+    val (service, shutdown) = ConcurrentRestrictions.completionService(oneSlot, _ => ())
+    try {
+      val started = new ConcurrentLinkedQueue[String]
+      val occupied = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+
+      def submit(name: String, priority: Int)(body: => Unit): Unit =
+        service.submit(
+          std.TaskExtra.task(()).withPriority(priority),
+          () => {
+            started.add(name)
+            body
+            Execute.completed(())
+          }
+        )
+
+      submit("occupier", 0) {
+        occupied.countDown()
+        release.await(Timeout.toLong, TimeUnit.SECONDS)
+        ()
+      }
+      occupied.await(Timeout.toLong, TimeUnit.SECONDS)
+
+      // Submitted worst first, so plain submission order would run them in exactly this order.
+      submit("second-jvm", 2)(())
+      submit("first-jvm", -1)(())
+      release.countDown()
+
+      (1 to 3).foreach(_ => service.take().process())
+      val order = started.asScala.toList
+      s"ran in order $order" |: (order == List("occupier", "first-jvm", "second-jvm"))
+    } finally shutdown()
+  }
+
+  property("tasks of equal priority keep the order they were held back in") = {
+    val (service, shutdown) = ConcurrentRestrictions.completionService(oneSlot, _ => ())
+    try {
+      val started = new ConcurrentLinkedQueue[String]
+      val occupied = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+
+      def submit(name: String)(body: => Unit): Unit =
+        service.submit(
+          std.TaskExtra.task(()),
+          () => {
+            started.add(name)
+            body
+            Execute.completed(())
+          }
+        )
+
+      submit("occupier") {
+        occupied.countDown()
+        release.await(Timeout.toLong, TimeUnit.SECONDS)
+        ()
+      }
+      occupied.await(Timeout.toLong, TimeUnit.SECONDS)
+
+      val rest = (1 to 5).map(i => s"task-$i")
+      rest.foreach(name => submit(name)(()))
+      release.countDown()
+
+      (0 to rest.size).foreach(_ => service.take().process())
+      val order = started.asScala.toList
+      s"ran in order $order" |: (order == "occupier" :: rest.toList)
+    } finally shutdown()
+  }
+}

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -8,7 +8,7 @@
 
 package sbt
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicLong }
 
 import sbt.internal.util.AttributeKey
 import java.util.concurrent.atomic.AtomicBoolean
@@ -48,7 +48,7 @@ private[sbt] sealed trait CancelSentinels {
   def cancelSentinels(): Unit
 }
 
-import java.util.{ LinkedList, Queue }
+import java.util.{ Comparator, LinkedList, PriorityQueue, Queue }
 import java.util.concurrent.{ Executor, Executors, ExecutorCompletionService }
 import annotation.tailrec
 
@@ -136,6 +136,7 @@ object ConcurrentRestrictions {
     n.foldLeft(m) { case (acc, (a, b)) => update(acc, a, b)(f) }
 
   private val poolID = new AtomicInteger(1)
+  private val enqueueCount = new AtomicLong
 
   /**
    * Constructs a CompletionService suitable for backing task execution based on the provided
@@ -210,7 +211,16 @@ object ConcurrentRestrictions {
   ): CompletionService & CancelSentinels & AutoCloseable = {
 
     // Represents submitted work for a task.
-    final class Enqueue(val node: TaskId[?], val work: () => Completed)
+    final class Enqueue(val node: TaskId[?], val work: () => Completed):
+      val index: Long = enqueueCount.getAndIncrement()
+
+    // `index` breaks priority ties: a total order is required by PriorityQueue, and it is what makes
+    // equal-priority tasks come back out in the order they were held back.
+    val byPriority: Comparator[Enqueue] = (a, b) =>
+      a.node.priority.compareTo(b.node.priority) match {
+        case 0 => a.index.compareTo(b.index)
+        case n => n
+      }
 
     new CompletionService with CancelSentinels with AutoCloseable {
       completionServices.put(this, true)
@@ -231,9 +241,10 @@ object ConcurrentRestrictions {
 
       /**
        * Tasks that cannot be run yet because they cannot execute concurrently with the currently
-       * running tasks.
+       * running tasks. Ordered by [[TaskId.priority]], then by submission, so a task that says it
+       * matters more than the default gets the next free slot even if it asked for one later.
        */
-      private val pending = new LinkedList[Enqueue]
+      private val pending = new PriorityQueue[Enqueue](11, byPriority)
 
       private val sentinels: mutable.ListBuffer[JFuture[?]] = mutable.ListBuffer.empty
 

--- a/tasks/src/main/scala/sbt/TaskId.scala
+++ b/tasks/src/main/scala/sbt/TaskId.scala
@@ -2,3 +2,10 @@ package sbt
 
 trait TaskId[A]:
   def tags: ConcurrentRestrictions.TagMap
+
+  /**
+   * Which task a [[CompletionService]] should start next when one it is holding back becomes
+   * runnable. 0 is the same standing as every other task, negative is increasingly ahead of them,
+   * positive increasingly behind. Equal priorities keep submission order.
+   */
+  def priority: Int = 0

--- a/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
+++ b/testing/src/main/scala/sbt/JUnitXmlTestsListener.scala
@@ -14,8 +14,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Hashtable
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit.NANOSECONDS
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{ AtomicInteger, AtomicReference }
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Properties
@@ -220,19 +221,33 @@ class JUnitXmlTestsListener(val targetDir: File, legacyTestReport: Boolean, logg
     override def initialValue(): SuiteRef = new SuiteRef(None)
   }
 
-  private def withTestSuite[T](f: TestSuite => T): T =
-    testSuite.get().current.map(f).getOrElse(sys.error("no test suite"))
+  /**
+   * Suites started and not yet written, by group name rather than by thread: a forked worker runs a
+   * group's classes concurrently and sbt delivers all their events on the one thread reading that
+   * connection, so several suites are open per thread.
+   */
+  private val openSuites = new ConcurrentHashMap[String, TestSuite]()
+
+  /**
+   * Groups that have called [[doInit]] and not yet [[doComplete]]. One listener serves every group of
+   * a test task and both are per group, so only the last group out may drop what is still open.
+   */
+  private val openRuns = new AtomicInteger(0)
 
   /** Creates the output Dir */
   override def doInit(): Unit = {
+    openRuns.incrementAndGet()
     val _ = targetDir.mkdirs()
   }
 
   /**
    * Starts a new, initially empty Suite with the given name.
    */
-  override def startGroup(name: String): Unit =
-    testSuite.set(new SuiteRef(Some(new TestSuite(name))))
+  override def startGroup(name: String): Unit = {
+    val suite = new TestSuite(name)
+    openSuites.put(name, suite)
+    testSuite.set(new SuiteRef(Some(suite)))
+  }
 
   /**
    * Adds all details for the given even to the current suite.
@@ -245,15 +260,23 @@ class JUnitXmlTestsListener(val targetDir: File, legacyTestReport: Boolean, logg
    * late event into an error line via `TestFramework.safeForeach`.
    */
   override def testEvent(event: TestEvent): Unit =
-    testSuite.get().current match {
-      case Some(suite) => for (e <- event.detail) suite.addEvent(e)
+    for (e <- event.detail) suiteOf(e) match {
+      case Some(suite) => suite.addEvent(e)
       case None        =>
         if (logger != null) {
-          logger.debug(
-            s"ignoring ${event.detail.size} test event(s) reported after the suite was written"
-          )
+          logger.debug("ignoring a test event reported after the suite was written")
         } else ()
     }
+
+  /**
+   * The open suite an event belongs to: the one it names, since that is the only thing telling two
+   * suites on one thread apart, else the thread's own -- for an event named after something other
+   * than its group, a nested task's class say, which only that thread can attribute.
+   */
+  private def suiteOf(e: TEvent): Option[TestSuite] =
+    Option(e.fullyQualifiedName)
+      .flatMap(name => Option(openSuites.get(name)))
+      .orElse(testSuite.get().current)
 
   /**
    * called for each class or equivalent grouping We map one group to one Testsuite, so for each
@@ -284,8 +307,8 @@ class JUnitXmlTestsListener(val targetDir: File, legacyTestReport: Boolean, logg
       def selector = null
       def throwable = new OptionalThrowable(t)
     }
-    withTestSuite(_.addEvent(event))
-    writeSuite()
+    suiteOf(event).foreach(_.addEvent(event))
+    writeSuite(name)
   }
 
   /**
@@ -293,7 +316,7 @@ class JUnitXmlTestsListener(val targetDir: File, legacyTestReport: Boolean, logg
    * that is named after the suite.
    */
   override def endGroup(name: String, result: TestResult): Unit = {
-    writeSuite()
+    writeSuite(name)
   }
 
   // Here we normalize the name to ensure that it's a nicer filename, rather than
@@ -306,29 +329,46 @@ class JUnitXmlTestsListener(val targetDir: File, legacyTestReport: Boolean, logg
   private def formatISO8601DateTime(d: LocalDateTime): String =
     d.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
-  private def writeSuite(): Unit = {
-    val file = if (legacyTestReport) {
-      new File(targetDir, s"${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
-    } else {
-      new File(targetDir, s"TEST-${normalizeName(withTestSuite(_.name))}.xml").getAbsolutePath
-    }
-    if (logger != null) {
-      logger.debug(s"writing JUnit XML test report: $file")
-    }
-    val testSuiteResult = withTestSuite(_.stop())
-    XML.save(file, testSuiteResult, "UTF-8", xmlDecl = true, null)
-    /* Order matters: `clear()` releases the suite for this thread *and* for every thread that
-     * inherited the cell, which `remove()` cannot reach. `remove()` then drops this thread's
-     * own entry. Without the `clear()` the suite -- and through its buffered events the test
-     * class loader with its open jar handles -- would stay reachable from pooled worker threads
-     * for the life of the JVM.
-     */
-    testSuite.get().clear()
-    testSuite.remove()
+  /**
+   * Writes the suite `name` stands for, if it is still open. By name, not by the ending thread: a
+   * suite can end on a thread that never started it, since sbt reports the suites a dying worker left
+   * open from the thread watching that process. Ending a name twice writes it once.
+   */
+  private def writeSuite(name: String): Unit = Option(openSuites.remove(name)) match {
+    case None =>
+      if (logger != null) {
+        logger.debug(s"ignoring the end of test suite $name, which is not open")
+      }
+    case Some(suite) =>
+      val file = if (legacyTestReport) {
+        new File(targetDir, s"${normalizeName(suite.name)}.xml").getAbsolutePath
+      } else {
+        new File(targetDir, s"TEST-${normalizeName(suite.name)}.xml").getAbsolutePath
+      }
+      if (logger != null) {
+        logger.debug(s"writing JUnit XML test report: $file")
+      }
+      XML.save(file, suite.stop(), "UTF-8", xmlDecl = true, null)
+      /* Only when this thread's cell is the suite just written -- the other suites open on this
+       * thread still need theirs. Order matters: `clear()` releases the suite for this thread
+       * *and* for every thread that inherited the cell, which `remove()` cannot reach. `remove()`
+       * then drops this thread's own entry. Without the `clear()` the suite -- and through its
+       * buffered events the test class loader with its open jar handles -- would stay reachable
+       * from pooled worker threads for the life of the JVM.
+       */
+      val ref = testSuite.get()
+      if (ref.current.exists(_ eq suite)) {
+        ref.clear()
+        testSuite.remove()
+      }
   }
 
-  /** Does nothing, as we write each file after a suite is done. */
-  override def doComplete(finalResult: TestResult): Unit = {}
+  /**
+   * Drops any suite left open, which no longer has an end to write it -- but only once the last group
+   * is out, since a suite still open belongs to a group still running. See [[openRuns]].
+   */
+  override def doComplete(finalResult: TestResult): Unit =
+    if (openRuns.decrementAndGet() <= 0) openSuites.clear()
 
   /** Returns None */
   override def contentLogger(test: TestDefinition): Option[ContentLogger] = None

--- a/testing/src/test/scala/sbt/JUnitXmlTestsListenerSpec.scala
+++ b/testing/src/test/scala/sbt/JUnitXmlTestsListenerSpec.scala
@@ -90,7 +90,8 @@ object JUnitXmlTestsListenerSpec extends BasicTestSuite:
 
   test("JUnitXmlTestsListener should release the suite from threads that inherited it"):
     IO.withTemporaryDirectory: tempDir =>
-      val listener = new JUnitXmlTestsListener(tempDir, false, null)
+      val debugMessages = new AtomicReference[List[String]](Nil)
+      val listener = new JUnitXmlTestsListener(tempDir, false, recordingLogger(debugMessages))
       listener.doInit()
 
       def event(name: String) = new TEvent:
@@ -111,7 +112,7 @@ object JUnitXmlTestsListenerSpec extends BasicTestSuite:
       val testEventOutcome = new AtomicReference[Option[Throwable]](None)
       val child = new Thread(() =>
         suiteWritten.await()
-        // The inherited cell must no longer reach a TestSuite, so the strict path fails...
+        // The inherited cell must no longer reach a TestSuite, which the debug line below reports...
         endGroupOutcome.set(
           scala.util.Try(listener.endGroup("InheritSuite", TestResult.Passed)).failed.toOption
         )
@@ -130,12 +131,128 @@ object JUnitXmlTestsListenerSpec extends BasicTestSuite:
       assert(childDone.await(30, java.util.concurrent.TimeUnit.SECONDS), "child thread timed out")
 
       assert(
-        endGroupOutcome.get().isDefined,
-        "a thread that inherited the suite could still reach it after writeSuite"
+        debugMessages.get().exists(_.contains("which is not open")),
+        s"a thread that inherited the suite could still reach it: ${debugMessages.get()}"
+      )
+      assert(
+        endGroupOutcome.get().isEmpty,
+        s"ending a suite this thread never started should be skipped, but threw: ${endGroupOutcome.get()}"
       )
       assert(
         testEventOutcome.get().isEmpty,
         s"a late test event should be dropped, but threw: ${testEventOutcome.get()}"
       )
+      // The report the parent wrote still has its test case: nothing invented an empty replacement.
+      val written = scala.xml.XML.loadFile(new File(tempDir, "TEST-InheritSuite.xml"))
+      assert((written \\ "testcase").size == 1, written.toString)
+
+  test("a suite ended on a thread that never started one is skipped, not an error"):
+    // How sbt reports a forked worker that died mid-suite: the process watch thread ends the suites
+    // the worker left open, and it never saw them start. Raising there used to cost every listener
+    // after this one the crash report.
+    IO.withTemporaryDirectory: tempDir =>
+      val debugMessages = new AtomicReference[List[String]](Nil)
+      val listener = new JUnitXmlTestsListener(tempDir, false, recordingLogger(debugMessages))
+      listener.doInit()
+      listener.endGroup("Crashed", TestResult.Error)
+      listener.endGroup("Crashed", new RuntimeException("the worker died"))
+      assert(tempDir.listFiles().isEmpty, tempDir.listFiles().mkString(", "))
+      assert(debugMessages.get().count(_.contains("which is not open")) == 2)
+
+  test("suites open at the same time on one thread each end as themselves"):
+    // How a forked worker reports a group: it runs the group's classes concurrently, and sbt hands
+    // every one of their events to this listener on the single thread reading that connection. Keyed
+    // by the ending thread, the whole group collapsed into one report under one class's name.
+    IO.withTemporaryDirectory: tempDir =>
+      val listener = new JUnitXmlTestsListener(tempDir, false, null)
+      listener.doInit()
+
+      val names = Vector("SpecA", "SpecB", "SpecC")
+      for (n <- names) listener.startGroup(n)
+      for (n <- names) listener.testEvent(sbt.TestEvent(Seq(passed(n, s"only-$n"))))
+      for (n <- names) listener.endGroup(n, TestResult.Passed)
+
+      // What a suite's report says it is, and which test cases reached it.
+      def summarize(n: String): (String, List[String]) =
+        val report = new File(tempDir, s"TEST-$n.xml")
+        if !report.exists() then ("<no report>", Nil)
+        else
+          val xml = scala.xml.XML.loadFile(report)
+          ((xml \ "@name").text, (xml \\ "testcase" \ "@name").map(_.text).toList)
+
+      val written = names.map(summarize)
+      assert(
+        written == names.map(n => (n, List(s"only-$n"))),
+        s"each suite must end as itself with only its own events, but got: $written"
+      )
+
+  test("a group that finishes does not drop the suites another group still has open"):
+    // One listener serves every group of a project's test task, and doInit/doComplete bracket a
+    // single group -- ForkTests does it per group, and so does TestFramework.createTestTasks. Groups
+    // overlap whenever a build raises Tags.ForkedTestGroup, which is what work stealing asks for, or
+    // puts an in-process group beside a forked one, which needs no setting at all. Clearing the open
+    // suites on the first doComplete took the other group's report with it, and the only trace was a
+    // debug line saying the suite was not open.
+    IO.withTemporaryDirectory: tempDir =>
+      val listener = new JUnitXmlTestsListener(tempDir, false, null)
+      listener.doInit() // the group running FirstGroupSpec
+      listener.doInit() // and the group running SecondGroupSpec, which outlives it
+      listener.startGroup("FirstGroupSpec")
+      listener.startGroup("SecondGroupSpec")
+      listener.testEvent(sbt.TestEvent(Seq(passed("FirstGroupSpec", "first"))))
+      listener.testEvent(sbt.TestEvent(Seq(passed("SecondGroupSpec", "second"))))
+      listener.endGroup("FirstGroupSpec", TestResult.Passed)
+      listener.doComplete(TestResult.Passed)
+      // The second group's suite was open across that doComplete, and its end still has to write it.
+      listener.endGroup("SecondGroupSpec", TestResult.Passed)
+      listener.doComplete(TestResult.Passed)
+
+      val report = new File(tempDir, "TEST-SecondGroupSpec.xml")
+      assert(report.exists(), s"only wrote: ${tempDir.listFiles().mkString(", ")}")
+      val cases = (scala.xml.XML.loadFile(report) \\ "testcase" \ "@name").map(_.text).toList
+      assert(cases == List("second"), cases.toString)
+
+  test("the last group out still drops a suite nothing ended"):
+    // The other half of that contract: a suite whose group died without ending it has no end left to
+    // write it, so once every group is out it must not be held any longer.
+    IO.withTemporaryDirectory: tempDir =>
+      val debugMessages = new AtomicReference[List[String]](Nil)
+      val listener = new JUnitXmlTestsListener(tempDir, false, recordingLogger(debugMessages))
+      listener.doInit()
+      listener.startGroup("AbandonedSpec")
+      listener.doComplete(TestResult.Error)
+      listener.endGroup("AbandonedSpec", TestResult.Error)
+      assert(tempDir.listFiles().isEmpty, tempDir.listFiles().mkString(", "))
+      assert(
+        debugMessages.get().exists(_.contains("which is not open")),
+        debugMessages.get().toString
+      )
+
+  /** A passing event reported by `suite` for the test `testName`. */
+  private def passed(suite: String, testName: String): TEvent =
+    new TEvent:
+      def fullyQualifiedName = suite
+      def duration() = 1L
+      def status = TStatus.Success
+      def fingerprint = null
+      def selector = new TestSelector(testName)
+      def throwable = new OptionalThrowable()
+
+  private def recordingLogger(into: AtomicReference[List[String]]): AbstractLogger =
+    new AbstractLogger:
+      def getLevel: Level.Value = Level.Debug
+      def setLevel(newLevel: Level.Value): Unit = ()
+      def getTrace: Int = 0
+      def setTrace(flag: Int): Unit = ()
+      def successEnabled: Boolean = false
+      def setSuccessEnabled(flag: Boolean): Unit = ()
+      def control(event: ControlEvent.Value, message: => String): Unit = ()
+      def logAll(events: Seq[LogEvent]): Unit = ()
+      def trace(t: => Throwable): Unit = ()
+      def success(message: => String): Unit = ()
+      def log(level: Level.Value, message: => String): Unit =
+        if level == Level.Debug then
+          into.updateAndGet(_ :+ message)
+          ()
 
 end JUnitXmlTestsListenerSpec

--- a/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
@@ -198,7 +198,13 @@ public class ForkTestMain {
 
   public static void main(long id, TestInfo info, PrintStream originalOut, ClassLoader classLoader)
       throws Exception {
-    new Run(originalOut, id).run(info, classLoader);
+    main(id, info, originalOut, classLoader, null);
+  }
+
+  public static void main(
+      long id, TestInfo info, PrintStream originalOut, ClassLoader classLoader, WorkerRpc rpc)
+      throws Exception {
+    new Run(originalOut, id, rpc).run(info, classLoader);
   }
 
   // ----------------------------------------------------------------------------------------------------------------
@@ -207,11 +213,13 @@ public class ForkTestMain {
     final PrintStream originalOut;
     final long id;
     final Gson gson;
+    final WorkerRpc rpc;
 
-    Run(PrintStream originalOut, long id) {
+    Run(PrintStream originalOut, long id, WorkerRpc rpc) {
       this.originalOut = originalOut;
       this.id = id;
       this.gson = WorkerMain.mkGson();
+      this.rpc = rpc;
     }
 
     private void run(TestInfo info, ClassLoader classLoader) {
@@ -358,8 +366,15 @@ public class ForkTestMain {
       this.originalOut.flush();
     }
 
-    private ExecutorService executorService(final boolean parallel, final Integer parallelism) {
-      if (parallel) {
+    private ExecutorService executorService(
+        final boolean parallel, final Integer parallelism, final boolean queueMode) {
+      if (queueMode) {
+        // Nothing submitted here waits on anything else submitted here, so a fixed pool cannot
+        // deadlock.
+        final int nbThreads = stealerCount(parallel, parallelism);
+        logDebug("Create a test executor with a thread pool of " + nbThreads + " threads.");
+        return Executors.newFixedThreadPool(nbThreads);
+      } else if (parallel) {
         final int nbThreads =
             (parallelism != null && parallelism > 0)
                 ? parallelism
@@ -374,12 +389,28 @@ public class ForkTestMain {
 
     private void runTests(TestInfo info, ClassLoader classLoader) throws Exception {
       Thread.currentThread().setContextClassLoader(classLoader);
-      final ExecutorService executor = executorService(info.parallel, info.parallelism);
+      final ExecutorService executor =
+          executorService(info.parallel, info.parallelism, info.queueMode);
       final TaskDef[] tests = info.taskDefs.toArray(new TaskDef[] {});
-      final int nFrameworks = info.testRunners.size();
       final Logger[] loggers = {remoteLogger(info.ansiCodesSupported)};
 
-      for (TestInfo.TestRunner testRunner : info.testRunners) {
+      try {
+        runFrameworks(info, classLoader, executor, tests, loggers);
+      } finally {
+        // The worker JVM exits at the end of a run, so only an in-process driver notices the pool.
+        executor.shutdown();
+      }
+    }
+
+    private void runFrameworks(
+        TestInfo info,
+        ClassLoader classLoader,
+        final ExecutorService executor,
+        final TaskDef[] tests,
+        final Logger[] loggers)
+        throws Exception {
+      for (int frameworkIndex = 0; frameworkIndex < info.testRunners.size(); frameworkIndex++) {
+        final TestInfo.TestRunner testRunner = info.testRunners.get(frameworkIndex);
         final String[] frameworkArgs = testRunner.mainRunnerArgs.toArray(new String[] {});
         final String[] remoteFrameworkArgs =
             testRunner.mainRunnerRemoteArgs.toArray(new String[] {});
@@ -397,41 +428,134 @@ public class ForkTestMain {
           }
         }
 
-        if (framework == null) continue;
+        // sbt only sends frameworks it loaded from this same classpath. Skipping one that fails to
+        // load here would run none of its classes and still exit 0.
+        if (framework == null)
+          throw new IllegalStateException(
+              "Could not load test framework "
+                  + testRunner.implClassNames
+                  + " in the forked JVM, so none of the test classes it matched would have run");
 
-        final LinkedHashSet<TaskDef> filteredTests = new LinkedHashSet<>();
-        for (final Fingerprint testFingerprint : framework.fingerprints()) {
-          for (final TaskDef test : tests) {
-            // TODO: To pass in correct explicitlySpecified and selectors
-            if (matches(testFingerprint, test.fingerprint()))
-              filteredTests.add(
-                  new TaskDef(
-                      test.fullyQualifiedName(),
-                      test.fingerprint(),
-                      test.explicitlySpecified(),
-                      test.selectors()));
-          }
-        }
         final Runner runner = framework.runner(frameworkArgs, remoteFrameworkArgs, classLoader);
-        final Task[] tasks = runner.tasks(filteredTests.toArray(new TaskDef[filteredTests.size()]));
-        logDebug(
-            "Runner for "
-                + framework.getClass().getName()
-                + " produced "
-                + tasks.length
-                + " initial tasks for "
-                + filteredTests.size()
-                + " tests.");
 
         Thread callDoneOnShutdown = new Thread(() -> runner.done());
         Runtime.getRuntime().addShutdownHook(callDoneOnShutdown);
 
-        runTestTasks(executor, tasks, loggers);
+        if (info.queueMode) {
+          logDebug(
+              "Runner for " + framework.getClass().getName() + " will steal from sbt's queue.");
+          // `tests`, not a filtered set: sbt hands out indices into the full taskDefs vector.
+          runStealing(
+              runner, tests, frameworkIndex, loggers, executor, info.parallel, info.parallelism);
+        } else {
+          final LinkedHashSet<TaskDef> filteredTests = new LinkedHashSet<>();
+          for (final Fingerprint testFingerprint : framework.fingerprints()) {
+            for (final TaskDef test : tests) {
+              // TODO: To pass in correct explicitlySpecified and selectors
+              if (matches(testFingerprint, test.fingerprint()))
+                filteredTests.add(
+                    new TaskDef(
+                        test.fullyQualifiedName(),
+                        test.fingerprint(),
+                        test.explicitlySpecified(),
+                        test.selectors()));
+            }
+          }
+          final Task[] tasks =
+              runner.tasks(filteredTests.toArray(new TaskDef[filteredTests.size()]));
+          logDebug(
+              "Runner for "
+                  + framework.getClass().getName()
+                  + " produced "
+                  + tasks.length
+                  + " initial tasks for "
+                  + filteredTests.size()
+                  + " tests.");
+          runTestTasks(executor, tasks, loggers);
+        }
 
         runner.done();
 
         Runtime.getRuntime().removeShutdownHook(callDoneOnShutdown);
       }
+    }
+
+    /**
+     * How many classes this worker runs at once in queue mode: one unless asked for more, since the
+     * JVM count is the parallelism dial. `parallel` off means one whatever the thread count.
+     */
+    private static int stealerCount(final boolean parallel, final Integer parallelism) {
+      if (!parallel) return 1;
+      return (parallelism != null && parallelism > 0) ? parallelism : 1;
+    }
+
+    private void runStealing(
+        final Runner runner,
+        final TaskDef[] all,
+        final int frameworkIndex,
+        final Logger[] loggers,
+        final ExecutorService executor,
+        final boolean parallel,
+        final Integer parallelism) {
+      // Queue mode over a transport with no reply channel; returning would run no tests at all.
+      if (this.rpc == null)
+        throw new IllegalStateException(
+            "sbt asked this worker to lease test classes but gave it no channel to ask on");
+      final int threads = stealerCount(parallel, parallelism);
+      // A pool of its own: each steal loop blocks on futures it submits to `executor`.
+      final ExecutorService stealerPool = Executors.newFixedThreadPool(threads);
+      final List<Future<?>> stealers = new ArrayList<>();
+      for (int t = 0; t < threads; t++) {
+        stealers.add(
+            stealerPool.submit(
+                () -> {
+                  // Each request acknowledges the class this thread just finished, so sbt can
+                  // tell a class that ran from one that was handed out and lost.
+                  String done = "null";
+                  while (true) {
+                    final String params =
+                        String.format(
+                            "{\"id\": %d, \"framework\": %d, \"done\": %s}",
+                            this.id, frameworkIndex, done);
+                    final Integer i = this.rpc.requestIndex("nextTest", params);
+                    if (i == null) {
+                      if (this.rpc.isBroken())
+                        throw new IllegalStateException(
+                            "Lost contact with sbt while asking for the next test class to run");
+                      return null;
+                    }
+                    if (i < 0 || i >= all.length)
+                      throw new IllegalStateException(
+                          "sbt handed out test index "
+                              + i
+                              + ", which is not one of the "
+                              + all.length
+                              + " test classes this worker was given");
+                    runTestTasks(executor, runner.tasks(new TaskDef[] {all[i]}), loggers);
+                    // Acknowledged only once the class and its nested tasks are finished.
+                    done = i.toString();
+                  }
+                }));
+      }
+      // Join every thread before failing, so none reports into a session sbt gave up on.
+      Throwable failure = null;
+      try {
+        for (final Future<?> s : stealers) {
+          try {
+            s.get();
+          } catch (final ExecutionException e) {
+            if (failure == null) failure = e.getCause() == null ? e : e.getCause();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (failure == null) failure = e;
+          }
+        }
+      } finally {
+        stealerPool.shutdown();
+      }
+      // Exiting 0 would drop the failing thread's unacknowledged lease from the report.
+      if (failure != null)
+        throw new RuntimeException("A forked test worker thread failed: " + failure, failure);
     }
 
     private void runTestTasks(
@@ -446,13 +570,25 @@ public class ForkTestMain {
         // executes immediately the nested tasks
         //       At the moment, I'm especially interested in JUnit, which doesn't have nested tasks.
         final List<Task> nestedTasks = new ArrayList<>();
+        // Join every task before raising, so none of them reports into a run already given up on.
+        Throwable failure = null;
         for (final Future<Task[]> futureNestedTask : futureNestedTasks) {
           try {
             nestedTasks.addAll(Arrays.asList(futureNestedTask.get()));
-          } catch (final Exception e) {
-            logError("Failed to execute task " + futureNestedTask);
+          } catch (final ExecutionException e) {
+            final Throwable cause = e.getCause() == null ? e : e.getCause();
+            logError("Failed to execute a test task: " + cause);
+            if (failure == null) failure = cause;
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (failure == null) failure = e;
           }
         }
+        // A task can fail outside runTest's guard -- writing the group's start or end, or asking
+        // the
+        // task what it is. Swallowed, the class reported nothing while its lease was acknowledged.
+        if (failure != null)
+          throw new RuntimeException("A forked test task failed: " + failure, failure);
         runTestTasks(executor, nestedTasks.toArray(new Task[nestedTasks.size()]), loggers);
       }
     }

--- a/worker/src/main/java/sbt/internal/worker1/TestInfo.java
+++ b/worker/src/main/java/sbt/internal/worker1/TestInfo.java
@@ -37,6 +37,12 @@ public class TestInfo implements Serializable {
   public final ArrayList<TaskDef> taskDefs;
   public final ArrayList<TestRunner> testRunners;
 
+  /**
+   * When true, the worker leases test classes one at a time from sbt via the {@code nextTest}
+   * request instead of running the whole {@code taskDefs} batch it was given.
+   */
+  public final boolean queueMode;
+
   public TestInfo(
       boolean jvm,
       RunInfo.JvmRunInfo jvmRunInfo,
@@ -46,6 +52,28 @@ public class TestInfo implements Serializable {
       Integer parallelism,
       ArrayList<TaskDef> taskDefs,
       ArrayList<TestRunner> testRunners) {
+    this(
+        jvm,
+        jvmRunInfo,
+        nativeRunInfo,
+        ansiCodesSupported,
+        parallel,
+        parallelism,
+        taskDefs,
+        testRunners,
+        false);
+  }
+
+  public TestInfo(
+      boolean jvm,
+      RunInfo.JvmRunInfo jvmRunInfo,
+      RunInfo.NativeRunInfo nativeRunInfo,
+      boolean ansiCodesSupported,
+      boolean parallel,
+      Integer parallelism,
+      ArrayList<TaskDef> taskDefs,
+      ArrayList<TestRunner> testRunners,
+      boolean queueMode) {
     this.jvm = jvm;
     this.jvmRunInfo = jvmRunInfo;
     this.nativeRunInfo = nativeRunInfo;
@@ -54,5 +82,6 @@ public class TestInfo implements Serializable {
     this.parallelism = parallelism;
     this.taskDefs = taskDefs;
     this.testRunners = testRunners;
+    this.queueMode = queueMode;
   }
 }

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -21,6 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Scanner;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.scalasbt.shadedgson.com.google.gson.Gson;
 import org.scalasbt.shadedgson.com.google.gson.GsonBuilder;
 import org.scalasbt.shadedgson.com.google.gson.JsonElement;
@@ -34,6 +36,12 @@ import sbt.testing.*;
  * (https://www.jsonrpc.org/specification).
  */
 public final class WorkerMain {
+  /**
+   * How long to wait for sbt to answer a request. Deliberately generous: if sbt goes away the
+   * socket EOF releases every waiter anyway, and timing out is fatal to the run.
+   */
+  private static final long RPC_TIMEOUT_MILLIS = 600000L;
+
   private PrintStream originalOut;
   private InputStream originalIn;
 
@@ -41,6 +49,7 @@ public final class WorkerMain {
   // When using tcp, this is going to be the socket out
   private PrintStream jsonOut;
   private Scanner inScanner;
+  private WorkerRpc rpc;
 
   public static Gson mkGson() {
     RuntimeTypeAdapterFactory<Fingerprint> fingerprintFac =
@@ -115,10 +124,15 @@ public final class WorkerMain {
     Socket client = new Socket(loopback, serverPort);
     this.jsonOut = new PrintStream(client.getOutputStream(), true, "UTF-8");
     this.inScanner = new Scanner(client.getInputStream(), "UTF-8");
-    if (this.inScanner.hasNextLine()) {
-      String line = this.inScanner.nextLine();
-      process(line);
-    }
+    this.rpc = new WorkerRpc(this.jsonOut, this.inScanner, RPC_TIMEOUT_MILLIS);
+    // The request runs here, not on the reader thread: in queue mode the test session blocks on
+    // nextTest replies that only the reader thread can deliver.
+    final BlockingQueue<String> requests = new LinkedBlockingQueue<>();
+    final String endOfStream = new String(); // sentinel, compared by reference
+    this.rpc.start(requests::add, () -> requests.add(endOfStream));
+    final String line = requests.take();
+    if (line != endOfStream) process(line);
+    this.rpc.close();
   }
 
   /** This processes single request of supposed JSON line. */
@@ -187,10 +201,10 @@ public final class WorkerMain {
       ClassLoader parent = new ForkTestMain().getClass().getClassLoader();
       // empty virtual classpath means raw mode
       if (jvmRunInfo.classpath.isEmpty()) {
-        ForkTestMain.main(id, info, this.jsonOut, parent);
+        ForkTestMain.main(id, info, this.jsonOut, parent, this.rpc);
       } else {
         try (URLClassLoader cl = createClassLoader(jvmRunInfo, parent)) {
-          ForkTestMain.main(id, info, this.jsonOut, cl);
+          ForkTestMain.main(id, info, this.jsonOut, cl, this.rpc);
         }
       }
     } else {

--- a/worker/src/main/java/sbt/internal/worker1/WorkerRpc.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerRpc.java
@@ -1,0 +1,150 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal.worker1;
+
+import java.io.PrintStream;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.scalasbt.shadedgson.com.google.gson.JsonElement;
+import org.scalasbt.shadedgson.com.google.gson.JsonObject;
+import org.scalasbt.shadedgson.com.google.gson.JsonParser;
+
+/**
+ * Correlates JSON-RPC requests the worker sends to sbt with their replies. A single reader thread
+ * owns the socket: replies complete the matching future, every other line goes to the handler
+ * supplied to {@link #start}. Every failure resolves to a {@code null} reply rather than throwing,
+ * so a null means "no more work" or "channel failed" — {@link #isBroken()} tells them apart.
+ */
+public final class WorkerRpc {
+  private final PrintStream out;
+  private final Scanner in;
+  private final long timeoutMillis;
+  private final AtomicLong nextId = new AtomicLong(1000000L);
+  private final ConcurrentHashMap<Long, CompletableFuture<JsonElement>> pending =
+      new ConcurrentHashMap<>();
+  private volatile boolean closed = false;
+  private volatile boolean broken = false;
+
+  public WorkerRpc(final PrintStream out, final Scanner in, final long timeoutMillis) {
+    this.out = out;
+    this.in = in;
+    this.timeoutMillis = timeoutMillis;
+  }
+
+  /**
+   * Starts the reader thread. Non-reply lines go to onRequest; onEnd runs once when the reader
+   * stops for any reason.
+   */
+  public void start(final Consumer<String> onRequest, final Runnable onEnd) {
+    final Thread reader =
+        new Thread(
+            () -> {
+              try {
+                while (!closed && in.hasNextLine()) {
+                  final String line = in.nextLine();
+                  if (!completeIfReply(line)) onRequest.accept(line);
+                }
+                // Running out of lines before close() means sbt went away.
+                if (!closed) broken = true;
+              } catch (final Throwable t) {
+                broken = true;
+              } finally {
+                failAllPending();
+                onEnd.run();
+              }
+            });
+    reader.setName("sbt-worker-rpc-reader");
+    reader.setDaemon(true);
+    reader.start();
+  }
+
+  private boolean completeIfReply(final String line) {
+    final JsonObject o;
+    try {
+      o = JsonParser.parseString(line).getAsJsonObject();
+    } catch (final Throwable t) {
+      return false;
+    }
+    if (o.has("method") || !o.has("id")) return false;
+    if (!o.has("result") && !o.has("error")) return false;
+    final long id;
+    try {
+      id = o.getAsJsonPrimitive("id").getAsLong();
+    } catch (final Throwable t) {
+      return false;
+    }
+    final CompletableFuture<JsonElement> f = pending.remove(id);
+    if (f == null) return false;
+    if (o.has("error")) {
+      broken = true;
+      f.complete(null);
+    } else {
+      f.complete(o.get("result"));
+    }
+    return true;
+  }
+
+  private void failAllPending() {
+    for (final Long key : pending.keySet()) {
+      final CompletableFuture<JsonElement> f = pending.remove(key);
+      if (f != null) f.complete(null);
+    }
+  }
+
+  /** Whether the channel failed, so a null reply must not be read as "no more work". */
+  public boolean isBroken() {
+    return broken;
+  }
+
+  /**
+   * Sends a request and blocks for its reply, returning the {@code result} as an Integer, or null
+   * on a JSON null, EOF, timeout, or error reply — check {@link #isBroken()} to tell "no more work"
+   * from a channel failure.
+   */
+  public Integer requestIndex(final String method, final String params) {
+    // `broken` too: a stopped reader has drained `pending`, so a future registered later is never
+    // completed and the caller would wait out the ten-minute reply timeout.
+    if (closed || broken) return null;
+    final long id = nextId.getAndIncrement();
+    final CompletableFuture<JsonElement> f = new CompletableFuture<>();
+    pending.put(id, f);
+    // Again after registering: the reader sets the flag before draining `pending`, so whichever way
+    // the two interleave, one of these checks sees it. The check above alone cannot.
+    if (closed || broken) {
+      pending.remove(id);
+      return null;
+    }
+    synchronized (out) {
+      out.println(
+          String.format(
+              "{ \"jsonrpc\": \"2.0\", \"method\": \"%s\", \"params\": %s, \"id\": %d }",
+              method, params, id));
+      out.flush();
+    }
+    try {
+      final JsonElement result = f.get(timeoutMillis, TimeUnit.MILLISECONDS);
+      if (result == null || result.isJsonNull()) return null;
+      return Integer.valueOf(result.getAsInt());
+    } catch (final Throwable t) {
+      // Timed out, interrupted, or the reply was not an int; not a clean drain.
+      broken = true;
+      pending.remove(id);
+      return null;
+    }
+  }
+
+  public void close() {
+    closed = true;
+    failAllPending();
+  }
+}

--- a/worker/src/test/scala/sbt/internal/worker1/StealingFramework.scala
+++ b/worker/src/test/scala/sbt/internal/worker1/StealingFramework.scala
@@ -1,0 +1,105 @@
+package sbt.internal.worker1
+
+import sbt.testing.*
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A framework whose only job is to record which classes a run was handed, so a test can drive
+ * [[ForkTestMain]]'s queue mode against it. Loaded by name from the worker, as a real one is.
+ */
+object StealingFramework:
+  /** Classes executed, in completion order, across every run in this JVM. */
+  val executed: ConcurrentLinkedQueue[String] = ConcurrentLinkedQueue()
+
+  /** Set to make that class's task throw, standing in for a test that dies mid-run. */
+  @volatile var failOn: Option[String] = None
+
+  /** Set to make `tasks` throw for that class, standing in for a framework that cannot load it. */
+  @volatile var failTasksOn: Option[String] = None
+
+  /**
+   * Set to make that class's task refuse to say what it is. The worker asks before it starts
+   * guarding the run, so this fails the task's future rather than becoming a reported test error --
+   * the same place writing a group's start or end would fail.
+   */
+  @volatile var failTaskDefOn: Option[String] = None
+
+  /**
+   * Classes whose task returns one nested task, keyed by class name. This is how ScalaTest and
+   * specs2 hand a nested suite back to the runner rather than running it themselves.
+   */
+  @volatile var nestedOf: Map[String, String] = Map.empty
+
+  /** Times `Runner.done` was called, which is where a framework flushes its run summary. */
+  val doneCalls: AtomicInteger = AtomicInteger(0)
+
+  private val running = AtomicInteger(0)
+
+  /** The most classes this JVM ever had under way at once. */
+  val peak: AtomicInteger = AtomicInteger(0)
+
+  /** Held long enough for an overlapping run to be visible in `peak`. */
+  private def occupy(): Unit =
+    val now = running.incrementAndGet()
+    peak.getAndUpdate(p => math.max(p, now))
+    Thread.sleep(50)
+    running.decrementAndGet()
+    ()
+
+  val print: SubclassFingerprint = new SubclassFingerprint:
+    def isModule(): Boolean = false
+    def superclassName(): String = "junit.framework.TestCase"
+    def requireNoArgConstructor(): Boolean = false
+
+  def reset(): Unit =
+    executed.clear()
+    failOn = None
+    failTasksOn = None
+    failTaskDefOn = None
+    nestedOf = Map.empty
+    doneCalls.set(0)
+    running.set(0)
+    peak.set(0)
+
+class StealingFramework extends Framework:
+  def name(): String = "stealing"
+  def fingerprints(): Array[Fingerprint] = Array(StealingFramework.print)
+  def runner(args: Array[String], remoteArgs: Array[String], loader: ClassLoader): Runner =
+    new Runner:
+      def args(): Array[String] = Array.empty
+      def remoteArgs(): Array[String] = Array.empty
+      def done(): String =
+        StealingFramework.doneCalls.incrementAndGet()
+        ""
+      def tasks(defs: Array[TaskDef]): Array[Task] =
+        defs
+          .find(d => StealingFramework.failTasksOn.contains(d.fullyQualifiedName()))
+          .foreach: d =>
+            throw RuntimeException(s"${d.fullyQualifiedName()} cannot be loaded")
+        defs.map(task)
+
+  private def task(td: TaskDef): Task = new Task:
+    def taskDef(): TaskDef =
+      if StealingFramework.failTaskDefOn.contains(td.fullyQualifiedName()) then
+        throw RuntimeException(s"${td.fullyQualifiedName()} will not say what it is")
+      td
+    def tags(): Array[String] = Array.empty
+    def execute(handler: EventHandler, loggers: Array[Logger]): Array[Task] =
+      val name = td.fullyQualifiedName()
+      if StealingFramework.failOn.contains(name) then
+        throw RuntimeException(s"$name was told to fail")
+      StealingFramework.occupy()
+      StealingFramework.executed.add(name)
+      handler.handle(new Event:
+        def fullyQualifiedName(): String = name
+        def fingerprint(): Fingerprint = StealingFramework.print
+        def selector(): Selector = SuiteSelector()
+        def status(): Status = Status.Success
+        def throwable(): OptionalThrowable = OptionalThrowable()
+        def duration(): Long = 1L)
+      // Handed back for the runner to execute, not run here — the worker has to walk into it.
+      StealingFramework.nestedOf.get(name) match
+        case Some(child) =>
+          Array(task(TaskDef(child, StealingFramework.print, false, Array(SuiteSelector()))))
+        case None => Array.empty

--- a/worker/src/test/scala/sbt/internal/worker1/WorkerTest.scala
+++ b/worker/src/test/scala/sbt/internal/worker1/WorkerTest.scala
@@ -1,19 +1,625 @@
 package sbt.internal.worker1
 
-import sbt.io.IO
+import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser }
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  PipedInputStream,
+  PipedOutputStream,
+  PrintStream
+}
+import sbt.testing.*
+import java.net.{ InetAddress, ServerSocket }
+import java.util.{ ArrayList, List as JList, Scanner }
+import java.util.concurrent.{ Callable, ConcurrentLinkedQueue, CountDownLatch, Executors, TimeUnit }
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters.*
 
+/**
+ * Every request a test here feeds `WorkerMain` must be well-formed JSON-RPC.
+ *
+ * This project's tests run unforked -- see `workerProj` in build.sbt for why -- so they share the sbt
+ * server's JVM, and `WorkerMain.process` calls `System.exit(1)` on a request with no "jsonrpc" field.
+ * Forked that ends one worker; here it takes the whole build down, with no diagnostic to say which
+ * test did it.
+ */
 object WorkerTest extends verify.BasicTestSuite:
-  val main = WorkerMain()
 
-  test("process") {
-    val u0 = IO.classLocationPath(classOf[example.Hello]).toUri()
-    val u1 = IO.classLocationPath(classOf[scala.quoted.Quotes]).toUri()
-    val u2 = IO.classLocationPath(classOf[scala.collection.immutable.List[?]]).toUri()
-    val cp =
-      s"""[{ "path": "${u0}", "digest": "" }, { "path": "${u1}", "digest": "" }, { "path": "${u2}", "digest": "" }]"""
+  test("the reader reports the end of the stream even when no request ever arrives") {
+    // socketWork blocks taking the one request the reader hands over, and when sbt goes away
+    // before sending anything only the end-of-stream signal stops the JVM waiting there forever.
+    val out = PrintStream(ByteArrayOutputStream())
+    val in = Scanner(ByteArrayInputStream(Array.empty[Byte]), "UTF-8")
+    val rpc = WorkerRpc(out, in, 1000L)
+    val ended = CountDownLatch(1)
+    val requests = AtomicInteger(0)
+    rpc.start(_ => { requests.incrementAndGet(); () }, () => ended.countDown())
+    // A generous bound, not a timing assertion: this can only fail if the signal never fires.
+    assert(ended.await(30, TimeUnit.SECONDS))
+    assert(requests.get() == 0)
+    // Running out of lines before close() means sbt went away, which is not a drained queue.
+    assert(rpc.isBroken())
+    rpc.close()
+  }
+
+  /**
+   * Runs `body` against a WorkerRpc whose sbt answers each request id with `reply(id)`; a None
+   * leaves that request unanswered.
+   */
+  private def withFakeSbt[A](timeoutMillis: Long, onRequest: String => Unit = _ => ())(
+      reply: Long => Option[String]
+  )(
+      body: WorkerRpc => A
+  ): A =
+    val sbtIn = PipedInputStream(64 * 1024)
+    val workerOut = PrintStream(PipedOutputStream(sbtIn), true, "UTF-8")
+    val workerIn = PipedInputStream(64 * 1024)
+    val sbtOut = PrintStream(PipedOutputStream(workerIn), true, "UTF-8")
+    val rpc = WorkerRpc(workerOut, Scanner(workerIn, "UTF-8"), timeoutMillis)
+    rpc.start(onRequest(_), () => ())
+    val fakeSbt = Thread(() => {
+      // Ends by throwing when the pipe closes, which is how this thread is meant to stop.
+      try
+        val scanner = Scanner(sbtIn, "UTF-8")
+        while scanner.hasNextLine() do
+          val o = JsonParser.parseString(scanner.nextLine()).getAsJsonObject()
+          reply(o.getAsJsonPrimitive("id").getAsLong()).foreach(sbtOut.println)
+      catch case _: Throwable => ()
+    })
+    fakeSbt.setDaemon(true)
+    fakeSbt.start()
+    try body(rpc)
+    finally
+      rpc.close()
+      workerOut.close()
+      sbtOut.close()
+
+  test("a null result means no more work, which is not a broken channel") {
+    // The distinction the whole run rests on: a drained queue must let the worker finish and exit 0,
+    // while a channel failure must be fatal. Read the wrong way round, either every healthy run
+    // fails or a worker silently abandons the classes sbt handed it.
+    withFakeSbt(30000L)(id => Some(s"""{ "jsonrpc": "2.0", "result": null, "id": $id }""")): rpc =>
+      val got = rpc.requestIndex("nextTest", """{"id": 1, "framework": 0, "done": null}""")
+      assert(got == null)
+      assert(!rpc.isBroken())
+  }
+
+  test("an error reply is a broken channel, not a drained queue") {
+    withFakeSbt(30000L)(id => Some(s"""{ "jsonrpc": "2.0", "error": {"code": 1}, "id": $id }""")):
+      rpc =>
+        assert(rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""") == null)
+        assert(rpc.isBroken())
+  }
+
+  test("a request sbt never answers times out as a broken channel") {
+    // Short on purpose: the assertion is that the wait ends at all and is not read as "no work".
+    withFakeSbt(500L)(_ => None): rpc =>
+      assert(rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""") == null)
+      assert(rpc.isBroken())
+  }
+
+  test("a request after close is refused rather than left waiting") {
+    withFakeSbt(30000L)(id => Some(s"""{ "jsonrpc": "2.0", "result": 0, "id": $id }""")): rpc =>
+      rpc.close()
+      assert(rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""") == null)
+  }
+
+  test("a request after the channel broke is refused rather than left waiting") {
+    // The shape this takes in a real run: sbt goes away while a stealer is part way through a class,
+    // and the request that stealer makes when the class finishes arrives after the reader thread has
+    // already failed every future it found waiting. Nothing is left to complete a future registered
+    // after that, so the caller would sit out the reply timeout -- ten minutes -- and runStealing
+    // joins every stealer before it fails, which keeps the whole worker JVM alive that long after
+    // sbt is gone.
+    val out = PrintStream(ByteArrayOutputStream())
+    val in = Scanner(ByteArrayInputStream(Array.empty[Byte]), "UTF-8")
+    val rpc = WorkerRpc(out, in, 600000L)
+    val ended = CountDownLatch(1)
+    rpc.start(_ => (), () => ended.countDown())
+    assert(ended.await(30, TimeUnit.SECONDS), "the reader never reported the end of the stream")
+    assert(rpc.isBroken())
+
+    val returned = CountDownLatch(1)
+    val caller = Thread(() => {
+      val _ = rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""")
+      returned.countDown()
+    })
+    caller.setDaemon(true)
+    caller.start()
+    // A generous bound, not a timing assertion: the wait it replaces is the ten minute timeout above.
+    assert(returned.await(30, TimeUnit.SECONDS), "a request made after EOF waited for the timeout")
+    rpc.close()
+  }
+
+  test("closing the channel releases a request already waiting on it") {
+    // The other half of that contract: a caller registered before the close must be let go, not left
+    // on the reply timeout, which is ten minutes. Nothing closes mid-run today, so this pins the
+    // release for whatever cancellation path is added next.
+    val asked = CountDownLatch(1)
+    // Never answered, so the only way out is the close below.
+    withFakeSbt(600000L)(_ => { asked.countDown(); None }): rpc =>
+      val returned = CountDownLatch(1)
+      val caller = Thread(() => {
+        val _ = rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""")
+        returned.countDown()
+      })
+      caller.setDaemon(true)
+      caller.start()
+      // sbt having read the request means it was registered first: requestIndex puts the future in
+      // `pending` before writing. Without this the close could win the race and take the cheap
+      // `closed` path instead, which is the case above.
+      assert(asked.await(30, TimeUnit.SECONDS), "the request was never written")
+      rpc.close()
+      assert(returned.await(30, TimeUnit.SECONDS), "close left the caller on the reply timeout")
+  }
+
+  test("a line carrying a method is never taken as a reply") {
+    // sbt's requests and its replies share one channel. Matching a request as a reply would both
+    // complete a waiting stealer with a payload meant for nobody and lose the request, so the shape
+    // decides this, not whether the id happens to be outstanding.
+    val served = ConcurrentLinkedQueue[String]()
+    // Well-formed but for the `method`, and carrying this request's own id: only the method tells it
+    // apart from the reply the caller is waiting for.
+    withFakeSbt(1500L, s => { served.add(s); () })(id =>
+      Some(s"""{ "jsonrpc": "2.0", "method": "ping", "params": {}, "result": 7, "id": $id }""")
+    ): rpc =>
+      val got = rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""")
+      assert(got == null, s"a request completed a pending reply with $got")
+      val lines = served.toArray(Array.empty[String]).toVector
+      assert(lines.size == 1 && lines.head.contains("\"method\""), s"served=$lines")
+  }
+
+  test("a line carrying neither a result nor an error is never taken as a reply") {
+    // The other half of the reply shape, the `method` case above being the first. A line with a
+    // matching id but no payload would complete the waiting stealer with nothing, and a null that is
+    // not marked broken means "the queue is drained" -- so the worker would stop leasing and exit 0.
+    // sbt's undrained-queue check is the backstop for that, so what this guard buys is the run
+    // failing where the two sides disagreed rather than one layer out.
+    val served = ConcurrentLinkedQueue[String]()
+    withFakeSbt(1500L, s => { served.add(s); () })(id =>
+      Some(s"""{ "jsonrpc": "2.0", "id": $id }""")
+    ): rpc =>
+      val got = rpc.requestIndex("nextTest", """{"id": 1, "framework": 0}""")
+      assert(got == null, s"a payloadless line completed a pending reply with $got")
+      assert(rpc.isBroken(), "a request nothing answered must not read as a drained queue")
+      val lines = served.toArray(Array.empty[String]).toVector
+      assert(lines.size == 1 && !lines.head.contains("result"), s"served=$lines")
+  }
+
+  test("concurrent requests each get their own reply, whatever order sbt answers in") {
+    // The stealer threads of one worker share a WorkerRpc, so a reply matched by arrival rather
+    // than by id would hand a thread the class index meant for another: one class run twice and
+    // another never run, which the queue's own accounting cannot see.
+    val callers = 8
+    // Requests the worker writes and the fake sbt below reads.
+    val sbtIn = PipedInputStream(64 * 1024)
+    val workerOut = PrintStream(PipedOutputStream(sbtIn), true, "UTF-8")
+    // Replies the fake sbt writes and the rpc reader thread reads.
+    val workerIn = PipedInputStream(64 * 1024)
+    val sbtOut = PrintStream(PipedOutputStream(workerIn), true, "UTF-8")
+    val rpc = WorkerRpc(workerOut, Scanner(workerIn, "UTF-8"), 30000L)
+    rpc.start(_ => (), () => ())
+
+    // Holds every request until all of them have arrived, then answers in reverse, so the replies
+    // come back in the opposite order to the asking. Each caller asked for its own number back.
+    val fakeSbt = Thread(() => {
+      val scanner = Scanner(sbtIn, "UTF-8")
+      val pending = ListBuffer.empty[(Long, Int)]
+      while pending.size < callers && scanner.hasNextLine() do
+        val o = JsonParser.parseString(scanner.nextLine()).getAsJsonObject()
+        pending += ((
+          o.getAsJsonPrimitive("id").getAsLong(),
+          o.getAsJsonObject("params").getAsJsonPrimitive("caller").getAsInt()
+        ))
+      pending.reverse.foreach: (id, caller) =>
+        sbtOut.println(s"""{ "jsonrpc": "2.0", "result": $caller, "id": $id }""")
+    })
+    fakeSbt.setDaemon(true)
+    fakeSbt.start()
+
+    // One thread per caller, so every request really is in flight together: the fake sbt answers
+    // nothing until it holds all of them.
+    val pool = Executors.newFixedThreadPool(callers)
+    try
+      val jobs = (0 until callers).map: c =>
+        new Callable[(Int, Integer)]:
+          def call(): (Int, Integer) = (c, rpc.requestIndex("nextTest", s"""{"caller": $c}"""))
+      val got = pool.invokeAll(jobs.asJava).asScala.toVector.map(_.get)
+      assert(got.size == callers)
+      assert(
+        got.forall((c, reply) => reply != null && reply.intValue() == c),
+        s"crossed replies: $got"
+      )
+    finally
+      pool.shutdown()
+      pool.awaitTermination(30, TimeUnit.SECONDS)
+      rpc.close()
+      fakeSbt.join(30000L)
+      workerOut.close()
+      sbtOut.close()
+  }
+
+  /** A TestInfo asking for `names` in queue mode, as ForkTests builds it for a spread group. */
+  private def queueModeInfo(
+      names: Seq[String],
+      threads: Integer,
+      frameworkClass: String = "sbt.internal.worker1.StealingFramework",
+      queueMode: Boolean = true
+  ): TestInfo =
+    val defs = ArrayList[TaskDef]()
+    // Wrapped as ForkTests wraps it, so this TestInfo is one gson can put on the wire.
+    val print = ForkTestMain.SubclassFingerscan(StealingFramework.print)
+    names.foreach(n => defs.add(TaskDef(n, print, false, Array(SuiteSelector()))))
+    val runners = ArrayList[TestInfo.TestRunner]()
+    runners.add(
+      TestInfo.TestRunner(
+        ArrayList(JList.of(frameworkClass)),
+        ArrayList[String](),
+        ArrayList[String]()
+      )
+    )
+    TestInfo(
+      true,
+      RunInfo.JvmRunInfo(ArrayList[String](), ArrayList[FilePath](), "", false),
+      null,
+      false,
+      true,
+      threads,
+      defs,
+      runners,
+      queueMode
+    )
+
+  /**
+   * Drives the worker's queue mode against sbt's side of the protocol: `hand` decides what to answer
+   * each nextTest request. Returns the requests the worker sent and the notifications it wrote, the
+   * latter being how a failure reaches sbt — ForkTestMain reports rather than throws.
+   */
+  private def runStealing(
+      names: Seq[String],
+      threads: Integer,
+      failOn: Option[String] = None,
+      failTasksOn: Option[String] = None,
+      failTaskDefOn: Option[String] = None,
+      nestedOf: Map[String, String] = Map.empty
+  )(hand: Int => String): (Vector[String], String) =
+    StealingFramework.reset()
+    StealingFramework.failOn = failOn
+    StealingFramework.failTasksOn = failTasksOn
+    StealingFramework.failTaskDefOn = failTaskDefOn
+    StealingFramework.nestedOf = nestedOf
+    val sbtIn = PipedInputStream(64 * 1024)
+    val workerOut = PrintStream(PipedOutputStream(sbtIn), true, "UTF-8")
+    val workerIn = PipedInputStream(64 * 1024)
+    val sbtOut = PrintStream(PipedOutputStream(workerIn), true, "UTF-8")
+    val rpc = WorkerRpc(workerOut, Scanner(workerIn, "UTF-8"), 30000L)
+    rpc.start(_ => (), () => ())
+    val requests = ConcurrentLinkedQueue[String]()
+    val served = AtomicInteger(0)
+    val fakeSbt = Thread(() => {
+      try
+        val scanner = Scanner(sbtIn, "UTF-8")
+        while scanner.hasNextLine() do
+          val line = scanner.nextLine()
+          val o = JsonParser.parseString(line).getAsJsonObject()
+          if o.has("method") && o.getAsJsonPrimitive("method").getAsString() == "nextTest" then
+            requests.add(o.getAsJsonObject("params").toString)
+            val id = o.getAsJsonPrimitive("id").getAsLong()
+            val next = hand(served.getAndIncrement())
+            sbtOut.println(s"""{ "jsonrpc": "2.0", "result": $next, "id": $id }""")
+      catch case _: Throwable => ()
+    })
+    fakeSbt.setDaemon(true)
+    fakeSbt.start()
+    val notifications = ByteArrayOutputStream()
+    ForkTestMain.main(
+      1L,
+      queueModeInfo(names, threads),
+      PrintStream(notifications, true, "UTF-8"),
+      getClass.getClassLoader,
+      rpc
+    )
+    rpc.close()
+    workerOut.close()
+    sbtOut.close()
+    (requests.toArray(Array.empty[String]).toVector, notifications.toString("UTF-8"))
+
+  test("a worker in queue mode runs the classes it leases and acknowledges each one") {
+    // The whole point of the mode: sbt hands out indices into the full taskDefs vector, the worker
+    // runs exactly those, and every one comes back acknowledged so sbt can tell run from lost.
+    val (requests, notes) =
+      runStealing(Seq("A", "B", "C", "D"), 1): i =>
+        // Lease index 2, then 0, then say there is no more work.
+        if i == 0 then "2" else if i == 1 then "0" else "null"
+    assert(StealingFramework.executed.toArray.toVector == Vector("C", "A"))
+    assert(!notes.contains("forkError"), notes)
+    // Three requests: the opening one, one acknowledging C, one acknowledging A.
+    assert(requests.size == 3, s"requests=$requests")
+    assert(requests(0).contains("\"done\":null"), requests(0))
+    assert(requests(1).contains("\"done\":2"), requests(1))
+    assert(requests(2).contains("\"done\":0"), requests(2))
+    // Each class it ran is reported, so sbt records a result rather than an absence.
+    assert(notes.contains("startTestGroup") && notes.contains("endTestGroup"))
+  }
+
+  test("the runner is told the run is done, once, after its classes have finished") {
+    // done() is where a framework flushes what it accumulated over the whole run — ScalaTest prints
+    // its summary there. Skipping it loses that with the worker still exiting 0, and calling it twice
+    // would print the summary twice, since the shutdown hook is armed for the crash case.
+    val (_, _) = runStealing(Seq("A", "B"), 1): i =>
+      if i < 2 then i.toString else "null"
+    assert(StealingFramework.executed.size == 2)
+    val calls = StealingFramework.doneCalls.get()
+    assert(calls == 1, s"done() was called $calls times")
+  }
+
+  test("the nested tasks a class hands back are run and reported too") {
+    // ScalaTest and specs2 return a nested suite as a task for the runner to execute rather than
+    // running it themselves. Not walking into them would run the outer class, report it as a pass,
+    // and never touch a single test inside — with nothing anywhere saying so.
+    val (_, notes) =
+      runStealing(Seq("A"), 1, nestedOf = Map("A" -> "A.Inner")): i =>
+        if i == 0 then "0" else "null"
+    val ran = StealingFramework.executed.toArray(Array.empty[String]).toVector
+    assert(ran == Vector("A", "A.Inner"), s"ran=$ran")
+    // Reported as a suite of its own, so sbt records a result rather than an absence.
+    assert(notes.contains("A.Inner"), notes)
+  }
+
+  test("a test task that fails outside the run's own guard fails the worker") {
+    // runTest guards `execute`, so a test that throws becomes a reported error. What is not guarded
+    // is asking the task what it is, and writing the group's start and end -- a failure there fails
+    // the task's future. Joined and swallowed, that class ended with no report at all while its
+    // lease was acknowledged like any other, so sbt saw a run that owed nothing and read the whole
+    // group as a pass.
+    val (requests, notes) =
+      runStealing(Seq("A", "B"), 1, failTaskDefOn = Some("B")): i =>
+        if i < 2 then i.toString else "null"
+    assert(notes.contains("forkError"), notes)
+    // A ran and was acknowledged; B never reports, and its lease is not acknowledged either, so
+    // sbt's own guard names it as well.
+    assert(StealingFramework.executed.toArray.toVector == Vector("A"))
+    assert(!requests.exists(_.contains("\"done\":1")), s"requests=$requests")
+  }
+
+  test("a worker in queue mode refuses an index that is not one of its classes") {
+    // sbt and the worker index the same vector. If that ever drifts, running whatever sits at the
+    // index would report the wrong class, so the worker must reject it instead of guessing.
+    val (_, notes) = runStealing(Seq("A", "B"), 1)(_ => "9")
+    assert(StealingFramework.executed.isEmpty)
+    assert(notes.contains("forkError"), notes)
+  }
+
+  test("a worker with no parallelism asked for runs one class at a time") {
+    // In queue mode the JVM count is the parallelism dial, not availableProcessors.
+    val (_, _) = runStealing(Seq("A", "B", "C", "D"), null): i =>
+      if i < 4 then i.toString else "null"
+    assert(StealingFramework.executed.size == 4)
+    assert(StealingFramework.peak.get() == 1, s"peak=${StealingFramework.peak.get()}")
+  }
+
+  test("a worker asked for two threads runs two classes at a time") {
+    val (_, _) = runStealing(Seq("A", "B", "C", "D"), 2): i =>
+      if i < 4 then i.toString else "null"
+    assert(StealingFramework.executed.size == 4)
+    assert(StealingFramework.peak.get() == 2, s"peak=${StealingFramework.peak.get()}")
+  }
+
+  test("a stealer thread that fails reports rather than finishing quietly") {
+    // The class it held is leased on sbt's side and unacknowledged, so a silent finish would drop it
+    // from the report and the group would pass with a class missing. An exception inside a test does
+    // not reach here — the task wrapper turns that into an error event — so this needs the framework
+    // itself to fail on the class.
+    val (_, notes) =
+      runStealing(Seq("A", "B"), 1, failTasksOn = Some("B")): i =>
+        if i == 0 then "1" else "null"
+    assert(notes.contains("A forked test worker thread failed"), notes)
+  }
+
+  test("a failing stealer does not cut short the suites its siblings are running") {
+    // Every stealer is joined before the failure is reported. Reporting first would let sbt fail the
+    // group and the JVM exit while another thread was still running a class, leaving that class's
+    // suite half-reported. The failing class is the first one handed out, so the thread that dies is
+    // the one whose result is collected first — the case where abandoning the rest is observable.
+    val (_, notes) =
+      runStealing(Seq("A", "B", "C", "D"), 2, failTasksOn = Some("A")): i =>
+        if i < 4 then i.toString else "null"
+    assert(notes.contains("A forked test worker thread failed"), notes)
+    val ran = StealingFramework.executed.toArray(Array.empty[String]).toVector.sorted
+    assert(ran == Vector("B", "C", "D"), s"ran=$ran\n$notes")
+  }
+
+  test("queue mode with no channel to ask on fails instead of running nothing") {
+    // Over a transport with no reply channel there is nobody to lease from. Returning quietly would
+    // run none of the group's classes and still exit 0.
+    StealingFramework.reset()
+    val notifications = ByteArrayOutputStream()
+    ForkTestMain.main(
+      1L,
+      queueModeInfo(Seq("A"), 1),
+      PrintStream(notifications, true, "UTF-8"),
+      getClass.getClassLoader
+    )
+    val notes = notifications.toString("UTF-8")
+    assert(StealingFramework.executed.isEmpty)
+    assert(notes.contains("forkError"), notes)
+  }
+
+  test("the notifications a worker writes are readable by the side that consumes them") {
+    // sbt parses these with this same gson and hands the events to SuiteResult, which dereferences
+    // every event's throwable and reads its fingerprint and selector back. An adapter that writes a
+    // shape its own reader cannot take back does not lose one field: it loses the whole suite.
+    val (_, notes) =
+      runStealing(Seq("A"), 1, failOn = Some("A")): i =>
+        if i == 0 then "0" else "null"
+    val g = WorkerMain.mkGson()
+    val byMethod = notes.linesIterator
+      .map(l => JsonParser.parseString(l).getAsJsonObject())
+      .filter(_.has("method"))
+      .toVector
+      .groupBy(_.getAsJsonPrimitive("method").getAsString())
+    def params(method: String): Vector[JsonObject] =
+      byMethod.getOrElse(method, Vector.empty).map(_.getAsJsonObject("params"))
+
+    val start = params("startTestGroup").map(g.fromJson(_, classOf[ForkTestMain.ForkGroupStart]))
+    val end = params("endTestGroup").map(g.fromJson(_, classOf[ForkTestMain.ForkGroupEnd]))
+    assert(start.map(_.group) == Vector("A"), notes)
+    assert(end.map(_.group) == Vector("A"), notes)
+    assert(start.map(_.id) == Vector(1L) && end.map(_.id) == Vector(1L), notes)
+
+    val progress = params("testProgress").map(g.fromJson(_, classOf[ForkTestMain.ForkEventsInfo]))
+    assert(progress.size == 1, notes)
+    val event = progress.head.events.get(0)
+    assert(progress.head.group == "A", notes)
+    // Compared outside the assertion: verify's macro rewrites a Java enum constant into a reference
+    // that does not exist at runtime.
+    val reportedAsError = event.status() == Status.Error
+    assert(reportedAsError, notes)
+    // The unset-throwable case is what SuiteResult cannot survive, so both halves are asserted.
+    assert(event.throwable() != null && event.throwable().isDefined(), notes)
+    assert(event.throwable().get().getMessage().contains("A was told to fail"), notes)
+    // What the XML report and the failure recap print, so an asymmetric field name loses it.
+    assert(event.throwable().get().getStackTrace().nonEmpty, notes)
+    assert(event.fingerprint().isInstanceOf[SubclassFingerprint], notes)
+    assert(event.selector().isInstanceOf[SuiteSelector], notes)
+
+    val errors = params("forkError").map(g.fromJson(_, classOf[ForkTestMain.ForkErrorInfo]))
+    assert(errors.nonEmpty && errors.forall(_.error != null), notes)
+  }
+
+  /**
+   * Plays sbt to a real `socketWork`: accepts its connection, answers `nextTest` and returns the
+   * lines it wrote. The read timeout is what keeps a worker that stops answering from hanging this
+   * suite rather than failing it.
+   */
+  private def withSocketWorker(
+      request: TestInfo => String
+  )(hand: Int => String): (Vector[String], Boolean) =
+    val server = ServerSocket(0, 1, InetAddress.getByName(null))
+    val worker = Thread(() => WorkerMain().socketWork(server.getLocalPort()))
+    worker.setDaemon(true)
+    worker.start()
+    val socket = server.accept()
+    socket.setSoTimeout(30000)
+    val lines = ListBuffer.empty[String]
+    try
+      val toWorker = PrintStream(socket.getOutputStream(), true, "UTF-8")
+      val fromWorker = Scanner(socket.getInputStream(), "UTF-8")
+      toWorker.println(request(queueModeInfo(Seq("A", "B"), 1)))
+      var served = 0
+      var responded = false
+      try
+        while !responded && fromWorker.hasNextLine() do
+          val line = fromWorker.nextLine()
+          lines += line
+          val o = JsonParser.parseString(line).getAsJsonObject()
+          if o.has("method") then
+            if o.getAsJsonPrimitive("method").getAsString() == "nextTest" then
+              val id = o.getAsJsonPrimitive("id").getAsLong()
+              toWorker.println(s"""{ "jsonrpc": "2.0", "result": ${hand(served)}, "id": $id }""")
+              served += 1
+          else if o.has("id") then responded = true
+      catch case _: Throwable => ()
+      worker.join(30000L)
+      (lines.toVector, responded && !worker.isAlive())
+    finally
+      socket.close()
+      server.close()
+
+  test("the worker answers a request without occupying the thread that reads sbt's replies") {
+    // In queue mode the run blocks on nextTest replies, and only the reader thread can deliver them.
+    // Serving the request on that thread deadlocks the worker: it would sit waiting for an answer it
+    // is itself keeping from being read, until the RPC timeout kills the whole test run.
+    StealingFramework.reset()
+    val g = WorkerMain.mkGson()
+    val (lines, finished) =
+      withSocketWorker(info =>
+        s"""{ "jsonrpc": "2.0", "method": "test", "params": ${g
+            .toJson(info, classOf[TestInfo])}, "id": 1 }"""
+      )(i => if i < 2 then i.toString else "null")
+    assert(finished, lines.mkString("\n"))
+    val ran = StealingFramework.executed.toArray(Array.empty[String]).toVector.sorted
+    assert(ran == Vector("A", "B"), lines.mkString("\n"))
+    assert(lines.last.contains("\"result\": 0"), lines.last)
+  }
+
+  test("a worker whose sbt goes away without asking anything stops instead of waiting") {
+    // socketWork blocks on the one request the reader hands over. Without the end-of-stream signal
+    // the JVM would sit there for ever, holding a slot in the build's forked-JVM budget.
+    val server = ServerSocket(0, 1, InetAddress.getByName(null))
+    val worker = Thread(() => WorkerMain().socketWork(server.getLocalPort()))
+    worker.setDaemon(true)
+    worker.start()
+    val socket = server.accept()
+    socket.close()
+    server.close()
+    worker.join(30000L)
+    assert(!worker.isAlive())
+  }
+
+  test("a framework the fork cannot load fails the run instead of skipping its classes") {
+    // sbt only sends frameworks it loaded from this same test classpath, so one missing here means
+    // the fork's classpath is not what sbt discovered against. Skipping ran none of that
+    // framework's classes and still exited 0, which reads as a group that passed.
+    StealingFramework.reset()
+    val notifications = ByteArrayOutputStream()
+    ForkTestMain.main(
+      1L,
+      queueModeInfo(Seq("A"), 1, frameworkClass = "does.not.Exist", queueMode = false),
+      PrintStream(notifications, true, "UTF-8"),
+      getClass.getClassLoader
+    )
+    val notes = notifications.toString("UTF-8")
+    assert(StealingFramework.executed.isEmpty)
+    assert(notes.contains("forkError"), notes)
+    assert(notes.contains("Could not load test framework"), notes)
+  }
+
+  test("a run releases the threads it created") {
+    // The worker's own JVM exits when its run is over, which hides a pool left running. sbt's does
+    // not: this project's tests drive ForkTestMain in-process, and a leaked pool would add a thread
+    // to the build server for every run.
+    def poolThreads: Int =
+      Thread.getAllStackTraces.keySet.asScala.count(t => t.getName.startsWith("pool-") && t.isAlive)
+    val before = poolThreads
+    runStealing(Seq("A", "B"), 2)(i => if i < 2 then i.toString else "null")
+    val deadline = System.currentTimeMillis() + 30000L
+    while poolThreads > before && System.currentTimeMillis() < deadline do Thread.sleep(50)
+    assert(poolThreads <= before, s"before=$before after=$poolThreads")
+  }
+
+  test("a run request is answered once, and a run that failed is not answered with a result") {
+    // The reply goes to `jsonOut`, which the constructor captures from `System.out` -- so redirecting
+    // stdout across the construction is what makes it readable. Without that there is nothing to
+    // assert on, and this test could not fail whatever `process` did.
+    //
+    // The main class is deliberately one that is not there. These tests run unforked, so `run`
+    // delegates parent-first to the system classloader, which is then sbt's own: a Scala main class
+    // would resolve `scala.Predef$` from sbt's library rather than from the classpath the request
+    // carries, and could not run whatever the request said. A class that is absent fails the same way
+    // on any classloader, and the outcome worth pinning is the protocol one -- the failure comes back
+    // as an error against the request's id rather than as a result, which is the only thing telling
+    // sbt a run that worked from one that did not. The stack trace this prints is the worker
+    // reporting that failure, not this test failing.
+    val captured = ByteArrayOutputStream()
+    val saved = System.out
+    val worker = {
+      System.setOut(PrintStream(captured, true, "UTF-8"))
+      try WorkerMain()
+      finally System.setOut(saved)
+    }
     val runInfo =
-      s"""{ "jvm": true, "jvmRunInfo": { "args": ["hi"], "classpath": $cp, "mainClass": "example.Hello" } }"""
-    val json = s"""{ "jsonrpc": "2.0", "id": 1, "method": "run", "params": $runInfo }"""
-    main.process(json)
+      """{ "jvm": true, "jvmRunInfo":
+        |{ "args": ["hi"], "classpath": [], "mainClass": "example.NoSuchMainClass" } }""".stripMargin
+    worker.process(s"""{ "jsonrpc": "2.0", "id": 1, "method": "run", "params": $runInfo }""")
+    val replies = captured.toString("UTF-8").linesIterator.filter(_.contains("jsonrpc")).toList
+    assert(replies.size == 1, s"expected exactly one reply, got $replies")
+    val o = JsonParser.parseString(replies.head).getAsJsonObject()
+    assert(
+      o.getAsJsonPrimitive("id").getAsLong() == 1L,
+      s"the reply carried the wrong id: $replies"
+    )
+    assert(o.has("error") && !o.has("result"), s"a failed run replied with a result: $replies")
   }
 end WorkerTest


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes https://github.com/sbt/sbt/issues/9561

A forked test group runs in exactly one JVM. This serves its classes from a queue that several worker JVMs steal from, one class at a time, so a group's throughput is the number of JVMs it holds.

Off by default (`testForkedWorkStealing := false`), and inert until the `ForkedTestGroup` limit is raised. Two changes do reach the existing forked path regardless — see **Compatibility**.

Dogfooded in our own CI with `ForkedTestGroup = 6, testForkParallel = false`, cut integration test time from 1h40min to 40 mins, which is comparable to our current Mill baseline.

### How it works

sbt already forks a worker JVM per test group and talks to it over a socket with JSON-RPC. Work stealing adds a second mode to that existing protocol rather than a new channel. Three new pieces:

- **`TestQueue`** (sbt) — one `AtomicInteger` cursor per framework over indices into the `taskDefs` vector both sides already share. `lease(framework)`, `poison()`, `remaining`.
- **`WorkerRpc`** (worker) — correlates the worker's own requests with sbt's replies. One reader thread owns the socket, so the test session can block on a reply only that thread can deliver.
- **`runStealing`** (worker) — replaces the batch run: N threads, each looping on `nextTest` until sbt says there is no more work.

```mermaid
sequenceDiagram
    participant S as sbt · ForkTests / React
    participant Q as TestQueue
    participant W as worker JVM · runStealing
    Note over S: n = min(ceiling, class count)<br/>n worker tasks: priority −1 for the first, index for the rest
    S->>Q: TestQueue(indices, per framework)
    S->>W: fork, then test request with queueMode = true
    loop per stealer thread, until sbt answers null
        W->>S: nextTest { framework, done }
        S->>Q: lease(framework)
        Q-->>S: index | empty
        S-->>W: result: index | null
        W->>S: startTestGroup / testProgress / endTestGroup
    end
    W-->>S: response to the test request
    Note over S: fails unless every lease was acknowledged,<br/>every result recorded, and the queue drained
```

Each request carries `done`, the class that thread just finished, so a class handed out is distinguishable from a class actually run. Frameworks are still run in sequence within a worker, which is why the queue keeps one sub-queue per framework — a worker must never be handed a class belonging to a framework it is not currently on.

Because classes arrive one at a time, `runner.tasks()` is called per class rather than once with the whole batch, and concurrently when a worker is given more than one thread. Every other sbt path calls it once with every `TaskDef`; the default of one thread per worker keeps the calls serial.

### Enabling it

```scala
// Build-wide. Read at the test task's own scope, so it delegates down to every project...
Global / testForkedWorkStealing := true

// ...and a project whose suites clobber shared external state opts out on its own:
Test / testForkedWorkStealing := false

// The ceiling. Replace the Seq -- `+=` cannot raise a limit, because rules are anded together
// (Tags.predicate) and the default already carries Tags.limit(Tags.ForkedTestGroup, 1).
Global / concurrentRestrictions := Seq(
  Tags.limitAll(java.lang.Runtime.getRuntime.availableProcessors),
  Tags.limit(Tags.ForkedTestGroup, 4),
  Tags.exclusiveGroup(Tags.Clean)
)
```

`ForkedTestGroup` tags each worker task rather than each group, so the limit counts forked test JVMs: `4` means at most four at once across the build, whether that is one group spread over four or four groups holding one each. Left at its default of `1` there is nothing to spread into, so `testForkedWorkStealing := true` alone does nothing — which is what keeps the default behaviour of an existing build unchanged even if the flag is turned on globally.

### Design decisions

| | |
| --- | --- |
| **Queue lives in sbt** | Mill keeps its queue on disk — one file per class, claimed by an atomic `os.move` — to avoid IPC. sbt already has the socket and the request/reply protocol, so the queue stays in sbt. That also means sbt sees every hand-out, which is what lets it fail a run holding a lease nobody acknowledged. |
| **Fan-out ceiling is not a new knob** | Reusing `concurrentRestrictions` means the rule that caps forked test JVMs also sizes the fan-out, so the two cannot disagree. Read at the task's own scope — the scope the engine reads it at — so a limit raised at `ThisBuild` or on a project counts, not only one at `Global`. Rules naming no total limit at all fall back to the core count rather than a JVM per class. A project's budget is split across the groups that will fork. |
| **Scheduling** | A group's first JVM asks for a slot ahead of ordinary tasks, the workers that only widen its queue behind them by index: Mill's `if (processIndex == 0) -1 else processIndex`. It orders *held-back* tasks only — `submit` starts a task the moment its tags validate — so it governs freed slots, not idle ones. Ties break by submission, so at the default priority the queue behaves exactly as the old FIFO. |
| **JVM count is the parallelism dial** | `testForkedParallelism` defaults to one thread per worker in queue mode; more concurrency comes from more JVMs. |
| **Some groups must not spread** | A class matching two frameworks is two work units, and spreading them would put two writers on one `TEST-<suite>.xml`, so that group stays in one JVM. |
| **Nothing fails quietly** | A group whose results went missing reads as a pass, so the run fails on: a lease never run, a result sbt cannot record or attribute, a request or notification sbt has no case for, an undrained queue, a framework the fork cannot load, a task failing outside `runTest`'s guard, a broken RPC channel. |

### Compatibility

New API: the `testForkedWorkStealing` setting, and `TaskId.priority` (concrete, default `0`). `Task.withPriority` is `private[sbt]`. MiMa is clean with no new filters.

Two changes are not gated by the flag and reach the existing forked path.

**The JUnit listener now keys open suites by name, not by thread.** A worker runs a group's classes concurrently and reports all their events on the one thread reading that connection, so several suites are open on one thread at once. Keying by name fixes three things:

- the group no longer collapses into one report named after whichever class started last;
- a suite that ends on a thread that never started it — how sbt reports the suites a dying worker left open — no longer raises, which used to cost every later listener the crash report;
- a group's `doComplete` no longer drops a still-running group's open suites.

**A framework the fork cannot load now fails the run** instead of being skipped, which would run none of that framework's classes and still exit 0. `filteredFrameworks` spans every group, so a group with no classes for framework Y still loads Y; both sides load from the same test classpath, so this should be unreachable in practice.

### Verification

```
unit      testing 7 · worker 26 · tasks 16 · tasks-standard 1 · main-actions 106 · main 236(+19)
mima      clean on tasks, tasks-standard, main-actions, main, testing, worker
scripted  new         fork-work-stealing (8 scenarios), fork-work-stealing-multi,
                      fork-pool-sharing, fork-parallel-limit
          extended    fork-test-group-parallel
          regression  fork, fork-parallel, fork-working-directory,
                      fork-test-group-parallel-custom-tags, resources
```

Six new unit suites, three extended, covering the queue under concurrent leasing (20 000 units over `max(4, cores)` threads), the protocol shapes and every filter in `React`, the fan-out arithmetic and priority ordering. The scripted tests use barriers rather than timing, so "N JVMs ran at once" is a property of what was recorded.

Three assertions were confirmed to fail without the code they cover:

- `ThisBuild`-scoped `concurrentRestrictions` — without the delegating scope the group ran in one JVM.
- `testForkedParallelism` at its default — the sibling barrier reports `saw only 1`, so the several-suites-per-thread path really is exercised.
- The per-group `doComplete` fix — without it, only the first group's `TEST-*.xml` is written.

One combination is unit-covered but not covered end to end: more than one group in a single project with a group actually spreading, which is the only shape where a project's budget gets divided. `fork-parallel-limit` does pair `testGrouping` with stealing, but its groups hold one class each, so none of them spreads.
