### PR TITLE
[2.x] feat: workerMaxInstances + testTopology

### DIFF
--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -57,26 +57,25 @@ private[sbt] object ForkTests:
       this.getClass.getClassLoader // can't provide the loader for test classes, which is in another jvm
     def all(work: Seq[ClassLoader => Unit]) = work.fork(f => f(dummyLoader))
 
-    val main =
-      if opts.tests.isEmpty then
-        // Nothing selected after filtering, so don't run setup/cleanup either.
-        constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
-      else
-        mainTestTask(
-          runners = runners,
-          opts = opts,
-          classpath = classpath,
-          converter = converter,
-          fork = fork,
-          log = log,
-          parallel = config.parallel,
-          parallelism = parallelism,
-          virtualClasspath = virtualClasspath,
-        ).tagw(config.tags*)
-          .dependsOn(all(opts.setup)*)
-          .flatMap: results =>
-            all(opts.cleanup).join.map(_ => results)
-    main.tagw(tags*)
+    if opts.tests.isEmpty then
+      // Nothing selected after filtering, so don't run setup/cleanup either.
+      constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
+    else
+      mainTestTask(
+        runners = runners,
+        opts = opts,
+        classpath = classpath,
+        converter = converter,
+        fork = fork,
+        log = log,
+        parallel = config.parallel,
+        parallelism = parallelism,
+        virtualClasspath = virtualClasspath,
+      ).tagw(config.tags*)
+        .tagw(tags*)
+        .dependsOn(all(opts.setup)*)
+        .flatMap: results =>
+          all(opts.cleanup).join.map(_ => results)
   }
 
   private def mainTestTask(

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -55,7 +55,11 @@ private[sbt] object ForkTests:
     import std.TaskExtra.*
     val dummyLoader =
       this.getClass.getClassLoader // can't provide the loader for test classes, which is in another jvm
-    def all(work: Seq[ClassLoader => Unit]) = work.fork(f => f(dummyLoader))
+    // Tag setup/cleanup the same as the actual test run -- otherwise a restriction like
+    // Tags.limit(Tags.ExclusiveTestGroup, 1) only ever sees the forked JVM in between them, and
+    // another subproject's setup/cleanup (or its own exclusive run) can freely overlap either end.
+    def all(work: Seq[ClassLoader => Unit]) =
+      work.fork(f => f(dummyLoader)).map(_.tagw(config.tags*).tagw(tags*))
 
     if opts.tests.isEmpty then
       // Nothing selected after filtering, so don't run setup/cleanup either.

--- a/main-actions/src/main/scala/sbt/ForkTests.scala
+++ b/main-actions/src/main/scala/sbt/ForkTests.scala
@@ -59,6 +59,7 @@ private[sbt] object ForkTests:
 
     val main =
       if opts.tests.isEmpty then
+        // Nothing selected after filtering, so don't run setup/cleanup either.
         constant(TestOutput(TestResult.Passed, Map.empty[String, SuiteResult], Iterable.empty))
       else
         mainTestTask(
@@ -72,9 +73,10 @@ private[sbt] object ForkTests:
           parallelism = parallelism,
           virtualClasspath = virtualClasspath,
         ).tagw(config.tags*)
-    main.tagw(tags*).dependsOn(all(opts.setup)*) flatMap { results =>
-      all(opts.cleanup).join.map(_ => results)
-    }
+          .dependsOn(all(opts.setup)*)
+          .flatMap: results =>
+            all(opts.cleanup).join.map(_ => results)
+    main.tagw(tags*)
   }
 
   private def mainTestTask(

--- a/main-actions/src/main/scala/sbt/TestTopology.scala
+++ b/main-actions/src/main/scala/sbt/TestTopology.scala
@@ -1,0 +1,37 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+/**
+ * Each subproject declares its testTopology setting to inform how
+ * its test classes are grouped together for scheduling.
+ */
+enum TestTopology:
+  case Default
+  case ClassParallel
+  case SubprojectExclusive
+  case SubprojectSplit(n: Int)
+
+object TestTopology:
+  private final val defaultSplit = 2
+  def default: TestTopology = TestTopology.Default
+  def subprojectExclusive: TestTopology = TestTopology.SubprojectExclusive
+  def subprojectSplit(n: Int): TestTopology = TestTopology.SubprojectSplit(n)
+
+  private[sbt] def isSingleGroup(topo: TestTopology, fork: Boolean): Boolean =
+    !fork || (topo match
+      case TestTopology.SubprojectExclusive => true
+      case _                                => false)
+
+  private[sbt] def requestedSplit(topo: TestTopology): Int =
+    topo match
+      case TestTopology.SubprojectExclusive => 1
+      case TestTopology.SubprojectSplit(n)  => n
+      case _                                => defaultSplit
+end TestTopology

--- a/main-actions/src/main/scala/sbt/Tests.scala
+++ b/main-actions/src/main/scala/sbt/Tests.scala
@@ -403,7 +403,8 @@ object Tests {
       testListeners: Vector[TestReportListener],
       config: Execution
   ): Task[Output] = {
-    def fj(actions: Iterable[() => Unit]): Task[Unit] = nop.dependsOn(actions.toSeq.fork(_())*)
+    def fj(actions: Iterable[() => Unit]): Task[Unit] =
+      nop.dependsOn(actions.toSeq.fork(_()).map(_.tagw(config.tags*))*)
     def partApp(actions: Iterable[ClassLoader => Unit]) = actions.toSeq map { a => () =>
       a(loader)
     }
@@ -411,7 +412,7 @@ object Tests {
     val (frameworkSetup, runnables, frameworkCleanup) =
       TestFramework.testTasks(frameworks, runners, loader, tests, log, testListeners)
 
-    val setupTasks = fj(partApp(userSetup) :+ frameworkSetup)
+    val setupTasks = fj(partApp(userSetup) :+ frameworkSetup).tagw(config.tags*)
     val mainTasks =
       if (config.parallel)
         makeParallel(loader, runnables, setupTasks, config.tags).map(_.toList)
@@ -421,7 +422,8 @@ object Tests {
     taggedMainTasks
       .map(processResults)
       .flatMap { results =>
-        val cleanupTasks = fj(partApp(userCleanup) :+ frameworkCleanup(results.overall))
+        val cleanupTasks =
+          fj(partApp(userCleanup) :+ frameworkCleanup(results.overall)).tagw(config.tags*)
         cleanupTasks map { _ =>
           results
         }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -193,7 +193,7 @@ object Defaults extends BuildCommon with DefExtra {
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
       testForkedParallel :== true,
       testForkedParallelism :== None,
-      testForkedWorker :== SysProp.testForkedWorker,
+      workerMaxInstances :== SysProp.workerMaxInstances,
       javaOptions :== Nil,
       sbtPlugin :== false,
       isMetaBuild :== false,
@@ -1453,7 +1453,7 @@ object Defaults extends BuildCommon with DefExtra {
       val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
       val n = math.max(
         1,
-        math.min(testForkedWorker.value, byName.size)
+        math.min((GlobalScope / workerMaxInstances).value, byName.size)
       )
       fork.value && n > 1
     } then
@@ -1462,7 +1462,7 @@ object Defaults extends BuildCommon with DefExtra {
       val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
       val n = math.max(
         1,
-        math.min(testForkedWorker.value, byName.size)
+        math.min((GlobalScope / workerMaxInstances).value, byName.size)
       )
       val buckets = Array.fill(n)(Vector.newBuilder[TestDefinition])
       byName.zipWithIndex.foreach { case ((_, defs), i) => buckets(i % n) ++= defs }
@@ -1817,7 +1817,7 @@ object Defaults extends BuildCommon with DefExtra {
     Def.setting {
       val par = parallelExecution.value
       val max = EvaluateTask.SystemProcessors
-      val maxWorker = testForkedWorker.value
+      val maxWorker = workerMaxInstances.value
       Tags.limitAll(if (par) max else 1) ::
         Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
         Tags.exclusiveGroup(Tags.Clean) ::

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1834,7 +1834,7 @@ object Defaults extends BuildCommon with DefExtra {
       val maxWorker = workerMaxInstances.value
       Tags.limitAll(if (par) max else 1) ::
         Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
-        Tags.exclusiveGroup(Tags.ExclusiveTestGroup) ::
+        Tags.exclusiveWithin(Tags.ExclusiveTestGroup, Tags.Test) ::
         Tags.exclusiveGroup(Tags.Clean) ::
         Nil
     }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -193,6 +193,7 @@ object Defaults extends BuildCommon with DefExtra {
       fullJavaHomes := CrossJava.expandJavaHomes(discoveredJavaHomes.value ++ javaHomes.value),
       testForkedParallel :== true,
       testForkedParallelism :== None,
+      testForkedWorker :== SysProp.testForkedWorker,
       javaOptions :== Nil,
       sbtPlugin :== false,
       isMetaBuild :== false,
@@ -1404,7 +1405,7 @@ object Defaults extends BuildCommon with DefExtra {
       )
     ) ++ inScope(GlobalScope)(
       Seq(
-        derive(testGrouping := Def.uncached(singleTestGroupDefault.value))
+        derive(testGrouping := Def.uncached(splitTestGroupDefault.value))
       )
     )
 
@@ -1441,6 +1442,35 @@ object Defaults extends BuildCommon with DefExtra {
         Seq.empty
       )
     )
+  }
+
+  def splitTestGroup(key: Scoped): Initialize[Task[Seq[Tests.Group]]] =
+    inTask(key, splitTestGroupDefault)
+
+  lazy val splitTestGroupDefault: Initialize[Task[Seq[Tests.Group]]] = Def.taskIf {
+    if {
+      val tests = definedTests.value
+      val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
+      val n = math.max(
+        1,
+        math.min(testForkedWorker.value, byName.size)
+      )
+      fork.value && n > 1
+    } then
+      val tests = definedTests.value
+      val opts = forkOptions.value
+      val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
+      val n = math.max(
+        1,
+        math.min(testForkedWorker.value, byName.size)
+      )
+      val buckets = Array.fill(n)(Vector.newBuilder[TestDefinition])
+      byName.zipWithIndex.foreach { case ((_, defs), i) => buckets(i % n) ++= defs }
+      buckets.toVector.zipWithIndex.collect {
+        case (b, i) if b.result().nonEmpty =>
+          new Tests.Group(s"<split-$i>", b.result(), Tests.SubProcess(opts), Seq.empty)
+      }
+    else singleTestGroupDefault.value
   }
 
   def forkOptionsTask: Initialize[Task[ForkOptions]] =
@@ -1787,8 +1817,9 @@ object Defaults extends BuildCommon with DefExtra {
     Def.setting {
       val par = parallelExecution.value
       val max = EvaluateTask.SystemProcessors
+      val maxWorker = (LocalRootProject / Test / testForkedWorker).value
       Tags.limitAll(if (par) max else 1) ::
-        Tags.limit(Tags.ForkedTestGroup, 1) ::
+        Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
         Tags.exclusiveGroup(Tags.Clean) ::
         Nil
     }

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1832,6 +1832,7 @@ object Defaults extends BuildCommon with DefExtra {
       val par = parallelExecution.value
       val max = EvaluateTask.SystemProcessors
       val maxWorker = workerMaxInstances.value
+      if maxWorker < 1 then sys.error("workerMaxInstances must be >= 1")
       Tags.limitAll(if (par) max else 1) ::
         Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
         Tags.exclusiveWithin(Tags.ExclusiveTestGroup, Tags.Test) ::

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1817,7 +1817,7 @@ object Defaults extends BuildCommon with DefExtra {
     Def.setting {
       val par = parallelExecution.value
       val max = EvaluateTask.SystemProcessors
-      val maxWorker = (LocalRootProject / Test / testForkedWorker).value
+      val maxWorker = testForkedWorker.value
       Tags.limitAll(if (par) max else 1) ::
         Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
         Tags.exclusiveGroup(Tags.Clean) ::

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1247,6 +1247,7 @@ object Defaults extends BuildCommon with DefExtra {
         testResultLogger :== TestResultLogger.SilentWhenNoTests,
         testSummary :== SysProp.testSummary,
         testSummaryLogger := TestResultLogger.Defaults.Summary(testSummary.value),
+        testTopology :== TestTopology.default,
         testOnly / testFilter :== (IncrementalTest.selectedFilter),
         testSelected / testFilter :== (IncrementalTest.selectedFilter),
         extraTestDigests :== Nil,
@@ -1405,7 +1406,14 @@ object Defaults extends BuildCommon with DefExtra {
       )
     ) ++ inScope(GlobalScope)(
       Seq(
-        derive(testGrouping := Def.uncached(splitTestGroupDefault.value))
+        derive(testGrouping := Def.uncached {
+          if TestTopology.isSingleGroup(
+              testTopology.value,
+              fork.value
+            ) || !parallelExecution.value || !testForkedParallel.value
+          then singleTestGroupDefault.value
+          else splitTestGroupDefault.value
+        })
       )
     )
 
@@ -1451,18 +1459,20 @@ object Defaults extends BuildCommon with DefExtra {
     if {
       val tests = definedTests.value
       val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
+      val reqSplit = TestTopology.requestedSplit(testTopology.value)
       val n = math.max(
         1,
-        math.min((GlobalScope / workerMaxInstances).value, byName.size)
+        math.min(math.min(workerMaxInstances.value, byName.size), reqSplit)
       )
       fork.value && n > 1
     } then
       val tests = definedTests.value
       val opts = forkOptions.value
       val byName = tests.groupBy(_.name).toVector.sortBy(_._1)
+      val reqSplit = TestTopology.requestedSplit(testTopology.value)
       val n = math.max(
         1,
-        math.min((GlobalScope / workerMaxInstances).value, byName.size)
+        math.min(math.min(workerMaxInstances.value, byName.size), reqSplit)
       )
       val buckets = Array.fill(n)(Vector.newBuilder[TestDefinition])
       byName.zipWithIndex.foreach { case ((_, defs), i) => buckets(i % n) ++= defs }
@@ -1501,10 +1511,14 @@ object Defaults extends BuildCommon with DefExtra {
 
   def testExecutionTask(task: Scoped): Initialize[Task[Tests.Execution]] =
     Def.task {
+      val topo = (task / testTopology).value
       new Tests.Execution(
         (task / testOptions).value,
         (task / parallelExecution).value,
-        (task / tags).value
+        (topo match
+          case TestTopology.SubprojectExclusive => Vector((Tags.ExclusiveTestGroup, 1))
+          case _                                => Vector()
+        ) ++ (task / tags).value
       )
     }
 
@@ -1741,7 +1755,7 @@ object Defaults extends BuildCommon with DefExtra {
             s.log,
             forkedParallelism,
             strategy != ClassLoaderLayeringStrategy.Raw,
-            (Tags.ForkedTestGroup, 1) +: group.tags*
+            Vector((Tags.ForkedTestGroup, 1)) ++ config.tags ++ group.tags*
           )
         case Tests.InProcess =>
           if (javaOptions.nonEmpty) {
@@ -1820,6 +1834,7 @@ object Defaults extends BuildCommon with DefExtra {
       val maxWorker = workerMaxInstances.value
       Tags.limitAll(if (par) max else 1) ::
         Tags.limit(Tags.ForkedTestGroup, maxWorker) ::
+        Tags.exclusiveGroup(Tags.ExclusiveTestGroup) ::
         Tags.exclusiveGroup(Tags.Clean) ::
         Nil
     }

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -405,7 +405,7 @@ object Keys {
   val testListeners = taskKey[Seq[TestReportListener]]("Defines test listeners.").withRank(DTask)
   val testForkedParallel = settingKey[Boolean]("Whether forked tests should be executed in parallel").withRank(CTask)
   val testForkedParallelism = settingKey[Option[Int]]("Maximum number of parallel test threads when using testForkedParallel. Default: 2.").withRank(CTask)
-  val testForkedWorker = settingKey[Int]("Maximum number of test workers. Default available processors / 3.")
+  val workerMaxInstances = settingKey[Int]("Maximum number of test workers. Default: 2")
   val testExecution = taskKey[Tests.Execution]("Settings controlling test execution").withRank(DTask)
   val testFilter = taskKey[Seq[String] => Seq[String => Boolean]]("Filter controlling whether the test is executed").withRank(DTask)
   @transient

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -413,6 +413,7 @@ object Keys {
   val testSummary = settingKey[TestSummary]("The style of the test summary displayed after an aggregated test run.").withRank(CSetting)
   @transient
   val testSummaryLogger = settingKey[TestResultLogger]("Logs test summary after an aggregated test completes.").withRank(DTask)
+  val testTopology = settingKey[TestTopology]("The topology of how test classes are grouped.").withRank(CSetting)
   val testGrouping = taskKey[Seq[Tests.Group]]("Collects discovered tests into groups. Whether to fork and the options for forking are configurable on a per-group basis.").withRank(BMinusTask)
   val isModule = AttributeKey[Boolean]("isModule", "True if the target is a module.", DSetting)
   val extraTestDigests = taskKey[Seq[Digest]]("Extra digests that would invalidate test caching").withRank(DTask)

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -404,7 +404,8 @@ object Keys {
   @transient
   val testListeners = taskKey[Seq[TestReportListener]]("Defines test listeners.").withRank(DTask)
   val testForkedParallel = settingKey[Boolean]("Whether forked tests should be executed in parallel").withRank(CTask)
-  val testForkedParallelism = settingKey[Option[Int]]("Maximum number of parallel test threads when using testForkedParallel. Defaults to the number of available processors.").withRank(CTask)
+  val testForkedParallelism = settingKey[Option[Int]]("Maximum number of parallel test threads when using testForkedParallel. Default: 2.").withRank(CTask)
+  val testForkedWorker = settingKey[Int]("Maximum number of test workers. Default available processors / 3.")
   val testExecution = taskKey[Tests.Execution]("Settings controlling test execution").withRank(DTask)
   val testFilter = taskKey[Seq[String] => Seq[String => Boolean]]("Filter controlling whether the test is executed").withRank(DTask)
   @transient

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -124,4 +124,20 @@ object Tags {
     val groups = exclusiveTags.count(tag => tags.getOrElse(tag, 0) > 0)
     groups <= 1
   }
+
+  /**
+   * Like [[exclusive]], but the isolation is only enforced among tasks tagged `withinTag` instead
+   * of every task in the build: a task tagged `exclusiveTag` (which must itself also carry
+   * `withinTag`) will not execute alongside any other `withinTag`-tagged task, including another
+   * `exclusiveTag` one, but tasks carrying neither tag are unaffected either way. Unlike
+   * [[exclusiveGroup]], there is no escape hatch admitting several `exclusiveTag` tasks together --
+   * this alone is enough to cap them at one, with no separate `limit` rule needed to back it up.
+   */
+  def exclusiveWithin(exclusiveTag: Tag, withinTag: Tag): Rule = customLimit {
+    (tags: Map[Tag, Int]) =>
+      // if there are no exclusive tasks in this group, this rule adds no restrictions
+      tags.getOrElse(exclusiveTag, 0) == 0 ||
+      // If there is only one withinTag task, allow it to execute.
+      tags.getOrElse(withinTag, 0) == 1
+  }
 }

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -30,6 +30,7 @@ object Tags {
   val Disk = Tag("disk")
 
   val ForkedTestGroup = Tag("forked-test-group")
+  val ExclusiveTestGroup = Tag("exclusive-test-group")
 
   /**
    * Describes a restriction on concurrently executing tasks.

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -127,7 +127,8 @@ object SysProp:
   def cacheTestResult: Boolean =
     getOrTrue("sbt.cache_test_result")
 
-  def testForkedWorker: Int = int("sbt.test_forked_worker", EvaluateTask.SystemProcessors / 3)
+  def testForkedWorker: Int =
+    int("sbt.test_forked_worker", math.max(EvaluateTask.SystemProcessors / 3, 1))
 
   /**
    * Indicates whether formatting has been disabled in environment variables.

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -127,8 +127,7 @@ object SysProp:
   def cacheTestResult: Boolean =
     getOrTrue("sbt.cache_test_result")
 
-  def testForkedWorker: Int =
-    int("sbt.test_forked_worker", math.max(EvaluateTask.SystemProcessors / 3, 1))
+  def workerMaxInstances: Int = int("sbt.worker_max_instances", 2)
 
   /**
    * Indicates whether formatting has been disabled in environment variables.

--- a/main/src/main/scala/sbt/internal/SysProp.scala
+++ b/main/src/main/scala/sbt/internal/SysProp.scala
@@ -127,6 +127,8 @@ object SysProp:
   def cacheTestResult: Boolean =
     getOrTrue("sbt.cache_test_result")
 
+  def testForkedWorker: Int = int("sbt.test_forked_worker", EvaluateTask.SystemProcessors / 3)
+
   /**
    * Indicates whether formatting has been disabled in environment variables.
    * 1. -Dsbt.log.noformat=true means no formatting.

--- a/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
@@ -12,11 +12,11 @@ val checkAtLeast4 = taskKey[Unit]("Check that testForkedParallelism raises concu
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 Test / fork := true
 // Pin to one JVM at the subproject-level
-testForkedWorker := 1
+Global / workerMaxInstances := 1
 
 check := {
   // testForkedParallelism unset: the default is a flat 2 threads per worker JVM, not
-  // availableProcessors -- JVM count (testForkedWorker) is the parallelism dial now, not in-JVM
+  // availableProcessors -- JVM count (workerMaxInstances) is the parallelism dial now, not in-JVM
   // threads. So we expect concurrency of exactly 2, never more.
   if !file("max-concurrent-tests_2").exists() then
     sys.error("Forked tests were not executed in parallel at the default of 2!")

--- a/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
@@ -12,7 +12,7 @@ val checkAtLeast4 = taskKey[Unit]("Check that testForkedParallelism raises concu
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 Test / fork := true
 // Pin to one JVM at the subproject-level
-Global / workerMaxInstances := 1
+testTopology := TestTopology.subprojectExclusive
 
 check := {
   // testForkedParallelism unset: the default is a flat 2 threads per worker JVM, not

--- a/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-parallel/build.sbt
@@ -2,22 +2,33 @@ import Tests._
 import Defaults._
 
 scalaVersion := "2.12.21"
-val check = taskKey[Unit]("Check that tests are executed in parallel")
+
+@transient
+val check = taskKey[Unit]("Check that tests are executed in parallel at the default of 2 threads")
+
+@transient
+val checkAtLeast4 = taskKey[Unit]("Check that testForkedParallelism raises concurrency above the default")
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 Test / fork := true
+// Pin to one JVM at the subproject-level
+testForkedWorker := 1
 
 check := {
+  // testForkedParallelism unset: the default is a flat 2 threads per worker JVM, not
+  // availableProcessors -- JVM count (testForkedWorker) is the parallelism dial now, not in-JVM
+  // threads. So we expect concurrency of exactly 2, never more.
+  if !file("max-concurrent-tests_2").exists() then
+    sys.error("Forked tests were not executed in parallel at the default of 2!")
+  if file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() then
+    sys.error("Forked tests exceeded the default parallelism of 2 -- did the default change?")
+}
+
+checkAtLeast4 := {
   val nbProc = java.lang.Runtime.getRuntime().availableProcessors()
   val log = streams.value.log
   if nbProc < 4 then
-    log.warn("With fewer than 4 processors this test is meaningless")
-    // mimic behavior expected by scripted
-    if !testForkedParallel.value then sys.error("Exiting with error (note: test not performed)")
-  else
-    // we've got at least 4 processors, we'll check the upper end but also 3 and 4 as the upper might not
-    // be reached if the system is under heavy load.
-    if ! (file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists() ||
-           file("max-concurrent-tests_" + (nbProc -1)).exists() || file("max-concurrent-tests_" + nbProc).exists()) then
-      sys.error("Forked tests were not executed in parallel!")
+    log.warn("With fewer than 4 processors this check is meaningless")
+  else if !(file("max-concurrent-tests_3").exists() || file("max-concurrent-tests_4").exists()) then
+    sys.error("testForkedParallelism := Some(4) did not raise concurrency above the default of 2!")
 }

--- a/sbt-app/src/sbt-test/tests/fork-parallel/test
+++ b/sbt-app/src/sbt-test/tests/fork-parallel/test
@@ -1,7 +1,12 @@
-# Note: this test is meaningless on less than four cores
-
 > testFull
 > check
+> clean
+$ delete max-concurrent-tests_1
+$ delete max-concurrent-tests_2
+
+> set testForkedParallelism := Some(4)
+> testFull
+> checkAtLeast4
 > clean
 $ delete max-concurrent-tests_1
 $ delete max-concurrent-tests_2

--- a/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
@@ -1,8 +1,8 @@
 import Tests._
 import Defaults._
 
-// 4 classes, 4 workers: splitTestGroupDefault puts one class per group, so testOnly selecting a
-// single class leaves the other 3 groups empty after Tests.processOptions filters them down.
+// 4 classes, 4 workers: TestTopology.subprojectSplit(classCount) puts one class per group,
+// so testOnly selecting a single class leaves the other 3 groups empty after Tests.processOptions filters them down.
 val classCount = 4
 
 val checkOne = TaskKey[Unit]("checkOne", "Check setup/cleanup ran exactly once, then reset.")
@@ -16,6 +16,7 @@ organization := "com.example"
 
 Test / fork := true
 Global / workerMaxInstances := classCount
+Test / testTopology := TestTopology.subprojectSplit(classCount)
 
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 

--- a/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
@@ -1,0 +1,49 @@
+import Tests._
+import Defaults._
+
+// 4 classes, 4 workers: splitTestGroupDefault puts one class per group, so testOnly selecting a
+// single class leaves the other 3 groups empty after Tests.processOptions filters them down.
+val classCount = 4
+
+val checkOne = TaskKey[Unit]("checkOne", "Check setup/cleanup ran exactly once, then reset.")
+val checkAll = TaskKey[Unit](
+  "checkAll",
+  "Check setup/cleanup ran once per class (no filtering), then reset."
+)
+
+scalaVersion := "3.8.4"
+organization := "com.example"
+
+Test / fork := true
+testForkedWorker := classCount
+
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
+
+Test / testOptions += {
+  val baseDir = baseDirectory.value
+  Tests.Setup { () =>
+    IO.append(baseDir / "setup-log", "x\n")
+  }
+}
+Test / testOptions += {
+  val baseDir = baseDirectory.value
+  Tests.Cleanup { () =>
+    IO.append(baseDir / "cleanup-log", "x\n")
+  }
+}
+
+def checkTask(expected: Int) = Def.uncached {
+  def count(name: String): Int =
+    if file(name).exists then IO.readLines(file(name)).count(_.nonEmpty) else 0
+  val setups = count("setup-log")
+  val cleanups = count("cleanup-log")
+  if setups != expected || cleanups != expected then
+    sys.error(
+      s"Expected setup/cleanup to run $expected times, saw setup=$setups cleanup=$cleanups"
+    )
+  IO.delete(file("setup-log"))
+  IO.delete(file("cleanup-log"))
+}
+
+checkOne := checkTask(1)
+checkAll := checkTask(classCount)

--- a/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/build.sbt
@@ -15,7 +15,7 @@ scalaVersion := "3.8.4"
 organization := "com.example"
 
 Test / fork := true
-testForkedWorker := classCount
+Global / workerMaxInstances := classCount
 
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 

--- a/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/src/test/scala/example/Marker.scala
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/src/test/scala/example/Marker.scala
@@ -1,0 +1,12 @@
+package example
+
+import munit.FunSuite
+
+trait Marker extends FunSuite:
+  def n: Int
+  test(s"mark $n") { () }
+
+class Test1 extends Marker { def n = 1 }
+class Test2 extends Marker { def n = 2 }
+class Test3 extends Marker { def n = 3 }
+class Test4 extends Marker { def n = 4 }

--- a/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/test
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split-empty-setup/test
@@ -1,0 +1,5 @@
+> testFull
+> checkAll
+
+> testOnly example.Test1
+> checkOne

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "3.8.4"
 organization := "com.example"
 
 Test / fork := true
-testForkedWorker := expectedWorkers
+Global / testForkedWorker := expectedWorkers
 
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := "3.8.4"
 organization := "com.example"
 
 Test / fork := true
-Global / testForkedWorker := expectedWorkers
+Global / workerMaxInstances := expectedWorkers
 
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
@@ -1,0 +1,38 @@
+// 6 test classes, 3 workers: splitTestGroupDefault buckets classes round-robin by name,
+// so this should fork exactly 3 JVMs of 2 classes each -- not 1 (unsplit) and not 6 (one per class).
+val expectedWorkers = 3
+val classCount = 6
+
+@transient
+val check = TaskKey[Unit]("check", "Check tests were split across the expected number of JVMs.")
+
+scalaVersion := "3.8.4"
+organization := "com.example"
+
+Test / fork := true
+testForkedWorker := expectedWorkers
+
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
+
+check := {
+  val seen = (1 to classCount).map(i => file(s"seen-$i"))
+  val peers = (1 to classCount).map(i => file(s"peers-$i"))
+  val (existSeen, absentSeen) = seen.partition(_.exists)
+  if absentSeen.nonEmpty then
+    sys.error("Files were not created:\n\t" + absentSeen.mkString("\n\t"))
+
+  // The split itself: exactly `expectedWorkers` distinct JVMs ran the 6 classes -- not 1
+  // (unsplit) and not 6 (one JVM per class).
+  val pids = existSeen.map(f => IO.read(f)).toSet
+  if pids.size != expectedWorkers then
+    sys.error(s"Expected $expectedWorkers distinct forked JVMs but saw ${pids.size}: $pids")
+
+  // Concurrency, not just distinctness: at least one class must have observed all
+  // `expectedWorkers` JVMs announced at once, proving they overlapped in time rather than
+  // running the 3 groups one after another through the default's own limit.
+  val maxPeers = peers.map(f => IO.read(f).trim.toInt).max
+  if maxPeers < expectedWorkers then
+    sys.error(s"Expected to see $expectedWorkers JVMs running at once, but max observed was $maxPeers")
+
+  (seen ++ peers).foreach(_.delete())
+}

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/build.sbt
@@ -11,6 +11,7 @@ organization := "com.example"
 
 Test / fork := true
 Global / workerMaxInstances := expectedWorkers
+Test / testTopology := TestTopology.subprojectSplit(expectedWorkers)
 
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/src/test/scala/example/Marker.scala
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/src/test/scala/example/Marker.scala
@@ -1,0 +1,40 @@
+package example
+
+import java.io.{ File, PrintWriter }
+import java.lang.management.ManagementFactory
+import java.nio.file.Files
+import munit.FunSuite
+
+trait Marker extends FunSuite:
+  def n: Int
+  test(s"mark $n") {
+    val pid = ManagementFactory.getRuntimeMXBean.getName
+    val w = new PrintWriter(new File(s"seen-$n"))
+    try w.print(pid)
+    finally w.close()
+
+    // Concurrency probe: announce this JVM as running, wait long enough for siblings to do the
+    // same, then snapshot how many *distinct JVMs* (not threads) are announced right now. Fingerprint
+    // by pid, not just presence, since one JVM's own threads (testForkedParallelism) would otherwise
+    // inflate the count without proving another JVM was involved.
+    val running = new File(s"running-$n")
+    Files.write(running.toPath, pid.getBytes)
+    Thread.sleep(1000)
+    val peers = new File(".").listFiles().toVector
+      .filter(_.getName.startsWith("running-"))
+      .map(f => new String(Files.readAllBytes(f.toPath)))
+      .toSet
+    val pw = new PrintWriter(new File(s"peers-$n"))
+    try pw.print(peers.size)
+    finally pw.close()
+    running.delete()
+    ()
+  }
+end Marker
+
+class Test1 extends Marker { def n = 1 }
+class Test2 extends Marker { def n = 2 }
+class Test3 extends Marker { def n = 3 }
+class Test4 extends Marker { def n = 4 }
+class Test5 extends Marker { def n = 5 }
+class Test6 extends Marker { def n = 6 }

--- a/sbt-app/src/sbt-test/tests/fork-worker-split/test
+++ b/sbt-app/src/sbt-test/tests/fork-worker-split/test
@@ -1,0 +1,2 @@
+> testFull
+> check

--- a/sbt-app/src/sbt-test/tests/fork/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork/build.sbt
@@ -14,7 +14,7 @@ def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 Global / localCacheDirectory := baseDirectory.value / "diskcache"
 scalaVersion := "3.9.0"
 organization := "com.example"
-Global / testForkedWorker := 2
+Global / workerMaxInstances := 2
 
 lazy val root = rootProject
   .settings(

--- a/sbt-app/src/sbt-test/tests/fork/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork/build.sbt
@@ -14,6 +14,7 @@ def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 Global / localCacheDirectory := baseDirectory.value / "diskcache"
 scalaVersion := "3.9.0"
 organization := "com.example"
+testForkedWorker := 2
 
 lazy val root = rootProject
   .settings(
@@ -36,7 +37,6 @@ lazy val root = rootProject
       if absent.nonEmpty then
         sys.error("Files were not created:\n\t" + absent.mkString("\n\t"))
     },
-    concurrentRestrictions := Tags.limit(Tags.ForkedTestGroup, 2) :: Nil,
     libraryDependencies ++= List(
       munit % Test
     )

--- a/sbt-app/src/sbt-test/tests/fork/build.sbt
+++ b/sbt-app/src/sbt-test/tests/fork/build.sbt
@@ -14,7 +14,7 @@ def groupPrefix(idx: Int) = groupId(idx) + "_file_"
 Global / localCacheDirectory := baseDirectory.value / "diskcache"
 scalaVersion := "3.9.0"
 organization := "com.example"
-testForkedWorker := 2
+Global / testForkedWorker := 2
 
 lazy val root = rootProject
   .settings(

--- a/sbt-app/src/sbt-test/tests/topology-exclusive/a/src/test/scala/example/ATest.scala
+++ b/sbt-app/src/sbt-test/tests/topology-exclusive/a/src/test/scala/example/ATest.scala
@@ -1,0 +1,8 @@
+package example
+
+import munit.FunSuite
+
+class ATest extends FunSuite:
+  test("a") {
+    assert(true)
+  }

--- a/sbt-app/src/sbt-test/tests/topology-exclusive/b/src/test/scala/example/BTest.scala
+++ b/sbt-app/src/sbt-test/tests/topology-exclusive/b/src/test/scala/example/BTest.scala
@@ -1,0 +1,8 @@
+package example
+
+import munit.FunSuite
+
+class BTest extends FunSuite:
+  test("b") {
+    assert(true)
+  }

--- a/sbt-app/src/sbt-test/tests/topology-exclusive/build.sbt
+++ b/sbt-app/src/sbt-test/tests/topology-exclusive/build.sbt
@@ -1,0 +1,99 @@
+import java.util.concurrent.atomic.AtomicInteger
+import Tests._
+
+lazy val exclusivePhases = new AtomicInteger(0)
+def probe(name: String): Unit = probeWith(exclusivePhases, "overlaps.log", name)
+lazy val aPhaseActive = new AtomicInteger(0)
+
+@transient val checkNoOverlap =
+  taskKey[Unit]("Fail if any subproject's setup/cleanup phase overlapped another's")
+@transient val otherWork = taskKey[Unit]("Stand-in for unrelated, non-test build work")
+@transient val checkConcurrentWithOtherWork =
+  taskKey[Unit]("Fail unless a's exclusive phase and unrelated work were seen running at the same time")
+@transient val allWork =
+  taskKey[Unit]("Run both subprojects' testFull and otherWork as concurrent dependencies")
+
+Global / workerMaxInstances := 2
+
+scalaVersion := "3.8.4"
+organization := "com.example"
+
+lazy val a = project
+  .settings(
+    testTopology := TestTopology.subprojectExclusive,
+    Test / testOptions += Tests.Setup(() => {
+      aPhaseActive.incrementAndGet()
+      probe("a setup")
+      aPhaseActive.decrementAndGet()
+      ()
+    }),
+    Test / testOptions += Tests.Cleanup(() => {
+      aPhaseActive.incrementAndGet()
+      probe("a cleanup")
+      aPhaseActive.decrementAndGet()
+      ()
+    }),
+    libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test,
+  )
+lazy val b = project
+  .settings(
+    testTopology := TestTopology.subprojectExclusive,
+    Test / testOptions += Tests.Setup(() => probe("b setup")),
+    Test / testOptions += Tests.Cleanup(() => probe("b cleanup")),
+    libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test,
+  )
+
+lazy val root = (project in file("."))
+  .autoAggregate
+  .settings(
+    checkNoOverlap / aggregate := false,
+    otherWork / aggregate := false,
+    checkConcurrentWithOtherWork / aggregate := false,
+    allWork / aggregate := false,
+    checkNoOverlap := {
+      val found = readAndClear("overlaps.log")
+      if found.nonEmpty then
+        sys.error(
+          "SubprojectExclusive should fully serialize each subproject's setup-through-cleanup phase, but:\n\t"
+            + found.mkString("\n\t")
+        )
+    },
+    otherWork := {
+      val deadline = System.currentTimeMillis() + 8000
+      var witnessed = false
+      while System.currentTimeMillis() < deadline do
+        if aPhaseActive.get() > 0 then witnessed = true
+        Thread.sleep(50)
+      if witnessed then IO.append(file("concurrent-with-other.log"), "otherWork witnessed a's exclusive phase\n")
+      ()
+    },
+    checkConcurrentWithOtherWork := {
+      val found = readAndClear("concurrent-with-other.log")
+      if found.isEmpty then
+        sys.error(
+          "Expected a's exclusive test phase and unrelated work to run concurrently at some point, " +
+            "but they never overlapped -- exclusiveGroupWithin may be blocking more than just other tests."
+        )
+    },
+    allWork := {
+      (a / Test / testFull).value
+      (b / Test / testFull).value
+      otherWork.value
+      ()
+    },
+  )
+
+def probeWith(counter: AtomicInteger, log: String, name: String): Unit = {
+  val now = counter.incrementAndGet()
+  if now > 1 then IO.append(file(log), s"$name saw $now concurrent\n")
+  Thread.sleep(1000)
+  counter.decrementAndGet()
+  ()
+}
+
+def readAndClear(log: String): List[String] = {
+  val f = file(log)
+  val found = if f.exists then IO.readLines(f).filter(_.nonEmpty) else Nil
+  IO.delete(f)
+  found
+}

--- a/sbt-app/src/sbt-test/tests/topology-exclusive/test
+++ b/sbt-app/src/sbt-test/tests/topology-exclusive/test
@@ -1,0 +1,11 @@
+> set a / Test / fork := true
+> set b / Test / fork := true
+> allWork
+> checkNoOverlap
+> checkConcurrentWithOtherWork
+
+> set a / Test / fork := false
+> set b / Test / fork := false
+> allWork
+> checkNoOverlap
+> checkConcurrentWithOtherWork

--- a/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
+++ b/worker/src/main/java/sbt/internal/worker1/ForkTestMain.java
@@ -358,12 +358,14 @@ public class ForkTestMain {
       this.originalOut.flush();
     }
 
+    private int defaultParallelism() {
+      return 2;
+    }
+
     private ExecutorService executorService(final boolean parallel, final Integer parallelism) {
       if (parallel) {
         final int nbThreads =
-            (parallelism != null && parallelism > 0)
-                ? parallelism
-                : Runtime.getRuntime().availableProcessors();
+            (parallelism != null && parallelism > 0) ? parallelism : defaultParallelism();
         logDebug("Create a test executor with a thread pool of " + nbThreads + " threads.");
         return Executors.newFixedThreadPool(nbThreads);
       } else {


### PR DESCRIPTION
## Problem
A major bottleneck of the default setting is that concurrentRestriction allows exactly one forked test in flight at a time, and partly due to the restriction all test suites from a subproject runs within the forked process.

## Solution
This adds a new setting called workerMaxInstances, which lets the build users tune the number of concurrent worker process in flight. I've set the default to 2.
Within a single worker, the default parallelism is reduced to `2`.

The default test grouping now splits the test suites into testForkedWorker count.

## Example

```scala
Global / workerMaxInstances := 3 // or use -Dsbt.worker_max_instances=3 for CI

Test / fork := true

lazy val foo = project
  .settings(
    // this restores one JVM per subproject testing for this subproject
    Test / testTopology := TestTopology.subprojectExclusive,
  )
lazy val bar = project
```
