### PR TITLE
[1.x] bport: Fixes -V parsing in sbt runners

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -153,6 +153,67 @@ object RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUtil:
     assertVersionOutput(out)
     ()
 
+  testOutput("sbt -V should work")("-V"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt -version should work")("-version"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt -V followed by a launcher option should work")("-V", "-v"): (out: List[String]) =>
+    assertVersionOutput(out)
+    ()
+
+  testOutput("sbt launcher option followed by --version should work")("--no-colors", "--version"):
+    (out: List[String]) =>
+      assertVersionOutput(out)
+      ()
+
+  testOutput("sbt --version followed by an empty argument should work")("--version", ""):
+    (out: List[String]) =>
+      assertVersionOutput(out)
+      ()
+
+  testOutput("sbt tasks -V forwards the tasks option")("tasks", "-V", "-v"): (out: List[String]) =>
+    assert(out.contains("-V"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt tasks -version forwards the tasks option",
+    windowsSupport = false,
+  )("tasks", "-version", "-v"): (out: List[String]) =>
+    assert(out.contains("-version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt tasks --version forwards the tasks option",
+    windowsSupport = false,
+  )("tasks", "--version", "-v"): (out: List[String]) =>
+    assert(out.contains("--version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt -V tasks forwards the tasks option",
+    windowsSupport = false,
+  )("-V", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("-V"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt -version tasks forwards the tasks option",
+    windowsSupport = false,
+  )("-version", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("-version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
+  testOutput(
+    "sbt --version tasks forwards the tasks option",
+    windowsSupport = false,
+  )("--version", "tasks", "-v"): (out: List[String]) =>
+    assert(out.contains("--version"))
+    assert(!out.exists(_.startsWith("sbt runner version:")))
+
   testOutput(
     "sbt --version reports spaced sbt.version from project/build.properties (sbt 1.x)",
     citestVariant = "citest",

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -54,6 +54,8 @@ set sbt_args_mem=
 set sbt_args_client=
 set sbt_args_jvm_client=
 set sbt_args_no_server=
+set sbt_args_experimental_execution_log=
+set sbt_args_seen_command=
 set is_this_dir_sbt=0
 
 rem users can set SBT_OPTS via .sbtopts
@@ -182,7 +184,7 @@ if defined _verbose_arg (
   goto args_loop
 )
 
-if "%~0" == "-V" set _version_arg=true
+if "%~0" == "-V" if not defined sbt_args_seen_command set _version_arg=true
 if "%~0" == "-version" set _version_arg=true
 if "%~0" == "--version" set _version_arg=true
 
@@ -574,6 +576,7 @@ if defined sbt_new if "%g:~0,2%" == "--" (
 )
 
 rem the %0 (instead of %~0) preserves original argument quoting
+set sbt_args_seen_command=1
 set SBT_ARGS=!SBT_ARGS! %0
 
 goto args_loop

--- a/sbt
+++ b/sbt
@@ -737,7 +737,7 @@ process_args () {
     case "$1" in
             -h|-help|--help) usage; exit 1 ;;
       -v|-verbose|--verbose) sbt_verbose=1 && shift ;;
-      -V|-version|--version) print_version=1 && shift ;;
+      -V|-version|--version) print_version=1 && addResidual "$1" && shift ;;
           --numeric-version) print_sbt_version=1 && shift ;;
            --script-version) print_sbt_script_version=1 && shift ;;
                 shutdownall) shutdownall=1 && shift ;;
@@ -776,6 +776,19 @@ process_args () {
     residual_args=()
     process_my_args "${myargs[@]}"
   }
+
+  if [[ $print_version ]]; then
+    for arg in "${residual_args[@]}"; do
+      case "$arg" in
+        -V|-version|--version) ;;
+        *) if [[ "$arg" =~ [^[:space:]] ]]; then
+             print_version=
+             break
+           fi ;;
+      esac
+    done
+    [[ $print_version ]] && residual_args=()
+  fi
 }
 
 loadConfigFile() {


### PR DESCRIPTION
This is a 1.x backport of #9626

Problem: -V is consumed by the launcher instead of sbt in sbt tasks -V.

Solution: in the parser's -V behavior, lookback to see if there are commands going before it, in which case, forward -V to sbt.