### PR TITLE
[1.x] Avoid rewriting unchanged plugin descriptors

### DIFF
--- a/main/src/main/scala/sbt/internal/PluginDiscovery.scala
+++ b/main/src/main/scala/sbt/internal/PluginDiscovery.scala
@@ -88,7 +88,10 @@ object PluginDiscovery {
       IO.delete(descriptor)
       None
     } else {
-      IO.writeLines(descriptor, names.distinct.sorted)
+      val lines = names.distinct.sorted
+      // Do not invalidate timestamp-based downstream caches when the descriptor content is unchanged.
+      if (!descriptor.exists || IO.readLines(descriptor) != lines)
+        IO.writeLines(descriptor, lines)
       Some(descriptor)
     }
   }

--- a/main/src/test/scala/sbt/internal/PluginDiscoveryTest.scala
+++ b/main/src/test/scala/sbt/internal/PluginDiscoveryTest.scala
@@ -1,0 +1,57 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.nio.file.attribute.FileTime
+import java.nio.file.Files
+
+import sbt.io.IO
+
+object PluginDiscoveryTest extends verify.BasicTestSuite {
+  import PluginDiscovery.Paths.AutoPlugins
+
+  test("writeDescriptor preserves mtime when the descriptor content is unchanged") {
+    val directory = Files.createTempDirectory("plugin-discovery-test").toFile
+    try {
+      val descriptor =
+        PluginDiscovery.writeDescriptor(Seq("example.B", "example.A"), directory, AutoPlugins).get
+      val expectedTime = FileTime.fromMillis(1234L)
+      Files.setLastModifiedTime(descriptor.toPath, expectedTime)
+
+      PluginDiscovery.writeDescriptor(
+        Seq("example.A", "example.B", "example.A"),
+        directory,
+        AutoPlugins
+      )
+
+      assert(Files.getLastModifiedTime(descriptor.toPath) == expectedTime)
+    } finally IO.delete(directory)
+  }
+
+  test("writeDescriptor updates the descriptor when its content changes") {
+    val directory = Files.createTempDirectory("plugin-discovery-test").toFile
+    try {
+      val descriptor = PluginDiscovery.writeDescriptor(Seq("example.A"), directory, AutoPlugins).get
+
+      PluginDiscovery.writeDescriptor(Seq("example.B"), directory, AutoPlugins)
+
+      assert(IO.readLines(descriptor) == Seq("example.B"))
+    } finally IO.delete(directory)
+  }
+
+  test("writeDescriptor deletes the descriptor when no modules are discovered") {
+    val directory = Files.createTempDirectory("plugin-discovery-test").toFile
+    try {
+      val descriptor = PluginDiscovery.writeDescriptor(Seq("example.A"), directory, AutoPlugins).get
+
+      assert(PluginDiscovery.writeDescriptor(Nil, directory, AutoPlugins).isEmpty)
+      assert(!descriptor.exists)
+    } finally IO.delete(directory)
+  }
+}

--- a/sbt-app/src/sbt-test/package/sbt-plugin-incremental/build.sbt
+++ b/sbt-app/src/sbt-test/package/sbt-plugin-incremental/build.sbt
@@ -1,0 +1,26 @@
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+
+sbtPlugin := true
+
+val expectedMtime = FileTime.fromMillis(1234L)
+val setPackageBinMtime = taskKey[Unit]("Sets the packageBin output mtime")
+val checkPackageBinMtime = taskKey[Unit]("Checks that packageBin did not rewrite its output")
+val checkPackageBinRebuilt = taskKey[Unit]("Checks that packageBin rebuilt its output")
+
+setPackageBinMtime := {
+  val artifact = (Compile / packageBin / artifactPath).value
+  Files.setLastModifiedTime(artifact.toPath, expectedMtime)
+}
+
+checkPackageBinMtime := {
+  val artifact = (Compile / packageBin / artifactPath).value
+  val actual = Files.getLastModifiedTime(artifact.toPath)
+  assert(actual == expectedMtime, s"packageBin rewrote $artifact: $actual")
+}
+
+checkPackageBinRebuilt := {
+  val artifact = (Compile / packageBin / artifactPath).value
+  val actual = Files.getLastModifiedTime(artifact.toPath)
+  assert(actual != expectedMtime, s"packageBin did not rebuild $artifact")
+}

--- a/sbt-app/src/sbt-test/package/sbt-plugin-incremental/changes/AdditionalPlugin.scala
+++ b/sbt-app/src/sbt-test/package/sbt-plugin-incremental/changes/AdditionalPlugin.scala
@@ -1,0 +1,5 @@
+package example
+
+import sbt.AutoPlugin
+
+object AdditionalPlugin extends AutoPlugin

--- a/sbt-app/src/sbt-test/package/sbt-plugin-incremental/src/main/scala/example/ExamplePlugin.scala
+++ b/sbt-app/src/sbt-test/package/sbt-plugin-incremental/src/main/scala/example/ExamplePlugin.scala
@@ -1,0 +1,5 @@
+package example
+
+import sbt.AutoPlugin
+
+object ExamplePlugin extends AutoPlugin

--- a/sbt-app/src/sbt-test/package/sbt-plugin-incremental/test
+++ b/sbt-app/src/sbt-test/package/sbt-plugin-incremental/test
@@ -1,0 +1,8 @@
+> packageBin
+> setPackageBinMtime
+> packageBin
+> checkPackageBinMtime
+
+$ copy-file changes/AdditionalPlugin.scala src/main/scala/example/AdditionalPlugin.scala
+> packageBin
+> checkPackageBinRebuilt

--- a/sbt-app/src/sbt-test/plugins/sbt-assembly/build.sbt
+++ b/sbt-app/src/sbt-test/plugins/sbt-assembly/build.sbt
@@ -1,0 +1,28 @@
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+
+import sbtassembly.AssemblyPlugin.autoImport._
+
+sbtPlugin := true
+
+val expectedMtime = FileTime.fromMillis(1234L)
+val setAssemblyMtime = taskKey[Unit]("Sets the assembly output mtime")
+val checkAssemblyMtime = taskKey[Unit]("Checks that assembly did not rewrite its output")
+val checkAssemblyRebuilt = taskKey[Unit]("Checks that assembly rebuilt its output")
+
+setAssemblyMtime := {
+  val artifact = (assembly / assemblyOutputPath).value
+  Files.setLastModifiedTime(artifact.toPath, expectedMtime)
+}
+
+checkAssemblyMtime := {
+  val artifact = (assembly / assemblyOutputPath).value
+  val actual = Files.getLastModifiedTime(artifact.toPath)
+  assert(actual == expectedMtime, s"assembly rewrote $artifact: $actual")
+}
+
+checkAssemblyRebuilt := {
+  val artifact = (assembly / assemblyOutputPath).value
+  val actual = Files.getLastModifiedTime(artifact.toPath)
+  assert(actual != expectedMtime, s"assembly did not rebuild $artifact")
+}

--- a/sbt-app/src/sbt-test/plugins/sbt-assembly/changes/AdditionalPlugin.scala
+++ b/sbt-app/src/sbt-test/plugins/sbt-assembly/changes/AdditionalPlugin.scala
@@ -1,0 +1,5 @@
+package example
+
+import sbt.AutoPlugin
+
+object AdditionalPlugin extends AutoPlugin

--- a/sbt-app/src/sbt-test/plugins/sbt-assembly/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/plugins/sbt-assembly/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")

--- a/sbt-app/src/sbt-test/plugins/sbt-assembly/src/main/scala/example/ExamplePlugin.scala
+++ b/sbt-app/src/sbt-test/plugins/sbt-assembly/src/main/scala/example/ExamplePlugin.scala
@@ -1,0 +1,5 @@
+package example
+
+import sbt.AutoPlugin
+
+object ExamplePlugin extends AutoPlugin

--- a/sbt-app/src/sbt-test/plugins/sbt-assembly/test
+++ b/sbt-app/src/sbt-test/plugins/sbt-assembly/test
@@ -1,0 +1,8 @@
+> assembly
+> setAssemblyMtime
+> assembly
+> checkAssemblyMtime
+
+$ copy-file changes/AdditionalPlugin.scala src/main/scala/example/AdditionalPlugin.scala
+> assembly
+> checkAssemblyRebuilt


### PR DESCRIPTION
Fixes #9612.

## Summary

Make `PluginDiscovery.writeDescriptor` content-aware. When the discovered
plugin names are unchanged, the generated `sbt/sbt.autoplugins` or
`sbt/sbt.builds` descriptor is no longer rewritten.

## Root cause and impact

`sbtPlugin` runs the descriptor generator during packaging. Previously it
unconditionally wrote the descriptor even when its normalized lines were
identical. That changed the descriptor mtime, invalidated timestamp-based
package inputs, and caused repeated direct `packageBin` and `assembly` runs to
rewrite otherwise identical JARs.

The generator now keeps the descriptor untouched when its existing lines equal
the newly discovered, sorted names. A real plugin discovery change still writes
the descriptor and correctly invalidates the artifact.

## Validation

- Added unit coverage for unchanged, changed, and empty discovery results.
- Added scripted end-to-end fixtures for direct `packageBin` and real
  `sbt-assembly` 2.4.1 `assembly` packaging.
- TDD confirmation: both no-op packaging scenarios failed with the former
  unconditional write and pass with this change; both fixtures also verify that
  adding an `AutoPlugin` rebuilds the JAR.
- Ran:

  ```text
  CI=true sbt -batch ';project mainProj; testOnly sbt.internal.PluginDiscoveryTest'
  CI=true sbt -batch 'scripted package/sbt-plugin-incremental plugins/sbt-assembly'
  ```
