### PR TITLE
[2.x] fix: Remove -Dsbt.global.base in Windows runner script

### DIFF
--- a/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
+++ b/launcher-package/integration-test/src/test/scala/RunnerScriptTest.scala
@@ -127,6 +127,15 @@ abstract class RunnerScriptTest extends verify.BasicTestSuite with ShellScriptUt
       assert(out.contains[String]("-Dsbt.boot.directory=project/.boot"))
       assert(out.contains[String]("-Dsbt.ivy.home=project/.ivy"))
 
+  testOutput("sbt does not set sbt.global.base without --sbt-dir", citestVariant = "citest")(
+    "-v"
+  ): (out: List[String]) =>
+    val globalBaseArgs = out.filter(_.contains("-Dsbt.global.base"))
+    assert(
+      globalBaseArgs.isEmpty,
+      s"-Dsbt.global.base should not be set: ${globalBaseArgs.mkString(", ")}"
+    )
+
   testOutput("accept `--ivy` in `SBT_OPTS`", sbtOpts = "--ivy /ivy/dir")("-v"):
     (out: List[String]) =>
       if (isWindows) cancel("Test not supported on windows")

--- a/launcher-package/src/universal/bin/sbt.bat
+++ b/launcher-package/src/universal/bin/sbt.bat
@@ -730,8 +730,6 @@ if defined sbt_args_sbt_version (
 
 if defined sbt_args_sbt_dir (
   set _SBT_OPTS="-Dsbt.global.base=!sbt_args_sbt_dir!" !_SBT_OPTS!
-) else if defined LOCALAPPDATA (
-  set _SBT_OPTS="-Dsbt.global.base=!LOCALAPPDATA!\sbt" !_SBT_OPTS!
 )
 
 if defined sbt_args_sbt_boot (


### PR DESCRIPTION
This is essentially applying the same fix as in #8795 but for the Windows `sbt.bat` script. 
We now only set `-Dsbt.global.base` when explicitly asked for with the `--sbt-dir` option.

Currently, using a sbt 2.x launcher for a sbt 1.x project on Windows reads the global configuration from `%LOCALAPPDATA%\sbt` (without version) and `%USERPROFILE%\.sbt\1.0\*.sbt` is not loaded. I can confirm I have 1.x written artifacts in `%LOCALAPPDATA%\sbt` but no plugins, while `%USERPROFILE%\.sbt\1.0\plugins` exists.

For sbt 2.x projects, this should change the global configuration directory from `%LOCALAPPDATA%\sbt` to `%LOCALAPPDATA%\sbt\2`, which seems to be the intention according to the [2.0 change summary](https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html). However, it does mean users who put configuration in `%LOCALAPPDATA%\sbt` will have to move it to `%LOCALAPPDATA%\sbt\2`.

> In sbt 2.x, the global base directory follows directory standard. The default value on Windows is `%LOCALAPPDATA%/sbt/2`.

I've confirmed the following workarounds locally.

- `sbt --sbt-dir %USERPROFILE%/.sbt/1.0`.
- `-Dsbt.global.base=%USERPROFILE%/.sbt/1.0` in `SBT_OPTS`.
- `-J-Dsbt.global.base=%USERPROFILE%/.sbt/1.0` in `.sbtopts`.

Note `%USERPROFILE%` should be replaced with the actual path (e.g. `C:/Users/vlovgr`) here.

I've added a test and tested the fix manually for a sbt 1.x project, and it seems to work as expected.