### PR TITLE
[2.x] fix: Fixes -V parsing in sbt runners

### DIFF
--- a/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
+++ b/launcher-package/integration-test/src/test/scala/ExtendedRunnerTest.scala
@@ -47,6 +47,12 @@ object ExtendedRunnerTest extends BasicTestSuite:
     ()
   }
 
+  test("sbt tasks -V lists verbose tasks") {
+    val out = sbtProcessInDir(IntegrationTestPaths.citestDir("citest2"))("tasks", "-V").!!
+    assert(out.linesIterator.exists(_.contains("allCredentials")))
+    assert(!out.linesIterator.exists(_.startsWith("sbt runner version:")))
+  }
+
   def testVersion(lines: List[String]): Unit = {
     assert(lines.size >= 2)
     val expected0 = s"(?m)^sbt version in this project: $versionRegEx(\\r)?"

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -154,6 +154,14 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
     assertVersionOutput(out)
     ()
 
+  testOutput("sbt -V should work")("-V"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt tasks -V forwards the tasks option")("tasks", "-V", "-v"): (out: List[String]) =>
+    assert(out.contains("-V"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
   testOutput(
     "sbt --version reports spaced sbt.version from project/build.properties (sbt 1.x)",
     citestVariant = "citest",

--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -158,8 +158,61 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
     assertVersionOutput(out)
     ()
 
+  testOutput("sbt -version should work")("-version"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt -V followed by a launcher option should work")("-V", "-v"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt launcher option followed by --version should work")("--no-colors", "--version"):
+    (out: List[String]) =>
+      assertVersionOutput(out)
+      ()
+
+  testOutput("sbt --version followed by an empty argument should work")("--version", ""):
+    (out: List[String]) =>
+      assertVersionOutput(out)
+      ()
+
   testOutput("sbt tasks -V forwards the tasks option")("tasks", "-V", "-v"): (out: List[String]) =>
     assert(out.contains("-V"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt tasks -version forwards the tasks option",
+    windowsSupport = false,
+  )("tasks", "-version", "-v"): (out: List[String]) =>
+    assert(out.contains("-version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt tasks --version forwards the tasks option",
+    windowsSupport = false,
+  )("tasks", "--version", "-v"): (out: List[String]) =>
+    assert(out.contains("--version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt -V tasks forwards the tasks option",
+    windowsSupport = false,
+  )("-V", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("-V"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt -version tasks forwards the tasks option",
+    windowsSupport = false,
+  )("-version", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("-version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt --version tasks forwards the tasks option",
+    windowsSupport = false,
+  )("--version", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("--version"))
     assert(!out.exists(_.startsWith("sbt runner version:")))
 
   testOutput(

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -55,6 +55,7 @@ set sbt_args_client=-1
 set sbt_args_jvm_client=
 set sbt_args_no_server=
 set sbt_args_experimental_execution_log=
+set sbt_args_seen_command=
 set is_this_dir_sbt=0
 
 rem users can set SBT_OPTS via .sbtopts
@@ -184,7 +185,7 @@ if defined _verbose_arg (
   goto args_loop
 )
 
-if "%~0" == "-V" set _version_arg=true
+if "%~0" == "-V" if not defined sbt_args_seen_command set _version_arg=true
 if "%~0" == "-version" set _version_arg=true
 if "%~0" == "--version" set _version_arg=true
 
@@ -607,6 +608,7 @@ if defined sbt_new if "%g:~0,2%" == "--" (
 )
 
 rem the %0 (instead of %~0) preserves original argument quoting
+set sbt_args_seen_command=1
 set SBT_ARGS=!SBT_ARGS! %0
 
 goto args_loop

--- a/sbt
+++ b/sbt
@@ -801,7 +801,7 @@ process_args () {
     case "$1" in
             -h|-help|--help) print_help=1 && shift ;;
       -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
-                         -V) if (( ${#residual_args[@]} == 0 )); then
+                         -V) if [[ ! "${residual_args[*]}" =~ [^[:space:]] ]]; then
                                print_version=1
                              else
                                addResidual "$1"

--- a/sbt
+++ b/sbt
@@ -801,13 +801,7 @@ process_args () {
     case "$1" in
             -h|-help|--help) print_help=1 && shift ;;
       -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
-                         -V) if [[ ! "${residual_args[*]}" =~ [^[:space:]] ]]; then
-                               print_version=1
-                             else
-                               addResidual "$1"
-                             fi
-                             shift ;;
-         -version|--version) print_version=1 && shift ;;
+      -V|-version|--version) print_version=1 && addResidual "$1" && shift ;;
           --numeric-version) print_sbt_version=1 && shift ;;
            --script-version) print_sbt_script_version=1 && shift ;;
                 shutdownall) shutdownall=1 && shift ;;
@@ -847,6 +841,19 @@ process_args () {
     residual_args=()
     process_my_args "${myargs[@]}"
   }
+
+  if [[ $print_version ]]; then
+    for arg in "${residual_args[@]}"; do
+      case "$arg" in
+        -V|-version|--version) ;;
+        *) if [[ "$arg" =~ [^[:space:]] ]]; then
+             print_version=
+             break
+           fi ;;
+      esac
+    done
+    [[ $print_version ]] && residual_args=()
+  fi
 }
 
 loadConfigFile() {

--- a/sbt
+++ b/sbt
@@ -801,7 +801,13 @@ process_args () {
     case "$1" in
             -h|-help|--help) print_help=1 && shift ;;
       -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
-      -V|-version|--version) print_version=1 && shift ;;
+                         -V) if (( ${#residual_args[@]} == 0 )); then
+                               print_version=1
+                             else
+                               addResidual "$1"
+                             fi
+                             shift ;;
+         -version|--version) print_version=1 && shift ;;
           --numeric-version) print_sbt_version=1 && shift ;;
            --script-version) print_sbt_script_version=1 && shift ;;
                 shutdownall) shutdownall=1 && shift ;;

--- a/sbtw/src/main/scala/sbtw/ArgParser.scala
+++ b/sbtw/src/main/scala/sbtw/ArgParser.scala
@@ -52,10 +52,34 @@ object ArgParser:
           .optional()
           .action((x, c) => c.copy(residual = c.residual :+ x)),
       )
+    val protectedResidualMarker = "\u0000sbt-residual:"
+    def protectResidual(arg: String): String =
+      if arg.startsWith("-J") || arg.startsWith("-X") || arg.startsWith("-D") then
+        protectedResidualMarker + arg
+      else arg
+    def restoreResidual(arg: String): String =
+      if arg.startsWith(protectedResidualMarker) then arg.stripPrefix(protectedResidualMarker)
+      else arg
+    def hasSbtCommand(opts: LauncherOptions): Boolean =
+      Runner
+        .splitResidual(opts.residual.map(restoreResidual))
+        ._2
+        .exists(arg => !arg.startsWith("-D") && !arg.startsWith("-XX"))
+
+    val taskVersionMarker = "\u0000sbt-task-version"
+    val protectedArgs = args.foldLeft(Vector.empty[String]): (acc, arg) =>
+      if arg == "-V" && OParser
+          .parse(parser, acc.toArray, LauncherOptions())
+          .exists(hasSbtCommand)
+      then acc :+ taskVersionMarker
+      else acc :+ protectResidual(arg)
     OParser
-      .parse(parser, args, LauncherOptions())
+      .parse(parser, protectedArgs.toArray, LauncherOptions())
       .map: opts =>
-        val sbtNew = opts.residual.contains("new") || opts.residual.contains("init")
-        val isScript = opts.residual.exists(_.startsWith("-Dsbt.main.class=sbt.ScriptMain"))
-        opts.copy(sbtNew = sbtNew, allowEmpty = opts.allowEmpty || isScript)
+        val residual = opts.residual.map:
+          case `taskVersionMarker` => "-V"
+          case arg                 => restoreResidual(arg)
+        val sbtNew = residual.contains("new") || residual.contains("init")
+        val isScript = residual.exists(_.startsWith("-Dsbt.main.class=sbt.ScriptMain"))
+        opts.copy(residual = residual, sbtNew = sbtNew, allowEmpty = opts.allowEmpty || isScript)
 end ArgParser

--- a/sbtw/src/main/scala/sbtw/ArgParser.scala
+++ b/sbtw/src/main/scala/sbtw/ArgParser.scala
@@ -14,7 +14,10 @@ object ArgParser:
         opt[Unit]('h', "help").action((_, c) => c.copy(help = true)),
         opt[Unit]('v', "verbose").action((_, c) => c.copy(verbose = true)),
         opt[Unit]('d', "debug").action((_, c) => c.copy(debug = true)),
-        opt[Unit]('V', "version").action((_, c) => c.copy(version = true)),
+        opt[Unit]('V', "version").action((_, c) =>
+          if c.residual.nonEmpty then c.copy(residual = c.residual :+ "-V")
+          else c.copy(version = true)
+        ),
         opt[Unit]("numeric-version").action((_, c) => c.copy(numericVersion = true)),
         opt[Unit]("script-version").action((_, c) => c.copy(scriptVersion = true)),
         opt[Unit]("shutdownall").action((_, c) => c.copy(shutdownAll = true)),
@@ -52,34 +55,10 @@ object ArgParser:
           .optional()
           .action((x, c) => c.copy(residual = c.residual :+ x)),
       )
-    val protectedResidualMarker = "\u0000sbt-residual:"
-    def protectResidual(arg: String): String =
-      if arg.startsWith("-J") || arg.startsWith("-X") || arg.startsWith("-D") then
-        protectedResidualMarker + arg
-      else arg
-    def restoreResidual(arg: String): String =
-      if arg.startsWith(protectedResidualMarker) then arg.stripPrefix(protectedResidualMarker)
-      else arg
-    def hasSbtCommand(opts: LauncherOptions): Boolean =
-      Runner
-        .splitResidual(opts.residual.map(restoreResidual))
-        ._2
-        .exists(arg => !arg.startsWith("-D") && !arg.startsWith("-XX"))
-
-    val taskVersionMarker = "\u0000sbt-task-version"
-    val protectedArgs = args.foldLeft(Vector.empty[String]): (acc, arg) =>
-      if arg == "-V" && OParser
-          .parse(parser, acc.toArray, LauncherOptions())
-          .exists(hasSbtCommand)
-      then acc :+ taskVersionMarker
-      else acc :+ protectResidual(arg)
     OParser
-      .parse(parser, protectedArgs.toArray, LauncherOptions())
+      .parse(parser, args, LauncherOptions())
       .map: opts =>
-        val residual = opts.residual.map:
-          case `taskVersionMarker` => "-V"
-          case arg                 => restoreResidual(arg)
-        val sbtNew = residual.contains("new") || residual.contains("init")
-        val isScript = residual.exists(_.startsWith("-Dsbt.main.class=sbt.ScriptMain"))
-        opts.copy(residual = residual, sbtNew = sbtNew, allowEmpty = opts.allowEmpty || isScript)
+        val sbtNew = opts.residual.contains("new") || opts.residual.contains("init")
+        val isScript = opts.residual.exists(_.startsWith("-Dsbt.main.class=sbt.ScriptMain"))
+        opts.copy(sbtNew = sbtNew, allowEmpty = opts.allowEmpty || isScript)
 end ArgParser

--- a/sbtw/src/test/scala/sbtw/ArgParserSpec.scala
+++ b/sbtw/src/test/scala/sbtw/ArgParserSpec.scala
@@ -31,16 +31,4 @@ object ArgParserSpec extends verify.BasicTestSuite:
     assert(!options.version)
     assert(options.residual == Seq("tasks", "-V"))
   }
-
-  test("-V after a JVM argument requests the runner version") {
-    val options = ArgParser.parse(Array("-J-Xmx1G", "-V")).get
-    assert(options.version)
-    assert(options.residual == Seq("-J-Xmx1G"))
-  }
-
-  test("-V after a system property requests the runner version") {
-    val options = ArgParser.parse(Array("-Dfoo=bar", "-V")).get
-    assert(options.version)
-    assert(options.residual == Seq("-Dfoo=bar"))
-  }
 end ArgParserSpec

--- a/sbtw/src/test/scala/sbtw/ArgParserSpec.scala
+++ b/sbtw/src/test/scala/sbtw/ArgParserSpec.scala
@@ -19,4 +19,28 @@ object ArgParserSpec extends verify.BasicTestSuite:
     val opts = ArgParser.parse(Array("--java-home", "C:\\jdk", "new")).get
     assert(opts.sbtNew)
   }
+
+  test("standalone -V requests the runner version") {
+    val options = ArgParser.parse(Array("-V")).get
+    assert(options.version)
+    assert(options.residual.isEmpty)
+  }
+
+  test("-V after a command is forwarded to sbt") {
+    val options = ArgParser.parse(Array("tasks", "-V")).get
+    assert(!options.version)
+    assert(options.residual == Seq("tasks", "-V"))
+  }
+
+  test("-V after a JVM argument requests the runner version") {
+    val options = ArgParser.parse(Array("-J-Xmx1G", "-V")).get
+    assert(options.version)
+    assert(options.residual == Seq("-J-Xmx1G"))
+  }
+
+  test("-V after a system property requests the runner version") {
+    val options = ArgParser.parse(Array("-Dfoo=bar", "-V")).get
+    assert(options.version)
+    assert(options.residual == Seq("-Dfoo=bar"))
+  }
 end ArgParserSpec


### PR DESCRIPTION
Fix https://github.com/sbt/sbt/issues/9557

Problem: -V is consumed by the launcher instead of sbt in `sbt tasks -V`.

Solution: in the parser's `-V` behavior, lookback to see if there are commands going before it, in which case, forward `-V` to sbt.