### PR TITLE
[2.x] Fixes pipelined build with Java sources

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -988,6 +988,22 @@ object Defaults extends BuildCommon with DefExtra {
           val converter = fileConverter.value
           val cp = cp1.map(converter.toPath).map(converter.toVirtualFile)
           opts.withClasspath(cp.toArray)
+        },
+        compileInputs2 := Def.uncached {
+          compileScalaBackend.value
+          val (_, _, packedBackendOutput) = compileIncremental.value
+          val inputs = compileInputs.value
+          val c = fileConverter.value
+          CompileInputs2(
+            packedBackendOutput +: data(dependencyClasspath.value).toVector,
+            sourcesVF.value,
+            scalacOptions.value.toVector,
+            javacOptions.value.toVector,
+            c.toVirtualFile(inputs.options.classesDirectory),
+            c.toVirtualFile(inputs.setup.cacheFile.toPath),
+            extraIncOptions.value.toVector,
+            scalaVersion.value,
+          )
         }
       )
     ) ++
@@ -2317,25 +2333,49 @@ object Defaults extends BuildCommon with DefExtra {
 
   private val incCompiler = ZincUtil.defaultIncrementalCompiler
   private[sbt] def compileJavaTask: Initialize[Task[CompileResult]] = Def.task {
-    val s = streams.value
-    val projectId = thisProject.value.id
-    val r = compileScalaBackend.value
-    val in0 = (compileJava / compileInputs).value
-    val in = in0.withPreviousResult(PreviousResult.of(r.analysis, r.setup))
+    val backendResult = compileScalaBackend.value
+    val result = cachedCompileJavaTask.result.value
     val reporter = (compile / bspReporter).value
-    val log = CompileDebugLogger(projectId, s.log)
-    try {
-      val result0 = incCompiler
-        .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
-        .compileAllJava(in, log)
-      reporter.sendSuccessReport(result0.analysis())
-      result0.withHasModified(result0.hasModified || r.hasModified)
-    } catch {
-      case NonFatal(e) =>
-        reporter.sendFailureReport(in.options.sources)
-        throw e
+    val inputs = (compileJava / compileInputs).value
+    val c = fileConverter.value
+    result match {
+      case Result.Value(hasModified) =>
+        val store = analysisStore(compileAnalysisFile.value.toPath(), c)
+        val contents = store.unsafeGet()
+        reporter.sendSuccessReport(contents.getAnalysis())
+        CompileResult.of(
+          contents.getAnalysis(),
+          contents.getMiniSetup(),
+          hasModified || backendResult.hasModified
+        )
+      case Result.Inc(cause) =>
+        reporter.sendFailureReport(inputs.options.sources)
+        throw cause
     }
   }
+
+  private val cachedCompileJavaTask = Def
+    .cachedTask {
+      val s = streams.value
+      val projectId = projectIdFromScope(s)
+      val in0 = (compileJava / compileInputs).value
+      val ci2 = (compileJava / compileInputs2).value
+      val c = fileConverter.value
+      val store = analysisStore(compileAnalysisFile.value.toPath(), c)
+      val previous = store.unsafeGet()
+      val in = in0.withPreviousResult(
+        PreviousResult.of(previous.getAnalysis(), previous.getMiniSetup())
+      )
+      val log = CompileDebugLogger(projectId, s.log)
+      val result = incCompiler
+        .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
+        .compileAllJava(in, log)
+      store.set(AnalysisContents.create(result.analysis(), result.setup()))
+      Def.declareOutput(c.toVirtualFile(in.setup.cacheFile.toPath))
+      Def.declareOutputDirectory(c.toVirtualFile(in.options.classesDirectory))
+      result.hasModified
+    }
+    .tag(Tags.Compile, Tags.CPU)
 
   private def compileIncrementalTaskImpl(
       task: BspCompileTask,
@@ -4413,9 +4453,9 @@ object Classpaths {
   def makeProducts: Initialize[Task[Seq[File]]] = Def.task {
     val c = fileConverter.value
     val resourceDirs = resourceDirectories.value
-    val _ = compile.value
+    compile.value
     val backendDir = c.toPath(backendOutput.value)
-    val _ = resources.value
+    resources.value
     backendDir.toFile() :: resourceDirs.toList.filter(_.exists())
   }
 

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2325,13 +2325,11 @@ object Defaults extends BuildCommon with DefExtra {
     val reporter = (compile / bspReporter).value
     val log = CompileDebugLogger(projectId, s.log)
     try {
-      if (r.hasModified) {
-        val result0 = incCompiler
-          .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
-          .compileAllJava(in, log)
-        reporter.sendSuccessReport(result0.analysis())
-        result0.withHasModified(result0.hasModified || r.hasModified)
-      } else r
+      val result0 = incCompiler
+        .asInstanceOf[sbt.internal.inc.IncrementalCompilerImpl]
+        .compileAllJava(in, log)
+      reporter.sendSuccessReport(result0.analysis())
+      result0.withHasModified(result0.hasModified || r.hasModified)
     } catch {
       case NonFatal(e) =>
         reporter.sendFailureReport(in.options.sources)
@@ -4415,8 +4413,8 @@ object Classpaths {
   def makeProducts: Initialize[Task[Seq[File]]] = Def.task {
     val c = fileConverter.value
     val resourceDirs = resourceDirectories.value
-    val vfBackendDir = compileIncremental.value._2
-    val backendDir = c.toPath(vfBackendDir)
+    val _ = compile.value
+    val backendDir = c.toPath(backendOutput.value)
     val _ = resources.value
     backendDir.toFile() :: resourceDirs.toList.filter(_.exists())
   }

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/build.sbt
@@ -1,6 +1,31 @@
 ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / usePipelining := true
 
+def countedCompilers(counter: File)(cs: xsbti.compile.Compilers): xsbti.compile.Compilers = {
+  val tools = cs.javaTools()
+  val underlying = tools.javac()
+  val counted = new xsbti.compile.JavaCompiler {
+    override def run(
+        sources: Array[xsbti.VirtualFile],
+        options: Array[String],
+        output: xsbti.compile.Output,
+        incToolOptions: xsbti.compile.IncToolOptions,
+        reporter: xsbti.Reporter,
+        log: xsbti.Logger
+    ): Boolean = {
+      IO.append(counter, "javac\n")
+      underlying.run(sources, options, output, incToolOptions, reporter, log)
+    }
+
+    override def supportsDirectToJar(): Boolean =
+      underlying.supportsDirectToJar()
+  }
+  cs.withJavaTools(new xsbti.compile.JavaTools {
+    override def javac(): xsbti.compile.JavaCompiler = counted
+    override def javadoc(): xsbti.compile.Javadoc = tools.javadoc()
+  })
+}
+
 lazy val root = (project in file("."))
   .aggregate(upstream, downstream)
 
@@ -8,6 +33,7 @@ lazy val upstream = project
   .settings(
     exportJars := true,
     exportPipelining := false,
+    Compile / compilers ~= countedCompilers(file("javac-invocations")),
   )
 
 lazy val downstream = project

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/build.sbt
@@ -1,0 +1,14 @@
+ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / usePipelining := true
+
+lazy val root = (project in file("."))
+  .aggregate(upstream, downstream)
+
+lazy val upstream = project
+  .settings(
+    exportJars := true,
+    exportPipelining := false,
+  )
+
+lazy val downstream = project
+  .dependsOn(upstream)

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/changes/Greeter.java
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/changes/Greeter.java
@@ -1,0 +1,7 @@
+package example;
+
+public class Greeter {
+  public static String greet(String name) {
+    return "Updated, " + name;
+  }
+}

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/changes/Marker.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/changes/Marker.scala
@@ -1,0 +1,5 @@
+package example
+
+object Marker {
+  val tag = "updated"
+}

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/downstream/src/main/scala/example/Main.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/downstream/src/main/scala/example/Main.scala
@@ -1,0 +1,5 @@
+package example
+
+object Main {
+  def run(): String = Greeter.greet("world")
+}

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/downstream/src/main/scala/example/Main.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/downstream/src/main/scala/example/Main.scala
@@ -2,4 +2,7 @@ package example
 
 object Main {
   def run(): String = Greeter.greet("world")
+
+  def main(args: Array[String]): Unit =
+    assert(run() == "Updated, world")
 }

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/test
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/test
@@ -1,0 +1,4 @@
+> compile
+
+$ exists target/**/upstream/classes/example/Greeter.class
+$ exists target/**/downstream/classes/example/Main.class

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/test
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/test
@@ -2,3 +2,20 @@
 
 $ exists target/**/upstream/classes/example/Greeter.class
 $ exists target/**/downstream/classes/example/Main.class
+
+$ copy-file javac-invocations javac-before
+> compile
+$ must-mirror javac-before javac-invocations
+
+$ copy-file changes/Marker.scala upstream/src/main/scala/example/Marker.scala
+> compile
+
+$ copy-file changes/Greeter.java upstream/src/main/java/example/Greeter.java
+> compile
+> downstream / run
+$ copy-file javac-invocations javac-after-java
+
+$ delete target/out/jvm/scala-2.13.18/upstream/classes/example/Greeter.class
+> compile
+$ exists target/out/jvm/scala-2.13.18/upstream/classes/example/Greeter.class
+$ must-mirror javac-after-java javac-invocations

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/upstream/src/main/java/example/Greeter.java
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/upstream/src/main/java/example/Greeter.java
@@ -1,0 +1,7 @@
+package example;
+
+public class Greeter {
+  public static String greet(String name) {
+    return "Hello, " + name;
+  }
+}

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/upstream/src/main/scala/example/Marker.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-java-scala-no-export/upstream/src/main/scala/example/Marker.scala
@@ -1,0 +1,5 @@
+package example
+
+object Marker {
+  val tag = "upstream"
+}


### PR DESCRIPTION
Fix #9343

With `usePipelining := true` set at an upstream project, Java and Scala sources compile separately. With same upstream `exportPipelining := false`, sbt created and exposed compilation artifacts downstream only after Scala compilation without waiting for the Java compilation to finish. Therefore downstream projects were missing Java artifacts.

This PR makes normal product generation wait for both Scala and Java compilation to finish. Because Java is a separate phase under `usePipelining`, this PR also adds caching this phase.