### PR TITLE
fix: include plugin classpath in action cache keys

### DIFF
--- a/main-command/src/main/scala/sbt/BasicKeys.scala
+++ b/main-command/src/main/scala/sbt/BasicKeys.scala
@@ -135,6 +135,18 @@ object BasicKeys {
     10000
   )
 
+  private[sbt] val metaBuildClasspathDigest = AttributeKey[String](
+    "metaBuildClasspathDigest",
+    "Digest of the metabuild classpath (plugin jars and compiled build definition products), incorporated into every action cache key.",
+    10000
+  )
+
+  private[sbt] val buildDefinitionDigest = AttributeKey[String](
+    "buildDefinitionDigest",
+    "Digest of the full build definition (metabuild classpath and compiled .sbt file classes), incorporated into cached failure keys.",
+    10000
+  )
+
   // Unlike other BasicKeys, this is not used directly as a setting key,
   // and severLog / logLevel is used instead.
   private[sbt] val serverLogLevel =

--- a/main-settings/src/main/scala/sbt/Def.scala
+++ b/main-settings/src/main/scala/sbt/Def.scala
@@ -19,6 +19,7 @@ import sbt.internal.util.{ Terminal as ITerminal, * }
 import sbt.util.{
   AggregateActionCacheStore,
   BuildWideCacheConfiguration,
+  Digest,
   DiskActionCacheStore,
   Uncached,
 }
@@ -300,6 +301,14 @@ object Def extends BuildSyntax with Init with InitializeImplicits:
       )
     val cacheByteSize = localDigestCacheByteSizeKey.value
     val cv = cacheVersionKey.value
+    val metaBuildDigest = state
+      .get(BasicKeys.metaBuildClasspathDigest)
+      .map(Digest.apply)
+      .getOrElse(Digest.zero)
+    val buildDefinitionDigest = state
+      .get(BasicKeys.buildDefinitionDigest)
+      .map(Digest.apply)
+      .getOrElse(Digest.zero)
     BuildWideCacheConfiguration(
       cacheStore,
       outputDirectory,
@@ -308,6 +317,8 @@ object Def extends BuildSyntax with Init with InitializeImplicits:
       cacheEventLog,
       cacheByteSize,
       cv,
+      metaBuildDigest,
+      buildDefinitionDigest,
     )
   }
 

--- a/main/src/main/scala/sbt/ProjectExtra.scala
+++ b/main/src/main/scala/sbt/ProjectExtra.scala
@@ -53,7 +53,7 @@ import sbt.internal.util.{ AttributeKey, AttributeMap, Relation }
 import sbt.internal.util.Types.const
 import sbt.internal.server.ServerHandler
 import sbt.librarymanagement.Configuration
-import sbt.util.{ ActionCacheStore, Show, Level }
+import sbt.util.{ ActionCacheStore, Digest, Show, Level }
 import sjsonnew.JsonFormat
 import scala.annotation.targetName
 import scala.concurrent.{ Await, TimeoutException }
@@ -395,6 +395,7 @@ trait ProjectExtra extends Scoped.Syntax:
       )
       val winSecurityLevel = get(windowsServerSecurityLevel).getOrElse(2)
       val useJni = get(serverUseJni).getOrElse(false)
+      val (metaBuildDigest, buildDefinitionDigest) = metaBuildDigests(structure)
       val newAttrs =
         s.attributes
           .put(historyPath.key, history)
@@ -416,10 +417,42 @@ trait ProjectExtra extends Scoped.Syntax:
           .setCond(cacheStores.key, caches)
           .setCond(rootOutputDirectory.key, rod)
           .setCond(BasicKeys.fileConverter, fileConverter)
+          .put(BasicKeys.metaBuildClasspathDigest, metaBuildDigest)
+          .put(BasicKeys.buildDefinitionDigest, buildDefinitionDigest)
       s.copy(
         attributes = newAttrs,
         definedCommands = newDefinedCommands
       )
+    }
+
+    /**
+     * Digests of the build definition, both incorporated into action cache keys.
+     * The first covers the metabuild classpath (plugin jars and compiled build definition
+     * products), whose code can change task behavior without changing any task tree hash.
+     * The second additionally covers the classes compiled from .sbt files and keys cached
+     * failures, so a failure is only replayed while the build definition is unchanged.
+     */
+    private def metaBuildDigests(structure: BuildStructure): (String, String) = {
+      val units = structure.units.values.toSeq
+      val classpathDigests = units
+        .flatMap(_.unit.plugins.pluginData.classpath)
+        .flatMap { a =>
+          try Some(Digest(a.data))
+          catch { case _: Exception => None }
+        }
+        .distinct
+        .sorted
+      val dslDigests = units
+        .flatMap(_.unit.definitions.dslDefinitions.generated)
+        .flatMap { p =>
+          try Some(Digest.sha256Hash(p))
+          catch { case _: java.io.IOException => None }
+        }
+        .distinct
+        .sorted
+      val metaBuildDigest = Digest.sha256Hash(classpathDigests*)
+      val buildDefinitionDigest = Digest.sha256Hash((classpathDigests ++ dslDigests)*)
+      (metaBuildDigest.toString, buildDefinitionDigest.toString)
     }
 
     def setCond[T](key: AttributeKey[T], vopt: Option[T], attributes: AttributeMap): AttributeMap =

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/build.sbt
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/build.sbt
@@ -1,0 +1,3 @@
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+scalaVersion := "3.8.4"

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/changes/OptsHelperLenient.scala
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/changes/OptsHelperLenient.scala
@@ -1,0 +1,3 @@
+object OptsHelper {
+  def opts: Seq[String] = Seq.empty
+}

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/changes/OptsHelperStrict.scala
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/changes/OptsHelperStrict.scala
@@ -1,0 +1,3 @@
+object OptsHelper {
+  def opts: Seq[String] = Seq("-Wnonunit-statement", "-Xfatal-warnings")
+}

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/project/OptsHelper.scala
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/project/OptsHelper.scala
@@ -1,0 +1,3 @@
+object OptsHelper {
+  def opts: Seq[String] = Seq.empty
+}

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/project/TogglePlugin.scala
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/project/TogglePlugin.scala
@@ -1,0 +1,11 @@
+import sbt.*
+import sbt.Keys.*
+
+// The settings tree below never changes; only the OptsHelper implementation does,
+// mimicking a plugin dependency whose new version contributes different scalacOptions.
+object TogglePlugin extends AutoPlugin {
+  override def trigger = allRequirements
+  override def projectSettings = Seq(
+    scalacOptions ++= OptsHelper.opts
+  )
+}

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/src/main/scala/App.scala
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/src/main/scala/App.scala
@@ -1,0 +1,4 @@
+object App:
+  def run(): List[Int] =
+    List(1).map(_ + 1)
+    List(2)

--- a/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/test
+++ b/sbt-app/src/sbt-test/cache/plugin-scalac-options-toggle/test
@@ -1,0 +1,24 @@
+# warm the disk cache with the lenient options
+> compile
+
+# switching the helper the plugin calls must invalidate the cache: the recompile
+# picks up -Wnonunit-statement -Xfatal-warnings and fails
+$ copy-file changes/OptsHelperStrict.scala project/OptsHelper.scala
+> reload
+-> compile
+
+# toggling back must compile with the lenient options again: neither the stale
+# strict options nor the cached failure may be replayed
+$ copy-file changes/OptsHelperLenient.scala project/OptsHelper.scala
+> reload
+> compile
+
+# clean must not resurrect the cached failure
+> clean
+> compile
+
+# switching to the strict helper again must fail again, whether recompiled or
+# replayed from the cached failure recorded for this exact build definition
+$ copy-file changes/OptsHelperStrict.scala project/OptsHelper.scala
+> reload
+-> compile

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -78,19 +78,21 @@ object ActionCache:
   ): O =
     import config.*
 
-    val inputDigest = mkInput(key, codeContentHash, extraHash, cacheVersion)
+    val inputDigest = mkInput(key, codeContentHash, extraHash, cacheVersion, metaBuildDigest)
+    // Failures are keyed strictly on the full build definition so that a recorded failure is
+    // never replayed for inputs whose real compilation succeeds.
+    val failureDigest = Digest.sha256Hash(inputDigest, buildDefinitionDigest)
 
     def cacheFailure(e: CompileFailed): Nothing =
       // Cache the failure so subsequent builds don't re-run failed compilation
       // This fixes https://github.com/sbt/sbt/issues/7662
-      // Use the same input digest as success, distinguished by exitCode
       cacheEventLog.append(ActionCacheEvent.OnsiteTask)
       val cachedFailure = CachedCompileFailure.fromException(e)
       val json = Converter.toJsonUnsafe(cachedFailure)
-      val valuePath = mkValuePath(inputDigest)
+      val valuePath = mkValuePath(failureDigest)
       val failureFile = StringVirtualFile1(valuePath, CompactPrinter(json))
       store.put(
-        UpdateActionResultRequest(inputDigest, Vector(failureFile), exitCode = failureExitCode)
+        UpdateActionResultRequest(failureDigest, Vector(failureFile), exitCode = failureExitCode)
       )
       throw e
 
@@ -163,7 +165,9 @@ object ActionCache:
     inline def logExec(inline event: SpawnExec): Unit =
       execLog.foreach: log =>
         logEvent(event, log)
-    // Single cache lookup - use exitCode to distinguish success from failure
+    // Successes live under inputDigest; failures under the stricter failureDigest.
+    // A failure entry found under inputDigest was written by an older sbt whose key
+    // was not sound for failures, so it is treated as a miss.
     getWithFailure(inputDigest, tags, config) match
       case Right((value, result)) =>
         logExec(
@@ -175,15 +179,17 @@ object ActionCache:
           )
         )
         value
-      case Left(Some(failure)) if CachedCompileFailure.hasSufficientInfo(failure.toException) =>
-        config.cacheEventLog.append(ActionCacheEvent.Found("cached-failure"))
-        // Replay problems to the logger so users see the cached errors/warnings
-        failure.replay(config.logger)
-        logExec(
-          SpawnExec(input = spawnInput, cacheHit = true, exitCode = 1)
-        )
-        throw failure.toException
-      case Left(_) => organicTask
+      case Left(_) =>
+        getWithFailure(failureDigest, tags, config) match
+          case Left(Some(failure)) if CachedCompileFailure.hasSufficientInfo(failure.toException) =>
+            config.cacheEventLog.append(ActionCacheEvent.Found("cached-failure"))
+            // Replay problems to the logger so users see the cached errors/warnings
+            failure.replay(config.logger)
+            logExec(
+              SpawnExec(input = spawnInput, cacheHit = true, exitCode = 1)
+            )
+            throw failure.toException
+          case _ => organicTask
   end cache
 
   /**
@@ -249,7 +255,8 @@ object ActionCache:
       tags: List[CacheLevelTag],
       config: BuildWideCacheConfiguration,
   ): Option[O] =
-    val inputDigest = mkInput(key, codeContentHash, extraHash, config.cacheVersion)
+    val inputDigest =
+      mkInput(key, codeContentHash, extraHash, config.cacheVersion, config.metaBuildDigest)
     getWithFailure(inputDigest, tags, config) match
       case Right(value) => Some(value._1)
       case Left(_)      => None
@@ -263,7 +270,8 @@ object ActionCache:
       extraHash: Digest,
       config: BuildWideCacheConfiguration,
   ): Boolean =
-    val inputDigest = mkInput(key, codeContentHash, extraHash, config.cacheVersion)
+    val inputDigest =
+      mkInput(key, codeContentHash, extraHash, config.cacheVersion, config.metaBuildDigest)
     findActionResult(inputDigest, config) match
       case Right(_) => true
       case Left(_)  => false
@@ -291,7 +299,8 @@ object ActionCache:
   ): Either[Throwable, ActionResult] =
     // val logger = config.logger
     CacheImplicits.setCacheSize(config.localDigestCacheByteSize)
-    val inputDigest = mkInput(key, codeContentHash, extraHash, config.cacheVersion)
+    val inputDigest =
+      mkInput(key, codeContentHash, extraHash, config.cacheVersion, config.metaBuildDigest)
     val getRequest =
       GetActionResultRequest(
         inputDigest,
@@ -306,6 +315,15 @@ object ActionCache:
       codeContentHash: Digest,
       extraHash: Digest,
       cacheVersion: Long,
+  ): Digest =
+    mkInput(key, codeContentHash, extraHash, cacheVersion, Digest.zero)
+
+  private[sbt] inline def mkInput[I: HashWriter](
+      key: I,
+      codeContentHash: Digest,
+      extraHash: Digest,
+      cacheVersion: Long,
+      metaBuildDigest: Digest,
   ): Digest =
     // Hashing serializes every task input; surface a missing input file directly rather than as an
     // opaque serialization failure that buries it.
@@ -325,6 +343,9 @@ object ActionCache:
       ) ++ {
         if cacheVersion == 0 then Vector.empty
         else Vector(Digest.dummy(cacheVersion))
+      } ++ {
+        if metaBuildDigest == Digest.zero then Vector.empty
+        else Vector(metaBuildDigest)
       })*
     )
 
@@ -468,7 +489,30 @@ class BuildWideCacheConfiguration(
     val cacheEventLog: CacheEventLog,
     val localDigestCacheByteSize: Long,
     val cacheVersion: Long,
+    val metaBuildDigest: Digest,
+    val buildDefinitionDigest: Digest,
 ):
+  def this(
+      store: ActionCacheStore,
+      outputDirectory: Path,
+      fileConverter: FileConverter,
+      logger: Logger,
+      cacheEventLog: CacheEventLog,
+      localDigestCacheByteSize: Long,
+      cacheVersion: Long,
+  ) =
+    this(
+      store,
+      outputDirectory,
+      fileConverter,
+      logger,
+      cacheEventLog,
+      localDigestCacheByteSize,
+      cacheVersion,
+      Digest.zero,
+      Digest.zero,
+    )
+
   def this(
       store: ActionCacheStore,
       outputDirectory: Path,

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -408,6 +408,89 @@ object ActionCacheTest extends BasicTestSuite:
       assert(v2 == 2)
       assert(called == 1, s"expected a success cache hit after the cure (called=$called)")
 
+  test("Changing the metabuild digest invalidates a cached value"):
+    withDiskCache: cache =>
+      import sjsonnew.BasicJsonProtocol.*
+      var called = 0
+      val action: ((Int, Int)) => InternalActionResult[Int] = { (a, b) =>
+        called += 1
+        InternalActionResult(a + b, Nil)
+      }
+      IO.withTemporaryDirectory: tempDir =>
+        val digestA = Digest.sha256Hash("plugins-A".getBytes(StandardCharsets.UTF_8))
+        val digestB = Digest.sha256Hash("plugins-B".getBytes(StandardCharsets.UTF_8))
+        val configA = getCacheConfig(cache, tempDir, metaBuildDigest = digestA)
+        val configB = getCacheConfig(cache, tempDir, metaBuildDigest = digestB)
+
+        val v1 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configA)(action)
+        assert(v1 == 2)
+        assert(called == 1)
+
+        val v2 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configA)(action)
+        assert(v2 == 2)
+        assert(called == 1, s"expected a cache hit under the same digest (called=$called)")
+
+        val v3 = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configB)(action)
+        assert(v3 == 2)
+        assert(called == 2, s"a different metabuild digest must miss (called=$called)")
+
+  test("A cached failure is not replayed once the build definition digest changes"):
+    withDiskCache: cache =>
+      import sjsonnew.BasicJsonProtocol.*
+      var called = 0
+      val problem = new Problem:
+        override def category(): String = "Test"
+        override def severity(): Severity = Severity.Error
+        override def message(): String = "Test error message"
+        override def position(): Position = new Position:
+          override def line(): Optional[Integer] = Optional.of(42)
+          override def lineContent(): String = "val x = 1"
+          override def offset(): Optional[Integer] = Optional.empty()
+          override def pointer(): Optional[Integer] = Optional.empty()
+          override def pointerSpace(): Optional[String] = Optional.empty()
+          override def sourcePath(): Optional[String] = Optional.of("/test/file.scala")
+          override def sourceFile(): Optional[java.io.File] = Optional.empty()
+      val exception = new CompileFailed:
+        override def arguments(): Array[String] = Array.empty
+        override def problems(): Array[Problem] = Array(problem)
+        override def getMessage(): String = "Compilation failed"
+      val failing: ((Int, Int)) => InternalActionResult[Int] = { (_, _) =>
+        called += 1
+        throw exception
+      }
+      val succeeding: ((Int, Int)) => InternalActionResult[Int] = { (a, b) =>
+        called += 1
+        InternalActionResult(a + b, Nil)
+      }
+      IO.withTemporaryDirectory: tempDir =>
+        val digestA = Digest.sha256Hash("build-def-A".getBytes(StandardCharsets.UTF_8))
+        val digestB = Digest.sha256Hash("build-def-B".getBytes(StandardCharsets.UTF_8))
+        val configA = getCacheConfig(cache, tempDir, buildDefinitionDigest = digestA)
+        val configB = getCacheConfig(cache, tempDir, buildDefinitionDigest = digestB)
+
+        try
+          ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configA)(failing)
+          assert(false, "Expected CompileFailed to be thrown")
+        catch case _: CompileFailed => ()
+        assert(called == 1)
+
+        try
+          ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configA)(failing)
+          assert(false, "Expected CompileFailed to be thrown")
+        catch case _: CompileFailed => ()
+        assert(
+          called == 1,
+          s"expected a cached-failure replay under the same digest (called=$called)"
+        )
+
+        // Same task inputs, but the build definition changed: the failure must not replay.
+        val v = ActionCache.cache((1, 1), Digest.zero, Digest.zero, tags, configB)(succeeding)
+        assert(v == 2)
+        assert(
+          called == 2,
+          s"a stale failure must not replay after the build definition changed (called=$called)"
+        )
+
   test("A file vanishing after its blob is stored no longer breaks the cache write"):
     withDiskCache: cache =>
       import sjsonnew.BasicJsonProtocol.*
@@ -786,6 +869,8 @@ object ActionCacheTest extends BasicTestSuite:
       outputDir: File,
       cacheVersion: Long = 0L,
       converter: FileConverter = fileConverter,
+      metaBuildDigest: Digest = Digest.zero,
+      buildDefinitionDigest: Digest = Digest.zero,
   ): BuildWideCacheConfiguration =
     val logger = new Logger:
       override def trace(t: => Throwable): Unit = ()
@@ -799,6 +884,8 @@ object ActionCacheTest extends BasicTestSuite:
       CacheEventLog(),
       CacheImplicits.defaultLocalDigestCacheByteSize,
       cacheVersion,
+      metaBuildDigest,
+      buildDefinitionDigest,
     )
 
   // The String-based fileConverter mangles binary blobs (zips).


### PR DESCRIPTION
Fixes #9631. Cached task keys ignored the metabuild classpath, so plugin version changes replayed stale values and poisoned CachedCompileFailure entries until cleanFull. Adds a metabuild classpath digest to every key and keys cached failures on the full build definition. Includes scripted regression test.