### PR TITLE
[2.x] fix: keep macro subprojects off the pipelined classpath

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -2320,14 +2320,19 @@ object Defaults extends BuildCommon with DefExtra {
         val ping = (TaskZero / earlyOutputPing).value
         result match
           case Result.Value(res) =>
-            // Zinc completes the ping during a real compile; on an action-cache hit
-            // zinc never runs, so complete it from the pickle jar. tryComplete is
-            // atomic: zinc's own completion always wins when it ran.
-            ping.tryComplete(Result.Value(c.toPath(earlyOutput.value).toFile.exists))
             val af = compileAnalysisFile.value
             val store = analysisStore(af.toPath(), c)
             if !af.exists then sys.error(s"${af} is missing")
             val analysis = store.unsafeGet().getAnalysis()
+            // Zinc completes the ping during a real compile; on an action-cache hit zinc
+            // never runs, so re-derive its decision. The early jar is written even for
+            // subprojects that define macros, so its presence alone is not enough.
+            // tryComplete is atomic: zinc's own completion always wins when it ran.
+            ping.tryComplete(
+              Result.Value(
+                c.toPath(earlyOutput.value).toFile.exists && !definesMacro(analysis)
+              )
+            )
             reporter.sendSuccessReport(analysis)
             bspTask.notifySuccess(analysis)
             res
@@ -2340,6 +2345,11 @@ object Defaults extends BuildCommon with DefExtra {
       },
     )
   )
+
+  private def definesMacro(analysis: CompileAnalysis): Boolean =
+    analysis match
+      case a: Analysis => a.apis.internal.values.exists(_.hasMacro)
+      case _           => false
 
   private def projectIdFromScope(s: TaskStreams): String =
     s.key.scope.project match {

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/app/src/main/scala/app/Impl.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/app/src/main/scala/app/Impl.scala
@@ -1,0 +1,14 @@
+package app
+
+import scala.quoted.*
+
+class Impl(val name: String) extends core.Base
+
+object Impl:
+  def create(name: String): Impl = new Impl(name)
+
+  inline def make: Impl = ${ makeImpl }
+
+  private def makeImpl(using Quotes): Expr[Impl] =
+    import quotes.reflect.*
+    '{ create(${ Expr(Symbol.spliceOwner.owner.owner.fullName) }) }

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/app/src/main/scala/app/Use.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/app/src/main/scala/app/Use.scala
@@ -1,0 +1,4 @@
+package app
+
+object Use:
+  val impl: Impl = Impl.make

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/build.sbt
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/build.sbt
@@ -1,0 +1,6 @@
+ThisBuild / scalaVersion := "3.9.0"
+ThisBuild / usePipelining := true
+
+lazy val core = project
+
+lazy val app = project.dependsOn(core)

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/changes/Use2.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/changes/Use2.scala
@@ -1,0 +1,5 @@
+package app
+
+object Use:
+  val impl: Impl = Impl.make
+  val other: Impl = Impl.make

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/core/src/main/scala/core/Base.scala
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/core/src/main/scala/core/Base.scala
@@ -1,0 +1,13 @@
+package core
+
+import scala.quoted.*
+
+trait Base:
+  def name: String
+
+object Base:
+  inline def enclosingName: String = ${ enclosingNameImpl }
+
+  private def enclosingNameImpl(using Quotes): Expr[String] =
+    import quotes.reflect.*
+    Expr(Symbol.spliceOwner.owner.owner.fullName)

--- a/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/test
+++ b/sbt-app/src/sbt-test/source-dependencies/pipelining-macro/test
@@ -1,0 +1,7 @@
+# core defines a macro, so app must compile against core's classes directory
+> app/compile
+
+# core is up to date, so its compile hits the action cache; app must still see
+# the classes directory rather than the TASTy-only early jar
+$ copy-file changes/Use2.scala app/src/main/scala/app/Use.scala
+> app/compile


### PR DESCRIPTION
On an action-cache hit zinc never runs, so sbt completed `earlyOutputPing` from the early jar's presence. That jar exists for macro-defining subprojects too, so downstream got a TASTy-only classpath entry and macro expansion failed. Re-derives zinc's macro check instead. Fixes #9715. New scripted fixture covers it.