### PR TITLE
[2.x] perf: Skip re-packaging the class directory when zinc recompiles nothing

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2319,13 +2319,21 @@ object Defaults extends BuildCommon with DefExtra {
       val store = analysisStore(compileAnalysisFile.value.toPath(), c)
       // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
       val analysisResult = Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping, projectId))
-      val analysisOut = c.toVirtualFile(setup.cachePath())
-      val contents = AnalysisContents.create(analysisResult.analysis(), analysisResult.setup())
-      store.set(contents)
-      Def.declareOutput(analysisOut)
       val dir = ci.options.classesDirectory
       val vfDir = c.toVirtualFile(dir)
-      val packedDir = Def.declareOutputDirectory(vfDir)
+      val dirZip = ActionCache.dirZipPath(dir)
+      // Zinc leaves the class directory alone when it invalidates nothing, so the zip the previous
+      // run left behind still describes it and re-packing only reproduces a blob the store has.
+      val packedDir =
+        if analysisResult.hasModified() || !Files.exists(dirZip) then
+          Def.declareOutputDirectory(vfDir)
+        else Def.declareOutput(c.toVirtualFile(dirZip))
+      val analysisOut = c.toVirtualFile(setup.cachePath())
+      val contents = AnalysisContents.create(analysisResult.analysis(), analysisResult.setup())
+      // Packaging precedes this write so that a run interrupted in between leaves a stale analysis,
+      // which forces a recompile, rather than a current analysis paired with an outdated zip.
+      store.set(contents)
+      Def.declareOutput(analysisOut)
       s.log.debug(s"wrote $vfDir")
       (analysisResult.hasModified(), vfDir: VirtualFileRef, packedDir: HashedVirtualFileRef)
     }

--- a/sbt-app/src/sbt-test/cache/compile-repackage-skip/a/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/cache/compile-repackage-skip/a/src/main/scala/A.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  def v: Int = 1

--- a/sbt-app/src/sbt-test/cache/compile-repackage-skip/b/src/main/scala/B.scala
+++ b/sbt-app/src/sbt-test/cache/compile-repackage-skip/b/src/main/scala/B.scala
@@ -1,0 +1,4 @@
+package example
+
+object B:
+  def w: Int = A.v + 1

--- a/sbt-app/src/sbt-test/cache/compile-repackage-skip/build.sbt
+++ b/sbt-app/src/sbt-test/cache/compile-repackage-skip/build.sbt
@@ -1,0 +1,78 @@
+import java.nio.file.{ Files, LinkOption }
+import java.nio.file.attribute.BasicFileAttributes
+
+val recordIds = taskKey[Unit]("records the on-disk identity of the compile outputs")
+val checkAnalysisChanged = taskKey[Unit]("asserts the analysis file was rewritten")
+val checkAnalysisUnchanged = taskKey[Unit]("asserts the analysis file was left alone")
+val checkClassesZipUnchanged = taskKey[Unit]("asserts the class directory was not re-packaged")
+val checkNotModified = taskKey[Unit]("asserts zinc recompiled nothing")
+val delClassesZip = taskKey[Unit]("deletes the sibling classes.sbtdir.zip")
+val checkClasses = taskKey[Unit]("asserts class files are present")
+
+// A rewritten output gets a fresh inode when the action cache relinks it into the CAS, and a fresh
+// mtime where symlinks are unavailable; either one moving means the file was written again.
+def idOf(f: File): String = {
+  val attrs =
+    Files.readAttributes(f.toPath, classOf[BasicFileAttributes], LinkOption.NOFOLLOW_LINKS)
+  s"${Option(attrs.fileKey()).getOrElse("<no-file-key>")}|${attrs.lastModifiedTime().toMillis}"
+}
+
+lazy val classesZip = Def.task {
+  val dir = (Compile / classDirectory).value
+  new File(dir.getParentFile, dir.getName + ".sbtdir.zip")
+}
+
+lazy val idFile = Def.task { target.value / "recorded-ids.txt" }
+
+def recorded(kind: String) = Def.task {
+  IO.readLines(idFile.value)
+    .collectFirst { case s"$k=$v" if k == kind => v }
+    .getOrElse(sys.error(s"no recorded id for $kind"))
+}
+
+Global / localCacheDirectory := (ThisBuild / baseDirectory).value / "diskcache"
+ThisBuild / scalaVersion := "3.8.4"
+ThisBuild / exportJars := true
+
+lazy val a = project.in(file("a"))
+
+lazy val b = project
+  .in(file("b"))
+  .dependsOn(a)
+  .settings(
+    recordIds := Def.uncached {
+      IO.writeLines(
+        idFile.value,
+        Seq(
+          s"analysis=${idOf((Compile / compileAnalysisFile).value)}",
+          s"classesZip=${idOf(classesZip.value)}",
+        )
+      )
+    },
+    checkAnalysisChanged := Def.uncached {
+      val now = idOf((Compile / compileAnalysisFile).value)
+      val before = recorded("analysis").value
+      assert(now != before, s"analysis was not rewritten, so compile was a cache hit: $now")
+    },
+    checkAnalysisUnchanged := Def.uncached {
+      val now = idOf((Compile / compileAnalysisFile).value)
+      val before = recorded("analysis").value
+      assert(now == before, s"analysis was rewritten: $before -> $now")
+    },
+    checkClassesZipUnchanged := Def.uncached {
+      val now = idOf(classesZip.value)
+      val before = recorded("classesZip").value
+      assert(now == before, s"class directory was re-packaged: $before -> $now")
+    },
+    checkNotModified := Def.uncached {
+      val (hasModified, _, _) = (Compile / compileIncremental).value
+      assert(!hasModified, "zinc reported modified output, expected nothing to recompile")
+    },
+    delClassesZip := Def.uncached {
+      IO.delete(classesZip.value)
+    },
+    checkClasses := Def.uncached {
+      val classes = ((Compile / classDirectory).value ** "*.class").get()
+      assert(classes.nonEmpty, "no class files")
+    },
+  )

--- a/sbt-app/src/sbt-test/cache/compile-repackage-skip/changes/A2.scala
+++ b/sbt-app/src/sbt-test/cache/compile-repackage-skip/changes/A2.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  def v: Int = 2

--- a/sbt-app/src/sbt-test/cache/compile-repackage-skip/test
+++ b/sbt-app/src/sbt-test/cache/compile-repackage-skip/test
@@ -1,0 +1,26 @@
+# An upstream method body change invalidates a downstream module's compile cache key without
+# invalidating any of its classes. Zinc then recompiles nothing, so its class directory must not
+# be packaged into the action cache again.
+
+> b/compile
+> b/recordIds
+
+# a no-op build: b's compile is a pure cache hit, nothing on disk moves
+> b/compile
+> b/checkAnalysisUnchanged
+> b/checkClassesZipUnchanged
+
+# the body change alters a's jar, so b's cached compile task re-runs -- rewriting b's analysis --
+# but zinc recompiles nothing in b
+$ copy-file changes/A2.scala a/src/main/scala/A.scala
+> b/compile
+> b/checkNotModified
+> b/checkAnalysisChanged
+> b/checkClassesZipUnchanged
+
+# the entry stored on that miss still has to describe b's class directory: dropping the sibling
+# zip forces the next hit to fetch it back out of the content-addressed store and re-extract it
+> b/recordIds
+> b/delClassesZip
+> b/compile
+> b/checkClasses

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -384,6 +384,10 @@ object ActionCache:
     outputs += vf
     vf
 
+  /** The zip `packageDirectory` writes for `dirPath`, as a sibling of the directory itself. */
+  def dirZipPath(dirPath: Path): Path =
+    Paths.get(dirPath.toString + dirZipExt)
+
   def packageDirectory(
       dir: VirtualFileRef,
       conv: FileConverter,
@@ -411,7 +415,7 @@ object ActionCache:
     IO.withTemporaryDirectory: tempDir =>
       val mPath = (tempDir / manifestFileName).toPath()
       makeManifest(mPath)
-      val zipPath = Paths.get(dirPath.toString + dirZipExt)
+      val zipPath = dirZipPath(dirPath)
       val rebase: Path => Seq[(File, String)] =
         (p: Path) =>
           p match


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes mechanism 3 of https://github.com/sbt/sbt/issues/9601.

## Problem

`cachedCompileIncrementalTask` ends with an unconditional `Def.declareOutputDirectory(vfDir)`, which the cached-task macro expands into `ActionCache.packageDirectory(...)` — walk the class directory, hash every file into a manifest, gzip it, install `classes.sbtdir.zip`, store the blob. That runs on every action-cache miss, whether or not zinc wrote anything.

Since `compileInputs2` puts each classpath entry's content hash into the compile cache key, a one-line body change invalidates every module downstream of it. Zinc's name hashing then invalidates nothing there, so those class directories come out byte-identical and re-zipping just reproduces a blob the CAS already holds. On the benchmark in #9601 a body change in `m1` invalidates the whole 27-module chain: one module recompiles, the other 26 re-pack ~2,000 untouched files each.

## Fix

```scala
val dirZip = ActionCache.dirZipPath(dir)
val packedDir =
  if analysisResult.hasModified() || !Files.exists(dirZip) then
    Def.declareOutputDirectory(vfDir)
  else Def.declareOutput(c.toVirtualFile(dirZip))
```

The output is still declared, so the stored `ActionResult` stays complete and a later hit restores the directory as before — same `HashedVirtualFileRef`, read off disk instead of rebuilt.

Two things worth a reviewer's attention:

- **`hasModified()` is reliable here**, though not everywhere. `compileScalaBackendTask` derives it from `readCompilations().getAllCompilations().nonEmpty`, which is always false because `ConsistentAnalysisFormat` never persists `Compilations`. At this site it comes from the live `incCompiler.compile(...)` result, where zinc computes `hasModified || hasSubprojectChange` (`Incremental.scala:378,432`) — false only when zinc took the branch that writes nothing, and conservatively true when the analysis changes but no class files do.
- **Packaging now precedes `store.set`.** A run killed between zinc writing class files and the zip being written used to leave a current analysis beside a stale zip, which the next run would reuse. Reordered, such an interruption leaves a stale analysis, forcing a recompile.

## Measurements

Benchmark: https://github.com/hoangmaihuy/sbt-compile-benchmark, 81 modules, 162,003 output files. Three runs per cell after a discarded warm run, each cell measured once, server restarted between configurations. Both builds published locally and verified by disassembly before measuring.

Deep edit (one method body in `m1`, exactly one module recompiles in every cell). `base` is `develop`, `fix` is this branch:

| tree state | exportJars | wall base | wall fix | `compileIncremental` base | `compileIncremental` fix |
| --- | --- | --- | --- | --- | --- |
| real files | false | 22.7 s | 17.5 s | 16,711 ms | 13,350 ms (−20 %) |
| real files | true | 12.0 s | **7.1 s** | 9,250 ms | **4,230 ms (−54 %)** |
| cache-restored | false | 68.1 s | 60.6 s | 45,214 ms | 38,738 ms (−14 %) |
| cache-restored | true | 21.6 s | **15.7 s** | 12,909 ms | **7,447 ms (−42 %)** |

Wall figures are the median of three runs; own-time is summed over the 82 projects under `-Dsbt.task.timings=true`. Per module, `m1` is the same in both builds (base 478 ms, fix 450 ms — it packages either way); the other 26 go from ~380–480 ms to ~150–200 ms.

The no-op and edit-leaf scenarios are unaffected, as they should be — a no-op is all cache hits, and `app` has no dependents. Three of those cells drift anyway, all in `exportJars=false`, up to −15 s on `cache-restored`/leaf; none is explicable by this change and that cell's triples overlap completely, so read it as noise. Judge the change by the `exportJars=true` rows.

## Test

`sbt-app/src/sbt-test/cache/compile-repackage-skip` — two projects, `exportJars := true`, a body-only edit upstream. It pins the condition, not just the outcome: the downstream analysis file must be rewritten (proving a real cache miss), zinc must report `hasModified = false`, the class-directory zip must not move, and deleting that zip must still let the next hit fetch it from the CAS and re-extract — so a skipped pack cannot leave an entry pointing at a missing blob.

File identity is `(fileKey, lastModifiedTime)` with `NOFOLLOW_LINKS`, which discriminates on both the symlink-relink and copy paths. Verified failing on `develop` and passing here, alongside the other 13 tests in `cache/`.

## Not included

`cachedCompileJavaTask` has the same unconditional pack, but this guard does not transfer: `Incremental.compileAllJava` returns `(sources.nonEmpty, analysis)`, so its `hasModified` reports whether the project has Java sources, not whether javac wrote anything.
