### PR TITLE
[2.x] fix: Fixes cross command parsing

### DIFF
--- a/main/src/main/scala/sbt/Cross.scala
+++ b/main/src/main/scala/sbt/Cross.scala
@@ -148,7 +148,8 @@ object Cross {
 
   private def crossBuildCommandImpl(state: State, args: CrossArgs): State = {
     val extracted = Project.extract(state)
-    val parser = Act.aggregatedKeyParser(extracted) ~ matched(any.*)
+    val parser = Act.aggregatedKeyParser(extracted) ~
+      (matched(Space ~ any.*) | Parser.success(""))
     val verbose = if (args.verbose) "-v" else ""
     val allCommands = Parser.parse(args.command, parser) match {
       case Left(_) =>

--- a/sbt-app/src/sbt-test/actions/cross-command-prefix/build.sbt
+++ b/sbt-app/src/sbt-test/actions/cross-command-prefix/build.sbt
@@ -1,0 +1,15 @@
+crossScalaVersions := Seq("2.11.12", "2.12.21")
+
+val versionsFile = settingKey[File]("file recording the versions compileAll ran under")
+versionsFile := baseDirectory.value / "versions.txt"
+
+commands += Command.command("compileAll") { s =>
+  val extracted = Project.extract(s)
+  IO.append(extracted.get(versionsFile), extracted.get(scalaVersion) + "\n")
+  s
+}
+
+TaskKey[Unit]("check") := {
+  val versions = IO.read(versionsFile.value).linesIterator.toList
+  assert(versions == List("2.11.12", "2.12.21"), s"got $versions")
+}

--- a/sbt-app/src/sbt-test/actions/cross-command-prefix/test
+++ b/sbt-app/src/sbt-test/actions/cross-command-prefix/test
@@ -1,0 +1,3 @@
+# a command whose name starts with a task key name must not be split by + (https://github.com/sbt/sbt/issues/9529)
+> +compileAll
+> check


### PR DESCRIPTION
`+cleanFull` failed with `Not a valid key: Full`. The cross command re-parses its argument with the key parser, and `clean` is an accepting prefix, so the rest was taken as task args. Args now have to be preceded by whitespace. Scripted test included.

Fixes #9529