### PR TITLE
[2.x] perf: Stop re-converting the classpath in `compileOptions`

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -984,9 +984,10 @@ object Defaults extends BuildCommon with DefExtra {
         compileOptions := Def.uncached {
           val opts = (compile / compileOptions).value
           val cp0 = dependencyClasspath.value
-          val cp1 = backendOutput.value +: data(cp0)
           val converter = fileConverter.value
-          val cp = cp1.map(converter.toPath).map(converter.toVirtualFile)
+          // backendOutput is a settingKey: its listing is captured at project load, so re-convert
+          val cp = converter.toVirtualFile(converter.toPath(backendOutput.value)) +:
+            data(cp0).map(converter.toVirtualFile)
           opts.withClasspath(cp.toArray)
         },
         compileInputs2 := Def.uncached {
@@ -2455,8 +2456,8 @@ object Defaults extends BuildCommon with DefExtra {
       compileOptions := Def.uncached {
         val c = fileConverter.value
         val cp0 = classpathTask.value
-        val cp1 = backendOutput.value +: data(cp0)
-        val cp = cp1.map(c.toPath).map(c.toVirtualFile)
+        // backendOutput is a settingKey: its listing is captured at project load, so re-convert
+        val cp = c.toVirtualFile(c.toPath(backendOutput.value)) +: data(cp0).map(c.toVirtualFile)
         val vs0 = sourcesVF.value
         val vs = vs0.toVector.map: x =>
           c.toVirtualFile(c.toPath(x))


### PR DESCRIPTION
**Disclaimer**: Investigated and developed with Claude Code and human review in the loop

Fixes mechanism 1 in #9601.

## Problem

Both `compileOptions` sites did `cp1.map(c.toPath).map(c.toVirtualFile)`. The `toPath` defeats `FileConverter.toVirtualFile(VirtualFileRef)`, which already returns the ref unchanged when it is a `VirtualFile`, and forces the `toVirtualFile(Path)` overload instead. For a class directory that runs `MappedFileConverter.toDirectory`: a recursive `FileTreeView.list` plus a `readAttributes` per class file — once per dependent project.

On an 82-module build that is 1,380 directory rebuilds per no-op compile over 82 distinct directories, against 163 live instances.

## Fix

```scala
val cp = c.toVirtualFile(c.toPath(backendOutput.value)) +: data(cp0).map(c.toVirtualFile)
```

`backendOutput` stays converted explicitly: it is a `settingKey` evaluated once at project load, so reusing it would pin a listing taken before anything compiled.

## Why reuse is safe

**`cp0` is rebuilt on every invocation.** Both sites read an uncached task: `compileJava / compileOptions` reads `dependencyClasspath`, and `compile / compileOptions` reads `classpathTask`, which defaults to `dependencyPicklePath`. Both are `Def.uncached` (`Defaults.scala:2804`, `:2909`), as are the classpaths they are built from, `internalDependencyClasspath` and `externalDependencyClasspath` (`:2808`, `:2801`). Nothing here is a cached task, so the `Classpath` is re-evaluated on every invocation and its elements are constructed anew — no instance survives from a previous run to be handed back stale. That is what makes passing the elements straight through equivalent to rebuilding them, rather than a lifetime extension.

**The one element that is not freshly built is still converted.** `backendOutput` is a `settingKey`, evaluated once at project load and held for the life of the server, so its directory listing and its lazy `contentHash` would be frozen. It keeps its explicit `toVirtualFile(toPath(...))`.

**Cached upstream producers are safe either way.** Some keys feeding `cp0` are cached tasks — `packageBin`, since `packageTask` is `Def.cachedTask` and `exportJars` defaults to `true`. On a miss the task builds a fresh `VirtualFile`; on a hit the value deserializes to `BasicHashedVirtualFileRef`, which does not implement `VirtualFile`, so `toVirtualFile(ref)` falls through to the full path round trip exactly as before.

**And zinc consumes classpath entries by path regardless.**

- `classpathHash` is `ClasspathCache.hashClasspath(classpath.map(converter.toPath))` (`MixedAnalyzingCompiler.scala:326`). The `ExternalHooks.Lookup` branch that would see the `VirtualFile[]` unmapped is unreachable in sbt — `incOptions` uses `IncOptions.defaultExternal()`, whose lookup is `Optional.empty()`.
- Products and libraries stamp via `Stamper.forHashInRootPaths`, i.e. `toPath` then `FarmHash.ofPath` (`Stamp.scala:222`).
- `contentHash` is read only by `Stamper.forContentHash`, wired as the *source* stamper (`Stamp.scala:87,289-291`). Hence `sourcesVF` keeps its round trip.

## Measurements

https://github.com/hoangmaihuy/sbt-compile-benchmark

82 modules, 162,007 outputs, JDK 25.0.4, macOS arm64. Baseline is `develop` built and published locally, so #9609 (already on `develop`) is not counted here. `compileOptions` totals are from `-Dsbt.task.timings=true`, summed over all modules.

| tree | `exportJars` | scenario | develop: 3 runs -> mean | this PR: 3 runs -> mean | saved | speedup | `compileOptions` total |
| --- | --- | --- | --- | --- | --- | --- | --- |
| cache-restored | `false` | no-op | 38.22/39.82/35.13 -> 37.72 s | 7.82/9.17/8.97 -> 8.65 s | **29.07 s** | **4.36x** | 71,820 -> 8,035 ms (8.9x) |
| cache-restored | `false` | edit leaf | 65.74/68.65/67.43 -> 67.27 s | 26.37/34.66/34.29 -> 31.77 s | **35.50 s** | **2.12x** | 76,839 -> 7,373 ms (10.4x) |
| cache-restored | `false` | edit deep dep | 75.82/62.36/60.46 -> 66.21 s | 52.01/52.53/52.19 -> 52.24 s | **13.97 s** | **1.27x** | 61,848 -> 13,046 ms (4.7x) |
| real files | `false` | no-op | 7.91/7.09/7.17 -> 7.39 s | 2.48/2.30/2.32 -> 2.37 s | **5.02 s** | **3.12x** | 14,904 -> 951 ms (15.7x) |
| real files | `false` | edit leaf | 9.61/8.90/8.68 -> 9.06 s | 5.06/4.05/3.96 -> 4.36 s | **4.71 s** | **2.08x** | 13,479 -> 987 ms (13.7x) |
| real files | `false` | edit deep dep | 17.02/16.25/17.23 -> 16.83 s | 12.59/11.83/11.70 -> 12.04 s | **4.79 s** | **1.40x** | 14,070 -> 898 ms (15.7x) |
| real files | `true` | no-op | 5.39/5.32/6.73 -> 5.81 s | 5.46/5.41/5.32 -> 5.40 s | 0.42 s | 1.08x | 941 -> 967 ms (1.0x) |
| real files | `true` | edit leaf | 6.40/5.44/5.30 -> 5.71 s | 6.22/5.55/5.33 -> 5.70 s | 0.01 s | 1.00x | 968 -> 991 ms (1.0x) |
| real files | `true` | edit deep dep | 6.65/6.92/7.07 -> 6.88 s | 6.70/7.12/6.91 -> 6.91 s | -0.03 s | 1.00x | 998 -> 971 ms (1.0x) |
| cache-restored | `true` | no-op | 13.39/13.07/12.80 -> 13.09 s | 12.82/13.04/12.79 -> 12.88 s | 0.20 s | 1.02x | 10,278 -> 12,517 ms (0.8x) |
| cache-restored | `true` | edit leaf | 14.06/12.99/13.14 -> 13.40 s | 13.93/13.13/12.92 -> 13.33 s | 0.07 s | 1.01x | 12,640 -> 12,389 ms (1.0x) |
| cache-restored | `true` | edit deep dep | 15.83/15.35/14.92 -> 15.37 s | 16.16/14.87/14.35 -> 15.13 s | 0.24 s | 1.02x | 13,224 -> 12,975 ms (1.0x) |

Every gain is in the `exportJars=false` half, where classpath entries are class directories. With `exportJars=true` they are jars, `toDirectory` is never reached, and the numbers are flat — the gain tracks exactly the condition the fix addresses.

In the worst cell `compileOptions` falls from 73% to 23% of all task time, while `compileIncremental` over the same pair is 16,667 -> 16,453 ms. The time removed is classpath conversion, not compilation.
