### PR TITLE
[2.x] fix: Remove Ivy API usage from build publishing plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1164,7 +1164,12 @@ def otherRootSettings =
     scriptedUnpublished / watchTriggers := (scripted / watchTriggers).value,
     scripted / includeFilter := AllPassFilter,
     scripted / excludeFilter := Scripted.sbtWindowsExcludeFilter,
-    scriptedLaunchOpts := List("-Xmx1500M", "-Xms512M", "-server") :::
+    scriptedLaunchOpts := List(
+      "-Xmx1500M",
+      "-Xms512M",
+      "-server",
+      s"-Dsbt.build.root=${(ThisBuild / baseDirectory).value.getAbsolutePath}"
+    ) :::
       (sys.props.get("sbt.ivy.home") match {
         case Some(home) => List(s"-Dsbt.ivy.home=$home")
         case _          => Nil

--- a/project/PackageSignerPlugin.scala
+++ b/project/PackageSignerPlugin.scala
@@ -1,7 +1,6 @@
 import sbt.*
 import Keys.*
 import sbt.util.CacheImplicits.given
-import sbt.internal.librarymanagement.IvyActions
 import com.jsuereth.sbtpgp.SbtPgp
 import com.typesafe.sbt.packager.universal.{ UniversalPlugin, UniversalDeployPlugin }
 import com.typesafe.sbt.packager.debian.{ DebianPlugin, DebianDeployPlugin }
@@ -18,7 +17,8 @@ object PackageSignerPlugin extends sbt.AutoPlugin {
   import RpmPlugin.autoImport.*
 
   override def projectSettings: Seq[Setting[?]] =
-    inConfig(Universal)(packageSignerSettings) ++
+    Seq(otherResolvers ~= (_.distinct)) ++
+      inConfig(Universal)(packageSignerSettings) ++
       inConfig(Debian)(packageSignerSettings) ++
       inConfig(Rpm)(packageSignerSettings)
 
@@ -79,14 +79,22 @@ object PackageSignerPlugin extends sbt.AutoPlugin {
       val config = publishSignedConfiguration.value
       val s = streams.value
       Def.task {
-        IvyActions.publish(ivyModule.value, config, s.log)
+        val p = publisher.value
+        val module = p.moduleDescriptor(
+          moduleSettings.value.asInstanceOf[sbt.librarymanagement.ModuleDescriptorConfiguration]
+        )
+        p.publish(module, config, s.log)
       }
     }.value,
     publishLocalSigned := Def.taskDyn {
       val config = publishLocalSignedConfiguration.value
       val s = streams.value
       Def.task {
-        IvyActions.publish(ivyModule.value, config, s.log)
+        val p = publisher.value
+        val module = p.moduleDescriptor(
+          moduleSettings.value.asInstanceOf[sbt.librarymanagement.ModuleDescriptorConfiguration]
+        )
+        p.publish(module, config, s.log)
       }
     }.value
   )

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -5,7 +5,6 @@ import java.nio.file.{ FileAlreadyExistsException, Files }
 import sbt.Keys.*
 import sbt.util.CacheImplicits.given
 import sbt.librarymanagement.LibraryManagementCodec.given
-import sbt.internal.librarymanagement.IvyXml
 
 /** This local plugin provides ways of publishing just the binary jar. */
 object PublishBinPlugin extends AutoPlugin {
@@ -24,7 +23,8 @@ object PublishBinPlugin extends AutoPlugin {
     publishLocalBin := Classpaths
       .publishOrSkip(publishLocalBinConfig, publishLocalBin / skip)
       .value,
-    publishLocalBinConfig := Def.uncached(
+    publishLocalBinConfig := Def.uncached {
+      val _ = makeIvyXmlLocalConfiguration.value
       Classpaths.publishConfig(
         false, // publishMavenStyle.value,
         Classpaths.deliverPattern(crossTarget.value),
@@ -37,22 +37,7 @@ object PublishBinPlugin extends AutoPlugin {
         logging = ivyLoggingLevel.value,
         overwrite = isSnapshot.value
       )
-    ),
-    publishLocalBinConfig := Def.uncached(
-      publishLocalBinConfig
-        .dependsOn(
-          // Copied from sbt.internal.
-          Def.task {
-            val currentProject = {
-              val proj = csrProject.value
-              val publications = csrPublications.value
-              proj.withPublications(publications)
-            }
-            IvyXml.writeFiles(currentProject, None, ivySbt.value, streams.value.log, Nil)
-          }
-        )
-        .value
-    ),
+    },
     dummyDoc := {
       val _ = projectID.value
       val dummyFile = target.value / "dummy-doc" / "doc.jar"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ Global / semanticdbVersion := "4.15.2"
 scalacOptions ++= Seq("-feature", "-language:implicitConversions")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.9.0")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/build.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/build.sbt
@@ -1,0 +1,180 @@
+/*
+ * sbt
+ * Copyright 2026, Scala center
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+import com.jsuereth.sbtpgp.PgpKeys.signedArtifacts
+import com.jsuereth.pgp.PGP
+
+ThisBuild / organization := "org.sbt.build-publishing"
+ThisBuild / version := "1.0-SNAPSHOT"
+ThisBuild / crossPaths := false
+ThisBuild / autoScalaLibrary := false
+val isolated = Seq(
+  csrCacheDirectory := (ThisBuild / baseDirectory).value / "resolution-cache",
+  ivyPaths := IvyPaths(
+    (ThisBuild / baseDirectory).value.toString,
+    Some(((ThisBuild / baseDirectory).value / "ivy-home").toString)
+  ),
+  resolvers += Resolver.file(
+    "fixture-local",
+    (ThisBuild / baseDirectory).value / "ivy-home" / "local"
+  )(Resolver.ivyStylePatterns)
+)
+
+val prepare = taskKey[Unit]("Generate temporary signing keys and package fixtures")
+val checkBinary = taskKey[Unit]("Check binary-only publication and dependency metadata")
+val checkSigned = taskKey[Unit]("Check local and remote package signatures")
+val checkUnsigned = taskKey[Unit]("Check signing skip retains only original artifacts")
+val clearPackages = taskKey[Unit]("Clear previously signed publications")
+val overwriteFixtures = taskKey[Unit]("Replace snapshot package content")
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(PackageSignerPlugin)
+  .settings(isolated)
+  .settings(
+    name := "build-publishing",
+    libraryDependencies += organization.value % "leaf" % version.value,
+    Compile / doc := sys.error("publishLocalBin must not generate documentation"),
+    publishTo := Some(
+      Resolver.file("signed", baseDirectory.value / "remote")(Resolver.mavenStylePatterns)
+    ),
+    publish / checksums := Seq("sha1", "md5"),
+    useGpg := false,
+    pgpPassphrase := Some("fixture".toCharArray),
+    pgpSigningKey := None,
+    pgpPublicRing := baseDirectory.value / "keys" / "public.asc",
+    pgpSecretRing := baseDirectory.value / "keys" / "secret.asc",
+
+    prepare := Def.uncached {
+      val root = baseDirectory.value
+      assert(otherResolvers.value.count(_.name == "signed") == 1)
+      IO.createDirectory(root / "keys")
+      PGP.makeKeys(
+        "sbt scripted fixture",
+        "fixture".toCharArray,
+        pgpPublicRing.value,
+        pgpSecretRing.value
+      )
+      Seq("zip", "deb", "rpm").foreach(ext => IO.write(root / s"package.$ext", "first"))
+    },
+
+    Seq(Universal -> "zip", Debian -> "deb", Rpm -> "rpm").flatMap { (conf, ext) =>
+      inConfig(conf)(
+        Seq(
+          packagedArtifacts := Def.uncached {
+            Map(
+              Artifact("build-publishing", ext, ext) -> fileConverter.value.toVirtualFile(
+                (baseDirectory.value / s"package.$ext").toPath
+              )
+            )
+          }
+        )
+      )
+    },
+
+    checkBinary := Def.uncached {
+      val root = baseDirectory.value
+      val dir = root / "ivy-home" / "local" / organization.value / name.value / version.value
+      Seq(
+        "jars/build-publishing.jar",
+        "srcs/build-publishing-sources.jar",
+        "poms/build-publishing.pom",
+        "ivys/ivy.xml",
+        "docs/build-publishing-javadoc.jar"
+      ).foreach { path =>
+        assert((dir / path).isFile, s"Missing $path")
+      }
+      val sources = new java.util.jar.JarFile(dir / "srcs/build-publishing-sources.jar")
+      try assert(sources.getEntry("Library.java") != null)
+      finally sources.close()
+      assert((dir / "docs/build-publishing-javadoc.jar").length == 0)
+      assert(IO.read(dir / "ivys/ivy.xml").contains("name=\"leaf\""))
+      assert(IO.read(dir / "poms/build-publishing.pom").contains("<artifactId>leaf</artifactId>"))
+      val jar = new java.util.jar.JarFile(dir / "jars/build-publishing.jar")
+      try assert(jar.getEntry("Library.class") != null)
+      finally jar.close()
+    },
+
+    checkSigned := Def.uncached {
+      val root = baseDirectory.value
+      val local = root / "ivy-home" / "local" / organization.value / name.value / version.value
+      val remote =
+        root / "remote" / organization.value.replace('.', '/') / name.value / version.value
+      val publicKey = PGP.loadPublicKeyRing(pgpPublicRing.value)
+      Seq("zip", "deb", "rpm").foreach { ext =>
+        Seq(
+          local / s"${ext}s/build-publishing.$ext",
+          remote / s"build-publishing-${version.value}.$ext"
+        ).foreach { f =>
+          assert(IO.read(f) == IO.read(root / s"package.$ext"), s"Incorrect content in $f")
+          val signature = file(f.toString + ".asc")
+          assert(publicKey.verifySignatureFile(f, signature), s"Invalid signature for $f")
+          Seq("sha1", "md5").foreach { hash =>
+            val algorithm = if (hash == "sha1") "SHA-1" else "MD5"
+            val digest = java.security.MessageDigest
+              .getInstance(algorithm)
+              .digest(IO.readBytes(f))
+              .map(b => f"${b & 0xff}%02x")
+              .mkString
+            assert(IO.read(file(f.toString + s".$hash")).trim == digest)
+            assert(!file(signature.toString + s".$hash").exists)
+          }
+        }
+      }
+      val tampered = root / "tampered.zip"
+      IO.write(tampered, "tampered")
+      assert(!publicKey.verifySignatureFile(tampered, local / "zips/build-publishing.zip.asc"))
+      assert((local / "ivys/ivy.xml").isFile)
+    },
+
+    checkUnsigned := Def.uncached {
+      val root = baseDirectory.value
+      val local = root / "ivy-home" / "local" / organization.value / name.value / version.value
+      val remote =
+        root / "remote" / organization.value.replace('.', '/') / name.value / version.value
+      Seq("zip", "deb", "rpm").foreach { ext =>
+        Seq(
+          local / s"${ext}s/build-publishing.$ext",
+          remote / s"build-publishing-${version.value}.$ext"
+        ).foreach { f =>
+          assert(IO.read(f) == "second")
+          assert(!file(f.toString + ".asc").exists)
+        }
+      }
+      val converter = fileConverter.value
+      Seq(
+        (Universal / signedArtifacts).value,
+        (Debian / signedArtifacts).value,
+        (Rpm / signedArtifacts).value
+      ).foreach { artifacts =>
+        assert(artifacts.size == 1)
+        artifacts.foreach { (artifact, ref) =>
+          assert(!artifact.extension.endsWith(".asc"))
+          assert(converter.toPath(ref).toFile.isFile)
+        }
+      }
+    },
+
+    clearPackages := Def.uncached {
+      val local =
+        baseDirectory.value / "ivy-home" / "local" / organization.value / name.value / version.value
+      Seq("zips", "debs", "rpms").foreach(dir => IO.delete(local / dir))
+      IO.delete(baseDirectory.value / "remote")
+    },
+
+    overwriteFixtures := Def.uncached {
+      Seq("zip", "deb", "rpm")
+        .foreach(ext => IO.write(baseDirectory.value / s"package.$ext", "second"))
+    }
+  )
+
+lazy val leaf = project.settings(isolated).settings(name := "leaf")
+lazy val consumer = project
+  .settings(isolated)
+  .settings(
+    name := "consumer",
+    libraryDependencies += organization.value % "build-publishing" % version.value
+  )

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/consumer/src/main/java/Consumer.java
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/consumer/src/main/java/Consumer.java
@@ -1,0 +1,7 @@
+/*
+ * sbt
+ * Copyright 2026, Scala center
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+public class Consumer { public static int value() { return Library.value() + Leaf.value(); } }

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/leaf/src/main/java/Leaf.java
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/leaf/src/main/java/Leaf.java
@@ -1,0 +1,7 @@
+/*
+ * sbt
+ * Copyright 2026, Scala center
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+public class Leaf { public static int value() { return 42; } }

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/project/plugins.sbt
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/project/plugins.sbt
@@ -1,0 +1,13 @@
+/*
+ * sbt
+ * Copyright 2026, Scala center
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.2")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
+
+Compile / unmanagedSources ++= {
+  val root = file(sys.props("sbt.build.root"))
+  Seq("PublishBinPlugin.scala", "PackageSignerPlugin.scala").map(root / "project" / _)
+}

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/src/main/java/Library.java
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/src/main/java/Library.java
@@ -1,0 +1,7 @@
+/*
+ * sbt
+ * Copyright 2026, Scala center
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+public class Library { public static int value() { return Leaf.value(); } }

--- a/sbt-app/src/sbt-test/dependency-management/build-publishing/test
+++ b/sbt-app/src/sbt-test/dependency-management/build-publishing/test
@@ -1,0 +1,34 @@
+> leaf/publishLocalBin
+> publishLocalBin
+> checkBinary
+> consumer/compile
+> prepare
+> set publish / skip := true
+> set publishLocal / skip := true
+> Universal/publishLocalSigned
+> Debian/publishLocalSigned
+> Rpm/publishLocalSigned
+> Universal/publishSigned
+> Debian/publishSigned
+> Rpm/publishSigned
+> checkSigned
+> overwriteFixtures
+> Universal/publishLocalSigned
+> Debian/publishLocalSigned
+> Rpm/publishLocalSigned
+> Universal/publishSigned
+> Debian/publishSigned
+> Rpm/publishSigned
+> checkSigned
+> set com.jsuereth.sbtpgp.PgpKeys.pgpSigner / skip := true
+> clearPackages
+> Universal/publishLocalSigned
+> Debian/publishLocalSigned
+> Rpm/publishLocalSigned
+> Universal/publishSigned
+> Debian/publishSigned
+> Rpm/publishSigned
+> checkUnsigned
+> set publishLocalBin / skip := true
+> set publishLocalBin / packagedArtifacts := Def.uncached(sys.error("skipped publication evaluated artifacts"))
+> publishLocalBin


### PR DESCRIPTION
Fixes #9681.

Use sbt's `publisher` API in `PackageSignerPlugin`, deduplicate identical publishing resolvers, and replace manual Ivy metadata generation in `PublishBinPlugin` with `makeIvyXmlLocalConfiguration`. Update `sbt-pgp` to `2.3.2` to remove its incompatible Ivy reference.

The `sbt.build.root` property added to `build.sbt` lets the scripted test to compile these plugins. Otherwise, the plugins are not available to the scripted testing framework as they are part of the meta-build.

Testing publisher plugin involves publishes a small project locally, inspects the published files and that the published classes are usable to compile another project that depends on them.

Testing signer plugin involves publishing and signing dummy files, checking they published correctly and their signatures verify. Also the test tests republishing behaves correctly.