### PR TITLE
[2.x] fix: Resolve the project axis to the current project in runAggregated

### DIFF
--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -118,12 +118,14 @@ final case class Extracted(
     if tasks.isEmpty then
       val shown = showKey.show(rkey.scopedKey)
       state.log.warn(s"$shown selected no tasks to aggregate; nothing was run")
-    Aggregation.runTasks(
-      state,
-      tasks,
-      DummyTaskMap(Nil),
-      show = Aggregation.defaultShow(state, false),
-    )
+      state
+    else
+      Aggregation.runTasks(
+        state,
+        tasks,
+        DummyTaskMap(Nil),
+        show = Aggregation.defaultShow(state, false),
+      )
 
   private def resolve[K <: Scoped.ScopingSetting[K] & Scoped](key: K): K =
     val current = Load.projectScope(currentRef)

--- a/main/src/main/scala/sbt/Extracted.scala
+++ b/main/src/main/scala/sbt/Extracted.scala
@@ -9,7 +9,6 @@
 package sbt
 
 import sbt.internal.{ Load, BuildStructure, Act, Aggregation, SessionSettings }
-import Scope.GlobalScope
 import sbt.ScopeAxis.This
 import Def.{ ScopedKey, Setting }
 import sbt.internal.util.complete.Parser
@@ -109,11 +108,16 @@ final case class Extracted(
    * If the project axis is not defined for the key, it is resolved to be the current project.
    * The project axis is what determines where aggregation starts, so ensure this is set to what you want.
    * Other axes are resolved to `Zero` if unspecified.
+   *
+   * Warns and runs nothing if the key selects no tasks.
    */
   def runAggregated[A1](key: TaskKey[A1], state: State): State =
     val rkey = resolve(key)
     val keys = Aggregation.aggregate(rkey, ScopeMask(), structure.extra)
     val tasks = Act.keyValues(structure)(keys)
+    if tasks.isEmpty then
+      val shown = showKey.show(rkey.scopedKey)
+      state.log.warn(s"$shown selected no tasks to aggregate; nothing was run")
     Aggregation.runTasks(
       state,
       tasks,
@@ -122,7 +126,8 @@ final case class Extracted(
     )
 
   private def resolve[K <: Scoped.ScopingSetting[K] & Scoped](key: K): K =
-    Scope.resolveScope(GlobalScope, currentRef.build, rootProject)(key.scope) / key
+    val current = Load.projectScope(currentRef)
+    Scope.resolveScope(current, currentRef.build, rootProject)(key.scope) / key
 
   private def getOrError[T](key: ScopedKey[?], value: Option[T])(using
       display: Show[ScopedKey[?]]

--- a/main/src/main/scala/sbt/UpperStateOps.scala
+++ b/main/src/main/scala/sbt/UpperStateOps.scala
@@ -93,6 +93,7 @@ trait UpperStateOps extends Any {
    * The project axis is what determines where aggregation starts, so ensure this is set to what you want.
    * Other axes are resolved to `Zero` if unspecified.
    *
+   * Warns and runs nothing if the key selects no tasks.
    * To avoid race conditions, this should NOT be called from a task.
    */
   def unsafeRunAggregated[A](key: TaskKey[A]): State

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/build.sbt
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/build.sbt
@@ -2,10 +2,14 @@ import Commands.*
 
 ThisBuild / autoScalaLibrary := false
 
+// Build-scoped: Project.updateCurrent registers only the current project's, the
+// build's and Global's commands, and this test navigates to projA.
+ThisBuild / commands ++= Seq(runAgg, runAggScoped, probeWarn, runAggOrphan, runTaskUndefined)
+
 lazy val root = (project in file("."))
   .aggregate(projA, projB)
   .settings(
-    commands ++= Seq(runAgg, runAggScoped, probeWarn, runAggOrphan, runTaskUndefined)
+    markTask := Def.uncached(IO.write(baseDirectory.value / "marker.txt", "root"))
   )
 
 lazy val projA = project

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/build.sbt
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/build.sbt
@@ -1,0 +1,19 @@
+import Commands.*
+
+ThisBuild / autoScalaLibrary := false
+
+lazy val root = (project in file("."))
+  .aggregate(projA, projB)
+  .settings(
+    commands ++= Seq(runAgg, runAggScoped, probeWarn, runAggOrphan, runTaskUndefined)
+  )
+
+lazy val projA = project
+  .settings(
+    markTask := Def.uncached(IO.write(baseDirectory.value / "marker.txt", "projA"))
+  )
+
+lazy val projB = project
+  .settings(
+    markTask := Def.uncached(IO.write(baseDirectory.value / "marker.txt", "projB"))
+  )

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/projA/build.sbt
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/projA/build.sbt
@@ -1,0 +1,1 @@
+name := "projA"

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/projB/build.sbt
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/projB/build.sbt
@@ -1,0 +1,1 @@
+name := "projB"

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
@@ -26,18 +26,20 @@ object Commands {
    * per-appender removal. Unbinding here would silence the rest of the session,
    * and for the same reason `pw` is left open rather than closed.
    */
-  private def capturingWarnings(st: State, file: File)(f: State => State): (State, String) =
+  private def capturingLog(st: State, file: File, level: Level.Value)(
+      f: State => State
+  ): (State, String) =
     val pw = new PrintWriter(new FileWriter(file), true)
     val appender: Appender =
       ConsoleAppender(s"i1210-${file.getName}", ConsoleOut.printWriterOut(pw), false)
-    LogExchange.bindLoggerAppenders(st.globalLogging.full.name, Seq(appender -> Level.Warn))
+    LogExchange.bindLoggerAppenders(st.globalLogging.full.name, Seq(appender -> level))
     val st1 = f(st)
     pw.flush()
     (st1, IO.read(file))
 
   val probeWarn = Command.command("probeWarn"): (st: State) =>
     val probe = "i1210 probe warning"
-    val (st1, captured) = capturingWarnings(st, st.baseDir / "captured.log"): s =>
+    val (st1, captured) = capturingLog(st, st.baseDir / "captured.log", Level.Warn): s =>
       s.log.warn(probe)
       s
     if !captured.contains(probe) then
@@ -45,10 +47,12 @@ object Commands {
     st1
 
   val runAggOrphan = Command.command("runAggOrphan"): (st: State) =>
-    val (st1, captured) = capturingWarnings(st, st.baseDir / "orphan.log"): s =>
+    val (st1, captured) = capturingLog(st, st.baseDir / "orphan.log", Level.Info): s =>
       Project.extract(s).runAggregated(orphanTask, s)
     if !captured.contains("selected no tasks to aggregate") then
       sys.error(s"expected a no-tasks warning; captured: [$captured]")
+    if captured.contains("elapsed time") then
+      sys.error(s"an empty aggregated run should not report success; captured: [$captured]")
     st1
 
   val runTaskUndefined = Command.command("runTaskUndefined"): (st: State) =>

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
@@ -20,11 +20,11 @@ object Commands {
    * `state.log` is `globalLogging.full`, created in `LoggerContext.globalContext`,
    * which is the context `LogExchange` binds into.
    *
-   * The appender is deliberately left bound. `LogExchange.unbindLoggerAppenders`
-   * delegates to `LoggerContext.clearAppenders`, which drops *every* appender on
-   * the logger - sbt's own console appender included - and `LoggerContext` has no
-   * per-appender removal. Unbinding here would silence the rest of the session,
-   * and for the same reason `pw` is left open rather than closed.
+   * The appender cannot be unbound: `LogExchange.unbindLoggerAppenders` delegates to
+   * `LoggerContext.clearAppenders`, which drops *every* appender on the logger -
+   * sbt's own console appender included - and there is no per-appender removal.
+   * Closing `pw` instead makes the still-bound appender inert, so it does not follow
+   * the shared sbt process into the rest of a scripted batch.
    */
   private def capturingLog(st: State, file: File, level: Level.Value)(
       f: State => State
@@ -35,7 +35,9 @@ object Commands {
     LogExchange.bindLoggerAppenders(st.globalLogging.full.name, Seq(appender -> level))
     val st1 = f(st)
     pw.flush()
-    (st1, IO.read(file))
+    val captured = IO.read(file)
+    pw.close()
+    (st1, captured)
 
   val probeWarn = Command.command("probeWarn"): (st: State) =>
     val probe = "i1210 probe warning"
@@ -49,9 +51,9 @@ object Commands {
   val runAggOrphan = Command.command("runAggOrphan"): (st: State) =>
     val (st1, captured) = capturingLog(st, st.baseDir / "orphan.log", Level.Info): s =>
       Project.extract(s).runAggregated(orphanTask, s)
-    if !captured.contains("selected no tasks to aggregate") then
-      sys.error(s"expected a no-tasks warning; captured: [$captured]")
-    if captured.contains("elapsed time") then
+    if !captured.contains("orphanTask selected no tasks to aggregate") then
+      sys.error(s"expected a no-tasks warning naming the key; captured: [$captured]")
+    if captured.contains("[success]") then
       sys.error(s"an empty aggregated run should not report success; captured: [$captured]")
     st1
 
@@ -62,7 +64,7 @@ object Commands {
     val message = outcome match
       case Left(m)  => m
       case Right(_) => sys.error("expected runTask to fail on an undefined key")
-    if !message.contains("orphanTask") || !message.contains("is undefined") then
-      sys.error(s"runTask error should name the key: [$message]")
+    if message != "orphanTask is undefined." then
+      sys.error(s"runTask error should name the resolved key: [$message]")
     st
 }

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/project/Commands.scala
@@ -1,0 +1,64 @@
+import sbt.*
+
+import sbt.internal.util.{ Appender, ConsoleAppender, ConsoleOut }
+import sbt.util.{ Level, LogExchange }
+import java.io.{ FileWriter, PrintWriter }
+
+object Commands {
+  lazy val markTask = taskKey[Unit]("Writes a marker file into the project's base directory")
+
+  lazy val orphanTask = taskKey[Unit]("Declared but never defined, so it selects no tasks")
+
+  val runAgg = Command.command("runAgg"): (st: State) =>
+    Project.extract(st).runAggregated(markTask, st)
+
+  val runAggScoped = Command.command("runAggScoped"): (st: State) =>
+    Project.extract(st).runAggregated(LocalProject("projA") / markTask, st)
+
+  /**
+   * Runs `f` with an appender bound to the global logger, returning what it wrote.
+   * `state.log` is `globalLogging.full`, created in `LoggerContext.globalContext`,
+   * which is the context `LogExchange` binds into.
+   *
+   * The appender is deliberately left bound. `LogExchange.unbindLoggerAppenders`
+   * delegates to `LoggerContext.clearAppenders`, which drops *every* appender on
+   * the logger - sbt's own console appender included - and `LoggerContext` has no
+   * per-appender removal. Unbinding here would silence the rest of the session,
+   * and for the same reason `pw` is left open rather than closed.
+   */
+  private def capturingWarnings(st: State, file: File)(f: State => State): (State, String) =
+    val pw = new PrintWriter(new FileWriter(file), true)
+    val appender: Appender =
+      ConsoleAppender(s"i1210-${file.getName}", ConsoleOut.printWriterOut(pw), false)
+    LogExchange.bindLoggerAppenders(st.globalLogging.full.name, Seq(appender -> Level.Warn))
+    val st1 = f(st)
+    pw.flush()
+    (st1, IO.read(file))
+
+  val probeWarn = Command.command("probeWarn"): (st: State) =>
+    val probe = "i1210 probe warning"
+    val (st1, captured) = capturingWarnings(st, st.baseDir / "captured.log"): s =>
+      s.log.warn(probe)
+      s
+    if !captured.contains(probe) then
+      sys.error(s"global logger appender captured nothing; file held: [$captured]")
+    st1
+
+  val runAggOrphan = Command.command("runAggOrphan"): (st: State) =>
+    val (st1, captured) = capturingWarnings(st, st.baseDir / "orphan.log"): s =>
+      Project.extract(s).runAggregated(orphanTask, s)
+    if !captured.contains("selected no tasks to aggregate") then
+      sys.error(s"expected a no-tasks warning; captured: [$captured]")
+    st1
+
+  val runTaskUndefined = Command.command("runTaskUndefined"): (st: State) =>
+    val outcome =
+      try Right(Project.extract(st).runTask(orphanTask, st))
+      catch case e: RuntimeException => Left(e.getMessage)
+    val message = outcome match
+      case Left(m)  => m
+      case Right(_) => sys.error("expected runTask to fail on an undefined key")
+    if !message.contains("orphanTask") || !message.contains("is undefined") then
+      sys.error(s"runTask error should name the key: [$message]")
+    st
+}

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/test
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/test
@@ -1,28 +1,49 @@
+# Pin the current project. Scripted runs project/* as one batch in a single sbt
+# process, and the reload injected between tests carries the previous test's
+# current project over. Every assertion below depends on what is current.
+> project root
+
 # Checkpoint: an appender bound to the global logger observes state.log
 # warnings. The assertion lives inside the command, which errors if the
 # captured file is missing the probe text.
 > probeWarn
 
 # An explicit project axis still decides where aggregation starts. projA
-# aggregates nothing, so only its marker appears. This must run before the
-# unscoped case below, while the two markers are still distinguishable.
+# aggregates nothing, so only its marker appears - not root's, and not projB's.
 > runAggScoped
 $ exists projA/marker.txt
+$ absent marker.txt
 $ absent projB/marker.txt
 
-# Reset so the unscoped run below has to write this marker itself, rather than
+# Reset so the unscoped run below has to write these markers itself, rather than
 # passing on the file the scoped run already left behind.
 $ delete projA/marker.txt
 
 # runAggregated with a key that has no project axis must aggregate from the
 # current project. Before sbt/sbt#1210 was fixed it resolved the axis to Zero,
-# selected no tasks, and silently did nothing.
+# selected no tasks, and silently did nothing. Aggregation starts at the current
+# project and includes it, so root's own marker must appear alongside both aggregates.
 > runAgg
+$ exists marker.txt
 $ exists projA/marker.txt
 $ exists projB/marker.txt
 
+$ delete marker.txt
+$ delete projA/marker.txt
+$ delete projB/marker.txt
+
+# The axis resolves to the CURRENT project, not to the build's root. From projA -
+# which aggregates nothing - an unscoped run must write projA's marker alone.
+# This is what distinguishes the fix from one that hardcodes the root project.
+> project projA
+> runAgg
+$ exists projA/marker.txt
+$ absent marker.txt
+$ absent projB/marker.txt
+> project root
+
 # An aggregated run that selects nothing warns instead of silently succeeding.
-# The command asserts the warning text was actually emitted to state.log.
+# The command asserts the warning names the key and that no success was reported.
 > runAggOrphan
 
 # runTask on an undefined key names the key it resolved.

--- a/sbt-app/src/sbt-test/project/i1210-run-aggregated/test
+++ b/sbt-app/src/sbt-test/project/i1210-run-aggregated/test
@@ -1,0 +1,29 @@
+# Checkpoint: an appender bound to the global logger observes state.log
+# warnings. The assertion lives inside the command, which errors if the
+# captured file is missing the probe text.
+> probeWarn
+
+# An explicit project axis still decides where aggregation starts. projA
+# aggregates nothing, so only its marker appears. This must run before the
+# unscoped case below, while the two markers are still distinguishable.
+> runAggScoped
+$ exists projA/marker.txt
+$ absent projB/marker.txt
+
+# Reset so the unscoped run below has to write this marker itself, rather than
+# passing on the file the scoped run already left behind.
+$ delete projA/marker.txt
+
+# runAggregated with a key that has no project axis must aggregate from the
+# current project. Before sbt/sbt#1210 was fixed it resolved the axis to Zero,
+# selected no tasks, and silently did nothing.
+> runAgg
+$ exists projA/marker.txt
+$ exists projB/marker.txt
+
+# An aggregated run that selects nothing warns instead of silently succeeding.
+# The command asserts the warning text was actually emitted to state.log.
+> runAggOrphan
+
+# runTask on an undefined key names the key it resolved.
+> runTaskUndefined


### PR DESCRIPTION
## Problem

Fixes #1210.

When a key does not say which project it belongs to, `Extracted.runAggregated` filled in the global scope instead of the current project. Nothing aggregates from there, so the call found no tasks, ran none, and still reported success:

```scala
Project.extract(state).runAggregated(Compile / compile, state)
```

The scaladoc has said the opposite since 0.13, and the sbt command line already fills in the current project. `Extracted` was the odd one out.

This reaches real builds. sbt-release's `releaseStepTaskAggregated` hands the key straight to `runAggregated`, so a key without a project does nothing there.

Happens on released 1.10.7 and 2.0.8.

## Solution

Fill in the current project instead, the way `runInputTask` always has. The only difference between the two scopes is the project, so a key that already names a project behaves exactly as before.

Also print a warning when an aggregated run finds no tasks, so a key that matches nothing is visible instead of quietly succeeding. Nothing inside sbt calls `runAggregated`, so only people who call it themselves will see this.

Calls that used to do nothing will now actually run.

Written with AI assistance (Claude Code) and verified by running sbt.
