### PR TITLE
[2.x] fix: Name the platform in CrossVersion(module, scalaModuleInfo)

### DIFF
--- a/lm-core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
+++ b/lm-core/src/main/scala/sbt/librarymanagement/CrossVersionExtra.scala
@@ -139,9 +139,17 @@ private[librarymanagement] abstract class CrossVersionFunctions {
         append(c.prefix + compat + c.suffix)
     }
 
-  /** Constructs the cross-version function defined by `module` and `is`, if one is configured. */
+  /**
+   * Constructs the cross-version function defined by `module` and `is`, if one is configured.
+   *
+   * The function names the artifact in full, platform suffix before cross suffix, matching the
+   * coordinate (sbt/sbt#9117). On sbt 1 the platform was a prefix inside the CrossVersion itself,
+   * so callers rebuilding a name from it got the platform for free; sbt 2 keeps the platform in a
+   * field of its own, and this is where the two are put back together.
+   */
   def apply(module: ModuleID, is: ScalaModuleInfo): Option[String => String] =
     CrossVersion(module.crossVersion, is.scalaFullVersion, is.scalaBinaryVersion)
+      .map(cross => name => cross(addPlatformSuffix(name, module.platformOpt, is.platform)))
 
   /** Constructs the cross-version function defined by `module` and `is`, if one is configured. */
   def apply(module: ModuleID, is: Option[ScalaModuleInfo]): Option[String => String] =

--- a/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -434,13 +434,11 @@ class CrossVersionTest extends UnitSpec {
     named("com.example" %% "foo" % "1.0", Some("jvm")) shouldBe Some("foo_2.13")
   }
   it should "put the platform suffix before the cross suffix" in {
-    // the platform is dropped: sbt 1 kept it inside the CrossVersion, sbt 2 keeps it in a field
-    // of its own and this overload never reads it
-    named("com.example" %% "foo" % "1.0", Some("sjs1")) shouldBe Some("foo_2.13")
+    named("com.example" %% "foo" % "1.0", Some("sjs1")) shouldBe Some("foo_sjs1_2.13")
   }
   it should "take the platform from the module over the project" in {
     val m = ("com.example" %% "foo" % "1.0").platform("native0.5")
-    named(m, Some("sjs1")) shouldBe Some("foo_2.13")
+    named(m, Some("sjs1")) shouldBe Some("foo_native0.5_2.13")
   }
   it should "add no platform suffix when there is no platform" in {
     named("com.example" %% "foo" % "1.0", None) shouldBe Some("foo_2.13")

--- a/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
+++ b/lm-core/src/test/scala/sbt/librarymanagement/CrossVersionTest.scala
@@ -2,6 +2,7 @@ package sbt.librarymanagement
 
 import sbt.internal.librarymanagement.UnitSpec
 import CrossVersion.*
+import sbt.librarymanagement.syntax.*
 import scala.annotation.nowarn
 
 class CrossVersionTest extends UnitSpec {
@@ -412,5 +413,42 @@ class CrossVersionTest extends UnitSpec {
     CrossVersion(CrossVersion.for2_13Use3, "2.13.4", "2.13").map(_("artefact")) shouldBe Some(
       "artefact_3"
     )
+  }
+
+  private def scalaInfo(platform: Option[String]) = ScalaModuleInfo(
+    "2.13.15",
+    "2.13",
+    Vector.empty,
+    true,
+    false,
+    true,
+    "org.scala-lang",
+    Vector.empty,
+    platform,
+  )
+
+  private def named(module: ModuleID, platform: Option[String]) =
+    CrossVersion(module, scalaInfo(platform)).map(_(module.name))
+
+  "CrossVersion(module, scalaModuleInfo)" should "name a JVM artifact with the cross suffix" in {
+    named("com.example" %% "foo" % "1.0", Some("jvm")) shouldBe Some("foo_2.13")
+  }
+  it should "put the platform suffix before the cross suffix" in {
+    // the platform is dropped: sbt 1 kept it inside the CrossVersion, sbt 2 keeps it in a field
+    // of its own and this overload never reads it
+    named("com.example" %% "foo" % "1.0", Some("sjs1")) shouldBe Some("foo_2.13")
+  }
+  it should "take the platform from the module over the project" in {
+    val m = ("com.example" %% "foo" % "1.0").platform("native0.5")
+    named(m, Some("sjs1")) shouldBe Some("foo_2.13")
+  }
+  it should "add no platform suffix when there is no platform" in {
+    named("com.example" %% "foo" % "1.0", None) shouldBe Some("foo_2.13")
+  }
+  it should "name nothing when the module is not cross-versioned" in {
+    named(
+      ("com.example" % "foo" % "1.0").withCrossVersion(CrossVersion.disabled),
+      Some("sjs1")
+    ) shouldBe None
   }
 }

--- a/lm-ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
+++ b/lm-ivy/src/main/scala/sbt/internal/librarymanagement/IvyActions.scala
@@ -234,18 +234,8 @@ object IvyActions {
   }
   private def crossVersionMap(moduleSettings: ModuleSettings): Option[String => String] =
     moduleSettings match {
-      case i: InlineConfiguration =>
-        // Platform suffix before cross suffix, matching the coordinate (sbt/sbt#9117).
-        CrossVersion(i.module, i.scalaModuleInfo).map { fn => (name: String) =>
-          fn(
-            CrossVersion.addPlatformSuffix(
-              name,
-              i.module.platformOpt,
-              i.scalaModuleInfo.flatMap(_.platform)
-            )
-          )
-        }
-      case _ => None
+      case i: InlineConfiguration => CrossVersion(i.module, i.scalaModuleInfo)
+      case _                      => None
     }
   def mapArtifacts(
       module: ModuleDescriptor,

--- a/main/src/main/scala/sbt/internal/PomGenerator.scala
+++ b/main/src/main/scala/sbt/internal/PomGenerator.scala
@@ -61,14 +61,9 @@ private[sbt] object PomGenerator:
     </project>
 
   private def crossVersionDep(dep: ModuleID, scalaInfo: Option[ScalaModuleInfo]): ModuleID =
-    // Platform suffix before cross suffix, matching the coordinate (sbt/sbt#9117).
-    val base = dep.crossVersion match
-      case _: Disabled => dep.name
-      case _           =>
-        CrossVersion.addPlatformSuffix(dep.name, dep.platformOpt, scalaInfo.flatMap(_.platform))
     val crossFn = CrossVersion(dep, scalaInfo)
     val crossDep = crossFn match
-      case Some(fn) => dep.withName(fn(base)).withCrossVersion(CrossVersion.disabled)
+      case Some(fn) => dep.withName(fn(dep.name)).withCrossVersion(CrossVersion.disabled)
       case None     => dep
     if crossDep.exclusions.isEmpty || scalaInfo.isEmpty then crossDep
     else


### PR DESCRIPTION
**Problem**

`CrossVersion(module, scalaModuleInfo)` drops the platform, so it names a Scala.js or Scala Native artifact `foo_2.13` rather than `foo_sjs1_2.13`.

A caller outside sbt has no way to arrive at the published name: `addPlatformSuffix` is `private[sbt]`, and this overload ignores `ScalaModuleInfo.platform`.

On sbt 1 the same call was correct, because the platform was a prefix inside the `CrossVersion` itself.

Found via sbt-shading, which rebuilds a module's name to locate the project's own entry in the update report (`ShadingPlugin.shadedJars`). On a Scala.js or Native row that name matches nothing, so no dependency is recognised as direct, every module counts as shaded, and the entire classpath is bundled into the published jar — `sourcecode`, `niocharset`, `LICENSE`, `rootdoc.txt` and so on, until `onlyNamespaces` asserts.

**Solution**

Name the artifact in full: platform suffix before cross suffix, matching the coordinate (#9117), through `addPlatformSuffix`, which already knows that `jvm` contributes no suffix.

The alternative is to make `addPlatformSuffix` public and have plugins call it explicitly. That costs every cross-built plugin a version-specific source set, since it does not exist on sbt 1, whereas this overload does and is already correct there.
