### PR TITLE
[2.x] perf: Populate the in-memory cache on a read

### DIFF
--- a/main/src/main/scala/sbt/internal/InMemoryCacheStore.scala
+++ b/main/src/main/scala/sbt/internal/InMemoryCacheStore.scala
@@ -52,11 +52,19 @@ private[sbt] object InMemoryCacheStore {
   private class CacheStoreImpl(path: Path, store: InMemoryCacheStore, cacheStore: CacheStore)
       extends CacheStore {
     override def delete(): Unit = cacheStore.delete()
+
+    /**
+     * A miss populates the cache. `write` is otherwise the only thing that fills it, and a task whose stored
+     * output is already up to date never writes -- so it would re-deserialise that output on every invocation.
+     */
     override def read[T]()(using reader: JsonReader[T]): T = {
       val lastModified = IO.getModifiedTimeOrZero(path.toFile)
       store.get[T](path) match {
         case Some((value, `lastModified`)) => value
-        case _                             => cacheStore.read[T]()
+        case _                             =>
+          val value = cacheStore.read[T]()
+          store.put(path, value, lastModified)
+          value
       }
     }
     override def write[T](value: T)(using writer: JsonWriter[T]): Unit = {

--- a/main/src/test/scala/sbt/internal/InMemoryCacheStoreTest.scala
+++ b/main/src/test/scala/sbt/internal/InMemoryCacheStoreTest.scala
@@ -1,0 +1,74 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import hedgehog.*
+import hedgehog.runner.*
+import _root_.sbt.io.IO
+import _root_.sbt.util.CacheStore
+import sjsonnew.BasicJsonProtocol.given
+import java.nio.file.{ Files, Path }
+
+object InMemoryCacheStoreTest extends Properties:
+  override def tests: List[Test] = List(
+    example("a read populates the cache", readPopulates),
+    example("a write populates the cache", writePopulates),
+    example("a newer file invalidates the cached value", newerFileInvalidates),
+    example("a read of a store with no file still reports absent", missingFileIsAbsent),
+  )
+
+  private def withStore[A](budget: Long = 1024L * 1024L)(f: (Path, CacheStore) => A): A =
+    val dir = Files.createTempDirectory("sbt-inmemory-cache")
+    val factoryFactory = InMemoryCacheStore.factory(budget)
+    try f(dir.resolve("value"), factoryFactory(dir).make("value"))
+    finally factoryFactory.close()
+
+  /**
+   * Rewrites the file's bytes while restoring its modification time, so only an in-memory entry can still
+   * answer with the original value. `write` would move the timestamp, so the replacement goes in plain.
+   */
+  private def overwriteKeepingTimestamp(path: Path, value: String): Unit =
+    val stamp = IO.getModifiedTimeOrZero(path.toFile)
+    CacheStore.file(path.toFile).write(value)
+    val _ = IO.setModifiedTimeOrFalse(path.toFile, stamp)
+
+  def readPopulates: Result =
+    withStore() { (path, store) =>
+      CacheStore.file(path.toFile).write("first")
+      val readFromDisk = store.read[String]()
+      overwriteKeepingTimestamp(path, "second")
+      val readFromCache = store.read[String]()
+      Result.assert(readFromDisk == "first").log(s"disk read gave $readFromDisk") and
+        Result
+          .assert(readFromCache == "first")
+          .log(s"expected the cached 'first', got '$readFromCache' -- the read did not populate")
+    }
+
+  def writePopulates: Result =
+    withStore() { (path, store) =>
+      store.write("written")
+      overwriteKeepingTimestamp(path, "clobbered")
+      val value = store.read[String]()
+      Result.assert(value == "written").log(s"expected 'written', got '$value'")
+    }
+
+  def newerFileInvalidates: Result =
+    withStore() { (path, store) =>
+      store.write("old")
+      CacheStore.file(path.toFile).write("new")
+      val _ = IO.setModifiedTimeOrFalse(path.toFile, IO.getModifiedTimeOrZero(path.toFile) + 5000L)
+      val value = store.read[String]()
+      Result.assert(value == "new").log(s"a moved timestamp must re-read from disk, got '$value'")
+    }
+
+  def missingFileIsAbsent: Result =
+    withStore() { (_, store) =>
+      Result.assert(store.read[String]("fallback") == "fallback")
+    }


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Fixes #9656.

## Fixes

Put the value after a successful read. Keying is unchanged — `(path, lastModified)`, re-stat on every read, `write` still invalidates first — so a populated read is sound for the same reason a populated write is. A failed read throws before the `put`, and `put` already ignores a non-positive timestamp.

## Measurements

https://github.com/hoangmaihuy/sbt-compile-benchmark

81-module workspace, **no-op** build, real output files, `exportJars=true`. Both sbt builds published from the same tree, differing only in this commit (bytecode-checked: `CacheStoreImpl` has one `store.put` before, two after). Alternated A-B-A-B, 8 runs per version, because this machine drifts by more than the effect size.

| | wall (median of 8) | `update` (threshold 0) | task total |
| --- | --- | --- | --- |
| before | 5.15 s | 398 ms / 82 projects | 4797 ms |
| after | **4.97 s** | **30 ms / 29 projects** | 4623 ms |

Nothing recompiled in any run; 53 of the 82 update tasks become too cheap to report. The 174 ms of task time recovered matches the ~180 ms of wall clock.

That workspace is generated, so its reports are small. On a private 306-project build with real dependency sets, `update` went **1763 ms -> 224 ms**.

## Tests

New `InMemoryCacheStoreTest` (hedgehog, 4 cases). The regression test rewrites the store file's bytes while restoring its mtime, so only an in-memory entry can answer with the original value — **it fails on `develop` and passes here**. Plus write-populates, moved-timestamp-re-reads, missing-file-absent.

## Note

This makes `maximumWeight` bind where it could not before — reads now admit entries, so a build whose working set exceeds `sbt.file.cache.size` evicts rather than never caching at all. Intended behaviour for a bounded cache, but a real change in what the budget means.
