### PR TITLE
[2.x] fix: Share a holder for a closeable

### DIFF
--- a/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
+++ b/internal/util-core/src/main/scala/sbt/internal/util/Util.scala
@@ -13,7 +13,7 @@ import java.util.Locale
 
 import scala.collection.concurrent.TrieMap
 import scala.reflect.Selectable.reflectiveSelectable
-import scala.util.Properties
+import scala.util.{ Properties, Try }
 import scala.util.control.NonFatal
 
 object Util:
@@ -58,6 +58,8 @@ object Util:
     val _ = f
     ()
   }
+
+  def ignoreTry[A](f: => A): Unit = ignoreResult(Try(f))
 
   lazy val isMac: Boolean =
     System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("mac")

--- a/main-command/src/main/scala/sbt/internal/AtomicCloseable.scala
+++ b/main-command/src/main/scala/sbt/internal/AtomicCloseable.scala
@@ -1,0 +1,40 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+import sbt.internal.util.Util
+
+/** Holds a closeable that a caller replaces, and closes the one it replaces. */
+private[sbt] class AtomicCloseable[A >: Null <: AutoCloseable](val ref: AtomicReference[A])
+    extends AnyVal:
+  def get: A = ref.get
+  def set(c: A): Unit = AtomicCloseable.close(ref.getAndSet(c))
+  def close(): Unit = AtomicCloseable.close(ref.getAndSet(null))
+
+  /** Keeps the value another caller put here, and closes the one this caller built. */
+  def setIfEmpty(ctor: => A): A =
+    var obj = ref.get
+    if obj eq null then
+      val value = ctor
+      require(value ne null, "AtomicCloseable.setIfEmpty: `ctor` must not return null")
+      while obj eq null do obj = if ref.compareAndSet(null, value) then value else ref.get
+      if obj ne value then AtomicCloseable.close(value)
+    obj
+end AtomicCloseable
+
+private[sbt] object AtomicCloseable:
+  def apply[A >: Null <: AutoCloseable](): AtomicCloseable[A] =
+    new AtomicCloseable(new AtomicReference[A])
+
+  def close(obj: AutoCloseable): Unit =
+    if obj ne null then Util.ignoreTry(obj.close())
+end AtomicCloseable

--- a/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
+++ b/main-command/src/main/scala/sbt/internal/client/NetworkClient.scala
@@ -143,7 +143,7 @@ class NetworkClient(
   private val pendingCompletions = new ConcurrentHashMap[String, CompletionResponse => Unit]
   private val attached = new AtomicBoolean(false)
   private val attachUUID = new AtomicReference[String](null)
-  private val connectionHolder = new AtomicReference[ServerSession]
+  private val connectionHolder = AtomicCloseable[ServerSession]()
   private val batchMode = new AtomicBoolean(false)
   private val interactiveThread = new AtomicReference[Thread](null)
   private val rebooting = new AtomicBoolean(false)
@@ -163,11 +163,9 @@ class NetworkClient(
 
   private def portfile = arguments.baseDirectory / "project" / "target" / "active.json"
 
-  def connection: ServerSession = connectionHolder.synchronized {
-    connectionHolder.get match {
-      case null => init(promptCompleteUsers = false, retry = true)
-      case c    => c
-    }
+  // initImpl may start a server, which no later discard can undo, so one caller at a time
+  def connection: ServerSession = connectionHolder.ref.synchronized {
+    connectionHolder.setIfEmpty(initImpl(promptCompleteUsers = false, retry = true))
   }
 
   private val stdinBytes = new LinkedBlockingQueue[Integer]
@@ -256,7 +254,7 @@ class NetworkClient(
   end connectOrStartServerAndConnect
 
   // Open server connection based on the portfile
-  def init(promptCompleteUsers: Boolean, retry: Boolean): ServerSession = {
+  private def initImpl(promptCompleteUsers: Boolean, retry: Boolean): ServerSession = {
     val (sk, tkn) = connectOrStartServerAndConnect(promptCompleteUsers, retry)
     val conn = new ServerSessionImpl(sk, s"sbt-serverconnection-${sk.getPort}") {
       override protected def onNotification(msg: JsonRpcNotificationMessage): Unit = {
@@ -272,10 +270,7 @@ class NetworkClient(
             if (rebootCommands.nonEmpty) {
               rebooting.set(true)
               attached.set(false)
-              connectionHolder.getAndSet(null) match {
-                case null =>
-                case c    => c.close()
-              }
+              connectionHolder.close()
               waitForServer(portfile, true, false)
               init(promptCompleteUsers = false, retry = false)
               attachUUID.set(sendJson(attach, s"""{"interactive": ${!batchMode.get}}"""))
@@ -318,7 +313,7 @@ class NetworkClient(
       override protected def onRequest(msg: JsonRpcRequestMessage): Unit = self.onRequest(msg)
       override protected def onResponse(msg: JsonRpcResponseMessage): Unit = self.onResponse(msg)
       override protected def onClose(): Unit = if (!rebooting.get) {
-        if (exitClean.get != false) {
+        if (exitClean.get) {
           val serverDropped = running.get
           exitClean.set(!serverDropped)
           if (serverDropped && !shutdownOnly)
@@ -344,6 +339,11 @@ class NetworkClient(
       initializationOptions = Some(opts),
     )
     conn.sendCommand(initCommand)
+    conn
+  }
+
+  def init(promptCompleteUsers: Boolean, retry: Boolean): ServerSession = {
+    val conn = initImpl(promptCompleteUsers = promptCompleteUsers, retry = retry)
     connectionHolder.set(conn)
     conn
   }
@@ -1139,12 +1139,9 @@ class NetworkClient(
       stdinBytes.offer(-1)
       val mainThread = interactiveThread.getAndSet(null)
       if (mainThread != null && mainThread != Thread.currentThread) mainThread.interrupt
-      connectionHolder.get match {
-        case null =>
-        case c    =>
-          try sendExecCommand("exit")
-          finally c.close()
-      }
+      if (connectionHolder.get ne null)
+        try sendExecCommand("exit")
+        finally connectionHolder.close()
       inputThread.close()
     } catch {
       case t: Throwable => t.printStackTrace(); throw t

--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -12,7 +12,7 @@ package server
 
 import java.io.{ File, IOException }
 import java.net.{ InetAddress, ServerSocket, Socket, SocketException, SocketTimeoutException }
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
+import java.util.concurrent.atomic.AtomicBoolean
 import java.nio.file.attribute.{ AclEntry, AclEntryPermission, AclEntryType, UserPrincipal }
 import java.security.SecureRandom
 import java.math.BigInteger
@@ -56,7 +56,7 @@ private[sbt] object Server {
       val ready: Future[Unit] = p.future
       private val rand = new SecureRandom
       private var token: String = nextToken
-      private val serverSocketHolder = new AtomicReference[ServerSocket]
+      private val serverSocketHolder = AtomicCloseable[ServerSocket]()
 
       val serverThread = new Thread("sbt-socket-server") {
         override def run(): Unit = {
@@ -93,10 +93,7 @@ private[sbt] object Server {
             case Failure(e)            => p.failure(e)
             case Success(serverSocket) =>
               serverSocket.setSoTimeout(5000)
-              serverSocketHolder.getAndSet(serverSocket) match {
-                case null =>
-                case s    => s.close()
-              }
+              serverSocketHolder.set(serverSocket)
               log.debug(s"sbt server started at ${connection.shortName}")
               writePortfile()
               if (connection.bspEnabled) {
@@ -118,10 +115,7 @@ private[sbt] object Server {
                   case _: SocketException if !running.get => // the server is shutting down
                 }
               }
-              serverSocketHolder.get match {
-                case null =>
-                case s    => s.close()
-              }
+              serverSocketHolder.close()
           }
         }
       }
@@ -166,10 +160,7 @@ private[sbt] object Server {
           IO.delete(tokenfile)
         }
         running.set(false)
-        serverSocketHolder.getAndSet(null) match {
-          case null =>
-          case s    => s.close()
-        }
+        serverSocketHolder.close()
         log.info("shutting down sbt server")
       }
 

--- a/main-command/src/test/scala/sbt/internal/AtomicCloseableSpec.scala
+++ b/main-command/src/test/scala/sbt/internal/AtomicCloseableSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import verify.BasicTestSuite
+
+object AtomicCloseableSpec extends BasicTestSuite:
+  class Probe extends AutoCloseable:
+    var closed: Boolean = false
+    override def close(): Unit = closed = true
+  end Probe
+
+  test("a value that replaces another closes it"):
+    val holder = AtomicCloseable[Probe]()
+    val first, second = new Probe
+    holder.set(first)
+    holder.set(second)
+    assert(first.closed)
+    assert(!second.closed)
+    assert(holder.get == second)
+
+  test("closing empties the holder"):
+    val holder = AtomicCloseable[Probe]()
+    val probe = new Probe
+    holder.set(probe)
+    holder.close()
+    assert(probe.closed)
+    assert(holder.get == null)
+
+  test("closing an empty holder does nothing"):
+    AtomicCloseable[Probe]().close()
+
+  test("a holder that has a value keeps it"):
+    val holder = AtomicCloseable[Probe]()
+    val first = new Probe
+    holder.set(first)
+    val second = new Probe
+    assert(holder.setIfEmpty(second) == first)
+    assert(!first.closed)
+    assert(!second.closed)
+
+  test("a holder that has no value takes the one it is given"):
+    val holder = AtomicCloseable[Probe]()
+    val probe = new Probe
+    assert(holder.setIfEmpty(probe) == probe)
+    assert(holder.get == probe)
+    assert(!probe.closed)
+
+  test("a value that loses a race is closed"):
+    val holder = AtomicCloseable[Probe]()
+    val winner, loser = new Probe
+    // the holder fills while this caller builds its own value
+    val result = holder.setIfEmpty { holder.set(winner); loser }
+    assert(result == winner)
+    assert(loser.closed)
+    assert(!winner.closed)
+end AtomicCloseableSpec

--- a/main/src/main/scala/sbt/internal/TaskProgress.scala
+++ b/main/src/main/scala/sbt/internal/TaskProgress.scala
@@ -33,7 +33,7 @@ private[sbt] class TaskProgress(
     with ExecuteProgress
     with AutoCloseable {
   private val lastTaskCount = new AtomicInteger(0)
-  private val reportLoop = new AtomicReference[AutoCloseable]
+  private val reportLoop = AtomicCloseable[AutoCloseable]()
   private val active = new ConcurrentHashMap[TaskId[?], AutoCloseable]
   private val nextReport = new AtomicReference(Deadline.now)
   private val scheduler =
@@ -69,7 +69,7 @@ private[sbt] class TaskProgress(
   private val executor =
     Executors.newSingleThreadExecutor(r => new Thread(r, "sbt-task-progress-report-thread"))
   override def close(): Unit = if (closed.compareAndSet(false, true)) {
-    Option(reportLoop.getAndSet(null)).foreach(_.close())
+    reportLoop.close()
     pending.forEach(f => Util.ignoreResult(f.cancel(true)))
     pending.clear()
     scheduler.shutdownNow()
@@ -97,17 +97,7 @@ private[sbt] class TaskProgress(
   override def beforeWork(task: TaskId[?]): Unit =
     if (!closed.get) {
       super.beforeWork(task)
-      reportLoop.get match {
-        case null =>
-          val loop = schedule(sleepDuration, recurring = true)(doReport())
-          reportLoop.getAndSet(loop) match {
-            case null =>
-            case l    =>
-              reportLoop.set(l)
-              loop.close()
-          }
-        case s =>
-      }
+      reportLoop.setIfEmpty(schedule(sleepDuration, recurring = true)(doReport()))
     } else {
       logger.debug(s"called beforeWork for ${taskName(task)} after task progress was closed")
     }
@@ -137,10 +127,7 @@ private[sbt] class TaskProgress(
     }
 
   override def afterAllCompleted(results: RMap[TaskId, Result]): Unit = {
-    reportLoop.getAndSet(null) match {
-      case null =>
-      case l    => l.close()
-    }
+    reportLoop.close()
     // send an empty progress report to clear out the previous report
     appendProgress(ProgressEvent("Info", Vector(), Some(lastTaskCount.get), None, None))
   }

--- a/main/src/main/scala/sbt/nio/CheckBuildSources.scala
+++ b/main/src/main/scala/sbt/nio/CheckBuildSources.scala
@@ -19,6 +19,7 @@ import sbt.Scope.Global
 import sbt.internal.CommandStrings.LoadProject
 import sbt.internal.SysProp
 import sbt.internal.server.BuildServerProtocol
+import sbt.internal.AtomicCloseable
 import sbt.internal.util.{ AttributeKey, Terminal }
 import sbt.io.syntax.*
 import sbt.nio.FileChanges
@@ -46,7 +47,7 @@ import scala.io.AnsiColor
  * the build files if the poll interval has elapsed.
  */
 private[sbt] class CheckBuildSources extends AutoCloseable {
-  private val repository = new AtomicReference[FileTreeRepository[FileAttributes]]
+  private val repository = AtomicCloseable[FileTreeRepository[FileAttributes]]()
   private val pollingPeriod = new AtomicReference[FiniteDuration]
   private val sources = new AtomicReference[Seq[Glob]](Nil)
   private val needUpdate = new AtomicBoolean(true)
@@ -71,7 +72,7 @@ private[sbt] class CheckBuildSources extends AutoCloseable {
       .getOrElse(CheckBuildSources.defaultPollInterval)
     val newSources = extracted.get(Global / checkBuildSources / fileInputs).distinct
     if (interval >= 0.seconds || "polling" == SysProp.watchMode) {
-      Option(repository.getAndSet(null)).foreach(_.close())
+      repository.close()
       pollingPeriod.set(interval)
     } else {
       pollingPeriod.set(0.seconds)


### PR DESCRIPTION
**Problem**

Four fields hold a closeable that a later caller replaces. Each one reads the field, closes what it finds and writes the new value in its own way.

**Solution**

AtomicCloseable holds such a value. It closes the value it replaces, and closes the value that loses a race to fill an empty field.

Two things change for a caller:
- we now close the old session when the client replaces it with a new one
- we now catch any exceptions from a close