### PR TITLE
[2.x] fix: Verify remote cache blobs against their digest

### DIFF
--- a/sbt-remote-cache/src/main/scala/sbt/plugins/RemoteCachePlugin.scala
+++ b/sbt-remote-cache/src/main/scala/sbt/plugins/RemoteCachePlugin.scala
@@ -19,6 +19,13 @@ object RemoteCachePlugin extends AutoPlugin:
           } match
             case Some(x) => x
             case None    => sys.error("disk store not found")
+          if remote.getScheme == "grpc" then
+            val headers = remoteCacheHeaders.value
+            val creds = if headers.nonEmpty then ", including credential headers," else ""
+            sLog.value.warn(
+              s"remoteCache $remote uses the plaintext grpc:// scheme; traffic$creds " +
+                "is not encrypted and can be read or altered in transit. Use grpcs:// for TLS."
+            )
           val r = GrpcActionCacheStore(
             uri = remote,
             rootCerts = remoteCacheTlsCertificate.value.map(_.toPath),

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -255,14 +255,14 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
     if isCompleteBlob(casFile, digest) then casFile
     else
       IO.move(blob.toFile(), casFile.toFile())
-      casFile
+      verifiedBlob(casFile, digest)
 
   def putBlob(input: InputStream, digest: Digest): Path =
     val casFile = toCasFile(digest)
     if isCompleteBlob(casFile, digest) then casFile
     else
       IO.transfer(input, casFile.toFile())
-      casFile
+      verifiedBlob(casFile, digest)
 
   def putBlob(input: ByteBuffer, digest: Digest): Path =
     val casFile = toCasFile(digest)
@@ -272,11 +272,25 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
       val bytes = new Array[Byte](input.remaining())
       input.get(bytes)
       IO.transfer(new ByteArrayInputStream(bytes), casFile.toFile())
-      casFile
+      verifiedBlob(casFile, digest)
 
   private def isCompleteBlob(casFile: Path, digest: Digest): Boolean =
     try Files.exists(casFile) && Digest.sameDigest(casFile, digest)
     catch case _: NoSuchFileException => false
+
+  /**
+   * Verifies that a just-written CAS file matches its digest. These blobs come
+   * from a remote cache, so their bytes are untrusted until re-hashed; on
+   * mismatch the file is removed and the caller fails rather than syncing
+   * tampered content into the build.
+   */
+  private def verifiedBlob(casFile: Path, digest: Digest): Path =
+    if Digest.sameDigest(casFile, digest) then casFile
+    else
+      Files.deleteIfExists(casFile)
+      throw new IOException(
+        s"Refusing to cache blob for $digest: downloaded content does not match its digest"
+      )
 
   private def requireWithinBase(base: Path, target: Path, ref: HashedVirtualFileRef): Path =
     val normalizedBase = base.toAbsolutePath.normalize()

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -813,6 +813,27 @@ object ActionCacheTest extends BasicTestSuite:
         )
         assert(!Files.exists(outDir.toPath.resolve("out.txt")))
 
+  test("Security (remote poisoning): putBlob rejects a stream whose bytes mismatch its digest"):
+    withDiskCache: cache =>
+      val digest = Digest.sha256Hash("expected".getBytes(StandardCharsets.UTF_8))
+      val casFile = cache.toCasFile(digest)
+      // A malicious/MITM'd cache server returns the requested digest but tampered bytes.
+      val tampered = new ByteArrayInputStream("tampered".getBytes(StandardCharsets.UTF_8))
+      intercept[IOException](cache.putBlob(tampered, digest))
+      assert(!Files.exists(casFile), "tampered bytes must not remain in the CAS")
+
+  test(
+    "Security (remote poisoning): putBlobInternal rejects a file whose bytes mismatch its digest"
+  ):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val digest = Digest.sha256Hash("expected".getBytes(StandardCharsets.UTF_8))
+        val casFile = cache.toCasFile(digest)
+        val downloaded = (tempDir / "downloaded").toPath
+        Files.write(downloaded, "tampered".getBytes(StandardCharsets.UTF_8))
+        intercept[IOException](cache.putBlobInternal(downloaded, digest))
+        assert(!Files.exists(casFile), "tampered bytes must not remain in the CAS")
+
   def withInMemoryCache(f: InMemoryActionCacheStore => Unit): Unit =
     val cache = InMemoryActionCacheStore()
     f(cache)


### PR DESCRIPTION
Fixes #9644.

Blobs pulled from a gRPC remote cache were written to the CAS and synced into the build without re-hashing, so a compromised cache server or plaintext MITM could substitute bytes under the requested digest. Re-hash remote blobs on write and reject on mismatch, and warn when a plaintext grpc:// endpoint is configured.