### PR TITLE
[2.x] feat: Add crossProjectSources to ProjectMatrix

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -101,6 +101,23 @@ object Keys {
 
   // Project Matrix
   val virtualAxes = settingKey[Seq[VirtualAxis]]("Virtual axes for the project")
+  /**
+   * If set, sbt expands the set of source directories to include those laid out compatibly with
+   * the `sbt-crossproject` plugin: `<platform_part>/src/main/<language_part>` where:
+   *  - `<platform_part>` is one of:
+   *    - `shared`
+   *    - each of the configured platform axes, such as `jvm`, `js`, or `native`
+   *    - each [sorted] sub-group of platforms, such as `js-jvm`, allowing them to share code.
+   *  - `<language_part>` is one of:
+   *    - `scala`
+   *    - `scala-<version_prefix>`, one for each prefix of the row's Scala version axis
+   *      (e.g. `scala-2.13.18`, `scala-2.13`, `scala-2`)
+   *    - `java` (only under the named platform)
+   *
+   * Set this when you move a build from `crossProject` to `projectMatrix`, or simply need the
+   * extra flexibility.
+   */
+  val crossProjectSources = settingKey[Boolean]("Whether to read a source layout compatible with sbt-crossproject")
   val projectMatrixBaseDirectory = settingKey[File]("Base directory of the current project matrix")
 
   // Command keys

--- a/main/src/main/scala/sbt/ProjectMatrix.scala
+++ b/main/src/main/scala/sbt/ProjectMatrix.scala
@@ -14,6 +14,7 @@ import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.quoted.*
 import scala.reflect.ClassTag
+import scala.util.Sorting
 import scala.util.Try
 
 /**
@@ -64,6 +65,12 @@ sealed trait ProjectMatrix extends CompositeProject {
 
   /** Appends settings to the current settings sequence for this project. */
   def settings(ss: Def.SettingsDefinition*): ProjectMatrix
+
+  /**
+   * Sets `crossProjectSources := true` for every row of this matrix.
+   * @see [[sbt.Keys.crossProjectSources]] for more information.
+   */
+  def crossProjectSources: ProjectMatrix = settings(Keys.crossProjectSources := true)
 
   /**
    * Sets the [[sbt.AutoPlugin]]s of this project.
@@ -395,8 +402,94 @@ object ProjectMatrix {
         else Seq.empty,
         ProjectExtra.inConfig(Compile)(makeSources(nonScalaDirSuffix, scalaDirSuffix)),
         ProjectExtra.inConfig(Test)(makeSources(nonScalaDirSuffix, scalaDirSuffix)),
+        ProjectExtra.inConfig(Compile)(crossProjectSourceDirs(r, "main")),
+        ProjectExtra.inConfig(Test)(crossProjectSourceDirs(r, "test")),
         virtualAxes := axes,
       )
+
+    private def platformOf(r: ProjectRow): Option[String] =
+      r.axisValues.collectFirst { case a: VirtualAxis.PlatformAxis => a.value }
+
+    /**
+     * The trees sbt reads for each platform this matrix builds for: the platform's own, `shared`,
+     * and one per group of platforms that share code. A group of every platform is
+     * left out, because `shared` is that group.
+     *
+     * Keyed by platform rather than computed per row, because every row of a platform reads the
+     * same trees, and a lookup that came from `rows` cannot miss.
+     */
+    private lazy val crossProjectSourceSubdirs: Map[String, Seq[String]] = {
+      val platforms = {
+        val distinct = Set.newBuilder[String]
+        rows.foreach(platformOf(_).foreach(distinct += _))
+        distinct.result().toArray
+      }
+      Sorting.quickSort(platforms)
+      val pend = platforms.length - 1
+      val fullMask = (1 << pend) - 1 // will exclude it, corresponds to "shared"
+      val map = Map.newBuilder[String, Seq[String]]
+      var pidx = 0
+      while (pidx < platforms.length) {
+        val platform = platforms(pidx)
+        val subdirs = Seq.newBuilder[String]
+        subdirs += platform
+        subdirs += "shared"
+        var mask = 1 // at least one bit must be set
+        while (mask < fullMask) {
+          val subdir = new StringBuilder
+          var i = 0
+          // the bits are consumed from the bottom, so a zero `remmask` has no members left
+          var remmask = mask
+          while (i < pidx && remmask != 0) {
+            if ((remmask & 1) != 0) subdir.append(platforms(i)).append('-')
+            remmask >>>= 1
+            i += 1
+          }
+          subdir.append(platform)
+          while (i < pend && remmask != 0) {
+            i += 1
+            if ((remmask & 1) != 0) subdir.append('-').append(platforms(i))
+            remmask >>>= 1
+          }
+          subdirs += subdir.result()
+          mask += 1
+        }
+        map += platform -> subdirs.result()
+        pidx += 1
+      }
+      map.result()
+    }
+
+    private def crossProjectEnabled =
+      Def.setting(Keys.crossProjectSources.?.value.contains(true))
+
+    private def crossProjectSourceDirs(r: ProjectRow, conf: String): Seq[Def.Setting[?]] = {
+      val platformOpt = platformOf(r)
+      val trees = platformOpt.fold(Seq.empty[String])(crossProjectSourceSubdirs)
+      // the axis, not `scalaBinaryVersion`, so a row that names 3.9 gets a tree of its own
+      val version = r.axisValues.collectFirst { case a: VirtualAxis.ScalaVersionAxis => a.value }
+      Def.settings(
+        unmanagedSourceDirectories ++= (platformOpt match {
+          case Some(platform) if crossProjectEnabled.value =>
+            val res = Seq.newBuilder[File]
+            val dir = projectMatrixBaseDirectory.value
+            def append(tree: String, subdir: String) = res += dir / tree / "src" / conf / subdir
+            // the shared trees carry Scala alone; the platform's own tree gets Java too
+            append(platform, "java")
+            val variants = crossProjectScalaDirs(version, crossPaths.value)
+            trees.foreach(tree => variants.foreach(append(tree, _)))
+            res.result()
+          case _ => Nil
+        }),
+        unmanagedResourceDirectories ++= {
+          if !crossProjectEnabled.value then Nil
+          else {
+            val dir = projectMatrixBaseDirectory.value
+            trees.map(dir / _ / "src" / conf / "resources")
+          }
+        },
+      )
+    }
 
     private def resolveMatrixAggregate(
         other: ProjectMatrix,
@@ -850,6 +943,21 @@ object ProjectMatrix {
     allMatrices(id) = matrix
     matrix
   }
+
+  /** `scala-2.13.18`, then every shorter prefix of it, then `scala`. */
+  private def crossProjectScalaDirs(version: Option[String], crossPaths: Boolean): List[String] =
+    version match {
+      case Some(v) if crossPaths =>
+        val res = List.newBuilder[String]
+        var end = v.length
+        while (end > 0) {
+          res += s"scala-${v.substring(0, end)}"
+          end = v.lastIndexOf('.', end - 1)
+        }
+        res += "scala"
+        res.result()
+      case _ => "scala" :: Nil
+    }
 
   private[sbt] def unresolved(
       id: String,

--- a/notes/2.1.0/crossproject-sources.md
+++ b/notes/2.1.0/crossproject-sources.md
@@ -1,0 +1,50 @@
+Adds `crossProjectSources`, so sbt can read the source directories using layout compatible with
+`sbt-crossproject` plugin.
+
+```scala
+lazy val core = (projectMatrix in file("core"))
+  .crossProjectSources
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3))
+  .jsPlatform(scalaVersions = Seq(scala3))
+```
+
+This `.crossProjectSources` is a shortcut for `crossProjectSources := true` in the project settings.
+Thus, `ThisBuild / crossProjectSources := true` sets it for every project matrix in the build.
+
+Normally, sbt reads the following directories for a JVM row of a project matrix
+(every axis is part of the leaf name, under one `src`):
+
+```
+src/main/scala          src/main/java          src/main/resources
+src/main/scalajvm       src/main/javajvm
+src/main/scalajvm-3
+```
+
+With `crossProjectSources`, sbt will also read a second layout which puts
+all platform groupings above `src`, with each group of platforms with a
+directory of its own; again, using JVM as an example:
+
+```
+shared/src/main/scala   shared/src/main/scala-3   shared/src/main/resources
+jvm/src/main/scala      jvm/src/main/java         jvm/src/main/resources
+js-jvm/src/main/scala   jvm-native/src/main/scala
+```
+
+`shared` is read for every platform, while `java` is only under the row's own platform: a Scala.js
+row, for example, reads `js/src/main/java`.
+
+Every Scala tree above comes in one form per prefix of the row's Scala version, longest first, and
+then `scala`. `jvmPlatform` names the binary version, so a Scala 3 row has two forms and a 2.13 row
+three, under every tree of its own layout, `shared` for example:
+
+```
+shared/src/main/scala-2.13   shared/src/main/scala-2   shared/src/main/scala
+```
+
+A row built with `VirtualAxis.scalaPartialVersion` or with `CrossVersion.full` names a longer
+version, and gets a tree for each of its prefixes: a `2.13.18` row reads `scala-2.13.18`,
+`scala-2.13`, `scala-2` and `scala`.
+
+The default layout has no epoch form: a 2.13 JVM row reads `src/main/scalajvm-2.13` and
+`src/main/scalajvm`, and no `src/main/scalajvm-2`. Its epoch tree is sbt's own `src/main/scala-2`,
+which every 2.13 row reads whatever its platform.

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/build.sbt
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/build.sbt
@@ -1,6 +1,7 @@
 lazy val check = taskKey[Unit]("")
 
 lazy val core = (projectMatrix in file("core"))
+  .crossProjectSources
   .settings(
     // Def.uncached: Seq[VirtualAxis] has no HashWriter, so the task cannot be cached
     check := Def.uncached {
@@ -22,19 +23,19 @@ lazy val core = (projectMatrix in file("core"))
         // the shared trees carry Scala alone; only the row's own platform tree carries java
         Seq("jvm", "src", "main", "java"),
       )
-      wanted.foreach(p => assert(!srcs(dir(p*)), s"unexpected ${dir(p*)} in $srcs"))
+      wanted.foreach(p => assert(srcs(dir(p*)), s"missing ${dir(p*)} in $srcs"))
       // the default layout
       val defaults = Seq(Seq("src", "main", "scala"), Seq("src", "main", "scalajvm"))
       defaults.foreach(p => assert(srcs(dir(p*)), s"missing ${dir(p*)} in $srcs"))
       val sharedMain = dir("shared", "src", "main")
       val shared = srcs.filter(_.getParentFile == sharedMain).map(_.getName)
-      assert(shared.isEmpty, s"$shared under $sharedMain")
+      assert(shared == variants, s"$shared under $sharedMain")
       // the group of every platform is what shared is
       assert(!srcs(dir("js-jvm-native", "src", "main", "scala")), "no all-platform group")
       val res = (Compile / unmanagedResourceDirectories).value.toSet
-      assert(!res(dir("shared", "src", "main", "resources")), s"unexpected resources in $res")
+      assert(res(dir("shared", "src", "main", "resources")), s"missing resources in $res")
       val tests = (Test / unmanagedSourceDirectories).value.toSet
-      assert(!tests(dir("shared", "src", "test", "scala")), s"unexpected test tree in $tests")
+      assert(tests(dir("shared", "src", "test", "scala")), s"missing test tree in $tests")
     },
   )
   .jvmPlatform(scalaVersions = Seq("2.13.18", "3.9.0"))

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/build.sbt
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/build.sbt
@@ -1,0 +1,51 @@
+lazy val check = taskKey[Unit]("")
+
+lazy val core = (projectMatrix in file("core"))
+  .settings(
+    // Def.uncached: Seq[VirtualAxis] has no HashWriter, so the task cannot be cached
+    check := Def.uncached {
+      val base = projectMatrixBaseDirectory.value
+      def dir(parts: String*): File = parts.foldLeft(base)(_ / _)
+      val srcs = (Compile / unmanagedSourceDirectories).value.toSet
+      // `scala-<axis>`, then `scala-<epoch>` where it differs, then `scala`
+      val axis = virtualAxes.value.collectFirst { case a: VirtualAxis.ScalaVersionAxis => a.value }
+      val variants = axis.get match {
+        case "2.13" => Set("scala-2.13", "scala-2", "scala")
+        case "3"    => Set("scala-3", "scala")
+        case "3.3"  => Set("scala-3.3", "scala-3", "scala")
+        // a full version, as `CrossVersion.full` and semanticdb use
+        case "2.13.17" => Set("scala-2.13.17", "scala-2.13", "scala-2", "scala")
+      }
+      // shared, the row's own platform, and each group short of every platform
+      val trees = Seq("shared", "jvm", "js-jvm", "jvm-native")
+      val wanted = trees.flatMap(t => variants.map(v => Seq(t, "src", "main", v))) ++ Seq(
+        // the shared trees carry Scala alone; only the row's own platform tree carries java
+        Seq("jvm", "src", "main", "java"),
+      )
+      wanted.foreach(p => assert(!srcs(dir(p*)), s"unexpected ${dir(p*)} in $srcs"))
+      // the default layout
+      val defaults = Seq(Seq("src", "main", "scala"), Seq("src", "main", "scalajvm"))
+      defaults.foreach(p => assert(srcs(dir(p*)), s"missing ${dir(p*)} in $srcs"))
+      val sharedMain = dir("shared", "src", "main")
+      val shared = srcs.filter(_.getParentFile == sharedMain).map(_.getName)
+      assert(shared.isEmpty, s"$shared under $sharedMain")
+      // the group of every platform is what shared is
+      assert(!srcs(dir("js-jvm-native", "src", "main", "scala")), "no all-platform group")
+      val res = (Compile / unmanagedResourceDirectories).value.toSet
+      assert(!res(dir("shared", "src", "main", "resources")), s"unexpected resources in $res")
+      val tests = (Test / unmanagedSourceDirectories).value.toSet
+      assert(!tests(dir("shared", "src", "test", "scala")), s"unexpected test tree in $tests")
+    },
+  )
+  .jvmPlatform(scalaVersions = Seq("2.13.18", "3.9.0"))
+  // a row whose axis names the minor version, which `jvmPlatform` never builds
+  .customRow(true, Seq(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion("3.3.8")), identity[Project])
+  .customRow(
+    true,
+    Seq(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis("2.13.17", "2.13.17")),
+    identity[Project],
+  )
+  // js and native rows so the groups they share with the JVM exist; the plugins are not needed
+  // to name a source tree
+  .customRow(true, Seq("3.9.0"), Seq(VirtualAxis.js), _.settings(platform := "sjs1"))
+  .customRow(true, Seq("3.9.0"), Seq(VirtualAxis.native), _.settings(platform := "native0.5"))

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/js-jvm/src/main/scala/JsJvm.scala
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/js-jvm/src/main/scala/JsJvm.scala
@@ -1,0 +1,2 @@
+package example
+object JsJvm { def three = Jvm.two + 1 }

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/jvm/src/main/scala/Jvm.scala
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/jvm/src/main/scala/Jvm.scala
@@ -1,0 +1,2 @@
+package example
+object Jvm { def two = Shared.one + 1 }

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/shared/src/main/scala-3/Scala3Only.scala
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/shared/src/main/scala-3/Scala3Only.scala
@@ -1,0 +1,2 @@
+package example
+object Scala3Only { def four = JsJvm.three + 1 }

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/shared/src/main/scala/Shared.scala
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/core/shared/src/main/scala/Shared.scala
@@ -1,0 +1,2 @@
+package example
+object Shared { def one = 1 }

--- a/sbt-app/src/sbt-test/project-matrix/crossproject-sources/test
+++ b/sbt-app/src/sbt-test/project-matrix/crossproject-sources/test
@@ -1,0 +1,6 @@
+> core/check
+> core2_13/check
+> core3_3/check
+> core2_13_17/check
+> core/compile
+> core2_13/compile


### PR DESCRIPTION
A build moving from `crossProject` to `projectMatrix` has to move every source file it has, or create custom rules around unmanaged sources.

Here we define `crossProjectSources` to add directories compatible with `crossproject` plugin.

*- Claude (on behalf of Albert)*
