### PR TITLE
[1.x] Fix Scala 3.9.x console crash by unifying the JLine version used

### DIFF
--- a/main/src/main/java/sbt/internal/MetaBuildLoader.java
+++ b/main/src/main/java/sbt/internal/MetaBuildLoader.java
@@ -66,8 +66,11 @@ public final class MetaBuildLoader extends URLClassLoader {
    *     library.
    */
   public static MetaBuildLoader makeLoader(final AppProvider appProvider) throws IOException {
+    // Every org.jline artifact must live in this tier together. The REPL's ScalaInstance
+    // loader is parented to it, so a partial match leaves the REPL running one JLine
+    // version's reader against another's terminal (#9317, #8294).
     final String jlineJars =
-        "jline-?[0-9.]+-sbt-.*|jline-terminal(-(jni))?-[0-9.]+|jline-native-[0-9.]+";
+        "jline-?[0-9.]+-sbt-.*|jline-(terminal(-jni)?|native|reader|builtins|style)-[0-9.]+";
     final String testInterfaceJars = "test-interface(-.*)?";
     final String compilerInterfaceJars = "compiler-interface(-.*)?";
     final String utilInterfaceJars = "util-interface(-.*)?";

--- a/sbt-app/src/sbt-test/console/jline-version-conflict/build.sbt
+++ b/sbt-app/src/sbt-test/console/jline-version-conflict/build.sbt
@@ -1,0 +1,14 @@
+scalaVersion := "3.9.0-RC4"
+
+lazy val markerFile = settingKey[java.io.File]("marker file written by the console REPL once it starts")
+
+markerFile := target.value / "console-jline-ok"
+
+console / initialCommands := {
+  val path = markerFile.value.getAbsolutePath.replace("\\", "\\\\")
+  // Scala 3.9 ships JLine 4 while sbt 1.x ships JLine 3. A partial match in
+  // MetaBuildLoader's JLine tier used to leave the REPL running jline-reader 4.x
+  // against jline-terminal 3.x, which throws NoSuchMethodError before the prompt
+  // (#9317). The marker is only written if the REPL actually starts.
+  s"""java.nio.file.Files.write(java.nio.file.Paths.get("$path"), Array.emptyByteArray)"""
+}

--- a/sbt-app/src/sbt-test/console/jline-version-conflict/test
+++ b/sbt-app/src/sbt-test/console/jline-version-conflict/test
@@ -1,0 +1,2 @@
+> console
+$ exists target/console-jline-ok


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9317
Fixes https://github.com/scala/scala3/issues/26678

The simple regex change enforces all `org.jline` jars to be of one version - the crash was caused by intermixing jars from JLine 3 and JLine 4, as far as I can tell.

A potential problem here is that technically speaking, this runs Scala 3.9.x REPL using SBT's own JLine 3, because the relevant APIs match those from JLine 4. This could possibly stop being true in a future JLine bump on the compiler's side, but seems to work fine as far as I have tested it for Scala 3.9.

## AI usage
I've used Cursor + Claude to help with debugging this and pointing me to potential solutions. This seems like the simplest way out. Verified the fix manually with a locally published snapshot of SBT vs Scala 3.9.0-RC4 REPL + included a scripted automated test