### PR TITLE
[2.x] perf: Copy instead of symlink in disk cache on APFS

### DIFF
--- a/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
@@ -8,12 +8,13 @@
 
 package sbt.internal.util
 
-import java.nio.file.{ Path, Paths }
+import java.nio.file.{ Files, Path, Paths }
 import java.util.Locale
 
 import scala.collection.concurrent.TrieMap
 import scala.reflect.Selectable.reflectiveSelectable
 import scala.util.Properties
+import scala.util.control.NonFatal
 
 object Util:
   def makeList[T](size: Int, value: T): List[T] = List.fill(size)(value)
@@ -76,6 +77,10 @@ object Util:
   lazy val isCygwinWindows: Boolean = isWindows && isCygwin
 
   lazy val isEmacs: Boolean = sys.env.contains("INSIDE_EMACS")
+
+  def isApfs(path: Path): Boolean =
+    try Files.getFileStore(path).`type`().equalsIgnoreCase("apfs")
+    catch case NonFatal(_) => false
 
   def nil[A]: List[A] = List.empty[A]
   def nilSeq[A]: Seq[A] = Seq.empty[A]

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -196,7 +196,9 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
     dir
   }
 
-  private val symlinkSupported: AtomicBoolean = AtomicBoolean(true)
+  // Files.copy clones on APFS, so a real file costs no extra disk while sparing every later
+  // directory walk the CAS inode lookup that resolving a symlink pays.
+  private lazy val symlinkSupported: AtomicBoolean = AtomicBoolean(!Util.isApfs(casBase))
 
   override def storeName: String = "disk"
 

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.{ CyclicBarrier, ExecutorService, Executors, TimeUni
 
 import sbt.internal.util.CacheEventLog
 import sbt.internal.util.StringVirtualFile1
+import sbt.internal.util.Util
 import sbt.io.IO
 import sbt.io.syntax.*
 import verify.BasicTestSuite
@@ -140,6 +141,7 @@ object ActionCacheTest extends BasicTestSuite:
         cache.syncBlobs(refs, outputDirectory)
         assert((dir / "a.txt").exists, "a.txt not re-extracted after the directory was deleted")
         assert((dir / "b.txt").exists, "b.txt not re-extracted after the directory was deleted")
+        assertMaterialized(cache, (dir / "a.txt").toPath)
 
   test("Disk cache does not re-extract a dirzip whose archive digest already matches"):
     withDiskCache: cache =>
@@ -160,7 +162,7 @@ object ActionCacheTest extends BasicTestSuite:
         cache.syncBlobs(refs, outputDirectory)
         assert(IO.read(dir / "a.txt") == "diverged")
 
-  test("Disk cache relinks a digest-matching dirzip to the CAS"):
+  test("Disk cache materializes a digest-matching dirzip from the CAS"):
     withDiskCache: cache =>
       IO.withTemporaryDirectory: tempDir =>
         val outputDirectory = tempDir.toPath()
@@ -176,7 +178,7 @@ object ActionCacheTest extends BasicTestSuite:
         assert(!Files.isSymbolicLink(zipPath), "packageDirectory should leave a regular file")
 
         cache.syncBlobs(refs, outputDirectory)
-        assert(Files.isSymbolicLink(zipPath), "digest-matching archive was not relinked to the CAS")
+        assertMaterialized(cache, zipPath)
 
   test("Disk cache re-extracts a dirzip whose archive digest differs"):
     withDiskCache: cache =>
@@ -873,6 +875,11 @@ object ActionCacheTest extends BasicTestSuite:
       },
       keepDirectory = false
     )
+
+  def assertMaterialized(cache: DiskActionCacheStore, p: Path): Unit =
+    if Util.isApfs(cache.casBase) then
+      assert(!Files.isSymbolicLink(p), s"$p was symlinked instead of copied")
+    else assert(Files.isSymbolicLink(p), s"$p was not symlinked into the CAS")
 
   def getCacheConfig(
       cache: ActionCacheStore,


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes mechanism 2 in #9601

### Problem

Resolving a symlink reads an inode out of a CAS far too large to stay in the OS metadata cache: **165 µs cold against 3.6 µs for a regular file**, measured on a real 57 GB / 952,605-blob CAS. A real-file tree answers a walk from `readdir`'s `d_type` with no per-file `stat` at all.

### Changes

`DiskActionCacheStore` seeds the existing `symlinkSupported` latch from the filesystem holding the CAS, and copies rather than symlinks on APFS:

```scala
// Util.scala, alongside isMac / isWindows
def isApfs(path: Path): Boolean =
  try Files.getFileStore(path).`type`().equalsIgnoreCase("apfs")
  catch case NonFatal(_) => false

// ActionCacheStore.scala
private lazy val symlinkSupported: AtomicBoolean = AtomicBoolean(!Util.isApfs(casBase))
```

**On APFS the copy is nearly free.** `copyFile` is `Files.copy(COPY_ATTRIBUTES, REPLACE_EXISTING)`, which on JDK 25 reaches `clonefile(2)`. Each entry becomes a real file with its own inode, so the walk runs at full speed while its data blocks stay shared with the CAS — **11 MB of real disk against 137 MB for the symlinked tree**. There is barely any disk to trade, which is why this is worth doing by default rather than as an option.

**A copy also cannot corrupt the cache.** Writing through a symlink writes into the CAS blob, so any tool that opens a restored output for update rather than replacing it damages the shared cache. This is the same hazard you raised against hard links; a copy does not have it.

**And `target/out` stops depending on the global cache.** Today it is symlinks into the shared CAS, so wiping that cache leaves a checkout's class files unreadable. sbt recovers on the next build, but that recovery is a full recompile, and until then anything else reading `target/out` — an IDE, `javap`, a packaging script — sees broken files.

### Benchmark

https://github.com/hoangmaihuy/sbt-compile-benchmark

81 modules, 162,003 output files, `exportJars=true`, macOS/APFS, JDK 25. Steady-state means; the two sbt builds published as separate versions and verified distinct.

| scenario | symlinks (today) | copies (this PR) | real files (ceiling) | speedup |
|---|---|---|---|---|
| no-op | 14.75s | **5.96s** | 5.89s | **2.47x** |
| edit leaf | 15.61s | **6.30s** | 6.01s | **2.48x** |
| edit deep dep | 17.84s | **7.54s** | 7.29s | **2.36x** |
| cache restore | 43.63s | 52.10s | 40.06s | +19% |

Copies land within 1-5% of the real-files ceiling. The +19% on restore is repaid by the first no-op.

Disk: **11 MB against 137 MB symlinked**, because `Files.copy` reaches `clonefile(2)`. Where cloning is unavailable the same tree costs **613 MB**, measured by dereferencing it with a non-cloning copy. `du` cannot see clones and reports 880 MB; `df` is the honest number.

### References

- [`DiskCacheClient.java`](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java) — Bazel's disk cache copies and never symlinks, through the same `Files.copy` call with the same flags.
- [bazelbuild/bazel#16711](https://github.com/bazelbuild/bazel/issues/16711) — "Symlinked sandbox is slow", with reports of 300K-input actions. Five mitigations listed, none taken; P3, unassigned.

