### PR TITLE
fix: re-extract a diverged output directory on cache hit

### DIFF
--- a/sbt-app/src/sbt-test/cache/classdir-partial-restore/build.sbt
+++ b/sbt-app/src/sbt-test/cache/classdir-partial-restore/build.sbt
@@ -1,0 +1,53 @@
+import sbt.internal.util.CacheEventSummary
+
+val delMixin = taskKey[Unit]("deletes the class files of the mixin object")
+val corruptTrait = taskKey[Unit]("overwrites the trait's class file with junk")
+val recordHashes = taskKey[Unit]("records the hash of every class file")
+val checkHashes = taskKey[Unit]("asserts every class file matches the recorded hash")
+val showClasses = taskKey[Unit]("lists the class files")
+
+Global / localCacheDirectory := baseDirectory.value / "diskcache"
+
+lazy val classdirPartialRestore = project
+  .in(file("."))
+  .settings(
+    scalaVersion := "3.8.4",
+    Compile / mainClass := Some("example.Main"),
+    delMixin := Def.uncached {
+      val dir = (Compile / classDirectory).value
+      val files = (dir ** "B*.class").get()
+      assert(files.nonEmpty, s"no B*.class under $dir")
+      IO.delete(files)
+      streams.value.log.info(s"deleted ${files.mkString(", ")}")
+    },
+    corruptTrait := Def.uncached {
+      val dir = (Compile / classDirectory).value
+      val file = dir / "example" / "T.class"
+      assert(file.exists, s"$file is missing")
+      IO.delete(file)
+      IO.write(file, "not a class file")
+      streams.value.log.info(s"corrupted $file")
+    },
+    recordHashes := Def.uncached {
+      val dir = (Compile / classDirectory).value
+      val lines = (dir ** "*.class").get().sorted.map { f =>
+        s"${dir.toPath.relativize(f.toPath)}=${Hash.toHex(Hash(f))}"
+      }
+      IO.writeLines(target.value / "recorded-hashes.txt", lines)
+    },
+    checkHashes := Def.uncached {
+      val dir = (Compile / classDirectory).value
+      val recorded = IO.readLines(target.value / "recorded-hashes.txt")
+      val current = (dir ** "*.class").get().sorted.map { f =>
+        s"${dir.toPath.relativize(f.toPath)}=${Hash.toHex(Hash(f))}"
+      }
+      assert(
+        current == recorded,
+        s"class directory does not match the cached output\nrecorded:\n  ${recorded.mkString("\n  ")}\ncurrent:\n  ${current.mkString("\n  ")}"
+      )
+    },
+    showClasses := Def.uncached {
+      val dir = (Compile / classDirectory).value
+      streams.value.log.info(s"classes under $dir: ${(dir ** "*.class").get().mkString(", ")}")
+    },
+  )

--- a/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/B.scala
+++ b/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/B.scala
@@ -1,0 +1,3 @@
+package example
+
+object B extends T

--- a/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/Main.scala
+++ b/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/Main.scala
@@ -1,0 +1,6 @@
+package example
+
+object Main:
+  def main(args: Array[String]): Unit =
+    assert(B.value == 1, s"expected 1, got ${B.value}")
+    println("ok")

--- a/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/T.scala
+++ b/sbt-app/src/sbt-test/cache/classdir-partial-restore/src/main/scala/T.scala
@@ -1,0 +1,4 @@
+package example
+
+trait T:
+  def value: Int = 1

--- a/sbt-app/src/sbt-test/cache/classdir-partial-restore/test
+++ b/sbt-app/src/sbt-test/cache/classdir-partial-restore/test
@@ -1,0 +1,18 @@
+# sbt/sbt#9607: a class directory that diverged from its packaged zip has to be repaired on a
+# cache hit. sbt/sbt#9473 only restores it when the whole directory goes missing.
+> compile
+> run
+> recordHashes
+
+# a deleted class file
+> delMixin
+> compile
+> showClasses
+> checkHashes
+> run
+
+# a class file left with stale (here: junk) content
+> corruptTrait
+> compile
+> checkHashes
+> run

--- a/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
+++ b/util-cache/src/main/scala/sbt/util/ActionCacheStore.scala
@@ -13,12 +13,14 @@ import java.nio.file.{
 }
 import java.nio.file.attribute.{ BasicFileAttributes, FileTime }
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.zip.ZipFile
 import sjsonnew.support.scalajson.unsafe.{ CompactPrinter, Converter, Parser }
 import sjsonnew.shaded.scalajson.ast.unsafe.JValue
 
 import scala.collection.mutable
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.collection.parallel.CollectionConverters.*
+import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 import sbt.internal.io.Retry
 import sbt.io.IO
@@ -470,7 +472,7 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
     if path.toString().endsWith(ActionCache.dirZipExt) then unpackageDirZip(path, outputDirectory)
     else ()
 
-  /** Re-extract a dirzip whose extracted directory is missing: one stat on the warm path. */
+  /** Re-extract a dirzip whose extracted tree is missing or no longer matches it. */
   private def afterFileUpToDate(
       ref: HashedVirtualFileRef,
       path: Path,
@@ -478,7 +480,25 @@ case class DiskActionCacheStore(base: Path, converter: FileConverter)
   ): Unit =
     if path.toString().endsWith(ActionCache.dirZipExt) then
       val dirPath = Paths.get(path.toString.dropRight(ActionCache.dirZipExt.size))
-      if !Files.isDirectory(dirPath) then Util.ignoreResult(unpackageDirZip(path, outputDirectory))
+      if !Files.isDirectory(dirPath) || !dirZipIsExtracted(path, outputDirectory) then
+        Util.ignoreResult(unpackageDirZip(path, outputDirectory))
+
+  /**
+   * Compares the tree a dirzip describes against the files on disk, using the sizes recorded in
+   * its central directory: a warm hit costs one stat per file rather than reading any of them
+   * back.
+   */
+  private def dirZipIsExtracted(dirzip: Path, outputDirectory: Path): Boolean =
+    try
+      Using.resource(ZipFile(dirzip.toFile())): zip =>
+        zip.entries.asScala.forall: entry =>
+          entry.isDirectory || entry.getName == ActionCache.manifestFileName || {
+            try
+              val size = Files.size(outputDirectory.resolve(entry.getName))
+              entry.getSize < 0L || size == entry.getSize
+            catch case _: IOException => false
+          }
+    catch case NonFatal(_) => false
 
   /**
    * Given a dirzip, unzip it in a temp directory, and sync each items to the outputDirectory.

--- a/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
+++ b/util-cache/src/test/scala/sbt/util/ActionCacheTest.scala
@@ -143,7 +143,7 @@ object ActionCacheTest extends BasicTestSuite:
         assert((dir / "b.txt").exists, "b.txt not re-extracted after the directory was deleted")
         assertMaterialized(cache, (dir / "a.txt").toPath)
 
-  test("Disk cache does not re-extract a dirzip whose archive digest already matches"):
+  test("Disk cache does not re-extract a dirzip whose extracted tree still matches"):
     withDiskCache: cache =>
       IO.withTemporaryDirectory: tempDir =>
         val outputDirectory = tempDir.toPath()
@@ -156,11 +156,47 @@ object ActionCacheTest extends BasicTestSuite:
         )
         val refs = cache.putBlobs(Seq(zipVf))
 
-        // packageDirectory leaves a regular file whose digest already matches the blob, so the
-        // extracted tree is in sync by construction and syncing must not unpackage it again.
+        // unpackaging removes files the archive does not list, so a surviving stray file is the
+        // observable sign that a matching tree was left alone.
+        IO.write(dir / "stray.txt", "stray")
+        cache.syncBlobs(refs, outputDirectory)
+        assert((dir / "stray.txt").exists, "in-sync tree was unpackaged again")
+
+  test("Disk cache re-extracts a dirzip missing one of its files"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        IO.write(dir / "b.txt", "contents B")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+
+        // the archive is untouched, so only the tree it describes can say the directory is stale
+        IO.delete(dir / "a.txt")
+        cache.syncBlobs(refs, outputDirectory)
+        assert(IO.read(dir / "a.txt") == "contents A", "deleted file was not restored")
+
+  test("Disk cache re-extracts a dirzip whose file was replaced"):
+    withDiskCache: cache =>
+      IO.withTemporaryDirectory: tempDir =>
+        val outputDirectory = tempDir.toPath()
+        val dir = tempDir / "gen-dir"
+        IO.write(dir / "a.txt", "contents A")
+        val zipVf = ActionCache.packageDirectory(
+          binaryFileConverter.toVirtualFile(dir.toPath()),
+          binaryFileConverter,
+          outputDirectory,
+        )
+        val refs = cache.putBlobs(Seq(zipVf))
+
         IO.write(dir / "a.txt", "diverged")
         cache.syncBlobs(refs, outputDirectory)
-        assert(IO.read(dir / "a.txt") == "diverged")
+        assert(IO.read(dir / "a.txt") == "contents A", "diverged file was not restored")
 
   test("Disk cache materializes a digest-matching dirzip from the CAS"):
     withDiskCache: cache =>


### PR DESCRIPTION
On a cache hit sbt only checked whether a declared output directory was missing, so a class directory that lost a file or kept a stale one stayed broken while compile reported a hit. It now compares the archive's recorded sizes against the files on disk. Refs #9607