### PR TITLE
[2.x] Fix MatchError in RunFromSourceMain if RC version

### DIFF
--- a/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMain.scala
@@ -150,22 +150,29 @@ object RunFromSourceMain {
           import lmcoursier.{ CoursierConfiguration, CoursierDependencyResolution }
           CoursierDependencyResolution(CoursierConfiguration())
         }
-        val Name = """(.*)(?:\-[\d.]+)\.jar""".r
-        val BinPre = """(.*)(?:\-[\d.]+)-(?:bin|pre)-.*\.jar""".r
         val module = "org.scala-lang" % "scala3-compiler_3" % scalaVersion
         lm.retrieve(module, scalaModuleInfo = None, scalaHome1Temp, log) match
           case Left(w)     => throw w.resolveException
           case Right(jars) =>
             assert(jars.nonEmpty, s"no jars for scala $scalaVersion")
             jars.foreach: f =>
-              val name = f.getName match
-                case Name(name)   => name
-                case BinPre(name) => name
+              val name = jarName(f.getName)
               IO.copyFile(f, scalaHome1Lib / s"$name.jar")
       }
       scalaHome1
     }
   }
+
+  private val Name = """(.*)(?:\-[\d.]+)\.jar""".r
+  private val BinPre = """(.*)(?:\-[\d.]+)-(?:bin|pre)-.*\.jar""".r
+  private val RC = """(.*)(?:\-[\d.]+)-(?:RC\d+)\.jar""".r
+
+  private[sbt] def jarName(value: String): String =
+    value match {
+      case Name(name)   => name
+      case BinPre(name) => name
+      case RC(name)     => name
+    }
 
   private def errorAndExit(msg: String): Nothing = { System.err.println(msg); exit(1) }
   private def exit(code: Int): Nothing = System.exit(code).asInstanceOf[Nothing]

--- a/sbt-app/src/test/scala/sbt/RunFromSourceMainSpec.scala
+++ b/sbt-app/src/test/scala/sbt/RunFromSourceMainSpec.scala
@@ -1,0 +1,12 @@
+package sbt
+
+import verify.BasicTestSuite
+
+object RunFromSourceMainSpec extends BasicTestSuite {
+  test("jarName") {
+    assert(RunFromSourceMain.jarName("scala3-compiler_3-3.8.4.jar") == "scala3-compiler_3")
+    assert(RunFromSourceMain.jarName("scala3-library_3-3.8.4.jar") == "scala3-library_3")
+    assert(RunFromSourceMain.jarName("scala3-library_3-3.9.0-RC6.jar") == "scala3-library_3")
+    assert(RunFromSourceMain.jarName("scala3-library_3-3.9.0-RC123.jar") == "scala3-library_3")
+  }
+}


### PR DESCRIPTION
```
scala.MatchError: tasty-core_3-3.9.0-RC3.jar (of class java.lang.String)
	at sbt.RunFromSourceMain$.scalaHome$$anonfun$4(RunFromSourceMain.scala:168)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:331)
	at sbt.RunFromSourceMain$.scalaHome(RunFromSourceMain.scala:165)
	at sbt.RunFromSourceMain$.launch(RunFromSourceMain.scala:118)
	at sbt.RunFromSourceMain$.runImpl(RunFromSourceMain.scala:98)
	at sbt.RunFromSourceMain$.run(RunFromSourceMain.scala:77)
	at sbt.RunFromSourceMain$.main$$anonfun$2(RunFromSourceMain.scala:63)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.util.Using$.resource(Using.scala:315)
	at sbt.RunFromSourceMain$.main(RunFromSourceMain.scala:64)
	at sbt.RunFromSourceMain.main(RunFromSourceMain.scala)
```