### PR TITLE
fix: keep in-use boot jars on cleanFull

### DIFF
--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -258,7 +258,7 @@ $AliasCommand name=
 
   val CleanFull: String = "cleanFull"
   def cleanFullDetailed: String =
-    "Clears sbt's local caches, keeping only the boot artifacts the running sbt instance uses, and shuts the server down once remaining commands finish."
+    "Clears sbt's local caches and shuts the server down once remaining commands finish. Boot artifacts the running sbt instance uses are deleted on exit."
 
   private[sbt] val networkExecPrefix = "__"
   private[sbt] val DisconnectNetworkChannel = s"${networkExecPrefix}disconnectNetworkChannel"

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -258,7 +258,7 @@ $AliasCommand name=
 
   val CleanFull: String = "cleanFull"
   def cleanFullDetailed: String =
-    "Clears sbt's local caches, keeping only the boot artifacts the running sbt instance uses."
+    "Clears sbt's local caches, keeping only the boot artifacts the running sbt instance uses, and shuts the server down once remaining commands finish."
 
   private[sbt] val networkExecPrefix = "__"
   private[sbt] val DisconnectNetworkChannel = s"${networkExecPrefix}disconnectNetworkChannel"

--- a/main-command/src/main/scala/sbt/BasicCommandStrings.scala
+++ b/main-command/src/main/scala/sbt/BasicCommandStrings.scala
@@ -257,7 +257,8 @@ $AliasCommand name=
   def ClearCachesDetailed: String = "Clears sbt's internal caches."
 
   val CleanFull: String = "cleanFull"
-  def cleanFullDetailed: String = "Clears sbt's local caches."
+  def cleanFullDetailed: String =
+    "Clears sbt's local caches, keeping only the boot artifacts the running sbt instance uses."
 
   private[sbt] val networkExecPrefix = "__"
   private[sbt] val DisconnectNetworkChannel = s"${networkExecPrefix}disconnectNetworkChannel"

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -228,13 +228,34 @@ private[sbt] object Clean {
           case _                       => ()
         val s2 = s.unsafeRunAggregated(LocalRootProject / clean)
         IO.delete(outputDirectory.toFile())
-        IO.delete(
-          s.configuration
-            .provider()
-            .scalaProvider()
-            .launcher()
-            .bootDirectory()
-        )
+        deleteBootCaches(s)
         s
     Command.command(CleanFull, h)(expunge andThen clearCachesFun)
+
+  /**
+   * Deletes cached artifacts in the launcher boot directory, keeping the jars the running
+   * sbt instance itself is loaded from. Deleting those breaks the live session: the next
+   * .sbt compilation fails with MissingCoreLibraryException and anything else resolving
+   * them by path fails until sbt is restarted by hand.
+   */
+  private def deleteBootCaches(s: State): Unit = {
+    val provider = s.configuration.provider
+    val scalaProvider = provider.scalaProvider
+    val bootDirectory = scalaProvider.launcher.bootDirectory.getCanonicalFile
+    if (bootDirectory.isDirectory) {
+      val keepDirs = (provider.mainClasspath ++ scalaProvider.jars)
+        .map(_.getCanonicalFile.getParentFile)
+        .filter(_.toPath.startsWith(bootDirectory.toPath))
+        .toSet
+      def loop(dir: File): Unit =
+        Option(dir.listFiles).toList.flatten.foreach { f =>
+          val cf = f.getCanonicalFile
+          if (cf.isDirectory) {
+            if (!keepDirs.exists(_.toPath.startsWith(cf.toPath))) IO.delete(cf)
+            else if (!keepDirs.contains(cf)) loop(cf)
+          } else if (dir != bootDirectory || f.getName != "sbt.boot.lock") IO.delete(f)
+        }
+      loop(bootDirectory)
+    }
+  }
 }

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -12,6 +12,8 @@ package internal
 import java.io.IOException
 import java.nio.file.{ DirectoryNotEmptyException, Files, Path }
 
+import scala.util.control.NonFatal
+
 import sbt.BasicCommandStrings.*
 import sbt.Def.*
 import sbt.Keys.*
@@ -250,10 +252,10 @@ private[sbt] object Clean {
     s.copy(remainingCommands = cmds)
 
   /**
-   * Deletes cached artifacts in the launcher boot directory, keeping the jars the running
-   * sbt instance itself is loaded from. Deleting those breaks the live session: the next
-   * .sbt compilation fails with MissingCoreLibraryException and anything else resolving
-   * them by path fails until sbt is restarted by hand.
+   * Deletes cached artifacts in the launcher boot directory. The jars the running sbt instance
+   * itself is loaded from are deleted on JVM exit instead: removing them while the server runs
+   * breaks the live session, since the next .sbt compilation fails with
+   * MissingCoreLibraryException and anything else resolving them by path fails until restart.
    */
   private def deleteBootCaches(s: State): Unit = {
     val provider = s.configuration.provider
@@ -273,6 +275,11 @@ private[sbt] object Clean {
           } else if (dir != bootDirectory || f.getName != "sbt.boot.lock") IO.delete(f)
         }
       loop(bootDirectory)
+      ShutdownHooks.add(() => deleteQuietly(bootDirectory))
     }
   }
+
+  private def deleteQuietly(dir: File): Unit =
+    try IO.delete(dir)
+    catch { case NonFatal(_) => () }
 }

--- a/main/src/main/scala/sbt/internal/Clean.scala
+++ b/main/src/main/scala/sbt/internal/Clean.scala
@@ -230,7 +230,24 @@ private[sbt] object Clean {
         IO.delete(outputDirectory.toFile())
         deleteBootCaches(s)
         s
-    Command.command(CleanFull, h)(expunge andThen clearCachesFun)
+    Command.command(CleanFull, h)(expunge andThen clearCachesFun andThen scheduleShutdown)
+
+  /**
+   * Queues a server shutdown after the current exec finishes and its result is reported,
+   * so the next invocation starts from a fresh JVM, boot directory and metabuild.
+   */
+  private def scheduleShutdown(s: State): State =
+    val exit = Exec(Shutdown, None)
+    def isShellLoop(e: Exec) = e.commandLine == Shell || e.commandLine == s"$IfLast $Shell"
+    val idx = s.remainingCommands.indexWhere(_.commandLine.startsWith(ReportResult)) match
+      case -1 => s.remainingCommands.indexWhere(isShellLoop)
+      case i  => i + 1
+    val cmds =
+      if idx < 0 then s.remainingCommands :+ exit
+      else
+        val (before, after) = s.remainingCommands.splitAt(idx)
+        before ::: exit :: after
+    s.copy(remainingCommands = cmds)
 
   /**
    * Deletes cached artifacts in the launcher boot directory, keeping the jars the running

--- a/server-test/src/server-test/cleanfull/build.sbt
+++ b/server-test/src/server-test/cleanfull/build.sbt
@@ -1,0 +1,3 @@
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+scalaVersion := "3.8.4"

--- a/server-test/src/server-test/cleanfull/src/main/scala/Hello.scala
+++ b/server-test/src/server-test/cleanfull/src/main/scala/Hello.scala
@@ -1,0 +1,2 @@
+object Hello:
+  def greeting: String = "hi"

--- a/server-test/src/test/scala/testpkg/AbstractServerTest.scala
+++ b/server-test/src/test/scala/testpkg/AbstractServerTest.scala
@@ -30,6 +30,7 @@ final class SbtServer(
     val baseDirectory: File,
     private val process: scala.sys.process.Process
 ) {
+  def isAlive: Boolean = process.isAlive()
   def close(): Unit = {
     val result = scala.util.Try(session.shutdown(process.isAlive(), () => process.destroy()).get)
     if (process.isAlive()) process.destroy()
@@ -71,7 +72,10 @@ trait AbstractServerTest extends AnyFunSuite with BeforeAndAfterAll {
     temp = base.toFile
     val buildDir = temp / testDirectory
     IO.copyDirectory(serverTestBase / testDirectory, buildDir)
+    svr = startServer(buildDir)
+  }
 
+  protected def startServer(buildDir: File): SbtServer = {
     val classpath = TestProperties.classpath.split(File.pathSeparator).map(new File(_))
     val process = RunFromSourceMain.fork(
       ForkOptions()
@@ -95,7 +99,14 @@ trait AbstractServerTest extends AnyFunSuite with BeforeAndAfterAll {
     val session = ServerSession.connect(portfile)
     session.initialize(10.seconds, subscribeToAllForTest)
 
-    svr = new SbtServer(session, buildDir, process)
+    new SbtServer(session, buildDir, process)
+  }
+
+  /** Starts a fresh server for this suite's build after the previous one terminated. */
+  protected def restartServer(): Unit = {
+    svr.close()
+    IO.delete(testPath.resolve("project/target/active.json").toFile)
+    svr = startServer(testPath.toFile)
   }
 
   private object BlockingInputStream extends InputStream {

--- a/server-test/src/test/scala/testpkg/CleanFullTest.scala
+++ b/server-test/src/test/scala/testpkg/CleanFullTest.scala
@@ -8,14 +8,17 @@
 
 package testpkg
 
+import java.io.File
+
 import sbt.io.IO
 
 /**
  * cleanFull used to delete the whole boot directory, including the jars the running server
  * itself is loaded from, so the server could no longer compile .sbt files
  * (MissingCoreLibraryException) until it was restarted by hand. It now keeps the in-use
- * boot artifacts, so commands chained after cleanFull still work, and shuts the server
- * down afterwards so the next invocation starts from a fresh JVM and metabuild.
+ * boot artifacts until the server shuts down, so commands chained after cleanFull still work,
+ * and deletes them on exit so the next invocation starts from a fresh JVM, boot directory and
+ * metabuild.
  */
 class CleanFullTest extends AbstractServerTest {
   override val testDirectory: String = "cleanfull"
@@ -29,6 +32,12 @@ class CleanFullTest extends AbstractServerTest {
     val deadline = System.currentTimeMillis + 60000
     while (svr.isAlive && System.currentTimeMillis < deadline) Thread.sleep(500)
     assert(!svr.isAlive, "server must shut itself down after cleanFull")
+    val bootDirectory = new File(sys.props("user.home"), ".sbt/scripted/boot")
+    val bootContents = Option(bootDirectory.list).toList.flatten
+    assert(
+      bootContents.isEmpty,
+      s"boot directory must be empty after server shutdown: ${bootContents.mkString(", ")}"
+    )
 
     restartServer()
     IO.write(testPath.resolve("project/extra.sbt").toFile, "// force a build source change\n")

--- a/server-test/src/test/scala/testpkg/CleanFullTest.scala
+++ b/server-test/src/test/scala/testpkg/CleanFullTest.scala
@@ -14,18 +14,27 @@ import sbt.io.IO
  * cleanFull used to delete the whole boot directory, including the jars the running server
  * itself is loaded from, so the server could no longer compile .sbt files
  * (MissingCoreLibraryException) until it was restarted by hand. It now keeps the in-use
- * boot artifacts.
+ * boot artifacts, so commands chained after cleanFull still work, and shuts the server
+ * down afterwards so the next invocation starts from a fresh JVM and metabuild.
  */
 class CleanFullTest extends AbstractServerTest {
   override val testDirectory: String = "cleanfull"
 
-  test("cleanFull keeps the server able to recompile the build definition") {
+  test("cleanFull keeps chained commands working and then shuts the server down") {
     assert(runBatchClient("compile") == 0, "initial compile must succeed")
-    assert(runBatchClient("cleanFull") == 0, "cleanFull must complete with exit 0")
+    assert(
+      runBatchClient("cleanFull; compile") == 0,
+      "compile chained after cleanFull must succeed"
+    )
+    val deadline = System.currentTimeMillis + 60000
+    while (svr.isAlive && System.currentTimeMillis < deadline) Thread.sleep(500)
+    assert(!svr.isAlive, "server must shut itself down after cleanFull")
+
+    restartServer()
     IO.write(testPath.resolve("project/extra.sbt").toFile, "// force a build source change\n")
     assert(
       runBatchClient("compile") == 0,
-      "compile after cleanFull and a build source change must succeed"
+      "compile on a fresh server after cleanFull and a build change must succeed"
     )
   }
 }

--- a/server-test/src/test/scala/testpkg/CleanFullTest.scala
+++ b/server-test/src/test/scala/testpkg/CleanFullTest.scala
@@ -1,0 +1,31 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package testpkg
+
+import sbt.io.IO
+
+/**
+ * cleanFull used to delete the whole boot directory, including the jars the running server
+ * itself is loaded from, so the server could no longer compile .sbt files
+ * (MissingCoreLibraryException) until it was restarted by hand. It now keeps the in-use
+ * boot artifacts.
+ */
+class CleanFullTest extends AbstractServerTest {
+  override val testDirectory: String = "cleanfull"
+
+  test("cleanFull keeps the server able to recompile the build definition") {
+    assert(runBatchClient("compile") == 0, "initial compile must succeed")
+    assert(runBatchClient("cleanFull") == 0, "cleanFull must complete with exit 0")
+    IO.write(testPath.resolve("project/extra.sbt").toFile, "// force a build source change\n")
+    assert(
+      runBatchClient("compile") == 0,
+      "compile after cleanFull and a build source change must succeed"
+    )
+  }
+}


### PR DESCRIPTION
Fixes #9633. cleanFull deleted the whole boot directory under the running server, whose next .sbt compilation then failed with MissingCoreLibraryException until restart. Boot cleanup now defers the jars the running instance is loaded from to a shutdown hook, and the server shuts down after the exec finishes. Adds a server test.