### PR TITLE
[2.x] fix: Retry a read before discarding a server

### DIFF
--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -227,15 +227,19 @@ class NetworkClient(
         val res =
           try Some(mkSocket(portfile))
           catch {
-            // This catches a pipe busy exception which can happen if two windows clients
-            // attempt to connect in rapid succession
-            case e: IOException if e.getMessage.contains("Couldn't open") && attempt < 10 =>
-              if (e.getMessage.contains("Access is denied") || e.getMessage.contains("(5)")) {
-                errorStream.println(s"Access denied for portfile $portfile")
-                throw new NetworkClient.AccessDeniedException
-              }
-              None
-            case e: IOException => throw new ConnectionRefusedException(e)
+            case _: ClientSocket.ConnectionFileReadException if attempt < 10 =>
+              None // server may be in the middle of writing the portfile
+            case e: IOException =>
+              if (attempt >= 10) throw new ConnectionRefusedException(e)
+              val msg = Option(e.getMessage).getOrElse("")
+              // This catches a pipe busy exception which can happen if two windows clients
+              // attempt to connect in rapid succession
+              if (msg.contains("Couldn't open"))
+                if (msg.contains("Access is denied") || msg.contains("(5)")) {
+                  errorStream.println(s"Access denied for portfile $portfile")
+                  throw new NetworkClient.AccessDeniedException
+                }
+              None // server could be busy, not down, so try again
           }
         res match {
           case Some(r) => r

--- a/main-command/src/test/scala/sbt/internal/client/ClientConnectSpec.scala
+++ b/main-command/src/test/scala/sbt/internal/client/ClientConnectSpec.scala
@@ -19,7 +19,6 @@ import scala.util.Try
 
 import sbt.internal.server.{ Server, ServerConnection }
 import sbt.internal.util.Util.isWindows
-import sbt.protocol.ClientSocket
 import sbt.util.Level
 import verify.BasicTestSuite
 
@@ -79,6 +78,7 @@ object ClientConnectSpec extends BasicTestSuite:
         def connect() = client.connectOrStartServerAndConnect(false, retry = false)
         val connected = Try(connect())
         restore.join()
-        // the client reads the portfile once, so a whole one arriving later is too late
-        assert(connected.failed.get.isInstanceOf[ClientSocket.ConnectionFileReadException])
+        // the client reads again, so it meets the whole portfile and reaches the server
+        assert(connected.isSuccess)
+        connected.foreach((socket, _) => socket.close())
 end ClientConnectSpec

--- a/main-command/src/test/scala/sbt/internal/client/ClientConnectSpec.scala
+++ b/main-command/src/test/scala/sbt/internal/client/ClientConnectSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+package client
+
+import java.io.{ ByteArrayInputStream, File, PrintStream }
+import java.nio.file.{ Files, Paths }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+import scala.util.Try
+
+import sbt.internal.server.{ Server, ServerConnection }
+import sbt.internal.util.Util.isWindows
+import sbt.protocol.ClientSocket
+import sbt.util.Level
+import verify.BasicTestSuite
+
+object ClientConnectSpec extends BasicTestSuite:
+  private val quiet = new ConsoleInterface:
+    override def appendLog(level: Level.Value, message: => String): Unit = ()
+    override def success(msg: String): Unit = ()
+
+  private def withServerAndClient(f: (NetworkClient, File) => Unit): Unit =
+    // the socket path has a length limit, so keep the directory short
+    val base = Files.createTempDirectory(Paths.get("/tmp"), "sbtcli").toFile
+    val portfile = new File(new File(new File(base, "project"), "target"), "active.json")
+    sbt.io.IO.createDirectory(portfile.getParentFile)
+    val connection = ServerConnection(
+      connectionType = ConnectionType.Local,
+      host = "127.0.0.1",
+      port = 0,
+      auth = Set.empty,
+      portfile = portfile,
+      tokenfile = new File(base, "token.json"),
+      socketfile = new File(base, "sock"),
+      pipeName = "sbt-test-" + base.getName,
+      appConfiguration = null, // only a bsp connection file reads it, and bsp is off here
+      windowsServerSecurityLevel = 0,
+      useJni = false,
+      bspEnabled = false,
+    )
+    val instance = Server.start(connection, (_, _) => (), sbt.util.Logger.Null)
+    Await.ready(instance.ready, 10.seconds)
+    val devNull = new PrintStream(java.io.OutputStream.nullOutputStream)
+    val arguments = new NetworkClient.Arguments(base, Nil, Nil, Nil, "sbt", false, None)
+    val client = new NetworkClient(
+      arguments,
+      quiet,
+      new ByteArrayInputStream(Array.emptyByteArray),
+      devNull,
+      devNull,
+      useJNI = false,
+    )
+    try f(client, portfile)
+    finally
+      Try(client.close())
+      instance.shutdown()
+      sbt.io.IO.delete(base)
+
+  test("a portfile that a server is still writing"):
+    if !isWindows then
+      withServerAndClient: (client, portfile) =>
+        val published = sbt.io.IO.read(portfile)
+        sbt.io.IO.write(portfile, published.take(published.length / 2))
+        val restore = new Thread(() =>
+          Thread.sleep(10)
+          sbt.io.IO.write(portfile, published)
+        )
+        restore.setDaemon(true)
+        restore.start()
+        def connect() = client.connectOrStartServerAndConnect(false, retry = false)
+        val connected = Try(connect())
+        restore.join()
+        // the client reads the portfile once, so a whole one arriving later is too late
+        assert(connected.failed.get.isInstanceOf[ClientSocket.ConnectionFileReadException])
+end ClientConnectSpec


### PR DESCRIPTION
**Problem**

One failure was enough for the client to delete the portfile and start a second server, which took the socket from a server that was still running. The client already tried ten times when a Windows pipe was busy. It tried once when the portfile would not parse, and once when the connection was refused.

**Solution**

Give those two failures the same ten attempts as the busy pipe. After ten the client still deletes the portfile, which a portfile left by a dead server needs.
