### PR TITLE
[2.x] feat: Add updateGlobalPlugins command to refresh global plugin dependencies

### DIFF
--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -758,6 +758,7 @@ object Keys {
   val globalPluginUpdate = taskKey[UpdateReport]("A hook to get the UpdateReport of the global plugin.").withRank(DTask)
   private[sbt] val taskCancelStrategy = settingKey[State => TaskCancellationStrategy]("Experimental task cancellation handler.").withRank(DTask)
   private[sbt] val cacheStoreFactoryFactory = AttributeKey[CacheStoreFactoryFactory]("cache-store-factory-factory")
+  private[sbt] val forceGlobalPluginUpdate = AttributeKey[Boolean]("force-global-plugin-update", "Forces dependency resolution of the global plugin project on the next load.")
   private[sbt] val bootServerSocket = AttributeKey[BootServerSocket]("boot-server-socket")
   private[sbt] val channelProjectCursors = AttributeKey[Map[String, ProjectRef]]("channel-project-cursors", "Per-channel project cursors for multi-client server mode.")
   val fileCacheSize = settingKey[String]("The approximate maximum size in bytes of the cache used to store previous task results. For example, it could be set to \"256M\" to make the maximum size 256 megabytes.")

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -965,7 +965,9 @@ object BuiltinCommands {
 
   def updateGlobalPlugins: Command =
     Command.command(UpdateGlobalPlugins, UpdateGlobalPluginsBrief, UpdateGlobalPluginsDetailed) {
-      s => loadProjectCommands("") ::: s.put(Keys.forceGlobalPluginUpdate, true)
+      s =>
+        sbt.coursierint.LMCoursier.clearResolutionCache()
+        loadProjectCommands("") ::: s.put(Keys.forceGlobalPluginUpdate, true)
     }
 
   private def loadProjectParser: State => Parser[String] =
@@ -1020,8 +1022,6 @@ object BuiltinCommands {
     val (s1, base) = Project.loadAction(SessionVar.clear(s0), action)
     IO.createDirectory(base)
     val s2 = if (s1 has Keys.stateCompilerCache) s1 else registerCompilerCache(s1)
-    if s2.get(Keys.forceGlobalPluginUpdate).getOrElse(false) then
-      sbt.coursierint.LMCoursier.clearResolutionCache()
     val (eval, structure) =
       try Load.defaultLoad(s2, base, s2.log, Project.inPluginProject(s2), Project.extraBuilds(s2))
       catch {

--- a/main/src/main/scala/sbt/Main.scala
+++ b/main/src/main/scala/sbt/Main.scala
@@ -364,6 +364,7 @@ object BuiltinCommands {
       tasks,
       settingsCommand,
       loadProject,
+      updateGlobalPlugins,
       templateCommand,
       templateCommandAlias,
       projects,
@@ -962,6 +963,11 @@ object BuiltinCommands {
       loadProjectCommands(arg) ::: s
     )
 
+  def updateGlobalPlugins: Command =
+    Command.command(UpdateGlobalPlugins, UpdateGlobalPluginsBrief, UpdateGlobalPluginsDetailed) {
+      s => loadProjectCommands("") ::: s.put(Keys.forceGlobalPluginUpdate, true)
+    }
+
   private def loadProjectParser: State => Parser[String] =
     _ => matched(Project.loadActionParser)
 
@@ -1014,6 +1020,8 @@ object BuiltinCommands {
     val (s1, base) = Project.loadAction(SessionVar.clear(s0), action)
     IO.createDirectory(base)
     val s2 = if (s1 has Keys.stateCompilerCache) s1 else registerCompilerCache(s1)
+    if s2.get(Keys.forceGlobalPluginUpdate).getOrElse(false) then
+      sbt.coursierint.LMCoursier.clearResolutionCache()
     val (eval, structure) =
       try Load.defaultLoad(s2, base, s2.log, Project.inPluginProject(s2), Project.extraBuilds(s2))
       catch {
@@ -1029,7 +1037,7 @@ object BuiltinCommands {
     val s3 = Project.setProject(
       session,
       structure,
-      s2,
+      s2.remove(Keys.forceGlobalPluginUpdate),
       st => setupGlobalFileTreeRepository(Clean.addCacheStoreFactoryFactory(st))
     )
     addSuperShellParams(

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -32,6 +32,11 @@ import sbt.io.syntax.*
 import xsbti.AppConfiguration
 
 object LMCoursier {
+
+  /** Drops the JVM-wide memoized resolutions so that a forced update resolves again. */
+  private[sbt] def clearResolutionCache(): Unit =
+    lmcoursier.internal.SbtCoursierCache.default.clear()
+
   private val credentialRegistry: ConcurrentHashMap[(String, String), IvyCredentials] =
     new ConcurrentHashMap
 

--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -312,8 +312,9 @@ $LoadProject return
   def UpdateGlobalPluginsDetailed =
     s"""$UpdateGlobalPlugins
 
-\tForces one dependency resolution of the global plugin project (the global plugins
-\tdirectory, `~/.sbt/2/plugins` by default) and then reloads the build.
+\tForces one dependency resolution of the global plugin project (the `plugins`
+\tdirectory under the global base, `~/.config/sbt/2/plugins` by default) and then
+\treloads the build.
 
 \tA plain `$LoadProject` reuses the cached resolution, so a newer snapshot or a newer
 \tmatch of a dynamic version is not picked up until this command runs. Remote snapshots

--- a/main/src/main/scala/sbt/internal/CommandStrings.scala
+++ b/main/src/main/scala/sbt/internal/CommandStrings.scala
@@ -306,6 +306,19 @@ $LoadProject return
 
 \t(Re)loads the root project (and leaves the plugins project)."""
 
+  def UpdateGlobalPlugins = "updateGlobalPlugins"
+  def UpdateGlobalPluginsBrief =
+    "Forces dependency resolution of the global plugin project and reloads."
+  def UpdateGlobalPluginsDetailed =
+    s"""$UpdateGlobalPlugins
+
+\tForces one dependency resolution of the global plugin project (the global plugins
+\tdirectory, `~/.sbt/2/plugins` by default) and then reloads the build.
+
+\tA plain `$LoadProject` reuses the cached resolution, so a newer snapshot or a newer
+\tmatch of a dynamic version is not picked up until this command runs. Remote snapshots
+\tare still subject to coursier's TTL (COURSIER_TTL)."""
+
   def InitCommand = "initialize"
   def InitBrief = (InitCommand, "Initializes command processing.")
   def InitDetailed =

--- a/main/src/main/scala/sbt/internal/GlobalPlugin.scala
+++ b/main/src/main/scala/sbt/internal/GlobalPlugin.scala
@@ -67,12 +67,16 @@ object GlobalPlugin {
     GlobalPlugin(data, structure, inject(data), base)
   }
 
+  /** Referencing `update` directly makes it an execution root, which forces resolution. */
+  private[sbt] def updateReportInit(force: Boolean): Def.Initialize[Task[UpdateReport]] =
+    if force then Def.task { update.value }
+    else (Def.task { () }).flatMapTask { case _ => Def.task { update.value } }
+
   def extract(state: State, structure: BuildStructure): (State, GlobalPluginData) = {
     import structure.{ data, root, rootProject }
     val p: Scope = Scope.GlobalScope.rescope(ProjectRef(root, rootProject(root)))
-
-    // If we reference it directly (if it's an executionRoot) then it forces an update, which is not what we want.
-    val updateReport = (Def.task { () }).flatMapTask { case _ => Def.task { update.value } }
+    val force = state.get(forceGlobalPluginUpdate).getOrElse(false)
+    val updateReport = updateReportInit(force)
     val taskInit = Def.task {
       val intcp = (Runtime / internalDependencyClasspath).value
       val prods = (Runtime / exportedProducts).value

--- a/main/src/test/scala/sbt/internal/GlobalPluginSpec.scala
+++ b/main/src/test/scala/sbt/internal/GlobalPluginSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package internal
+
+import hedgehog.*
+import hedgehog.runner.*
+
+object GlobalPluginSpec extends Properties:
+  override def tests: List[Test] =
+    List(
+      example("forced update report depends on update directly", forced),
+      example("cached update report keeps update out of the dependencies", cached),
+    )
+
+  private def dependsOnUpdate[A](init: Def.Initialize[Task[A]]): Boolean =
+    init.dependencies.exists(_.key == Keys.update.key)
+
+  def forced: Result =
+    Result.assert(dependsOnUpdate(GlobalPlugin.updateReportInit(force = true)))
+
+  def cached: Result =
+    Result.assert(!dependsOnUpdate(GlobalPlugin.updateReportInit(force = false)))
+end GlobalPluginSpec

--- a/sbt-app/src/sbt-test/project/global-plugin-update/build.sbt
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/build.sbt
@@ -1,0 +1,15 @@
+ThisBuild / organization := "com.example"
+
+lazy val root = (project in file("."))
+
+lazy val marker = (project in file("marker"))
+  .settings(
+    name := "marker",
+    version := "0.1.0",
+    publishMavenStyle := false,
+    publishTo := Some(
+      Resolver.file("test-repo", (ThisBuild / baseDirectory).value / "global" / "repo")(using
+        Resolver.ivyStylePatterns
+      )
+    ),
+  )

--- a/sbt-app/src/sbt-test/project/global-plugin-update/changes/Marker-0.2.0.scala
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/changes/Marker-0.2.0.scala
@@ -1,0 +1,2 @@
+object Marker:
+  def version: String = "0.2.0"

--- a/sbt-app/src/sbt-test/project/global-plugin-update/changes/Marker-0.3.0.scala
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/changes/Marker-0.3.0.scala
@@ -1,0 +1,2 @@
+object Marker:
+  def version: String = "0.3.0"

--- a/sbt-app/src/sbt-test/project/global-plugin-update/changes/plugins.sbt
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/changes/plugins.sbt
@@ -1,3 +1,5 @@
+csrCacheDirectory := (baseDirectory.value / ".." / "coursier-cache").getCanonicalFile
+
 resolvers += Resolver.file("test-repo", (baseDirectory.value / ".." / "repo").getCanonicalFile)(using
   Resolver.ivyStylePatterns
 )

--- a/sbt-app/src/sbt-test/project/global-plugin-update/changes/plugins.sbt
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/changes/plugins.sbt
@@ -1,0 +1,5 @@
+resolvers += Resolver.file("test-repo", (baseDirectory.value / ".." / "repo").getCanonicalFile)(using
+  Resolver.ivyStylePatterns
+)
+
+libraryDependencies += "com.example" %% "marker" % "latest.integration"

--- a/sbt-app/src/sbt-test/project/global-plugin-update/global/plugins/plugins.sbt
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/global/plugins/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.file("test-repo", (baseDirectory.value / ".." / "repo").getCanonicalFile)(using
+  Resolver.ivyStylePatterns
+)

--- a/sbt-app/src/sbt-test/project/global-plugin-update/marker/src/main/scala/Marker.scala
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/marker/src/main/scala/Marker.scala
@@ -1,0 +1,2 @@
+object Marker:
+  def version: String = "0.1.0"

--- a/sbt-app/src/sbt-test/project/global-plugin-update/test
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/test
@@ -1,0 +1,33 @@
+# sbt/sbt#1084: the global plugin's dependencies are resolved once and then served from
+# the update cache. The marker library comes from an ivy-style repository under global/repo,
+# so a newer release lives at a new path while the cached report still points at the old one.
+
+> marker/publish
+$ exists global/repo/com.example/marker_3/0.1.0/jars/marker_3.jar
+
+# A build with a project/ directory compiles its definition against the meta-build
+# classpath, which in 2.x does not include the global plugin's library dependencies.
+# Without one, the definition classpath is the global plugin classpath itself, which is
+# what this test observes. sbt writes project/build.properties on boot, after the first
+# sbt command has synchronised with it, and a project/ directory holding only target/
+# does not count as a definition.
+$ delete project/build.properties
+
+# depend on latest.integration from the global plugin and load it
+$ copy-file changes/plugins.sbt global/plugins/plugins.sbt
+> reload
+> eval assert(Marker.version == "0.1.0")
+# in 2.x the global plugin's update cache lives under the current build's output directory
+$ exists target/out/jvm/*/global-plugins/update/*/output
+
+# publish a newer release; a plain reload keeps serving the cached 0.1.0
+$ copy-file changes/Marker-0.2.0.scala marker/src/main/scala/Marker.scala
+> set marker / version := "0.2.0"
+> marker/publish
+$ exists global/repo/com.example/marker_3/0.2.0/jars/marker_3.jar
+> reload
+> eval assert(Marker.version == "0.1.0")
+
+# the batch runner preserves global/ between tests, so drop the definition again
+$ delete global/plugins/plugins.sbt
+> reload

--- a/sbt-app/src/sbt-test/project/global-plugin-update/test
+++ b/sbt-app/src/sbt-test/project/global-plugin-update/test
@@ -28,6 +28,18 @@ $ exists global/repo/com.example/marker_3/0.2.0/jars/marker_3.jar
 > reload
 > eval assert(Marker.version == "0.1.0")
 
+# updateGlobalPlugins forces one resolution of the global plugin project and reloads
+> updateGlobalPlugins
+> eval assert(Marker.version == "0.2.0")
+
+# the refreshed report is cached in turn: a plain reload does not resolve again
+$ copy-file changes/Marker-0.3.0.scala marker/src/main/scala/Marker.scala
+> set marker / version := "0.3.0"
+> marker/publish
+$ exists global/repo/com.example/marker_3/0.3.0/jars/marker_3.jar
+> reload
+> eval assert(Marker.version == "0.2.0")
+
 # the batch runner preserves global/ between tests, so drop the definition again
 $ delete global/plugins/plugins.sbt
 > reload


### PR DESCRIPTION
**Problem**

Fixes #1084.

The global plugin project is reloaded on every sbt start and every `reload`, but its `update` is deliberately kept out of the execution roots in `GlobalPlugin.extract`, so it is never forced and the cached report is served instead. A newer snapshot, or a newer match of a dynamic version, is never picked up unless the dependency list under the global plugins directory changes or its target directory is deleted. `reboot full` does not help, since it only wipes the boot directory.

A second cache hides the new version even when `update` is forced: lm-coursier memoizes resolutions for the lifetime of the JVM in `SbtCoursierCache.default`, keyed on the dependencies, repositories and cache.

**Solution**

Add an `updateGlobalPlugins` command. It drops the memoized resolutions, sets a private state flag and runs the normal `reload` sequence. While the flag is set, `GlobalPlugin.extract` references `update` directly rather than through the `flatMapTask` wrapper, which makes it an execution root and forces one resolution. The flag is cleared after a successful load, so plain `reload` and startup are unchanged; a failed load keeps it, so a retry from the load-failure prompt is still forced.

A dedicated command rather than a `reload` argument, because `reload plugins` and `reload return` already mean navigation between a build and its meta-build. Nothing re-resolves automatically on start, consistent with ordinary projects where users run `update` explicitly, and the forced resolution still honours the coursier TTL (`COURSIER_TTL`).

**Follow-up, not addressed here**

- The same JVM-wide memo makes `forceUpdatePeriod` ineffective within a session: the forced `update` re-runs but returns the memoized resolution.

AI usage: investigation and implementation drafted with Claude Code, verified by hand by running sbt.

