### PR TITLE
[2.x] perf: Bump IO to 1.13.0, write packageBin jars and action cache zips in parallel 

### DIFF
--- a/main-actions/src/main/scala/sbt/Pkg.scala
+++ b/main-actions/src/main/scala/sbt/Pkg.scala
@@ -13,6 +13,7 @@ import java.time.OffsetDateTime
 import java.util.jar.{ Attributes, Manifest }
 import scala.jdk.CollectionConverters.*
 import sbt.io.IO
+import sbt.io.IO.Implicits.zipContext
 
 import sjsonnew.{
   :*:,
@@ -229,7 +230,7 @@ object Pkg:
       if (!jar.isFile)
         sys.error(path + " exists, but is not a regular file")
     log.debug(sourcesDebugString(sources))
-    IO.jar(sources, jar, manifest, time)
+    IO.jarParallel(sources, jar, manifest, time)
     log.debug("Done packaging.")
   }
   def sourcesDebugString(sources: Seq[(File, String)]): String =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")
 
   // sbt modules
-  val ioVersion = nightlyVersion.getOrElse("1.12.2")
+  val ioVersion = nightlyVersion.getOrElse("1.13.0")
   val zincVersion = nightlyVersion.getOrElse("2.0.4")
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion

--- a/util-cache/src/main/scala/sbt/util/ActionCache.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCache.scala
@@ -28,6 +28,7 @@ import sbt.internal.util.{
 }
 import sbt.io.syntax.*
 import sbt.io.IO
+import sbt.io.IO.Implicits.zipContext
 import sbt.nio.file.{ **, FileTreeView }
 import sbt.nio.file.syntax.*
 import sbt.util.CacheImplicits
@@ -423,7 +424,7 @@ object ActionCache:
             case f                 => (f.toFile() -> outputDirectory.relativize(f).toString) :: Nil
       // Create the zip in a temp directory to avoid overwriting the cache if `zipPath` is a symlink to the CAS
       val tempZipPath = (tempDir / (dirPath.getFileName.toString + dirZipExt)).toPath()
-      IO.zip(
+      IO.zipParallel(
         (allPaths ++ Seq(mPath)).flatMap(rebase),
         tempZipPath.toFile(),
         Some(default2010Timestamp)


### PR DESCRIPTION
**Disclaimer**: Developed with Claude Code and human review in the loop

Follow up https://github.com/sbt/io/pull/540
Might fix https://github.com/sbt/sbt/issues/9558

### Summary

sbt writes two archives per module per build: the `packageBin`/`packageInternal` jar, and the zip the disk action cache stores an output directory as. Both deflate one entry at a time on the calling thread. io 1.13.0 adds `IO.jarParallel` / `IO.zipParallel`, which deflate concurrently and emit byte-identical archives.

On a workspace with realistic class-file sizes: **−61% to −63%** of the time inside those calls on a cold build, **−10% to −17%** of build wall clock, **−29%** on a one-line edit with pipelining.

### Changes

```
project/Dependencies.scala           io 1.12.2 -> 1.13.0
util-cache/…/ActionCache.scala:427   IO.zip -> IO.zipParallel   (packageDirectory)
main-actions/…/Pkg.scala:233         IO.jar -> IO.jarParallel   (Pkg.makeJar)
```

`Publishing.scala`'s `IO.zip` and the launcher plugin's are left alone; neither is on the compile path.

### Measurements

Rig, harness and method: [`sbt-compile-benchmark`, `scale-big`](https://github.com/hoangmaihuy/sbt-compile-benchmark/tree/main/scale-big) — 81 modules as three chains of depth 27, `app` depending on the three tips, emitting class files whose size distribution matches a real Scala 3 workspace (9.77 KiB mean, 0.48 GiB total). Reproduce with `tools/tracematrix.sh`.

Medians of 3 repetitions. `in-call` is time actually spent inside `IO.jar`/`IO.zip`, from a timer around the call site compiled into both builds.

| config | scenario | calls zip/jar | in-call base | in-call new | in-call gain | wall base | wall new | wall gain |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `exportJars=false` | cold | 82 / 0 | 11422 ms | 4429 ms | **−61.2%** | 27.57 s | 24.80 s | **−10.0%** |
| | edit deep dep | 1 / 0 | 141 ms | 49 ms | −65.2% | 5.74 s | 5.57 s | −3.0% |
| `exportJars=true` | cold | 82 / 81 | 22796 ms | 8413 ms | **−63.1%** | 28.87 s | 24.07 s | **−16.6%** |
| | edit deep dep | 1 / 1 | 282 ms | 86 ms | −69.5% | 4.70 s | 4.51 s | −4.0% |
| `exportJars=true` + pipelining | cold | 164 / 81 | 56577 ms | 37276 ms | **−34.1%** | 25.52 s | 23.31 s | **−8.7%** |
| | edit deep dep | 29 / 1 | 3928 ms | 1363 ms | **−65.3%** | 7.94 s | 5.63 s | **−29.1%** |

**No-op and leaf-edit make zero calls** in every configuration — `packageTask` is a `Def.cachedTask`, so a cache hit never reaches `Pkg`, and nothing is stored so `packageDirectory` never runs. The change cannot affect them, and the call counts in the log are the control that says so.

How much there is to gain is set by mean entry size, because deflation cost is proportional to bytes: below roughly 1 KiB an archive is mostly per-entry headers with nothing to share out, and above ~16 MiB an entry exceeds `MaxEntryBytes` and streams serially. Measured on `IO.jar` alone:

| input | entries | mean entry | base | new | speedup |
| --- | --- | --- | --- | --- | --- |
| tiny entries | 2002 | 0.43 KiB | 104.3 ms | 82.7 ms | 1.26× |
| sbt's own `main/classes` | 1133 | 8.90 KiB | 250.9 ms | 101.0 ms | 2.48× |
| a module of this workspace | 642 | 9.77 KiB | 138.4 ms | 42.8 ms | 3.23× |
| 20 large jars | 20 | 8 MiB | 3105.0 ms | 3064.3 ms | 1.01× |

Real Scala 3 output sits in the middle band, which is where the gain is largest.

### Why the gain varies

- **Idle cores are the precondition.** `ParallelZipOutputStream` has the writing thread deflate whatever the pool has not started, so on a saturated build it degrades to the serial path — the reason it cannot be slower than what it replaces.
- **Hence −34% on the pipelined cold build** against −61/−63% elsewhere: 245 concurrent archive operations saturate all 12 cores.
- **Pipelining is the heaviest user, for a caching reason rather than a compilation one.** A one-line body edit recompiles only `m1` either way, but with pipelining it re-archives **29** output directories instead of **1**: downstream modules take the upstream early-output pickle jar on their classpath (`makePickleProducts`, `Defaults.scala:4534`), and a pickle carries method bodies. The edit moved m1's early jar `3ff13e5a…` → `e8168e7e…`, 1689708 → 1690275 bytes, so every downstream key misses and re-stores an unchanged output. That is the 4.70 s → 7.94 s pipelining costs today, and why it recovers most from this change.

### Correctness

- **Byte-identical output** — SHA-256 equal for serial vs parallel, `jar` and `zip`, across four inputs from 0.43 KiB to 8 MiB mean entry. Cache keys, remote-cache hits and reproducible builds unaffected.

### Risk

- The writer holds up to a 16 MiB window per open archive (`WindowBytes`), so N concurrent packaging tasks can hold N×16 MiB more heap — up to ~190 MiB extra peak on 12 cores. Invisible on the 16 G heap used here; relevant to a build on a small default heap. No default changed to pre-empt it.