### PR TITLE
[2.x] fix: Fixes unhermetic semanticdbTargetRoot in the compile cache key

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -265,6 +265,7 @@ object Keys {
   val semanticdbVersion = settingKey[String]("SemanticDB version").withRank(CSetting)
   val semanticdbIncludeInJar = settingKey[Boolean]("Include *.semanticdb files in published artifacts").withRank(CSetting)
   val semanticdbTargetRoot = settingKey[File]("The output directory to produce META-INF/semanticdb/**/*.semanticdb files").withRank(CSetting)
+  private[sbt] val semanticdbTargetRootVF = taskKey[VirtualFileRef]("The output directory to produce META-INF/semanticdb/**/*.semanticdb files").withRank(Invisible)
   val semanticdbOptions = settingKey[Seq[String]]("The Scalac options introduced for SemanticDB").withRank(CSetting)
 
   val clean = taskKey[Unit]("Deletes files produced by the build, such as generated sources, compiled classes, and task caches.").withRank(APlusTask)

--- a/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
+++ b/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala
@@ -20,6 +20,7 @@ import ProjectExtra.inConfig
 import sbt.internal.inc.ScalaInstance
 import sbt.ScopeFilter.Make.*
 import sbt.util.CacheImplicits.given
+import xsbti.VirtualFileRef
 
 object SemanticdbPlugin extends AutoPlugin {
   override def requires = JvmPlugin
@@ -56,6 +57,9 @@ object SemanticdbPlugin extends AutoPlugin {
     inConfig(Test)(configurationSettings)
 
   lazy val configurationSettings: Seq[Def.Setting[?]] = List(
+    semanticdbTargetRootVF := Def.uncached(
+      fileConverter.value.toVirtualFile(semanticdbTargetRoot.value.toPath)
+    ),
     compileIncremental := Def.taskIf {
       if (semanticdbIncludeInJar.value || !semanticdbEnabled.value) compileIncremental.value
       else compileIncAndCacheSemanticdbTargetRootTask.value
@@ -101,10 +105,7 @@ object SemanticdbPlugin extends AutoPlugin {
 
   private val compileIncAndCacheSemanticdbTargetRootTask = Def.cachedTask {
     val prev = compileIncremental.value
-    val converter = fileConverter.value
-    val targetRoot = semanticdbTargetRoot.value
-
-    val vfTargetRoot = converter.toVirtualFile(targetRoot.toPath)
+    val vfTargetRoot = semanticdbTargetRootVF.value
     Def.declareOutputDirectory(vfTargetRoot)
     prev
   }

--- a/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/build.sbt
+++ b/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/build.sbt
@@ -1,0 +1,31 @@
+import sbt.internal.util.CacheEventSummary
+import java.nio.file.Paths
+
+lazy val checkHit = taskKey[Unit]("asserts the previous command was a pure cache hit")
+
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+ThisBuild / scalaVersion := "3.8.4"
+ThisBuild / semanticdbEnabled := true
+
+lazy val root = project.in(file("."))
+
+// -semanticdb-target reaches the cache keys as an absolute path too, which would move them by
+// itself; virtualize it so the target root is the only input left free to move.
+Compile / semanticdbOptions := {
+  val conv = fileConverter.value
+  val prev = (Compile / semanticdbOptions).value
+  prev.zipWithIndex.map { case (opt, i) =>
+    if (i > 0 && prev(i - 1) == "-semanticdb-target") conv.toVirtualFile(Paths.get(opt)).id
+    else opt
+  }
+}
+
+checkHit := Def.uncached {
+  val config = Def.cacheConfiguration.value
+  val prev = config.cacheEventLog.previous match
+    case s: CacheEventSummary.Data => s
+    case _                         => sys.error("empty event log")
+  streams.value.log.info(s"hitCount=${prev.hitCount} missCount=${prev.missCount}")
+  assert(prev.missCount == 0, s"expected a pure cache hit but missCount=${prev.missCount}")
+}

--- a/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/src/main/scala/A.scala
+++ b/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/src/main/scala/A.scala
@@ -1,0 +1,2 @@
+object A:
+  def value: Option[Int] = Some(1)

--- a/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/test
+++ b/sbt-app/src/sbt-test/cache/semanticdb-target-root-portable/test
@@ -1,0 +1,7 @@
+# A cache key names ${OUT} rather than the absolute path behind it, so moving the build's output
+# directory must leave the key alone. semanticdbTargetRoot reached the key of the cached task that
+# declares it as a bare File, whose absolute path pins every entry to one checkout and one machine.
+> compile
+> set Global / rootOutputDirectory := (baseDirectory.value / "out2").toPath
+> compile
+> checkHit


### PR DESCRIPTION
Problem
-------
SemanticdbPlugin.compileIncAndCacheSemanticdbTargetRootTask is a cached task that reads semanticdbTargetRoot as a bare File, so its absolute path is hashed into the action cache key:

  ((true,${OUT}/.../classes,${OUT}/.../classes.sbtdir.zip),/tmp/repro/target/out/.../meta)

Every other component of that key is virtualized. This one names one checkout on one machine, so the entry can never be served to a second checkout, to a colleague, or to CI. A monorepo we measured had 118 such keys, none of them reachable across machines.

Fixes #9709

Solution
--------
Read the target root through semanticdbTargetRootVF, following the convention sourcesVF and resourcesVF already set: an uncached task holding the virtualized form of a File-typed key, so that a cached task hashes ${OUT}/.../meta rather than the path behind it. A cached helper would key on the same bare File and reintroduce the problem one level up.

The scripted test asserts the property the bug breaks: relocating rootOutputDirectory must leave every key alone, so the second compile is a pure cache hit. It pins Compile / semanticdbOptions, because -semanticdb-target carries an absolute path into scalacOptions as well, which is a separate issue and would otherwise mask this one.

Generated-by: Claude Opus 5