### PR TITLE
[2.0.x] bport: Fixes scalacOptions in BSP using VirtualFileRef

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1097,6 +1097,9 @@ object Defaults extends BuildCommon {
       consoleQuick / scalacOptions := Def.uncached {
         Compiler.toConsoleScalacOptions(scalacOptions.value)
       },
+      resolvedScalacOptions := Def.uncached {
+        Compiler.resolveVirtualizedScalacOptions(scalacOptions.value, rootPaths.value)
+      },
       consoleQuick / forkOptions := Def.uncached((console / forkOptions).value),
       discoveredMainClasses := compile
         .map(discoverMainClasses)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -213,6 +213,8 @@ object Keys {
   val autoCompilerPlugins = settingKey[Boolean]("If true, enables automatically generating -Xplugin arguments to the compiler based on the classpath for the " + CompilerPlugin.name + " configuration.").withRank(AMinusSetting)
   val maxErrors = settingKey[Int]("The maximum number of errors, such as compile errors, to list.").withRank(ASetting)
   val scalacOptions = taskKey[Seq[String]]("Options for the Scala compiler.").withRank(BPlusTask)
+  @transient
+  val resolvedScalacOptions = taskKey[Seq[String]]("scalacOptions with cache placeholders (e.g. ${CSR_CACHE}) resolved to absolute machine paths.").withRank(BPlusTask)
   val javacOptions = taskKey[Seq[String]]("Options for the Java compiler.").withRank(BPlusTask)
   val incOptions = taskKey[IncOptions]("Options for the incremental compiler.").withRank(BTask)
   val extraIncOptions = taskKey[Seq[(String, String)]]("Extra options for the incremental compiler").withRank(CTask)
@@ -492,6 +494,7 @@ object Keys {
   val bspBuildTargetRun = inputKey[Unit]("Corresponds to buildTarget/run request").withRank(DTask)
   val bspBuildTargetCleanCache = inputKey[Unit]("Corresponds to buildTarget/cleanCache request").withRank(DTask)
   val bspBuildTargetScalacOptions = inputKey[Unit]("").withRank(DTask)
+  @transient
   val bspBuildTargetScalacOptionsItem = taskKey[ScalacOptionsItem]("").withRank(DTask)
   val bspBuildTargetJavacOptions = inputKey[Unit]("Implementation of buildTarget/javacOptions").withRank(DTask)
   val bspBuildTargetJavacOptionsItem = taskKey[JavacOptionsItem]("Item of buildTarget/javacOptions").withRank(DTask)

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -204,9 +204,11 @@ object BuildServerProtocol {
       val items = bspBuildTargetScalacOptionsItem.result.all(filter).value
       val appProvider = appConfiguration.value.provider()
       val sbtJars = appProvider.mainClasspath()
+      val rootPaths = Keys.rootPaths.value
       val buildItems = workspace.builds.map { build =>
         val plugins: LoadedPlugins = build._2.unit.plugins
-        val scalacOptions = plugins.pluginData.scalacOptions
+        val scalacOptions =
+          Compiler.resolveVirtualizedScalacOptions(plugins.pluginData.scalacOptions, rootPaths)
         val pluginClasspath = plugins.classpath
         val converter = plugins.pluginData.converter
         val classpath =
@@ -314,7 +316,7 @@ object BuildServerProtocol {
     bspBuildTargetRun := bspRunTask.evaluated,
     bspBuildTargetScalacOptionsItem := {
       val target = Keys.bspTargetIdentifier.value
-      val scalacOptions = Keys.scalacOptions.value.toVector
+      val scalacOptions = Keys.resolvedScalacOptions.value.toVector
       val classDirectory = Keys.classDirectory.value
       val classpath = classpathTask.value
       ScalacOptionsItem(target, scalacOptions, classpath, classDirectory.toURI)

--- a/sbt-app/src/sbt-test/compiler-project/resolved-scalac-options/build.sbt
+++ b/sbt-app/src/sbt-test/compiler-project/resolved-scalac-options/build.sbt
@@ -1,0 +1,26 @@
+val check = taskKey[Unit]("Verify resolvedScalacOptions resolves cache placeholders (#9578).")
+
+scalaVersion := "2.13.16"
+
+addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.13.3").cross(CrossVersion.full))
+
+check := Def.uncached {
+  val raw = (Compile / scalacOptions).value
+  val resolved = (Compile / resolvedScalacOptions).value
+
+  assert(
+    raw.exists(_.contains("${CSR_CACHE}")),
+    s"expected a virtualized coursier-cache placeholder in raw scalacOptions, got: $raw"
+  )
+  assert(
+    resolved.forall(!_.contains("${")),
+    s"resolvedScalacOptions still contains a cache placeholder: $resolved"
+  )
+
+  val pluginArg = resolved
+    .find(_.startsWith("-Xplugin:"))
+    .getOrElse(sys.error(s"no -Xplugin entry in resolvedScalacOptions: $resolved"))
+  val jar = new java.io.File(pluginArg.stripPrefix("-Xplugin:"))
+  assert(jar.isAbsolute, s"resolved -Xplugin path is not absolute: $jar")
+  assert(jar.exists, s"resolved -Xplugin jar does not exist: $jar")
+}

--- a/sbt-app/src/sbt-test/compiler-project/resolved-scalac-options/test
+++ b/sbt-app/src/sbt-test/compiler-project/resolved-scalac-options/test
@@ -1,0 +1,2 @@
+# resolvedScalacOptions must resolve ${CSR_CACHE} placeholders to absolute machine paths (#9578)
+> check

--- a/server-test/src/server-test/buildserver/build.sbt
+++ b/server-test/src/server-test/buildserver/build.sbt
@@ -38,6 +38,12 @@ lazy val util = project.settings(
   Compile / classDirectory := baseDirectory.value / "classes"
 )
 
+lazy val scalacOptionsPlugin = project
+  .in(file("scalac-options-plugin"))
+  .settings(
+    addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.13.3").cross(CrossVersion.full))
+  )
+
 lazy val diagnostics = project
 
 lazy val javaProj = project


### PR DESCRIPTION
This is a 2.0.x backport of https://github.com/sbt/sbt/pull/9610

Add a resolvedScalacOptions task that resolves cache placeholders in scalacOptions to absolute machine paths.