### PR TITLE
[2.x] feat: Forked compilation (rebased)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -591,6 +591,7 @@ lazy val actionsProj = (project in file("main-actions"))
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
     ),
+    Compile / scalacOptions --= Seq("-Werror"),
   )
   .dependsOn(lmCore)
   .configure(
@@ -603,7 +604,7 @@ lazy val actionsProj = (project in file("main-actions"))
 
 lazy val protocolProj = (project in file("protocol"))
   .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
-  .dependsOn(collectionProj, utilLogging)
+  .dependsOn(collectionProj, utilLogging, utilCache)
   .settings(
     testedBaseSettings,
     name := "Protocol",

--- a/build.sbt
+++ b/build.sbt
@@ -591,7 +591,6 @@ lazy val actionsProj = (project in file("main-actions"))
     mimaSettings,
     mimaBinaryIssueFilters ++= Vector(
     ),
-    Compile / scalacOptions --= Seq("-Werror"),
   )
   .dependsOn(lmCore)
   .configure(
@@ -814,7 +813,6 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.internal.IncrementalTest.cacheInput"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.GlobalPluginData.*"),
       exclude[IncompatibleResultTypeProblem]("sbt.internal.GlobalPluginData.*"),
-      exclude[DirectMissingMethodProblem]("sbt.internal.Compiler.*"),
     ),
   )
   .dependsOn(lmCore, lmCoursierShadedPublishing)

--- a/build.sbt
+++ b/build.sbt
@@ -814,6 +814,7 @@ lazy val mainProj = (project in file("main"))
       exclude[DirectMissingMethodProblem]("sbt.internal.IncrementalTest.cacheInput"),
       exclude[IncompatibleMethTypeProblem]("sbt.internal.GlobalPluginData.*"),
       exclude[IncompatibleResultTypeProblem]("sbt.internal.GlobalPluginData.*"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.Compiler.*"),
     ),
   )
   .dependsOn(lmCore, lmCoursierShadedPublishing)

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -1,0 +1,193 @@
+package sbt
+package internal
+
+import java.io.{ File, PrintStream }
+import java.nio.file.{ Path, Paths }
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Function as JavaFunction
+import sbt.internal.inc.{
+  AnalyzingCompiler,
+  ScalaInstance,
+  Locate,
+  IncrementalCompilerImpl,
+  MappedFileConverter,
+  ManagedLoggedReporter,
+  Stamps,
+  ZincUtil,
+}
+import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.internal.inc.JavaInterfaceUtil.*
+import sbt.internal.worker.{ CompileConfig, CompileResponse, ScalaInstanceConfig }
+import sbt.internal.worker.codec.JsonProtocol.given
+import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
+import sbt.io.IO
+import sbt.util.{ LoggerContext, Level }
+import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Parser, Converter }
+import xsbti.{ CompileFailed, HashedVirtualFileRef, Position, T2, VirtualFile }
+import xsbti.compile.{ ScalaInstance as _, * }
+
+object CompileMain:
+  lazy val zinc: IncrementalCompilerImpl = new IncrementalCompilerImpl
+
+  def run(config: CompileConfig, id: Long, jsonOut: PrintStream): Unit =
+    try
+      // println(s"config: $config")
+      val conv = MappedFileConverter(
+        Map((config.fileConverterConfig.rootPaths.map: x =>
+          (x.name, Paths.get(x.value)))*),
+        true
+      )
+      val si = scalaInstance(config.scalaInstanceConfig)
+      val bridgeJars = config.bridgeJars.map(Paths.get(_))
+      val scalac = analyzingCompiler(bridgeJars, si)
+      val co = ClasspathOptionsUtil.noboot(config.scalaInstanceConfig.scalaVersion)
+      val cs = ZincUtil.compilers(
+        instance = si,
+        classpathOptions = co,
+        javaHome = None,
+        scalac = scalac,
+      )
+      val analysisFile = Paths.get(config.analysisFile)
+      val setup = incSetup(config)
+      val log = mkLogger(Level.Warn)
+      val output = Paths.get(config.output)
+      val sources = config.sources.map(Paths.get(_)).map(conv.toVirtualFile)
+      val cp = config.externalDependencyJars.map(Paths.get(_)).map(conv.toVirtualFile)
+      val in = zinc.inputs(
+        classpath = cp.toArray,
+        sources = sources.toArray,
+        classesDirectory = output,
+        earlyJarPath = config.earlyJarPath.map(Paths.get(_)),
+        scalacOptions = config.scalacOptions.toArray,
+        javacOptions = config.javacOptions.toArray,
+        maxErrors = config.maxErrors,
+        sourcePositionMappers = Array.empty[JavaFunction[Position, Optional[Position]]],
+        order = CompileOrder.Mixed,
+        compilers = cs,
+        setup = setup,
+        pr = previousResult(analysisFile),
+        temporaryClassesDirectory = jnone[Path],
+        converter = conv,
+        stampReader = Stamps.timeWrapBinaryStamps(conv),
+      )
+      val r = zinc.compile(in, log)
+      val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+      store.set(AnalysisContents.create(r.getAnalysis(), r.getMiniSetup()))
+      val response = CompileResponse(
+        hasModified = r.hasModified()
+      )
+      val resJson = Converter.toJson(response).get
+      val json = CompactPrinter(resJson)
+      jsonOut.println(jsonRpcResponse(id, json))
+      jsonOut.flush()
+    catch
+      case e: CompileFailed =>
+        jsonOut.println(jsonRpcError(id, "compilation failed"))
+        jsonOut.flush()
+        ()
+
+  private def jsonRpcResponse(id: Long, result: String): String =
+    s"""{ "jsonrpc": "2.0", "result": $result, "id": $id }"""
+
+  private def jsonRpcError(id: Long, err: String): String =
+    s"""{ "jsonrpc": "2.0", "error": { "code": 1009, "message": "$err" }, "id": $id }"""
+
+  def incSetup(config: CompileConfig): Setup =
+    val analysisFile = Paths.get(config.analysisFile)
+    val analysisForCp: Map[HashedVirtualFileRef, Path] = Map((config.analysisMap.map: pair =>
+      pair.name -> Paths.get(pair.value))*)
+    val lookup: PerClasspathEntryLookup = new PerClasspathEntryLookup:
+      def read(p: Path) = FileAnalysisStore.getDefault(p.toFile).get().toOption.map(_.getAnalysis)
+      override def analysis(cpEntry: VirtualFile): Optional[CompileAnalysis] =
+        analysisForCp.get(cpEntry).flatMap(read).toOptional
+      override def definesClass(cpEntry: VirtualFile) = Locate.definesClass(cpEntry)
+    val incOptions = IncOptions.of()
+    val log = mkLogger(Level.Warn)
+    val reporter = ManagedLoggedReporter(100, log)
+    Setup.of(
+      lookup,
+      false,
+      analysisFile.toFile(),
+      CompilerCache.fresh(),
+      incOptions,
+      reporter,
+      jnone,
+      Array[T2[String, String]](),
+    )
+
+  lazy val console = ConsoleOut.systemOut
+  lazy val consoleAppender = MainAppender.defaultScreen(console)
+  val generateId: AtomicInteger = new AtomicInteger
+  def mkLogger(level: Level.Value): ManagedLogger =
+    val loggerName = "compile-" + generateId.incrementAndGet
+    val l = LoggerContext.globalContext.logger(loggerName, None, None)
+    LoggerContext.globalContext.clearAppenders(loggerName)
+    LoggerContext.globalContext.addAppender(loggerName, consoleAppender -> level)
+    l
+
+  def none[A]: Option[A] = (None: Option[A])
+  def jnone[A]: Optional[A] = none[A].toOptional
+
+  def analyzingCompiler(bridgeJars: Seq[Path], si: ScalaInstance): AnalyzingCompiler =
+    val bridgeProvider = ZincUtil.constantBridgeProvider(si, bridgeJars.head.toFile())
+    val classpathOptions = ClasspathOptionsUtil.auto()
+    AnalyzingCompiler(
+      si,
+      bridgeProvider,
+      classpathOptions,
+      _ => (),
+      None
+    )
+
+  def scalaInstance(config: ScalaInstanceConfig): ScalaInstance =
+    val libraryJars = config.libraryJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val allCompilerJars =
+      config.allCompilerJars
+        .map(Paths.get(_))
+        .sortBy(_.getFileName.toString())
+    val jlineJars = allCompilerJars.filter(_.getFileName.toString().contains("jline"))
+    val compilerJars =
+      allCompilerJars.filterNot(x => libraryJars.contains(x) || jlineJars.contains(x)).distinct
+    val extraToolJars0 = config.extraToolJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val extraToolJars = extraToolJars0
+      .filterNot(jar => libraryJars.contains(jar) || compilerJars.contains(jar))
+      .distinct
+    val allJars = libraryJars ++ compilerJars ++ extraToolJars
+    val currentLoader = classOf[CompileMain.type].getClassLoader()
+    val topLoader = classOf[Compilers].getClassLoader()
+    val libraryLoader = ClasspathUtil.toLoader(libraryJars, topLoader)
+    val compilerLoader = ClasspathUtil.toLoader(compilerJars, libraryLoader)
+    val fullLoader =
+      if extraToolJars.isEmpty then compilerLoader
+      else ClasspathUtil.toLoader(extraToolJars, compilerLoader)
+    new ScalaInstance(
+      version = config.scalaVersion,
+      loader = fullLoader,
+      loaderCompilerOnly = compilerLoader,
+      loaderLibraryOnly = libraryLoader,
+      libraryJars = libraryJars.map(_.toFile).toArray,
+      compilerJars = compilerJars.map(_.toFile).toArray,
+      allJars = allJars.map(_.toFile).toArray,
+      explicitActual = Some(config.scalaVersion)
+    )
+
+  def previousResult(analysisFile: Path): PreviousResult =
+    val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+    store.get().toOption match
+      case Some(contents) =>
+        val analysis = Option(contents.getAnalysis).toOptional
+        val setup = Option(contents.getMiniSetup).toOptional
+        PreviousResult.of(analysis, setup)
+      case None => PreviousResult.of(jnone[CompileAnalysis], jnone[MiniSetup])
+
+  def main(args: Array[String], id: java.lang.Long, jsonOut: PrintStream): Unit =
+    args.toList match
+      case Nil               => println("CompileMain")
+      case s"@${arg}" :: Nil =>
+        val s = IO.read(File(arg))
+        val json = Parser.parseFromString(s).get
+        val config = Converter.fromJson[CompileConfig](json).get
+        run(config, id, jsonOut)
+      case xs => sys.error(s"unknown args: $xs")
+end CompileMain

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -53,9 +53,10 @@ object CompileMain:
       val log = mkLogger(Level.Warn)
       val output = Paths.get(config.output)
       val sources = config.sources.map(Paths.get(_)).map(conv.toVirtualFile)
-      val cp = config.externalDependencyJars.map(Paths.get(_)).map(conv.toVirtualFile)
+      val cp = config.externalDependencyJars.map(Paths.get(_))
+      val cpVf = cp.map(conv.toVirtualFile)
       val in = zinc.inputs(
-        classpath = cp.toArray,
+        classpath = cpVf.toArray,
         sources = sources.toArray,
         classesDirectory = output,
         earlyJarPath = config.earlyJarPath.map(Paths.get(_)),

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -23,6 +23,7 @@ import sbt.internal.worker.codec.JsonProtocol.given
 import sbt.internal.util.{ ManagedLogger, ConsoleOut, MainAppender }
 import sbt.io.IO
 import sbt.util.{ LoggerContext, Level }
+import scala.util.control.NonFatal
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Parser, Converter }
 import xsbti.{ CompileFailed, HashedVirtualFileRef, Position, T2, VirtualFile }
 import xsbti.compile.{ ScalaInstance as _, * }
@@ -32,7 +33,6 @@ object CompileMain:
 
   def run(config: CompileConfig, id: Long, jsonOut: PrintStream): Unit =
     try
-      // println(s"config: $config")
       val conv = MappedFileConverter(
         Map((config.fileConverterConfig.rootPaths.map: x =>
           (x.name, Paths.get(x.value)))*),
@@ -64,7 +64,7 @@ object CompileMain:
         javacOptions = config.javacOptions.toArray,
         maxErrors = config.maxErrors,
         sourcePositionMappers = Array.empty[JavaFunction[Position, Optional[Position]]],
-        order = CompileOrder.Mixed,
+        order = CompileOrder.valueOf(config.compileOrder),
         compilers = cs,
         setup = setup,
         pr = previousResult(analysisFile),
@@ -84,15 +84,24 @@ object CompileMain:
       jsonOut.flush()
     catch
       case e: CompileFailed =>
-        jsonOut.println(jsonRpcError(id, "compilation failed"))
+        jsonOut.println(jsonRpcError(id, 1009, "compilation failed"))
         jsonOut.flush()
-        ()
+      case NonFatal(e) =>
+        e.printStackTrace()
+        jsonOut.println(jsonRpcError(id, 1, e.toString))
+        jsonOut.flush()
 
   private def jsonRpcResponse(id: Long, result: String): String =
     s"""{ "jsonrpc": "2.0", "result": $result, "id": $id }"""
 
-  private def jsonRpcError(id: Long, err: String): String =
-    s"""{ "jsonrpc": "2.0", "error": { "code": 1009, "message": "$err" }, "id": $id }"""
+  private def jsonRpcError(id: Long, code: Int, err: String): String =
+    val escaped = err
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+    s"""{ "jsonrpc": "2.0", "error": { "code": $code, "message": "$escaped" }, "id": $id }"""
 
   def incSetup(config: CompileConfig): Setup =
     val analysisFile = Paths.get(config.analysisFile)
@@ -155,7 +164,6 @@ object CompileMain:
       .filterNot(jar => libraryJars.contains(jar) || compilerJars.contains(jar))
       .distinct
     val allJars = libraryJars ++ compilerJars ++ extraToolJars
-    val currentLoader = classOf[CompileMain.type].getClassLoader()
     val topLoader = classOf[Compilers].getClassLoader()
     val libraryLoader = ClasspathUtil.toLoader(libraryJars, topLoader)
     val compilerLoader = ClasspathUtil.toLoader(compilerJars, libraryLoader)

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -73,7 +73,7 @@ object CompileMain:
         stampReader = Stamps.timeWrapBinaryStamps(conv),
       )
       val r = zinc.compile(in, log)
-      val store = FileAnalysisStore.getDefault(analysisFile.toFile)
+      val store = FileAnalysisStore.getDefault(analysisTmpPath(analysisFile).toFile)
       store.set(AnalysisContents.create(r.getAnalysis, r.getMiniSetup))
       val response = CompileResponse(
         hasModified = r.hasModified
@@ -116,16 +116,22 @@ object CompileMain:
     val incOptions = IncOptions.of()
     val log = mkLogger(Level.Warn)
     val reporter = ManagedLoggedReporter(100, log)
+    val earlyStore =
+      config.earlyAnalysisFile.map(u => FileAnalysisStore.getDefault(Paths.get(u).toFile))
     Setup.of(
       lookup,
       false,
-      analysisFile.toFile,
+      analysisFile,
       CompilerCache.fresh(),
       incOptions,
       reporter,
       jnone,
+      earlyStore.toOptional,
       Array[T2[String, String]](),
     )
+
+  def analysisTmpPath(analysisFile: Path): Path =
+    analysisFile.resolveSibling(analysisFile.getFileName.toString + ".tmp")
 
   lazy val console = ConsoleOut.systemOut
   lazy val consoleAppender = MainAppender.defaultScreen(console)

--- a/main-actions/src/main/scala/sbt/internal/CompileMain.scala
+++ b/main-actions/src/main/scala/sbt/internal/CompileMain.scala
@@ -29,7 +29,7 @@ import xsbti.{ CompileFailed, HashedVirtualFileRef, Position, T2, VirtualFile }
 import xsbti.compile.{ ScalaInstance as _, * }
 
 object CompileMain:
-  lazy val zinc: IncrementalCompilerImpl = new IncrementalCompilerImpl
+  private lazy val zinc: IncrementalCompilerImpl = new IncrementalCompilerImpl
 
   def run(config: CompileConfig, id: Long, jsonOut: PrintStream): Unit =
     try
@@ -39,7 +39,7 @@ object CompileMain:
         true
       )
       val si = scalaInstance(config.scalaInstanceConfig)
-      val bridgeJars = config.bridgeJars.map(Paths.get(_))
+      val bridgeJars = config.bridgeJars.map(Paths.get)
       val scalac = analyzingCompiler(bridgeJars, si)
       val co = ClasspathOptionsUtil.noboot(config.scalaInstanceConfig.scalaVersion)
       val cs = ZincUtil.compilers(
@@ -59,7 +59,7 @@ object CompileMain:
         classpath = cpVf.toArray,
         sources = sources.toArray,
         classesDirectory = output,
-        earlyJarPath = config.earlyJarPath.map(Paths.get(_)),
+        earlyJarPath = config.earlyJarPath.map(Paths.get),
         scalacOptions = config.scalacOptions.toArray,
         javacOptions = config.javacOptions.toArray,
         maxErrors = config.maxErrors,
@@ -73,10 +73,10 @@ object CompileMain:
         stampReader = Stamps.timeWrapBinaryStamps(conv),
       )
       val r = zinc.compile(in, log)
-      val store = FileAnalysisStore.getDefault(analysisFile.toFile())
-      store.set(AnalysisContents.create(r.getAnalysis(), r.getMiniSetup()))
+      val store = FileAnalysisStore.getDefault(analysisFile.toFile)
+      store.set(AnalysisContents.create(r.getAnalysis, r.getMiniSetup))
       val response = CompileResponse(
-        hasModified = r.hasModified()
+        hasModified = r.hasModified
       )
       val resJson = Converter.toJson(response).get
       val json = CompactPrinter(resJson)
@@ -103,22 +103,23 @@ object CompileMain:
       .replace("\t", "\\t")
     s"""{ "jsonrpc": "2.0", "error": { "code": $code, "message": "$escaped" }, "id": $id }"""
 
-  def incSetup(config: CompileConfig): Setup =
+  private def incSetup(config: CompileConfig): Setup =
     val analysisFile = Paths.get(config.analysisFile)
     val analysisForCp: Map[HashedVirtualFileRef, Path] = Map((config.analysisMap.map: pair =>
       pair.name -> Paths.get(pair.value))*)
     val lookup: PerClasspathEntryLookup = new PerClasspathEntryLookup:
-      def read(p: Path) = FileAnalysisStore.getDefault(p.toFile).get().toOption.map(_.getAnalysis)
+      def read(p: Path): Option[CompileAnalysis] =
+        FileAnalysisStore.getDefault(p.toFile).get().toOption.map(_.getAnalysis)
       override def analysis(cpEntry: VirtualFile): Optional[CompileAnalysis] =
         analysisForCp.get(cpEntry).flatMap(read).toOptional
-      override def definesClass(cpEntry: VirtualFile) = Locate.definesClass(cpEntry)
+      override def definesClass(cpEntry: VirtualFile): DefinesClass = Locate.definesClass(cpEntry)
     val incOptions = IncOptions.of()
     val log = mkLogger(Level.Warn)
     val reporter = ManagedLoggedReporter(100, log)
     Setup.of(
       lookup,
       false,
-      analysisFile.toFile(),
+      analysisFile.toFile,
       CompilerCache.fresh(),
       incOptions,
       reporter,
@@ -129,18 +130,18 @@ object CompileMain:
   lazy val console = ConsoleOut.systemOut
   lazy val consoleAppender = MainAppender.defaultScreen(console)
   val generateId: AtomicInteger = new AtomicInteger
-  def mkLogger(level: Level.Value): ManagedLogger =
+  private def mkLogger(level: Level.Value): ManagedLogger =
     val loggerName = "compile-" + generateId.incrementAndGet
     val l = LoggerContext.globalContext.logger(loggerName, None, None)
     LoggerContext.globalContext.clearAppenders(loggerName)
     LoggerContext.globalContext.addAppender(loggerName, consoleAppender -> level)
     l
 
-  def none[A]: Option[A] = (None: Option[A])
+  def none[A]: Option[A] = None: Option[A]
   def jnone[A]: Optional[A] = none[A].toOptional
 
-  def analyzingCompiler(bridgeJars: Seq[Path], si: ScalaInstance): AnalyzingCompiler =
-    val bridgeProvider = ZincUtil.constantBridgeProvider(si, bridgeJars.head.toFile())
+  private def analyzingCompiler(bridgeJars: Seq[Path], si: ScalaInstance): AnalyzingCompiler =
+    val bridgeProvider = ZincUtil.constantBridgeProvider(si, bridgeJars.head.toFile)
     val classpathOptions = ClasspathOptionsUtil.auto()
     AnalyzingCompiler(
       si,
@@ -151,20 +152,20 @@ object CompileMain:
     )
 
   def scalaInstance(config: ScalaInstanceConfig): ScalaInstance =
-    val libraryJars = config.libraryJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val libraryJars = config.libraryJars.map(Paths.get).sortBy(_.getFileName.toString())
     val allCompilerJars =
       config.allCompilerJars
-        .map(Paths.get(_))
+        .map(Paths.get)
         .sortBy(_.getFileName.toString())
-    val jlineJars = allCompilerJars.filter(_.getFileName.toString().contains("jline"))
+    val jlineJars = allCompilerJars.filter(_.getFileName.toString.contains("jline"))
     val compilerJars =
       allCompilerJars.filterNot(x => libraryJars.contains(x) || jlineJars.contains(x)).distinct
-    val extraToolJars0 = config.extraToolJars.map(Paths.get(_)).sortBy(_.getFileName.toString())
+    val extraToolJars0 = config.extraToolJars.map(Paths.get).sortBy(_.getFileName.toString())
     val extraToolJars = extraToolJars0
       .filterNot(jar => libraryJars.contains(jar) || compilerJars.contains(jar))
       .distinct
     val allJars = libraryJars ++ compilerJars ++ extraToolJars
-    val topLoader = classOf[Compilers].getClassLoader()
+    val topLoader = classOf[Compilers].getClassLoader
     val libraryLoader = ClasspathUtil.toLoader(libraryJars, topLoader)
     val compilerLoader = ClasspathUtil.toLoader(compilerJars, libraryLoader)
     val fullLoader =
@@ -182,7 +183,7 @@ object CompileMain:
     )
 
   def previousResult(analysisFile: Path): PreviousResult =
-    val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+    val store = FileAnalysisStore.getDefault(analysisFile.toFile)
     store.get().toOption match
       case Some(contents) =>
         val analysis = Option(contents.getAnalysis).toOptional

--- a/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
+++ b/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
@@ -3,7 +3,6 @@ package internal
 
 import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser, JsonSyntaxException }
 import sbt.internal.inc.CompileFailed
-import sbt.internal.worker1.*
 import sbt.util.Logger
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration.Duration
@@ -15,7 +14,6 @@ private[sbt] abstract class ProcessReact[A1](
     log: Logger,
     process: Process
 ) extends WorkerResponseListener:
-  val g = WorkerMain.mkGson()
   protected val promise: Promise[A1] = Promise()
 
   def processNotification(o: JsonObject): Unit
@@ -30,11 +28,16 @@ private[sbt] abstract class ProcessReact[A1](
           else if o.has("error") then
             val err = o.getAsJsonObject("error")
             val code = err.getAsJsonPrimitive("code").getAsLong()
-            val message = err.getAsJsonPrimitive("message").getAsString()
+            val message = Option(err.getAsJsonPrimitive("message"))
+              .map(_.getAsString())
+              .getOrElse(s"worker error (code $code)")
             code match
-              case 1009 => promise.failure(new CompileFailed(Array.empty, message, Array.empty))
-              case _    => promise.failure(new RuntimeException(message))
-          else processResponse(o)
+              case 1009 =>
+                promise.tryFailure(new CompileFailed(Array.empty, message, Array.empty))
+              case _ => promise.tryFailure(new RuntimeException(message))
+          else
+            try processResponse(o)
+            catch case NonFatal(e) => promise.tryFailure(e)
         else ()
       else if o.has("re") && o.has("method") then
         val resId = o.getAsJsonPrimitive("re").getAsLong()
@@ -46,9 +49,9 @@ private[sbt] abstract class ProcessReact[A1](
       case NonFatal(_)            => ()
 
   override def notifyExit(p: Process): Unit =
-    if !process.isAlive && !promise.isCompleted then
+    if (p eq process) && !process.isAlive() && !promise.isCompleted then
       val exitCode = process.exitValue()
-      promise.failure(new RuntimeException(s"worker exited with code $exitCode"))
+      promise.tryFailure(new RuntimeException(s"worker exited with code $exitCode"))
 
   def blockForResponse(): A1 =
     Await.result(promise.future, Duration.Inf)

--- a/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
+++ b/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
@@ -1,0 +1,55 @@
+package sbt
+package internal
+
+import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser, JsonSyntaxException }
+import sbt.internal.inc.CompileFailed
+import sbt.internal.worker1.*
+import sbt.util.Logger
+import scala.concurrent.{ Await, Promise }
+import scala.concurrent.duration.Duration
+import scala.sys.process.Process
+import scala.util.control.NonFatal
+
+private[sbt] abstract class ProcessReact[A1](
+    id: Long,
+    log: Logger,
+    process: Process
+) extends WorkerResponseListener:
+  val g = WorkerMain.mkGson()
+  protected val promise: Promise[A1] = Promise()
+
+  def processNotification(o: JsonObject): Unit
+  def processResponse(o: JsonObject): Unit
+  override def apply(line: String): Unit =
+    try
+      val o = JsonParser.parseString(line).getAsJsonObject()
+      if o.has("id") then
+        val resId = o.getAsJsonPrimitive("id").getAsLong()
+        if resId == id then
+          if promise.isCompleted then ()
+          else if o.has("error") then
+            val err = o.getAsJsonObject("error")
+            val code = err.getAsJsonPrimitive("code").getAsLong()
+            val message = err.getAsJsonPrimitive("message").getAsString()
+            code match
+              case 1009 => promise.failure(new CompileFailed(Array.empty, message, Array.empty))
+              case _    => promise.failure(new RuntimeException(message))
+          else processResponse(o)
+        else ()
+      else if o.has("re") && o.has("method") then
+        val resId = o.getAsJsonPrimitive("re").getAsLong()
+        if resId == id then processNotification(o)
+        else ()
+      else ()
+    catch
+      case _: JsonSyntaxException => log.info(line)
+      case NonFatal(_)            => ()
+
+  override def notifyExit(p: Process): Unit =
+    if !process.isAlive && !promise.isCompleted then
+      val exitCode = process.exitValue()
+      promise.failure(new RuntimeException(s"worker exited with code $exitCode"))
+
+  def blockForResponse(): A1 =
+    Await.result(promise.future, Duration.Inf)
+end ProcessReact

--- a/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
+++ b/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
@@ -20,14 +20,14 @@ private[sbt] abstract class ProcessReact[A1](
   def processResponse(o: JsonObject): Unit
   override def apply(line: String): Unit =
     try
-      val o = JsonParser.parseString(line).getAsJsonObject()
+      val o = JsonParser.parseString(line).getAsJsonObject
       if o.has("id") then
-        val resId = o.getAsJsonPrimitive("id").getAsLong()
+        val resId = o.getAsJsonPrimitive("id").getAsLong
         if resId == id then
           if promise.isCompleted then ()
           else if o.has("error") then
             val err = o.getAsJsonObject("error")
-            val code = err.getAsJsonPrimitive("code").getAsLong()
+            val code = err.getAsJsonPrimitive("code").getAsLong
             val message = Option(err.getAsJsonPrimitive("message"))
               .map(_.getAsString())
               .getOrElse(s"worker error (code $code)")
@@ -40,7 +40,7 @@ private[sbt] abstract class ProcessReact[A1](
             catch case NonFatal(e) => promise.tryFailure(e)
         else ()
       else if o.has("re") && o.has("method") then
-        val resId = o.getAsJsonPrimitive("re").getAsLong()
+        val resId = o.getAsJsonPrimitive("re").getAsLong
         if resId == id then processNotification(o)
         else ()
       else ()

--- a/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
+++ b/main-actions/src/main/scala/sbt/internal/ProcessReact.scala
@@ -4,8 +4,9 @@ package internal
 import org.scalasbt.shadedgson.com.google.gson.{ JsonObject, JsonParser, JsonSyntaxException }
 import sbt.internal.inc.CompileFailed
 import sbt.util.Logger
+import java.util.concurrent.TimeoutException
 import scala.concurrent.{ Await, Promise }
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, DurationInt }
 import scala.sys.process.Process
 import scala.util.control.NonFatal
 
@@ -51,6 +52,9 @@ private[sbt] abstract class ProcessReact[A1](
   override def notifyExit(p: Process): Unit =
     if (p eq process) && !process.isAlive() && !promise.isCompleted then
       val exitCode = process.exitValue()
+      if exitCode == 0 then
+        try Await.ready(promise.future, 5.seconds)
+        catch case _: TimeoutException => ()
       promise.tryFailure(new RuntimeException(s"worker exited with code $exitCode"))
 
   def blockForResponse(): A1 =

--- a/main-actions/src/main/scala/sbt/internal/WorkerExchange.scala
+++ b/main-actions/src/main/scala/sbt/internal/WorkerExchange.scala
@@ -98,6 +98,10 @@ object WorkerExchange:
     synchronized:
       listeners.foreach: wl =>
         wl(line)
+
+  def notifyExit(p: Process): Unit =
+    synchronized:
+      listeners.foreach(_.notifyExit(p))
 end WorkerExchange
 
 class WorkerProxy(
@@ -121,7 +125,7 @@ class WorkerProxy(
 
   val watch = Thread(() => {
     while process.isAlive() do Thread.sleep(100)
-    WorkerExchange.listeners.foreach(_.notifyExit(process))
+    WorkerExchange.notifyExit(process)
   })
   watch.start()
 end WorkerProxy

--- a/main-actions/src/test/scala/sbt/internal/ProcessReactSpec.scala
+++ b/main-actions/src/test/scala/sbt/internal/ProcessReactSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import org.scalasbt.shadedgson.com.google.gson.JsonObject
+import sbt.internal.inc.CompileFailed
+import sbt.util.Logger
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.DurationInt
+import scala.sys.process.Process
+import scala.util.{ Failure, Success, Try }
+
+object ProcessReactSpec extends verify.BasicTestSuite:
+  private class FakeProcess(alive: Boolean, exit: Int) extends Process:
+    def exitValue(): Int = exit
+    def destroy(): Unit = ()
+    override def isAlive(): Boolean = alive
+
+  private class TestReact(id: Long, process: Process, failResponse: Boolean = false)
+      extends ProcessReact[String](id, Logger.Null, process):
+    def processResponse(o: JsonObject): Unit =
+      if failResponse then throw IllegalStateException("boom")
+      else promise.success(o.getAsJsonPrimitive("result").getAsString())
+    def processNotification(o: JsonObject): Unit = ()
+    def future: Future[String] = promise.future
+
+  private def outcome[A1](f: Future[A1]): Try[A1] =
+    Try(Await.result(f, 10.seconds))
+
+  test("completes the promise from a matching response") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 7 }""")
+    assert(outcome(react.future) == Success("ok"))
+  }
+
+  test("ignores responses for other request ids") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 8 }""")
+    assert(!react.future.isCompleted)
+  }
+
+  test("fails with CompileFailed on error code 1009") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "error": { "code": 1009, "message": "bad" }, "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e: CompileFailed) => e.toString.contains("bad")
+      case _                         => false)
+  }
+
+  test("survives an error object without a message field") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react("""{ "jsonrpc": "2.0", "error": { "code": 5 }, "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e) => e.getMessage.contains("code 5")
+      case _          => false)
+  }
+
+  test("fails the promise when processResponse throws") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0), failResponse = true)
+    react("""{ "jsonrpc": "2.0", "result": "ok", "id": 7 }""")
+    assert(outcome(react.future) match
+      case Failure(e: IllegalStateException) => e.getMessage == "boom"
+      case _                                 => false)
+  }
+
+  test("notifyExit ignores other processes") {
+    val react = TestReact(7, FakeProcess(alive = true, exit = 0))
+    react.notifyExit(FakeProcess(alive = false, exit = 1))
+    assert(!react.future.isCompleted)
+  }
+
+  test("notifyExit fails immediately on a nonzero exit code") {
+    val process = FakeProcess(alive = false, exit = 2)
+    val react = TestReact(7, process)
+    react.notifyExit(process)
+    assert(outcome(react.future) match
+      case Failure(e) => e.getMessage.contains("exited with code 2")
+      case _          => false)
+  }
+
+  test("notifyExit with exit code 0 waits for a late response") {
+    val process = FakeProcess(alive = false, exit = 0)
+    val react = TestReact(7, process)
+    val t = Thread(() => {
+      Thread.sleep(200)
+      react("""{ "jsonrpc": "2.0", "result": "late", "id": 7 }""")
+    })
+    t.start()
+    react.notifyExit(process)
+    t.join()
+    assert(outcome(react.future) == Success("late"))
+  }
+
+  test("notifyExit with exit code 0 eventually fails without a response") {
+    val process = FakeProcess(alive = false, exit = 0)
+    val react = TestReact(7, process)
+    react.notifyExit(process)
+    assert(outcome(react.future) match
+      case Failure(e) => e.getMessage.contains("exited with code 0")
+      case _          => false)
+  }
+end ProcessReactSpec

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -9,7 +9,7 @@
 package sbt
 
 import java.io.File
-import java.nio.file.{ Files, Path as NioPath }
+import java.nio.file.{ Files, Path as NioPath, StandardCopyOption }
 import java.util.{ Optional, UUID }
 import java.util.concurrent.TimeUnit
 import lmcoursier.CoursierDependencyResolution
@@ -1434,18 +1434,26 @@ object Defaults extends BuildCommon with DefExtra {
     )
   }
 
+  private[sbt] def resolveForkJavaHome(
+      javaHome: Option[File],
+      jdkVersion: Option[String],
+      javaHomes: Map[String, File]
+  ): Option[File] =
+    javaHome.orElse(jdkVersion.map { j =>
+      javaHomes.getOrElse(
+        j,
+        sys.error(
+          s"jdkVersion \"$j\" was not found in fullJavaHomes: ${javaHomes.keys.toSeq.sorted.mkString(", ")}"
+        )
+      )
+    })
+
   def forkOptionsTask: Initialize[Task[ForkOptions]] =
     Def.task {
       val canUseArgumentsFile = sys.props
         .getOrElse("java.vm.specification.version", "1")
         .toFloat >= 9.0
-      val jhs = fullJavaHomes.value
-      val jh = jdkVersion.value match
-        case Some(j) =>
-          jhs.get(j) match
-            case Some(value) => Some(value)
-            case None        => sys.error(s"jdkVersion \"$j\" was not found")
-        case None => javaHome.value
+      val jh = resolveForkJavaHome(javaHome.value, jdkVersion.value, fullJavaHomes.value)
       ForkOptions(
         javaHome = jh,
         outputStrategy = outputStrategy.value,
@@ -2321,7 +2329,8 @@ object Defaults extends BuildCommon with DefExtra {
             res
           case Result.Inc(cause) =>
             ping.tryComplete(Result.Value(false))
-            val compileFailed = cause.directCause.collect { case c: CompileFailed => c }
+            val compileFailed =
+              Incomplete.allExceptions(cause).collectFirst { case c: CompileFailed => c }
             reporter.sendFailureReport(ci.options.sources, compileFailed)
             bspTask.notifyFailure(compileFailed)
             throw cause
@@ -2384,13 +2393,19 @@ object Defaults extends BuildCommon with DefExtra {
       val setup: Setup = (TaskZero / compileIncSetup).value
       val c = fileConverter.value
       val fo = ((compile / forkOptions).value: @nowarn("msg=transient"))
+      val jdkId = (compile / jdkVersion).value
+      val jhome = (compile / javaHome).value
       val sic = (scalaInstanceConfig.value: @nowarn("msg=transient"))
       val bridges = (scalaCompilerBridgeJars.value: @nowarn("msg=transient"))
       val rs = rootPaths.value
       val pickles = dependencyPicklePath.value
       val analysisFile = compileAnalysisFile.value.toPath()
+      val earlyAnalysis =
+        if exportPipelining.value then
+          Some((earlyCompileAnalysisFile.value: @nowarn("msg=transient")).toPath())
+        else None
       def forkImpl(): xsbti.compile.CompileResult =
-        try ForkCompile.compile(s, fo, rs, ci, sic, bridges, analysisFile, pickles)
+        try ForkCompile.compile(s, fo, rs, ci, sic, bridges, analysisFile, earlyAnalysis, pickles)
         catch
           case e: Throwable =>
             if !ping.isCompleted then
@@ -2407,6 +2422,11 @@ object Defaults extends BuildCommon with DefExtra {
         if analysisResult.hasModified() || !Files.exists(dirZip) then
           Def.declareOutputDirectory(vfDir)
         else Def.declareOutput(c.toVirtualFile(dirZip))
+      Files.move(
+        CompileMain.analysisTmpPath(analysisFile),
+        analysisFile,
+        StandardCopyOption.REPLACE_EXISTING
+      )
       val analysisOut = c.toVirtualFile(setup.cachePath())
       Def.declareOutput(analysisOut)
       s.log.debug(s"wrote $vfDir")

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -191,6 +191,7 @@ object Defaults extends BuildCommon with DefExtra {
       apiURL := None,
       releaseNotesURL := None,
       javaHome :== None,
+      jdkVersion :== None,
       discoveredJavaHomes := CrossJava.discoverJavaHomes,
       javaHomes :== ListMap.empty,
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
@@ -1160,6 +1161,10 @@ object Defaults extends BuildCommon with DefExtra {
       discoveredSbtPlugins := Def.uncached(discoverSbtPluginNames.value),
       // This fork options, scoped to the configuration is used for tests
       forkOptions := Def.uncached(forkOptionsTask.value),
+      extraIncOptions := {
+        val orig = extraIncOptions.value
+        orig
+      },
       selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
       run / mainClass := (run / selectMainClass).value,
       mainClass := Def.uncached {
@@ -1437,8 +1442,15 @@ object Defaults extends BuildCommon with DefExtra {
       val canUseArgumentsFile = sys.props
         .getOrElse("java.vm.specification.version", "1")
         .toFloat >= 9.0
+      val jhs = fullJavaHomes.value
+      val jh = jdkVersion.value match
+        case Some(j) =>
+          jhs.get(j) match
+            case Some(value) => Some(value)
+            case None        => sys.error(s"jdkVersion \"$j\" was not found")
+        case None => javaHome.value
       ForkOptions(
-        javaHome = javaHome.value,
+        javaHome = jh,
         outputStrategy = outputStrategy.value,
         // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
         bootJars = Vector(),
@@ -2338,8 +2350,27 @@ object Defaults extends BuildCommon with DefExtra {
       val setup: Setup = (TaskZero / compileIncSetup).value
       val c = fileConverter.value
       val store = analysisStore(compileAnalysisFile.value.toPath(), c)
+      val fk = (compile / fork).value
+      val jh = (compile / jdkVersion).value
+      val fo = ((compile / forkOptions).value: @nowarn("msg=transient"))
+      val sic = (scalaInstanceConfig.value: @nowarn("msg=transient"))
+      val bridges = (scalaCompilerBridgeJars.value: @nowarn("msg=transient"))
+      val rs = rootPaths.value
+      val pickles = dependencyPicklePath.value
       // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
-      val analysisResult = Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping, projectId))
+      val analysisResult =
+        if fk then
+          ForkCompile.compile(
+            s,
+            fo,
+            rs,
+            ci,
+            sic,
+            bridges,
+            compileAnalysisFile.value.toPath(),
+            pickles
+          )
+        else Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping, projectId))
       val dir = ci.options.classesDirectory
       val vfDir = c.toVirtualFile(dir)
       val dirZip = ActionCache.dirZipPath(dir)

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -379,6 +379,7 @@ object Defaults extends BuildCommon with DefExtra {
       aggregate :== true,
       maxErrors :== 100,
       fork :== false,
+      forkCompile :== false,
       clientSide :== true,
       initialize :== {},
       templateResolverInfos :== Nil,
@@ -1161,10 +1162,6 @@ object Defaults extends BuildCommon with DefExtra {
       discoveredSbtPlugins := Def.uncached(discoverSbtPluginNames.value),
       // This fork options, scoped to the configuration is used for tests
       forkOptions := Def.uncached(forkOptionsTask.value),
-      extraIncOptions := {
-        val orig = extraIncOptions.value
-        orig
-      },
       selectMainClass := mainClass.value orElse askForMainClass(discoveredMainClasses.value),
       run / mainClass := (run / selectMainClass).value,
       mainClass := Def.uncached {
@@ -2303,7 +2300,7 @@ object Defaults extends BuildCommon with DefExtra {
     Seq(
       TaskZero / compileIncremental := Def.uncached {
         val bspTask = (compile / bspCompileTask).value
-        val result = cachedCompileIncrementalTask.result.value
+        val result = selectCompileIncrementalTask.result.value
         val reporter = (compile / bspReporter).value
         val ci = (compile / compileInputs).value
         val c = fileConverter.value
@@ -2338,6 +2335,11 @@ object Defaults extends BuildCommon with DefExtra {
       case _                       => "root"
     }
 
+  private val selectCompileIncrementalTask = Def.taskDyn {
+    if forkCompile.value then forkedCompileIncrementalTask
+    else cachedCompileIncrementalTask
+  }
+
   private val cachedCompileIncrementalTask = Def
     .cachedTask {
       val s = streams.value
@@ -2350,27 +2352,8 @@ object Defaults extends BuildCommon with DefExtra {
       val setup: Setup = (TaskZero / compileIncSetup).value
       val c = fileConverter.value
       val store = analysisStore(compileAnalysisFile.value.toPath(), c)
-      val fk = (compile / fork).value
-      val jh = (compile / jdkVersion).value
-      val fo = ((compile / forkOptions).value: @nowarn("msg=transient"))
-      val sic = (scalaInstanceConfig.value: @nowarn("msg=transient"))
-      val bridges = (scalaCompilerBridgeJars.value: @nowarn("msg=transient"))
-      val rs = rootPaths.value
-      val pickles = dependencyPicklePath.value
       // TODO - Should readAnalysis + saveAnalysis be scoped by the compile task too?
-      val analysisResult =
-        if fk then
-          ForkCompile.compile(
-            s,
-            fo,
-            rs,
-            ci,
-            sic,
-            bridges,
-            compileAnalysisFile.value.toPath(),
-            pickles
-          )
-        else Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping, projectId))
+      val analysisResult = Retry.io(compileIncrementalTaskImpl(bspTask, s, ci, ping, projectId))
       val dir = ci.options.classesDirectory
       val vfDir = c.toVirtualFile(dir)
       val dirZip = ActionCache.dirZipPath(dir)
@@ -2385,6 +2368,46 @@ object Defaults extends BuildCommon with DefExtra {
       // Packaging precedes this write so that a run interrupted in between leaves a stale analysis,
       // which forces a recompile, rather than a current analysis paired with an outdated zip.
       store.set(contents)
+      Def.declareOutput(analysisOut)
+      s.log.debug(s"wrote $vfDir")
+      (analysisResult.hasModified(), vfDir: VirtualFileRef, packedDir: HashedVirtualFileRef)
+    }
+    .tag(Tags.Compile, Tags.CPU)
+
+  private val forkedCompileIncrementalTask = Def
+    .cachedTask {
+      val s = streams.value
+      val ci = (compile / compileInputs).value
+      // This is a cacheable version
+      val ci2 = (compile / compileInputs2).value
+      val ping = (TaskZero / earlyOutputPing).value
+      val setup: Setup = (TaskZero / compileIncSetup).value
+      val c = fileConverter.value
+      val fo = ((compile / forkOptions).value: @nowarn("msg=transient"))
+      val sic = (scalaInstanceConfig.value: @nowarn("msg=transient"))
+      val bridges = (scalaCompilerBridgeJars.value: @nowarn("msg=transient"))
+      val rs = rootPaths.value
+      val pickles = dependencyPicklePath.value
+      val analysisFile = compileAnalysisFile.value.toPath()
+      def forkImpl(): xsbti.compile.CompileResult =
+        try ForkCompile.compile(s, fo, rs, ci, sic, bridges, analysisFile, pickles)
+        catch
+          case e: Throwable =>
+            if !ping.isCompleted then
+              ping.failure(e)
+              ConcurrentRestrictions.cancelAllSentinels()
+            throw e
+      val analysisResult = Retry.io(forkImpl())
+      val dir = ci.options.classesDirectory
+      val vfDir = c.toVirtualFile(dir)
+      val dirZip = ActionCache.dirZipPath(dir)
+      // Zinc leaves the class directory alone when it invalidates nothing, so the zip the previous
+      // run left behind still describes it and re-packing only reproduces a blob the store has.
+      val packedDir =
+        if analysisResult.hasModified() || !Files.exists(dirZip) then
+          Def.declareOutputDirectory(vfDir)
+        else Def.declareOutput(c.toVirtualFile(dirZip))
+      val analysisOut = c.toVirtualFile(setup.cachePath())
       Def.declareOutput(analysisOut)
       s.log.debug(s"wrote $vfDir")
       (analysisResult.hasModified(), vfDir: VirtualFileRef, packedDir: HashedVirtualFileRef)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -363,7 +363,7 @@ object Keys {
   val outputStrategy = settingKey[Option[sbt.OutputStrategy]]("Selects how to log output when running a main class.").withRank(DSetting)
   val connectInput = settingKey[Boolean]("If true, connects standard input when running a main class forked.").withRank(CSetting)
   val javaHome = settingKey[Option[File]]("Selects the Java installation used for forking.  If None, uses the Java installation running the build.").withRank(CSetting)
-  val jdkVersion = settingKey[Option[String]]("Selects the Java installation used for forking.").withRank(ASetting)
+  val jdkVersion = settingKey[Option[String]]("Selects the Java installation used for forking by name from fullJavaHomes; an explicit javaHome takes precedence.").withRank(ASetting)
   val discoveredJavaHomes = settingKey[Map[String, File]]("Discovered Java home directories")
   val javaHomes = settingKey[Map[String, File]]("The user-defined additional Java home directories")
   val fullJavaHomes = settingKey[Map[String, File]]("Combines discoveredJavaHomes and custom javaHomes.").withRank(CTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -356,7 +356,8 @@ object Keys {
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)
 
   val fork = settingKey[Boolean]("If true, forks a new JVM when running.  If false, runs in the same JVM as the build.").withRank(ASetting)
-  
+  val forkCompile = settingKey[Boolean]("If true, forks incremental compilation in a worker JVM.").withRank(BSetting)
+
   @transient
   val forkOptions = taskKey[ForkOptions]("Configures JVM forking.").withRank(DSetting)
   val outputStrategy = settingKey[Option[sbt.OutputStrategy]]("Selects how to log output when running a main class.").withRank(DSetting)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -356,10 +356,13 @@ object Keys {
   val trapExit = settingKey[Boolean]("If true, enables exit trapping and thread management for 'run'-like tasks. This was removed in sbt 1.6.0 due to JDK 17 deprecating Security Manager.").withRank(CSetting)
 
   val fork = settingKey[Boolean]("If true, forks a new JVM when running.  If false, runs in the same JVM as the build.").withRank(ASetting)
+  
+  @transient
   val forkOptions = taskKey[ForkOptions]("Configures JVM forking.").withRank(DSetting)
   val outputStrategy = settingKey[Option[sbt.OutputStrategy]]("Selects how to log output when running a main class.").withRank(DSetting)
   val connectInput = settingKey[Boolean]("If true, connects standard input when running a main class forked.").withRank(CSetting)
-  val javaHome = settingKey[Option[File]]("Selects the Java installation used for compiling and forking.  If None, uses the Java installation running the build.").withRank(ASetting)
+  val javaHome = settingKey[Option[File]]("Selects the Java installation used for forking.  If None, uses the Java installation running the build.").withRank(CSetting)
+  val jdkVersion = settingKey[Option[String]]("Selects the Java installation used for forking.").withRank(ASetting)
   val discoveredJavaHomes = settingKey[Map[String, File]]("Discovered Java home directories")
   val javaHomes = settingKey[Map[String, File]]("The user-defined additional Java home directories")
   val fullJavaHomes = settingKey[Map[String, File]]("Combines discoveredJavaHomes and custom javaHomes.").withRank(CTask)

--- a/main/src/main/scala/sbt/internal/ForkCompile.scala
+++ b/main/src/main/scala/sbt/internal/ForkCompile.scala
@@ -1,0 +1,138 @@
+package sbt
+package internal
+
+import java.nio.file.{ Path, Paths }
+import java.net.URLClassLoader
+import java.util.ArrayList
+import org.scalasbt.shadedgson.com.google.gson.JsonObject
+import sbt.OptionSyntax.*
+import sbt.internal.worker.{
+  CompileConfig,
+  CompileResponse,
+  FileConverterConfig,
+  HVFRURI,
+  ScalaInstanceConfig,
+  StringURI,
+}
+import sbt.internal.util.Attributed
+import sbt.internal.worker.codec.JsonProtocol.given
+import sbt.internal.worker1.{ FilePath, RunInfo, WorkerMain }
+import sbt.io.IO
+import sbt.util.Logger
+
+import scala.jdk.CollectionConverters.*
+import scala.util.Random
+import scala.sys.process.Process
+import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter, Parser }
+import xsbti.compile.*
+import xsbti.{ HashedVirtualFileRef, VirtualFileRef }
+
+private[sbt] object ForkCompile:
+  val r = Random()
+
+  def compile(
+      s: Keys.TaskStreams,
+      fo: ForkOptions,
+      rs: Map[String, Path],
+      in: Inputs,
+      sic: ScalaInstanceConfig,
+      bridges: Seq[HashedVirtualFileRef],
+      analysisFile: Path,
+      acs: Seq[Attributed[HashedVirtualFileRef]],
+  ): CompileResult =
+    val g = WorkerMain.mkGson()
+    val ct = WorkerConnection.Tcp
+    val w = WorkerExchange.startWorker(fo, Nil, ct)
+    val randomId = r.nextLong()
+    val wl = ForkCompile.React(randomId, s.log, w.process)
+    val cpList = ArrayList[FilePath](
+      (currentClasspath
+        .map: p =>
+          FilePath(p.toUri(), ""))
+        .asJava
+    )
+    val fcConfig = FileConverterConfig(
+      rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri()))
+    )
+    val conv = in.options().converter().get()
+    val sources = in.options().sources().toVector.map(conv.toPath)
+    val cp = in.options().classpath().toVector.map(conv.toPath)
+    val earlyJarPath = for
+      o <- in.options().earlyOutput().asScala
+      single <- o.getSingleOutputAsPath().asScala
+    yield single
+    val analysisMap = for
+      entry <- acs.toVector
+      ref <- entry.metadata.get(Keys.analysis)
+    yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri())
+    // pseudo case class that is used to transport the server knowledge to the
+    // forked worker process.
+    val config = CompileConfig(
+      fileConverterConfig = fcConfig,
+      scalaInstanceConfig = sic,
+      bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri()),
+      sources = sources.map(_.toString()),
+      externalDependencyJars = cp.map(_.toString()),
+      output = in.options().classesDirectory().toUri(),
+      analysisFile = analysisFile.toUri(),
+      earlyJarPath = earlyJarPath.map(_.toUri()),
+      scalacOptions = in.options().scalacOptions().toVector,
+      javacOptions = in.options().javacOptions().toVector,
+      maxErrors = in.options().maxErrors(),
+      analysisMap = analysisMap,
+    )
+    val configJson = Converter.toJson[CompileConfig](config).get
+    IO.withTemporaryDirectory: tempDir =>
+      val params = tempDir.toPath().resolve("params.json")
+      IO.write(params.toFile(), CompactPrinter(configJson))
+      val param = RunInfo(
+        true,
+        RunInfo.JvmRunInfo(
+          ArrayList(List(s"@$params").asJava),
+          cpList,
+          "sbt.internal.CompileMain",
+          false,
+        ),
+        null
+      )
+      try
+        WorkerExchange.registerListener(wl)
+        val paramJson = g.toJson(param, param.getClass)
+        val json = jsonRpcRequest(randomId, "compile", paramJson)
+        w.println(json)
+        val response = wl.blockForResponse()
+        val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+        val contents = store.get().get()
+        CompileResult.of(
+          contents.getAnalysis(),
+          contents.getMiniSetup(),
+          response.hasModified,
+        )
+      finally WorkerExchange.unregisterListener(wl)
+
+  def currentClasspath: List[Path] =
+    val cl = classOf[CompileMain.type].getClassLoader() match
+      case cl: URLClassLoader => cl
+    val urls = cl.getURLs().toList
+    urls.map((u) => Paths.get(u.toURI())) ++ Vector(
+      IO.classLocationPath(classOf[xsbti.compile.ScalaInstance]),
+      IO.classLocationPath(classOf[xsbti.Logger]),
+      IO.classLocationPath(classOf[jline.Terminal]),
+      IO.classLocationPath(classOf[org.jline.utils.InfoCmp]),
+    )
+
+  private def jsonRpcRequest(id: Long, method: String, params: String): String =
+    s"""{ "jsonrpc": "2.0", "method": "$method", "params": $params, "id": $id }"""
+
+  private class React(id: Long, log: Logger, process: Process)
+      extends ProcessReact[CompileResponse](id, log, process):
+    override def processResponse(o: JsonObject): Unit =
+      val s = o.getAsJsonObject("result")
+      val json = Parser.parseFromString(s.toString()).get
+      val result = Converter.fromJson[CompileResponse](json).get
+      promise.success(result)
+
+    override def processNotification(o: JsonObject): Unit =
+      val params = o.getAsJsonObject("params")
+      // println(s"params: $params")
+end ForkCompile

--- a/main/src/main/scala/sbt/internal/ForkCompile.scala
+++ b/main/src/main/scala/sbt/internal/ForkCompile.scala
@@ -32,6 +32,7 @@ private[sbt] object ForkCompile:
       sic: ScalaInstanceConfig,
       bridges: Seq[HashedVirtualFileRef],
       analysisFile: Path,
+      earlyAnalysisFile: Option[Path],
       acs: Seq[Attributed[HashedVirtualFileRef]],
   ): CompileResult =
     val g = WorkerMain.mkGson()
@@ -42,8 +43,21 @@ private[sbt] object ForkCompile:
     try
       WorkerExchange.registerListener(wl)
       wl.notifyExit(w.process)
+      val allCp = currentClasspath
+      val parentCp =
+        (IO.classLocationPath(classOf[xsbti.compile.ScalaInstance]) ::
+          allCp.filter(p =>
+            Option(p.getFileName).exists(_.toString.startsWith("compiler-interface"))
+          )).distinct
+      val childCp = allCp.filterNot(parentCp.contains)
       val cpList = util.ArrayList[FilePath](
-        currentClasspath
+        childCp
+          .map: p =>
+            FilePath(p.toUri, "")
+          .asJava
+      )
+      val parentCpList = util.ArrayList[FilePath](
+        parentCp
           .map: p =>
             FilePath(p.toUri, "")
           .asJava
@@ -72,6 +86,7 @@ private[sbt] object ForkCompile:
         externalDependencyJars = cp.map(_.toString()),
         output = in.options().classesDirectory().toUri,
         analysisFile = analysisFile.toUri,
+        earlyAnalysisFile = earlyAnalysisFile.map(_.toUri),
         earlyJarPath = earlyJarPath.map(_.toUri()),
         scalacOptions = in.options().scalacOptions().toVector,
         javacOptions = in.options().javacOptions().toVector,
@@ -88,6 +103,7 @@ private[sbt] object ForkCompile:
           RunInfo.JvmRunInfo(
             util.ArrayList(List(s"@$params").asJava),
             cpList,
+            parentCpList,
             "sbt.internal.CompileMain",
             false,
           ),
@@ -97,7 +113,7 @@ private[sbt] object ForkCompile:
         val json = jsonRpcRequest(randomId, "compile", paramJson)
         w.println(json)
         val response = wl.blockForResponse()
-        val store = FileAnalysisStore.getDefault(analysisFile.toFile)
+        val store = FileAnalysisStore.getDefault(CompileMain.analysisTmpPath(analysisFile).toFile)
         val contents = store.get().get()
         CompileResult.of(
           contents.getAnalysis,

--- a/main/src/main/scala/sbt/internal/ForkCompile.scala
+++ b/main/src/main/scala/sbt/internal/ForkCompile.scala
@@ -1,31 +1,25 @@
 package sbt
 package internal
 
-import java.nio.file.{ Path, Paths }
-import java.net.URLClassLoader
-import java.util.ArrayList
 import org.scalasbt.shadedgson.com.google.gson.JsonObject
 import sbt.OptionSyntax.*
-import sbt.internal.worker.{
-  CompileConfig,
-  CompileResponse,
-  FileConverterConfig,
-  HVFRURI,
-  ScalaInstanceConfig,
-  StringURI,
-}
 import sbt.internal.util.Attributed
 import sbt.internal.worker.codec.JsonProtocol.given
+import sbt.internal.worker.*
 import sbt.internal.worker1.{ FilePath, RunInfo, WorkerMain }
 import sbt.io.IO
 import sbt.util.Logger
-
-import scala.jdk.CollectionConverters.*
-import scala.util.Random
-import scala.sys.process.Process
-import sjsonnew.support.scalajson.unsafe.{ Converter, CompactPrinter, Parser }
+import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser }
 import xsbti.compile.*
 import xsbti.{ HashedVirtualFileRef, VirtualFileRef }
+
+import java.net.URLClassLoader
+import java.nio.file.{ Path, Paths }
+import java.util
+import java.util.ArrayList
+import scala.jdk.CollectionConverters.*
+import scala.sys.process.Process
+import scala.util.Random
 
 private[sbt] object ForkCompile:
   val r = Random()
@@ -48,36 +42,36 @@ private[sbt] object ForkCompile:
     try
       WorkerExchange.registerListener(wl)
       wl.notifyExit(w.process)
-      val cpList = ArrayList[FilePath](
-        (currentClasspath
+      val cpList = util.ArrayList[FilePath](
+        currentClasspath
           .map: p =>
-            FilePath(p.toUri(), ""))
+            FilePath(p.toUri, "")
           .asJava
       )
       val fcConfig = FileConverterConfig(
-        rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri()))
+        rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri))
       )
       val conv = in.options().converter().get()
       val sources = in.options().sources().toVector.map(conv.toPath)
       val cp = in.options().classpath().toVector.map(conv.toPath)
       val earlyJarPath = for
         o <- in.options().earlyOutput().asScala
-        single <- o.getSingleOutputAsPath().asScala
+        single <- o.getSingleOutputAsPath.asScala
       yield single
       val analysisMap = for
         entry <- acs.toVector
         ref <- entry.metadata.get(Keys.analysis)
-      yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri())
+      yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri)
       // pseudo case class that is used to transport the server knowledge to the
       // forked worker process.
       val config = CompileConfig(
         fileConverterConfig = fcConfig,
         scalaInstanceConfig = sic,
-        bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri()),
+        bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri),
         sources = sources.map(_.toString()),
         externalDependencyJars = cp.map(_.toString()),
-        output = in.options().classesDirectory().toUri(),
-        analysisFile = analysisFile.toUri(),
+        output = in.options().classesDirectory().toUri,
+        analysisFile = analysisFile.toUri,
         earlyJarPath = earlyJarPath.map(_.toUri()),
         scalacOptions = in.options().scalacOptions().toVector,
         javacOptions = in.options().javacOptions().toVector,
@@ -87,12 +81,12 @@ private[sbt] object ForkCompile:
       )
       val configJson = Converter.toJson[CompileConfig](config).get
       IO.withTemporaryDirectory: tempDir =>
-        val params = tempDir.toPath().resolve("params.json")
-        IO.write(params.toFile(), CompactPrinter(configJson))
+        val params = tempDir.toPath.resolve("params.json")
+        IO.write(params.toFile, CompactPrinter(configJson))
         val param = RunInfo(
           true,
           RunInfo.JvmRunInfo(
-            ArrayList(List(s"@$params").asJava),
+            util.ArrayList(List(s"@$params").asJava),
             cpList,
             "sbt.internal.CompileMain",
             false,
@@ -103,20 +97,20 @@ private[sbt] object ForkCompile:
         val json = jsonRpcRequest(randomId, "compile", paramJson)
         w.println(json)
         val response = wl.blockForResponse()
-        val store = FileAnalysisStore.getDefault(analysisFile.toFile())
+        val store = FileAnalysisStore.getDefault(analysisFile.toFile)
         val contents = store.get().get()
         CompileResult.of(
-          contents.getAnalysis(),
-          contents.getMiniSetup(),
+          contents.getAnalysis,
+          contents.getMiniSetup,
           response.hasModified,
         )
     finally
       WorkerExchange.unregisterListener(wl)
       w.close()
 
-  def currentClasspath: List[Path] =
-    val urls = classOf[CompileMain.type].getClassLoader() match
-      case cl: URLClassLoader => cl.getURLs().toList.map(u => Paths.get(u.toURI()))
+  private def currentClasspath: List[Path] =
+    val urls = classOf[CompileMain.type].getClassLoader match
+      case cl: URLClassLoader => cl.getURLs.toList.map(u => Paths.get(u.toURI))
       case _                  =>
         sys
           .props("java.class.path")
@@ -138,7 +132,7 @@ private[sbt] object ForkCompile:
       extends ProcessReact[CompileResponse](id, log, process):
     override def processResponse(o: JsonObject): Unit =
       val s = o.getAsJsonObject("result")
-      val json = Parser.parseFromString(s.toString()).get
+      val json = Parser.parseFromString(s.toString).get
       val result = Converter.fromJson[CompileResponse](json).get
       promise.success(result)
 

--- a/main/src/main/scala/sbt/internal/ForkCompile.scala
+++ b/main/src/main/scala/sbt/internal/ForkCompile.scala
@@ -45,58 +45,60 @@ private[sbt] object ForkCompile:
     val w = WorkerExchange.startWorker(fo, Nil, ct)
     val randomId = r.nextLong()
     val wl = ForkCompile.React(randomId, s.log, w.process)
-    val cpList = ArrayList[FilePath](
-      (currentClasspath
-        .map: p =>
-          FilePath(p.toUri(), ""))
-        .asJava
-    )
-    val fcConfig = FileConverterConfig(
-      rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri()))
-    )
-    val conv = in.options().converter().get()
-    val sources = in.options().sources().toVector.map(conv.toPath)
-    val cp = in.options().classpath().toVector.map(conv.toPath)
-    val earlyJarPath = for
-      o <- in.options().earlyOutput().asScala
-      single <- o.getSingleOutputAsPath().asScala
-    yield single
-    val analysisMap = for
-      entry <- acs.toVector
-      ref <- entry.metadata.get(Keys.analysis)
-    yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri())
-    // pseudo case class that is used to transport the server knowledge to the
-    // forked worker process.
-    val config = CompileConfig(
-      fileConverterConfig = fcConfig,
-      scalaInstanceConfig = sic,
-      bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri()),
-      sources = sources.map(_.toString()),
-      externalDependencyJars = cp.map(_.toString()),
-      output = in.options().classesDirectory().toUri(),
-      analysisFile = analysisFile.toUri(),
-      earlyJarPath = earlyJarPath.map(_.toUri()),
-      scalacOptions = in.options().scalacOptions().toVector,
-      javacOptions = in.options().javacOptions().toVector,
-      maxErrors = in.options().maxErrors(),
-      analysisMap = analysisMap,
-    )
-    val configJson = Converter.toJson[CompileConfig](config).get
-    IO.withTemporaryDirectory: tempDir =>
-      val params = tempDir.toPath().resolve("params.json")
-      IO.write(params.toFile(), CompactPrinter(configJson))
-      val param = RunInfo(
-        true,
-        RunInfo.JvmRunInfo(
-          ArrayList(List(s"@$params").asJava),
-          cpList,
-          "sbt.internal.CompileMain",
-          false,
-        ),
-        null
+    try
+      WorkerExchange.registerListener(wl)
+      wl.notifyExit(w.process)
+      val cpList = ArrayList[FilePath](
+        (currentClasspath
+          .map: p =>
+            FilePath(p.toUri(), ""))
+          .asJava
       )
-      try
-        WorkerExchange.registerListener(wl)
+      val fcConfig = FileConverterConfig(
+        rootPaths = rs.toSeq.toVector.map((k, v) => StringURI(k, v.toUri()))
+      )
+      val conv = in.options().converter().get()
+      val sources = in.options().sources().toVector.map(conv.toPath)
+      val cp = in.options().classpath().toVector.map(conv.toPath)
+      val earlyJarPath = for
+        o <- in.options().earlyOutput().asScala
+        single <- o.getSingleOutputAsPath().asScala
+      yield single
+      val analysisMap = for
+        entry <- acs.toVector
+        ref <- entry.metadata.get(Keys.analysis)
+      yield HVFRURI(entry.data, conv.toPath(VirtualFileRef.of(ref)).toUri())
+      // pseudo case class that is used to transport the server knowledge to the
+      // forked worker process.
+      val config = CompileConfig(
+        fileConverterConfig = fcConfig,
+        scalaInstanceConfig = sic,
+        bridgeJars = bridges.toVector.map(vf => conv.toPath(vf).toUri()),
+        sources = sources.map(_.toString()),
+        externalDependencyJars = cp.map(_.toString()),
+        output = in.options().classesDirectory().toUri(),
+        analysisFile = analysisFile.toUri(),
+        earlyJarPath = earlyJarPath.map(_.toUri()),
+        scalacOptions = in.options().scalacOptions().toVector,
+        javacOptions = in.options().javacOptions().toVector,
+        maxErrors = in.options().maxErrors(),
+        analysisMap = analysisMap,
+        compileOrder = in.options().order().name(),
+      )
+      val configJson = Converter.toJson[CompileConfig](config).get
+      IO.withTemporaryDirectory: tempDir =>
+        val params = tempDir.toPath().resolve("params.json")
+        IO.write(params.toFile(), CompactPrinter(configJson))
+        val param = RunInfo(
+          true,
+          RunInfo.JvmRunInfo(
+            ArrayList(List(s"@$params").asJava),
+            cpList,
+            "sbt.internal.CompileMain",
+            false,
+          ),
+          null
+        )
         val paramJson = g.toJson(param, param.getClass)
         val json = jsonRpcRequest(randomId, "compile", paramJson)
         w.println(json)
@@ -108,13 +110,21 @@ private[sbt] object ForkCompile:
           contents.getMiniSetup(),
           response.hasModified,
         )
-      finally WorkerExchange.unregisterListener(wl)
+    finally
+      WorkerExchange.unregisterListener(wl)
+      w.close()
 
   def currentClasspath: List[Path] =
-    val cl = classOf[CompileMain.type].getClassLoader() match
-      case cl: URLClassLoader => cl
-    val urls = cl.getURLs().toList
-    urls.map((u) => Paths.get(u.toURI())) ++ Vector(
+    val urls = classOf[CompileMain.type].getClassLoader() match
+      case cl: URLClassLoader => cl.getURLs().toList.map(u => Paths.get(u.toURI()))
+      case _                  =>
+        sys
+          .props("java.class.path")
+          .split(java.io.File.pathSeparator)
+          .toList
+          .filter(_.nonEmpty)
+          .map(Paths.get(_))
+    urls ++ Vector(
       IO.classLocationPath(classOf[xsbti.compile.ScalaInstance]),
       IO.classLocationPath(classOf[xsbti.Logger]),
       IO.classLocationPath(classOf[jline.Terminal]),
@@ -132,7 +142,5 @@ private[sbt] object ForkCompile:
       val result = Converter.fromJson[CompileResponse](json).get
       promise.success(result)
 
-    override def processNotification(o: JsonObject): Unit =
-      val params = o.getAsJsonObject("params")
-      // println(s"params: $params")
+    override def processNotification(o: JsonObject): Unit = ()
 end ForkCompile

--- a/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
+++ b/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala
@@ -356,8 +356,10 @@ object BuildServerProtocol {
       val result = JvmTestEnvironmentResult(successfulItems.toVector, None)
       state.value.respondEvent(result)
     }.evaluated,
-    bspBuildTargetJvmEnvironmentItem := jvmEnvironmentItem(forkOptions).value,
-    run / bspBuildTargetJvmEnvironmentItem := jvmEnvironmentItem(run / forkOptions).value,
+    bspBuildTargetJvmEnvironmentItem := Def.uncached(jvmEnvironmentItem(forkOptions).value),
+    run / bspBuildTargetJvmEnvironmentItem := Def.uncached(
+      jvmEnvironmentItem(run / forkOptions).value
+    ),
     bspInternalDependencyConfigurations := internalDependencyConfigurationsSetting.value,
     bspScalaTestClassesItem := scalaTestClassesTask.value,
     bspScalaMainClassesItem := scalaMainClassesTask.value,

--- a/main/src/test/scala/sbt/internal/ForkJavaHomeSpec.scala
+++ b/main/src/test/scala/sbt/internal/ForkJavaHomeSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt.internal
+
+import java.io.File
+import sbt.Defaults
+
+object ForkJavaHomeSpec extends verify.BasicTestSuite:
+  private val homes = Map("temurin@17" -> File("/jdk/17"), "temurin@25" -> File("/jdk/25"))
+
+  test("javaHome takes precedence over jdkVersion") {
+    val explicit = File("/custom/jdk")
+    val resolved = Defaults.resolveForkJavaHome(Some(explicit), Some("temurin@17"), homes)
+    assert(resolved == Some(explicit))
+  }
+
+  test("jdkVersion resolves from the discovered java homes") {
+    val resolved = Defaults.resolveForkJavaHome(None, Some("temurin@25"), homes)
+    assert(resolved == Some(File("/jdk/25")))
+  }
+
+  test("returns None when neither javaHome nor jdkVersion is set") {
+    assert(Defaults.resolveForkJavaHome(None, None, homes) == None)
+  }
+
+  test("unknown jdkVersion fails and lists the available keys") {
+    val err =
+      try
+        Defaults.resolveForkJavaHome(None, Some("zulu@99"), homes)
+        None
+      catch case e: RuntimeException => Some(e)
+    assert(err.exists(_.getMessage.contains("zulu@99")))
+    assert(err.exists(_.getMessage.contains("temurin@17")))
+  }
+end ForkJavaHomeSpec

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
@@ -1,0 +1,80 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class CompileConfig private (
+  val fileConverterConfig: sbt.internal.worker.FileConverterConfig,
+  val scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig,
+  val bridgeJars: Vector[java.net.URI],
+  val sources: Vector[String],
+  val externalDependencyJars: Vector[String],
+  val output: java.net.URI,
+  val analysisFile: java.net.URI,
+  val earlyJarPath: Option[java.net.URI],
+  val scalacOptions: Vector[String],
+  val javacOptions: Vector[String],
+  val maxErrors: Int,
+  val analysisMap: Vector[sbt.internal.worker.HVFRURI]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##)
+  }
+  override def toString: String = {
+    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ")"
+  }
+  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap): CompileConfig = {
+    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+  }
+  def withFileConverterConfig(fileConverterConfig: sbt.internal.worker.FileConverterConfig): CompileConfig = {
+    copy(fileConverterConfig = fileConverterConfig)
+  }
+  def withScalaInstanceConfig(scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig): CompileConfig = {
+    copy(scalaInstanceConfig = scalaInstanceConfig)
+  }
+  def withBridgeJars(bridgeJars: Vector[java.net.URI]): CompileConfig = {
+    copy(bridgeJars = bridgeJars)
+  }
+  def withSources(sources: Vector[String]): CompileConfig = {
+    copy(sources = sources)
+  }
+  def withExternalDependencyJars(externalDependencyJars: Vector[String]): CompileConfig = {
+    copy(externalDependencyJars = externalDependencyJars)
+  }
+  def withOutput(output: java.net.URI): CompileConfig = {
+    copy(output = output)
+  }
+  def withAnalysisFile(analysisFile: java.net.URI): CompileConfig = {
+    copy(analysisFile = analysisFile)
+  }
+  def withEarlyJarPath(earlyJarPath: Option[java.net.URI]): CompileConfig = {
+    copy(earlyJarPath = earlyJarPath)
+  }
+  def withEarlyJarPath(earlyJarPath: java.net.URI): CompileConfig = {
+    copy(earlyJarPath = Option(earlyJarPath))
+  }
+  def withScalacOptions(scalacOptions: Vector[String]): CompileConfig = {
+    copy(scalacOptions = scalacOptions)
+  }
+  def withJavacOptions(javacOptions: Vector[String]): CompileConfig = {
+    copy(javacOptions = javacOptions)
+  }
+  def withMaxErrors(maxErrors: Int): CompileConfig = {
+    copy(maxErrors = maxErrors)
+  }
+  def withAnalysisMap(analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = {
+    copy(analysisMap = analysisMap)
+  }
+}
+object CompileConfig {
+  
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
@@ -16,22 +16,23 @@ final class CompileConfig private (
   val scalacOptions: Vector[String],
   val javacOptions: Vector[String],
   val maxErrors: Int,
-  val analysisMap: Vector[sbt.internal.worker.HVFRURI]) extends Serializable {
+  val analysisMap: Vector[sbt.internal.worker.HVFRURI],
+  val compileOrder: String) extends Serializable {
   
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap)
+    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap) && (this.compileOrder == x.compileOrder)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##) + compileOrder.##)
   }
   override def toString: String = {
-    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ")"
+    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ", " + compileOrder + ")"
   }
-  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap): CompileConfig = {
-    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap, compileOrder: String = compileOrder): CompileConfig = {
+    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
   }
   def withFileConverterConfig(fileConverterConfig: sbt.internal.worker.FileConverterConfig): CompileConfig = {
     copy(fileConverterConfig = fileConverterConfig)
@@ -72,9 +73,12 @@ final class CompileConfig private (
   def withAnalysisMap(analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = {
     copy(analysisMap = analysisMap)
   }
+  def withCompileOrder(compileOrder: String): CompileConfig = {
+    copy(compileOrder = compileOrder)
+  }
 }
 object CompileConfig {
   
-  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
-  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI]): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileConfig.scala
@@ -12,6 +12,7 @@ final class CompileConfig private (
   val externalDependencyJars: Vector[String],
   val output: java.net.URI,
   val analysisFile: java.net.URI,
+  val earlyAnalysisFile: Option[java.net.URI],
   val earlyJarPath: Option[java.net.URI],
   val scalacOptions: Vector[String],
   val javacOptions: Vector[String],
@@ -22,17 +23,17 @@ final class CompileConfig private (
   
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap) && (this.compileOrder == x.compileOrder)
+    case x: CompileConfig => (this.fileConverterConfig == x.fileConverterConfig) && (this.scalaInstanceConfig == x.scalaInstanceConfig) && (this.bridgeJars == x.bridgeJars) && (this.sources == x.sources) && (this.externalDependencyJars == x.externalDependencyJars) && (this.output == x.output) && (this.analysisFile == x.analysisFile) && (this.earlyAnalysisFile == x.earlyAnalysisFile) && (this.earlyJarPath == x.earlyJarPath) && (this.scalacOptions == x.scalacOptions) && (this.javacOptions == x.javacOptions) && (this.maxErrors == x.maxErrors) && (this.analysisMap == x.analysisMap) && (this.compileOrder == x.compileOrder)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##) + compileOrder.##)
+    37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (37 * (17 + "sbt.internal.worker.CompileConfig".##) + fileConverterConfig.##) + scalaInstanceConfig.##) + bridgeJars.##) + sources.##) + externalDependencyJars.##) + output.##) + analysisFile.##) + earlyAnalysisFile.##) + earlyJarPath.##) + scalacOptions.##) + javacOptions.##) + maxErrors.##) + analysisMap.##) + compileOrder.##)
   }
   override def toString: String = {
-    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ", " + compileOrder + ")"
+    "CompileConfig(" + fileConverterConfig + ", " + scalaInstanceConfig + ", " + bridgeJars + ", " + sources + ", " + externalDependencyJars + ", " + output + ", " + analysisFile + ", " + earlyAnalysisFile + ", " + earlyJarPath + ", " + scalacOptions + ", " + javacOptions + ", " + maxErrors + ", " + analysisMap + ", " + compileOrder + ")"
   }
-  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap, compileOrder: String = compileOrder): CompileConfig = {
-    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
+  private def copy(fileConverterConfig: sbt.internal.worker.FileConverterConfig = fileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig = scalaInstanceConfig, bridgeJars: Vector[java.net.URI] = bridgeJars, sources: Vector[String] = sources, externalDependencyJars: Vector[String] = externalDependencyJars, output: java.net.URI = output, analysisFile: java.net.URI = analysisFile, earlyAnalysisFile: Option[java.net.URI] = earlyAnalysisFile, earlyJarPath: Option[java.net.URI] = earlyJarPath, scalacOptions: Vector[String] = scalacOptions, javacOptions: Vector[String] = javacOptions, maxErrors: Int = maxErrors, analysisMap: Vector[sbt.internal.worker.HVFRURI] = analysisMap, compileOrder: String = compileOrder): CompileConfig = {
+    new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyAnalysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
   }
   def withFileConverterConfig(fileConverterConfig: sbt.internal.worker.FileConverterConfig): CompileConfig = {
     copy(fileConverterConfig = fileConverterConfig)
@@ -54,6 +55,12 @@ final class CompileConfig private (
   }
   def withAnalysisFile(analysisFile: java.net.URI): CompileConfig = {
     copy(analysisFile = analysisFile)
+  }
+  def withEarlyAnalysisFile(earlyAnalysisFile: Option[java.net.URI]): CompileConfig = {
+    copy(earlyAnalysisFile = earlyAnalysisFile)
+  }
+  def withEarlyAnalysisFile(earlyAnalysisFile: java.net.URI): CompileConfig = {
+    copy(earlyAnalysisFile = Option(earlyAnalysisFile))
   }
   def withEarlyJarPath(earlyJarPath: Option[java.net.URI]): CompileConfig = {
     copy(earlyJarPath = earlyJarPath)
@@ -79,6 +86,6 @@ final class CompileConfig private (
 }
 object CompileConfig {
   
-  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
-  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyAnalysisFile: Option[java.net.URI], earlyJarPath: Option[java.net.URI], scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyAnalysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
+  def apply(fileConverterConfig: sbt.internal.worker.FileConverterConfig, scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig, bridgeJars: Vector[java.net.URI], sources: Vector[String], externalDependencyJars: Vector[String], output: java.net.URI, analysisFile: java.net.URI, earlyAnalysisFile: java.net.URI, earlyJarPath: java.net.URI, scalacOptions: Vector[String], javacOptions: Vector[String], maxErrors: Int, analysisMap: Vector[sbt.internal.worker.HVFRURI], compileOrder: String): CompileConfig = new CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, Option(earlyAnalysisFile), Option(earlyJarPath), scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/CompileResponse.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/CompileResponse.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class CompileResponse private (
+  val hasModified: Boolean) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: CompileResponse => (this.hasModified == x.hasModified)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.worker.CompileResponse".##) + hasModified.##)
+  }
+  override def toString: String = {
+    "CompileResponse(" + hasModified + ")"
+  }
+  private def copy(hasModified: Boolean): CompileResponse = {
+    new CompileResponse(hasModified)
+  }
+  def withHasModified(hasModified: Boolean): CompileResponse = {
+    copy(hasModified = hasModified)
+  }
+}
+object CompileResponse {
+  
+  def apply(hasModified: Boolean): CompileResponse = new CompileResponse(hasModified)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/FileConverterConfig.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/FileConverterConfig.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class FileConverterConfig private (
+  val rootPaths: Vector[sbt.internal.worker.StringURI]) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: FileConverterConfig => (this.rootPaths == x.rootPaths)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.worker.FileConverterConfig".##) + rootPaths.##)
+  }
+  override def toString: String = {
+    "FileConverterConfig(" + rootPaths + ")"
+  }
+  private def copy(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = {
+    new FileConverterConfig(rootPaths)
+  }
+  def withRootPaths(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = {
+    copy(rootPaths = rootPaths)
+  }
+}
+object FileConverterConfig {
+  
+  def apply(rootPaths: Vector[sbt.internal.worker.StringURI]): FileConverterConfig = new FileConverterConfig(rootPaths)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/HVFRURI.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/HVFRURI.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class HVFRURI private (
+  val name: xsbti.HashedVirtualFileRef,
+  val value: java.net.URI) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: HVFRURI => (this.name == x.name) && (this.value == x.value)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.worker.HVFRURI".##) + name.##) + value.##)
+  }
+  override def toString: String = {
+    "HVFRURI(" + name + ", " + value + ")"
+  }
+  private def copy(name: xsbti.HashedVirtualFileRef = name, value: java.net.URI = value): HVFRURI = {
+    new HVFRURI(name, value)
+  }
+  def withName(name: xsbti.HashedVirtualFileRef): HVFRURI = {
+    copy(name = name)
+  }
+  def withValue(value: java.net.URI): HVFRURI = {
+    copy(value = value)
+  }
+}
+object HVFRURI {
+  
+  def apply(name: xsbti.HashedVirtualFileRef, value: java.net.URI): HVFRURI = new HVFRURI(name, value)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/StringURI.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/StringURI.scala
@@ -1,0 +1,36 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker
+final class StringURI private (
+  val name: String,
+  val value: java.net.URI) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: StringURI => (this.name == x.name) && (this.value == x.value)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbt.internal.worker.StringURI".##) + name.##) + value.##)
+  }
+  override def toString: String = {
+    "StringURI(" + name + ", " + value + ")"
+  }
+  private def copy(name: String = name, value: java.net.URI = value): StringURI = {
+    new StringURI(name, value)
+  }
+  def withName(name: String): StringURI = {
+    copy(name = name)
+  }
+  def withValue(value: java.net.URI): StringURI = {
+    copy(value = value)
+  }
+}
+object StringURI {
+  
+  def apply(name: String, value: java.net.URI): StringURI = new StringURI(name, value)
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
@@ -1,0 +1,49 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait CompileConfigFormats { self: sbt.internal.worker.codec.FileConverterConfigFormats & sbt.internal.worker.codec.StringURIFormats & sjsonnew.BasicJsonProtocol & sbt.internal.worker.codec.ScalaInstanceConfigFormats & sbt.internal.worker.codec.HVFRURIFormats & sbt.internal.util.codec.HashedVirtualFileRefFormats =>
+given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new JsonFormat[sbt.internal.worker.CompileConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.CompileConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val fileConverterConfig = unbuilder.readField[sbt.internal.worker.FileConverterConfig]("fileConverterConfig")
+      val scalaInstanceConfig = unbuilder.readField[sbt.internal.worker.ScalaInstanceConfig]("scalaInstanceConfig")
+      val bridgeJars = unbuilder.readField[Vector[java.net.URI]]("bridgeJars")
+      val sources = unbuilder.readField[Vector[String]]("sources")
+      val externalDependencyJars = unbuilder.readField[Vector[String]]("externalDependencyJars")
+      val output = unbuilder.readField[java.net.URI]("output")
+      val analysisFile = unbuilder.readField[java.net.URI]("analysisFile")
+      val earlyJarPath = unbuilder.readField[Option[java.net.URI]]("earlyJarPath")
+      val scalacOptions = unbuilder.readField[Vector[String]]("scalacOptions")
+      val javacOptions = unbuilder.readField[Vector[String]]("javacOptions")
+      val maxErrors = unbuilder.readField[Int]("maxErrors")
+      val analysisMap = unbuilder.readField[Vector[sbt.internal.worker.HVFRURI]]("analysisMap")
+      unbuilder.endObject()
+      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.CompileConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("fileConverterConfig", obj.fileConverterConfig)
+    builder.addField("scalaInstanceConfig", obj.scalaInstanceConfig)
+    builder.addField("bridgeJars", obj.bridgeJars)
+    builder.addField("sources", obj.sources)
+    builder.addField("externalDependencyJars", obj.externalDependencyJars)
+    builder.addField("output", obj.output)
+    builder.addField("analysisFile", obj.analysisFile)
+    builder.addField("earlyJarPath", obj.earlyJarPath)
+    builder.addField("scalacOptions", obj.scalacOptions)
+    builder.addField("javacOptions", obj.javacOptions)
+    builder.addField("maxErrors", obj.maxErrors)
+    builder.addField("analysisMap", obj.analysisMap)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
@@ -23,8 +23,9 @@ given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new J
       val javacOptions = unbuilder.readField[Vector[String]]("javacOptions")
       val maxErrors = unbuilder.readField[Int]("maxErrors")
       val analysisMap = unbuilder.readField[Vector[sbt.internal.worker.HVFRURI]]("analysisMap")
+      val compileOrder = unbuilder.readField[String]("compileOrder")
       unbuilder.endObject()
-      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap)
+      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -43,6 +44,7 @@ given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new J
     builder.addField("javacOptions", obj.javacOptions)
     builder.addField("maxErrors", obj.maxErrors)
     builder.addField("analysisMap", obj.analysisMap)
+    builder.addField("compileOrder", obj.compileOrder)
     builder.endObject()
   }
 }

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileConfigFormats.scala
@@ -18,6 +18,7 @@ given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new J
       val externalDependencyJars = unbuilder.readField[Vector[String]]("externalDependencyJars")
       val output = unbuilder.readField[java.net.URI]("output")
       val analysisFile = unbuilder.readField[java.net.URI]("analysisFile")
+      val earlyAnalysisFile = unbuilder.readField[Option[java.net.URI]]("earlyAnalysisFile")
       val earlyJarPath = unbuilder.readField[Option[java.net.URI]]("earlyJarPath")
       val scalacOptions = unbuilder.readField[Vector[String]]("scalacOptions")
       val javacOptions = unbuilder.readField[Vector[String]]("javacOptions")
@@ -25,7 +26,7 @@ given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new J
       val analysisMap = unbuilder.readField[Vector[sbt.internal.worker.HVFRURI]]("analysisMap")
       val compileOrder = unbuilder.readField[String]("compileOrder")
       unbuilder.endObject()
-      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
+      sbt.internal.worker.CompileConfig(fileConverterConfig, scalaInstanceConfig, bridgeJars, sources, externalDependencyJars, output, analysisFile, earlyAnalysisFile, earlyJarPath, scalacOptions, javacOptions, maxErrors, analysisMap, compileOrder)
       case None =>
       deserializationError("Expected JsObject but found None")
     }
@@ -39,6 +40,7 @@ given CompileConfigFormat: JsonFormat[sbt.internal.worker.CompileConfig] = new J
     builder.addField("externalDependencyJars", obj.externalDependencyJars)
     builder.addField("output", obj.output)
     builder.addField("analysisFile", obj.analysisFile)
+    builder.addField("earlyAnalysisFile", obj.earlyAnalysisFile)
     builder.addField("earlyJarPath", obj.earlyJarPath)
     builder.addField("scalacOptions", obj.scalacOptions)
     builder.addField("javacOptions", obj.javacOptions)

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileResponseFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/CompileResponseFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait CompileResponseFormats { self: sjsonnew.BasicJsonProtocol =>
+given CompileResponseFormat: JsonFormat[sbt.internal.worker.CompileResponse] = new JsonFormat[sbt.internal.worker.CompileResponse] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.CompileResponse = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val hasModified = unbuilder.readField[Boolean]("hasModified")
+      unbuilder.endObject()
+      sbt.internal.worker.CompileResponse(hasModified)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.CompileResponse, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("hasModified", obj.hasModified)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FileConverterConfigFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/FileConverterConfigFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait FileConverterConfigFormats { self: sbt.internal.worker.codec.StringURIFormats & sjsonnew.BasicJsonProtocol =>
+given FileConverterConfigFormat: JsonFormat[sbt.internal.worker.FileConverterConfig] = new JsonFormat[sbt.internal.worker.FileConverterConfig] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.FileConverterConfig = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val rootPaths = unbuilder.readField[Vector[sbt.internal.worker.StringURI]]("rootPaths")
+      unbuilder.endObject()
+      sbt.internal.worker.FileConverterConfig(rootPaths)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.FileConverterConfig, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("rootPaths", obj.rootPaths)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/HVFRURIFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/HVFRURIFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait HVFRURIFormats { self: sbt.internal.util.codec.HashedVirtualFileRefFormats & sjsonnew.BasicJsonProtocol =>
+given HVFRURIFormat: JsonFormat[sbt.internal.worker.HVFRURI] = new JsonFormat[sbt.internal.worker.HVFRURI] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.HVFRURI = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val name = unbuilder.readField[xsbti.HashedVirtualFileRef]("name")
+      val value = unbuilder.readField[java.net.URI]("value")
+      unbuilder.endObject()
+      sbt.internal.worker.HVFRURI(name, value)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.HVFRURI, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("name", obj.name)
+    builder.addField("value", obj.value)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/JsonProtocol.scala
@@ -11,4 +11,10 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.worker.codec.RunInfoFormats
   with sbt.internal.worker.codec.ClientJobParamsFormats
   with sbt.internal.worker.codec.ScalaInstanceConfigFormats
+  with sbt.internal.worker.codec.StringURIFormats
+  with sbt.internal.worker.codec.FileConverterConfigFormats
+  with sbt.internal.util.codec.HashedVirtualFileRefFormats
+  with sbt.internal.worker.codec.HVFRURIFormats
+  with sbt.internal.worker.codec.CompileConfigFormats
+  with sbt.internal.worker.codec.CompileResponseFormats
 object JsonProtocol extends JsonProtocol

--- a/protocol/src/main/contraband-scala/sbt/internal/worker/codec/StringURIFormats.scala
+++ b/protocol/src/main/contraband-scala/sbt/internal/worker/codec/StringURIFormats.scala
@@ -1,0 +1,29 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.worker.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait StringURIFormats { self: sjsonnew.BasicJsonProtocol =>
+given StringURIFormat: JsonFormat[sbt.internal.worker.StringURI] = new JsonFormat[sbt.internal.worker.StringURI] {
+  override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.worker.StringURI = {
+    __jsOpt match {
+      case Some(__js) =>
+      unbuilder.beginObject(__js)
+      val name = unbuilder.readField[String]("name")
+      val value = unbuilder.readField[java.net.URI]("value")
+      unbuilder.endObject()
+      sbt.internal.worker.StringURI(name, value)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.worker.StringURI, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("name", obj.name)
+    builder.addField("value", obj.value)
+    builder.endObject()
+  }
+}
+}

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -81,6 +81,7 @@ type CompileConfig {
   externalDependencyJars: [String]
   output: java.net.URI!
   analysisFile: java.net.URI!
+  earlyAnalysisFile: java.net.URI
   earlyJarPath: java.net.URI
   scalacOptions: [String]
   javacOptions: [String]

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -86,6 +86,7 @@ type CompileConfig {
   javacOptions: [String]
   maxErrors: Int!
   analysisMap: [sbt.internal.worker.HVFRURI]
+  compileOrder: String!
 }
 
 type CompileResponse {

--- a/protocol/src/main/contraband/worker.contra
+++ b/protocol/src/main/contraband/worker.contra
@@ -58,3 +58,36 @@ type ScalaInstanceConfig {
   allCompilerJars: [java.net.URI]
   extraToolJars: [java.net.URI] @since("0.1.0")
 }
+
+type StringURI {
+  name: String!
+  value: java.net.URI!
+}
+
+type FileConverterConfig {
+  rootPaths: [sbt.internal.worker.StringURI]
+}
+
+type HVFRURI {
+  name: xsbti.HashedVirtualFileRef!
+  value: java.net.URI!
+}
+
+type CompileConfig {
+  fileConverterConfig: sbt.internal.worker.FileConverterConfig!
+  scalaInstanceConfig: sbt.internal.worker.ScalaInstanceConfig!
+  bridgeJars: [java.net.URI]
+  sources: [String]
+  externalDependencyJars: [String]
+  output: java.net.URI!
+  analysisFile: java.net.URI!
+  earlyJarPath: java.net.URI
+  scalacOptions: [String]
+  javacOptions: [String]
+  maxErrors: Int!
+  analysisMap: [sbt.internal.worker.HVFRURI]
+}
+
+type CompileResponse {
+  hasModified: Boolean!
+}

--- a/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/a/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/a/src/main/scala/A.scala
@@ -1,0 +1,3 @@
+object A {
+  def greeting: String = "hi"
+}

--- a/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/b/src/main/scala/B.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/b/src/main/scala/B.scala
@@ -1,0 +1,3 @@
+object B {
+  def main(args: Array[String]): Unit = println(A.greeting)
+}

--- a/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/build.sbt
@@ -1,0 +1,7 @@
+ThisBuild / scalaVersion := "3.7.4"
+ThisBuild / usePipelining := true
+ThisBuild / forkCompile := true
+
+lazy val a = project
+
+lazy val b = project.dependsOn(a)

--- a/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/test
+++ b/sbt-app/src/sbt-test/source-dependencies/fork-pipelining/test
@@ -1,0 +1,3 @@
+> b/compile
+
+> b/run

--- a/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
@@ -1,5 +1,4 @@
 name := "hello"
 scalaVersion := "3.7.4"
 // jdkVersion := Some("zulu@25")
-Compile / fork := true
-Test / fork := true
+forkCompile := true

--- a/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/build.sbt
@@ -1,0 +1,5 @@
+name := "hello"
+scalaVersion := "3.7.4"
+// jdkVersion := Some("zulu@25")
+Compile / fork := true
+Test / fork := true

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/A1.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/A1.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  final val x = 1

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/A2.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/A2.scala
@@ -1,0 +1,4 @@
+package example
+
+object A:
+  final val x = 2

--- a/sbt-app/src/sbt-test/source-dependencies/fork/changes/B.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/changes/B.scala
@@ -1,0 +1,6 @@
+package example
+
+@main
+def hello(args: String*): Unit =
+  println("hello")
+  assert(args(0).toInt == A.x)

--- a/sbt-app/src/sbt-test/source-dependencies/fork/test
+++ b/sbt-app/src/sbt-test/source-dependencies/fork/test
@@ -1,0 +1,11 @@
+$ copy-file changes/B.scala B.scala
+
+-> compile
+
+$ copy-file changes/A1.scala A.scala
+
+> run 1
+
+$ copy-file changes/A2.scala A.scala
+
+> run 2

--- a/worker/src/main/java/sbt/internal/worker1/RunInfo.java
+++ b/worker/src/main/java/sbt/internal/worker1/RunInfo.java
@@ -15,6 +15,7 @@ public class RunInfo implements Serializable {
   public static class JvmRunInfo implements Serializable {
     public ArrayList<String> args;
     public ArrayList<FilePath> classpath;
+    public ArrayList<FilePath> parentClasspath;
     public String mainClass;
     public boolean connectInput;
 
@@ -23,8 +24,18 @@ public class RunInfo implements Serializable {
         ArrayList<FilePath> classpath,
         String mainClass,
         boolean connectInput) {
+      this(args, classpath, null, mainClass, connectInput);
+    }
+
+    public JvmRunInfo(
+        ArrayList<String> args,
+        ArrayList<FilePath> classpath,
+        ArrayList<FilePath> parentClasspath,
+        String mainClass,
+        boolean connectInput) {
       this.args = args;
       this.classpath = classpath;
+      this.parentClasspath = parentClasspath;
       this.mainClass = mainClass;
       this.connectInput = connectInput;
     }

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -161,7 +161,13 @@ public final class WorkerMain {
       this.jsonOut.println(response);
       this.jsonOut.flush();
     } catch (Throwable e) {
-      WorkerError err = new WorkerError(1, e.getMessage());
+      Throwable cause = e;
+      while (cause instanceof java.lang.reflect.InvocationTargetException
+          && cause.getCause() != null) {
+        cause = cause.getCause();
+      }
+      String message = cause.getMessage() != null ? cause.getMessage() : cause.toString();
+      WorkerError err = new WorkerError(1, message);
       String errMessage = g.toJson(err, err.getClass());
       String errJson =
           String.format("{ \"jsonrpc\": \"2.0\", \"error\": %s, \"id\": %d }", errMessage, id);
@@ -177,7 +183,8 @@ public final class WorkerMain {
         throw new RuntimeException("missing jvmRunInfo element");
       }
       RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
-      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
+      try (URLClassLoader cl =
+          createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader(), false)) {
         Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
         Method mainMethod = mainClass.getMethod("main", String[].class);
         String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
@@ -195,7 +202,8 @@ public final class WorkerMain {
         throw new RuntimeException("missing jvmRunInfo element");
       }
       RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
-      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
+      try (URLClassLoader cl =
+          createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader(), true)) {
         Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
         Method mainMethod =
             mainClass.getMethod("main", String[].class, Long.class, PrintStream.class);
@@ -215,7 +223,7 @@ public final class WorkerMain {
       if (jvmRunInfo.classpath.isEmpty()) {
         ForkTestMain.main(id, info, this.jsonOut, parent);
       } else {
-        try (URLClassLoader cl = createClassLoader(jvmRunInfo, parent)) {
+        try (URLClassLoader cl = createClassLoader(jvmRunInfo, parent, false)) {
           ForkTestMain.main(id, info, this.jsonOut, cl);
         }
       }
@@ -229,44 +237,43 @@ public final class WorkerMain {
     return;
   }
 
-  private URLClassLoader createClassLoader(RunInfo.JvmRunInfo info, ClassLoader parent) {
+  private URLClassLoader createClassLoader(
+      RunInfo.JvmRunInfo info, ClassLoader parent, boolean isolateCompilerInterface) {
+    if (!isolateCompilerInterface) {
+      return new URLClassLoader(toUrls(info.classpath), parent);
+    }
     Map<Boolean, List<FilePath>> groups =
         info.classpath.stream()
             .collect(
                 Collectors.partitioningBy(
-                    filePath ->
-                        Paths.get(filePath.path)
-                            .getFileName()
-                            .toString()
-                            .startsWith("compiler-interface")));
-    List<FilePath> xs0 = groups.get(true);
-    List<FilePath> xs1 = groups.get(false);
-    URL[] us1 =
-        xs1.stream()
-            .map(
-                filePath -> {
-                  try {
-                    return filePath.path.toURL();
-                  } catch (MalformedURLException e) {
-                    throw new RuntimeException(e);
-                  }
-                })
-            .toArray(URL[]::new);
-    if (!xs0.equals(null) && xs0.size() >= 1) {
-      URL[] us0 =
-          xs0.stream()
-              .map(
-                  filePath -> {
-                    try {
-                      return filePath.path.toURL();
-                    } catch (MalformedURLException e) {
-                      throw new RuntimeException(e);
-                    }
-                  })
-              .toArray(URL[]::new);
-      return new URLClassLoader(us1, new URLClassLoader(us0, parent));
-    } else {
-      return new URLClassLoader(us1, parent);
+                    filePath -> fileNameOf(filePath.path).startsWith("compiler-interface")));
+    List<FilePath> interfaceJars = groups.get(true);
+    List<FilePath> rest = groups.get(false);
+    if (interfaceJars.isEmpty()) {
+      return new URLClassLoader(toUrls(rest), parent);
     }
+    return new URLClassLoader(toUrls(rest), new URLClassLoader(toUrls(interfaceJars), parent));
+  }
+
+  private static URL[] toUrls(List<FilePath> classpath) {
+    return classpath.stream()
+        .map(
+            filePath -> {
+              try {
+                return filePath.path.toURL();
+              } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .toArray(URL[]::new);
+  }
+
+  private static String fileNameOf(java.net.URI uri) {
+    String path = uri.getPath();
+    if (path == null) {
+      return "";
+    }
+    int idx = path.lastIndexOf('/');
+    return idx >= 0 ? path.substring(idx + 1) : path;
   }
 }

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -147,6 +147,10 @@ public final class WorkerMain {
           ConsoleInfo consoleInfo = g.fromJson(params, ConsoleInfo.class);
           console(id, consoleInfo);
           return;
+        case "compile":
+          RunInfo r1 = g.fromJson(params, RunInfo.class);
+          compile(r1, id);
+          return;
         case "bye":
           break;
       }
@@ -175,6 +179,25 @@ public final class WorkerMain {
         Method mainMethod = mainClass.getMethod("main", String[].class);
         String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
         mainMethod.invoke(null, (Object) mainArgs);
+      }
+    } else {
+      throw new RuntimeException("only jvm is supported");
+    }
+  }
+
+  // This is similar to the run(...) method except for passing the printstream.
+  void compile(RunInfo info, long id) throws Exception {
+    if (info.jvm) {
+      if (info.jvmRunInfo == null) {
+        throw new RuntimeException("missing jvmRunInfo element");
+      }
+      RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
+      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
+        Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
+        Method mainMethod =
+            mainClass.getMethod("main", String[].class, Long.class, PrintStream.class);
+        String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
+        mainMethod.invoke(null, (Object) mainArgs, (Object) id, (Object) jsonOut);
       }
     } else {
       throw new RuntimeException("only jvm is supported");

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -20,7 +20,10 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 import org.scalasbt.shadedgson.com.google.gson.Gson;
 import org.scalasbt.shadedgson.com.google.gson.GsonBuilder;
 import org.scalasbt.shadedgson.com.google.gson.JsonElement;
@@ -227,8 +230,19 @@ public final class WorkerMain {
   }
 
   private URLClassLoader createClassLoader(RunInfo.JvmRunInfo info, ClassLoader parent) {
-    URL[] urls =
+    Map<Boolean, List<FilePath>> groups =
         info.classpath.stream()
+            .collect(
+                Collectors.partitioningBy(
+                    filePath ->
+                        Paths.get(filePath.path)
+                            .getFileName()
+                            .toString()
+                            .startsWith("compiler-interface")));
+    List<FilePath> xs0 = groups.get(true);
+    List<FilePath> xs1 = groups.get(false);
+    URL[] us1 =
+        xs1.stream()
             .map(
                 filePath -> {
                   try {
@@ -238,6 +252,21 @@ public final class WorkerMain {
                   }
                 })
             .toArray(URL[]::new);
-    return new URLClassLoader(urls, parent);
+    if (!xs0.equals(null) && xs0.size() >= 1) {
+      URL[] us0 =
+          xs0.stream()
+              .map(
+                  filePath -> {
+                    try {
+                      return filePath.path.toURL();
+                    } catch (MalformedURLException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .toArray(URL[]::new);
+      return new URLClassLoader(us1, new URLClassLoader(us0, parent));
+    } else {
+      return new URLClassLoader(us1, parent);
+    }
   }
 }

--- a/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/WorkerMain.java
@@ -21,9 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Map;
 import java.util.Scanner;
-import java.util.stream.Collectors;
 import org.scalasbt.shadedgson.com.google.gson.Gson;
 import org.scalasbt.shadedgson.com.google.gson.GsonBuilder;
 import org.scalasbt.shadedgson.com.google.gson.JsonElement;
@@ -183,8 +181,7 @@ public final class WorkerMain {
         throw new RuntimeException("missing jvmRunInfo element");
       }
       RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
-      try (URLClassLoader cl =
-          createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader(), false)) {
+      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
         Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
         Method mainMethod = mainClass.getMethod("main", String[].class);
         String[] mainArgs = jvmRunInfo.args.stream().toArray(String[]::new);
@@ -202,8 +199,7 @@ public final class WorkerMain {
         throw new RuntimeException("missing jvmRunInfo element");
       }
       RunInfo.JvmRunInfo jvmRunInfo = info.jvmRunInfo;
-      try (URLClassLoader cl =
-          createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader(), true)) {
+      try (URLClassLoader cl = createClassLoader(jvmRunInfo, ClassLoader.getSystemClassLoader())) {
         Class<?> mainClass = cl.loadClass(jvmRunInfo.mainClass);
         Method mainMethod =
             mainClass.getMethod("main", String[].class, Long.class, PrintStream.class);
@@ -223,7 +219,7 @@ public final class WorkerMain {
       if (jvmRunInfo.classpath.isEmpty()) {
         ForkTestMain.main(id, info, this.jsonOut, parent);
       } else {
-        try (URLClassLoader cl = createClassLoader(jvmRunInfo, parent, false)) {
+        try (URLClassLoader cl = createClassLoader(jvmRunInfo, parent)) {
           ForkTestMain.main(id, info, this.jsonOut, cl);
         }
       }
@@ -237,22 +233,12 @@ public final class WorkerMain {
     return;
   }
 
-  private URLClassLoader createClassLoader(
-      RunInfo.JvmRunInfo info, ClassLoader parent, boolean isolateCompilerInterface) {
-    if (!isolateCompilerInterface) {
+  private URLClassLoader createClassLoader(RunInfo.JvmRunInfo info, ClassLoader parent) {
+    if (info.parentClasspath == null || info.parentClasspath.isEmpty()) {
       return new URLClassLoader(toUrls(info.classpath), parent);
     }
-    Map<Boolean, List<FilePath>> groups =
-        info.classpath.stream()
-            .collect(
-                Collectors.partitioningBy(
-                    filePath -> fileNameOf(filePath.path).startsWith("compiler-interface")));
-    List<FilePath> interfaceJars = groups.get(true);
-    List<FilePath> rest = groups.get(false);
-    if (interfaceJars.isEmpty()) {
-      return new URLClassLoader(toUrls(rest), parent);
-    }
-    return new URLClassLoader(toUrls(rest), new URLClassLoader(toUrls(interfaceJars), parent));
+    return new URLClassLoader(
+        toUrls(info.classpath), new URLClassLoader(toUrls(info.parentClasspath), parent));
   }
 
   private static URL[] toUrls(List<FilePath> classpath) {
@@ -266,14 +252,5 @@ public final class WorkerMain {
               }
             })
         .toArray(URL[]::new);
-  }
-
-  private static String fileNameOf(java.net.URI uri) {
-    String path = uri.getPath();
-    if (path == null) {
-      return "";
-    }
-    int idx = path.lastIndexOf('/');
-    return idx >= 0 ? path.substring(idx + 1) : path;
   }
 }


### PR DESCRIPTION
Rebase of #8584 (eed3si9n:wip/worker2) onto current develop, keeping the original commits, plus one commit addressing review findings. Unit tests and the fork scripted test pass.

The rebase itself shrank the diff: develop already absorbed the scalaInstance config refactoring via the console PR (#8604), so Compiler.scala falls out entirely, and most conflicts came from the earlier merged worker PR (#8170).

Review fixes:

1. New `forkCompile` setting gates forked compilation; `Test / fork := true` no longer reroutes compile. The scripted test uses it.
2. Worker errors propagate: ProcessReact fails the promise on processing exceptions, WorkerMain unwraps InvocationTargetException, CompileMain catches NonFatal and replies with escaped JSON-RPC errors.
3. The exit listener registers right after proxy creation and self-checks a dead worker, so a startup crash can't hang the compile. Exit notification is synchronized and per-process.
4. The fork path runs under Retry.io and mirrors in-process failure handling. BSP progress and mid-compile ping still don't work forked; that's inherent.
5. The compiler-interface classloader split applies only to compile; run and test load flat. Non-file URIs handled, bogus null guard removed.
6. WorkerProxy closes in finally, fixing the fd leak. Worker reuse left for later.
7. compileOrder travels through CompileConfig. incOptions and sourcePositionMappers still don't; functions can't cross a process boundary. No-op extraIncOptions stub removed.
8. currentClasspath falls back to java.class.path instead of MatchError.
9. The compile task splits into two cachedTasks picked by taskDyn, so the non-fork path pays nothing extra. Dead `jh` and redundant analysis rewrite dropped.
10. -Werror is back on for actionsProj with its hidden warnings fixed; the unused Compiler.* mima exclude is gone.

Same branch is also proposed into eed3si9n:wip/worker2 as eed3si9n/sbt#6, so #8584 can pick up the rebase and fixes directly if preferred.
