### PR TITLE
[2.x] perf: avoid re-sorting watch inputs on every file event

### DIFF
--- a/main/src/main/scala/sbt/internal/Continuous.scala
+++ b/main/src/main/scala/sbt/internal/Continuous.scala
@@ -457,7 +457,7 @@ private[sbt] object Continuous {
           // We only want to create one event per actual source file event. It doesn't matter
           // which of the config inputs triggers the event because they all will be used in
           // the onEvent callback above.
-          configs.find(_.inputs().exists(_.glob.matches(e.path))) match {
+          configs.find(_.matches(e.path)) match {
             case Some(config) =>
               val configLogger = logger.withPrefix(config.command)
               configLogger.debug(s"Accepted event for ${e.path}")
@@ -576,7 +576,7 @@ private[sbt] object Continuous {
         }.toSeq
       } else {
         val acceptedConfigParameters = configs.flatMap { config =>
-          config.inputs().flatMap {
+          config.dynamicInputs.iterator.flatMap {
             case i if i.glob.matches(path) =>
               Some((i.forceTrigger, i.fileStamper, config.watchSettings.onFileInputEvent))
             case _ => None
@@ -970,6 +970,7 @@ private[sbt] object Continuous {
       val dynamicInputs: mutable.Set[DynamicInput],
       val watchSettings: WatchSettings,
   ):
+    def matches(path: Path): Boolean = dynamicInputs.exists(_.glob.matches(path))
     def inputs() = dynamicInputs.toSeq.sorted
     def arguments(logger: Logger): Arguments = new Arguments(logger, inputs())
   end Config


### PR DESCRIPTION
Watch mode copied and sorted the whole dynamic-input set on every file event, once per config (`Continuous.inputs()`). The sort is irrelevant to the glob match, so match against the set directly. Biggest relative gain on macOS, where FSEvents coalescing turns a git checkout into a burst of thousands of events.

1000-event burst, 3 configs, total matching time:

| watched globs | before | after |
|---|---|---|
| 2000 | ~430 ms | ~30 ms |
| 8000 | ~3000 ms | ~95 ms |

<details>
<summary>bench</summary>

```scala
val inputs = mutable.Set.empty[DynamicInput]
for i <- 0 until numProjects do
  val proj = base.resolve(s"proj$i")
  inputs += DynamicInput(Glob(proj.resolve("src/main/scala"), RecursiveGlob / "*.scala"), FileStamper.Hash, false)
  inputs += DynamicInput(Glob(proj.resolve("src/main/java"), RecursiveGlob / "*.java"), FileStamper.Hash, false)
  inputs += DynamicInput(Glob(proj.resolve("src/main/resources"), RecursiveGlob), FileStamper.LastModified, true)
  inputs += DynamicInput(Glob(proj.resolve("build.sbt")), FileStamper.Hash, false)
val configs = Seq.fill(3)(inputs)
val events = (0 until 1000).map { i =>
  val proj = base.resolve(s"proj${i % numProjects}")
  if i % 4 == 3 then proj.resolve(s"target/classes/C$i.class")
  else proj.resolve(s"src/main/scala/pkg/C$i.scala")
}
timed("before")(events.foreach(p => configs.exists(_.toSeq.sorted.exists(_.glob.matches(p)))))
timed("after")(events.foreach(p => configs.exists(_.exists(_.glob.matches(p)))))
```

</details>
