### PR TITLE
[2.x] fix: Fixes test setup/cleanup interleaving

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -1714,11 +1714,18 @@ object Defaults extends BuildCommon with DefExtra:
 
     val runners = createTestRunners(filteredFrameworks, loader, config)
 
+    val exclusive = config.tags.exists(_._1 == Tags.ExclusiveTestGroup)
+    // Under an exclusive topology, config.tags move to a Span-tagged bracket task holding
+    // them for the whole setup/main/cleanup span; the inner tasks must not repeat them.
+    val innerTags = if exclusive then Vector() else config.tags
     val groupTasks = groups map { group =>
       group.runPolicy match
         case Tests.SubProcess(opts) =>
           s.log.debug(s"javaOptions: ${opts.runJVMOptions}")
-          val forkedConfig = config.copy(parallel = config.parallel && forkedParallelExecution)
+          val forkedConfig = config.copy(
+            parallel = config.parallel && forkedParallelExecution,
+            tags = innerTags
+          )
           s.log.debug(
             s"Forking tests - parallelism = ${forkedConfig.parallel}, threads = ${forkedParallelism.getOrElse("auto")}"
           )
@@ -1732,7 +1739,7 @@ object Defaults extends BuildCommon with DefExtra:
             s.log,
             forkedParallelism,
             strategy != ClassLoaderLayeringStrategy.Raw,
-            Vector((Tags.ForkedTestGroup, 1)) ++ config.tags ++ group.tags*
+            Vector((Tags.ForkedTestGroup, 1)) ++ innerTags ++ group.tags*
           )
         case Tests.InProcess =>
           if javaOptions.nonEmpty then
@@ -1742,11 +1749,14 @@ object Defaults extends BuildCommon with DefExtra:
             loader,
             runners,
             processedOptions(group),
-            config.copy(tags = config.tags ++ group.tags),
+            config.copy(tags = innerTags ++ group.tags),
             s.log
           )
     }
-    val output = Tests.foldTasks(groupTasks, config.parallel)
+    val folded = Tests.foldTasks(groupTasks, config.parallel)
+    val output =
+      if exclusive then nop.tagw((config.tags :+ (Tags.Span, 1))*).flatMap(_ => folded)
+      else folded
     val result = output map { out =>
       out.events.foreachEntry { (suite, e) =>
         if strategy != ClassLoaderLayeringStrategy.Flat ||

--- a/main/src/main/scala/sbt/Tags.scala
+++ b/main/src/main/scala/sbt/Tags.scala
@@ -33,6 +33,12 @@ object Tags:
   val ExclusiveTestGroup = Tag("exclusive-test-group")
 
   /**
+   * Marker tag: keeps a task's tags held until it retires, spanning any flatMap continuation.
+   * Tasks inside the span must not carry tags conflicting with the held ones, or execution deadlocks.
+   */
+  val Span = ConcurrentRestrictions.Span
+
+  /**
    * Describes a restriction on concurrently executing tasks.
    * A Rule is constructed using one of the Tags.limit* methods.
    */

--- a/tasks-standard/src/test/scala/TagFlatMapTest.scala
+++ b/tasks-standard/src/test/scala/TagFlatMapTest.scala
@@ -1,0 +1,107 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package std
+
+import TaskExtra.*
+import TaskTest.tryRun
+import ConcurrentRestrictions.{ Span, Tag, tagged }
+
+import org.scalacheck.*
+import Prop.*
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Verifies that a limit-1 tag restriction is honored for every task in a
+ * setup/main/cleanup chain shaped like Tests.testTask: setup and cleanup work
+ * forked into individual tasks joined by a nop, the main task reached via
+ * dependsOn, and cleanup reached via map/flatMap. Tags apply to one task node
+ * only, so each node carrying real work must be tagged individually.
+ */
+object TagFlatMapTest extends Properties("flatMap tag handling"):
+  val testTag = Tag("test")
+  val tags = Seq(testTag -> 1)
+
+  def restrictions =
+    tagged(m => m.getOrElse(testTag, 0) <= 1 && m.getOrElse(ConcurrentRestrictions.All, 0) <= 8)
+
+  final class Probe:
+    val active = new AtomicInteger(0)
+    val maxActive = new AtomicInteger(0)
+    val events = new ConcurrentLinkedQueue[String]
+
+    def phase(name: String): Unit =
+      events.add(s"$name:start")
+      val now = active.incrementAndGet()
+      maxActive.updateAndGet(m => math.max(m, now))
+      Thread.sleep(100)
+      active.decrementAndGet()
+      events.add(s"$name:end")
+      ()
+
+    def eventList: List[String] = events.asScala.toList
+
+  def fj(actions: Seq[() => Unit]): Task[Unit] =
+    nop.dependsOn(actions.fork(_()).map(_.tagw(tags*))*)
+
+  def subproject(name: String, probe: Probe): Task[Unit] =
+    val setup = fj(Seq(() => probe.phase(s"$name-setup")))
+    val main = task(probe.phase(s"$name-main")).tagw(tags*).dependsOn(setup)
+    main.map(identity).flatMap { _ =>
+      fj(Seq(() => probe.phase(s"$name-cleanup"))).map(_ => ())
+    }
+
+  def run2(): Probe =
+    val probe = new Probe
+    val root = Seq(subproject("a", probe), subproject("b", probe)).join.map(_ => ())
+    tryRun(root, true, restrictions)
+    probe
+
+  property("tagged tasks stay exclusive through dependsOn/map/flatMap chains") =
+    val probe = run2()
+    s"maxActive=${probe.maxActive.get} events=${probe.eventList}" |: (probe.maxActive.get == 1)
+
+  /**
+   * Pins a current engine limitation: a node's tags are released (and the
+   * pending queue drained) between the nodes of a chain, so a tag cannot be
+   * held from setup through cleanup and the two subprojects' spans interleave.
+   * If this property starts failing, the engine has learned to hold tags
+   * across task boundaries and the first property alone is sufficient.
+   */
+  property("limitation: exclusivity is not held across task boundaries") =
+    val probe = run2()
+    val ev = probe.eventList
+    s"events=$ev" |: !spansDisjoint(ev)
+
+  def spansDisjoint(ev: List[String]): Boolean =
+    def span(p: String) = (ev.indexWhere(_.startsWith(p)), ev.lastIndexWhere(_.startsWith(p)))
+    val (a0, a1) = span("a-")
+    val (b0, b1) = span("b-")
+    a1 < b0 || b1 < a0
+
+  def spanSubproject(name: String, probe: Probe): Task[Unit] =
+    def fj0(actions: Seq[() => Unit]): Task[Unit] = nop.dependsOn(actions.fork(_())*)
+    val setup = fj0(Seq(() => probe.phase(s"$name-setup")))
+    val main = task(probe.phase(s"$name-main")).dependsOn(setup)
+    val chain = main.flatMap { _ =>
+      fj0(Seq(() => probe.phase(s"$name-cleanup"))).map(_ => ())
+    }
+    nop.tagw((tags :+ (Span -> 1))*).flatMap(_ => chain)
+
+  property("span-tagged bracket keeps subproject spans disjoint") =
+    val probe = new Probe
+    val root = Seq(spanSubproject("a", probe), spanSubproject("b", probe)).join.map(_ => ())
+    tryRun(root, true, restrictions)
+    val ev = probe.eventList
+    (s"events=$ev" |: spansDisjoint(ev)) &&
+    (s"maxActive=${probe.maxActive.get}" |: probe.maxActive.get == 1)
+end TagFlatMapTest

--- a/tasks-standard/src/test/scala/TagFlatMapTest.scala
+++ b/tasks-standard/src/test/scala/TagFlatMapTest.scala
@@ -16,7 +16,7 @@ import ConcurrentRestrictions.{ Span, Tag, tagged }
 import org.scalacheck.*
 import Prop.*
 
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.{ ConcurrentLinkedQueue, CountDownLatch, TimeUnit }
 import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters.*
 
@@ -104,4 +104,33 @@ object TagFlatMapTest extends Properties("flatMap tag handling"):
     val ev = probe.eventList
     (s"events=$ev" |: spansDisjoint(ev)) &&
     (s"maxActive=${probe.maxActive.get}" |: probe.maxActive.get == 1)
+
+  /**
+   * Regression: a held Span node must not count toward Tags.All, or a lone Span bracket run
+   * under limitAll(1) (sbt's serial-execution restriction) deadlocks itself -- the bracket
+   * parks holding All, and its own continuation can never be admitted. Run off-thread with a
+   * timeout since a regression here hangs rather than fails.
+   */
+  property("span bracket does not deadlock under limitAll(1)") =
+    val limitAll1 = tagged(_.getOrElse(ConcurrentRestrictions.All, 0) <= 1)
+    val probe = new Probe
+    val root = spanSubproject("a", probe)
+    val done = new CountDownLatch(1)
+    val runner = new Thread(() =>
+      tryRun(root, true, limitAll1)
+      done.countDown()
+    )
+    runner.setDaemon(true)
+    runner.start()
+    val completed = done.await(5, TimeUnit.SECONDS)
+    val ev = probe.eventList
+    (s"completed=$completed events=$ev" |: completed) &&
+    (completed ==> (s"events=$ev" |: ev == List(
+      "a-setup:start",
+      "a-setup:end",
+      "a-main:start",
+      "a-main:end",
+      "a-cleanup:start",
+      "a-cleanup:end"
+    )))
 end TagFlatMapTest

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -101,6 +101,8 @@ object CompletionService:
       service: CompletionService
   )(w: (TaskId[?], () => Completed) => (() => Completed)): CompletionService =
     new CompletionService:
-      def submit(node: TaskId[?], work: () => Completed) = service.submit(node, w(node, work))
-      def take() = service.take()
+      override def submit(node: TaskId[?], work: () => Completed) =
+        service.submit(node, w(node, work))
+      override def take() = service.take()
+      override def release(node: TaskId[?]): Unit = service.release(node)
 end CompletionService

--- a/tasks/src/main/scala/sbt/CompletionService.scala
+++ b/tasks/src/main/scala/sbt/CompletionService.scala
@@ -21,6 +21,13 @@ trait CompletionService:
    * In Execute this is used for tasks returning sbt.Completed.
    */
   def take(): Completed
+
+  /**
+   * Releases any concurrency-restriction tags still held for a retired node. Called by Execute
+   * when a node tagged with ConcurrentRestrictions.Span retires. Only meaningful for services
+   * enforcing concurrency restrictions; the default does nothing.
+   */
+  def release(node: TaskId[?]): Unit = ()
 end CompletionService
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -10,7 +10,7 @@ package sbt
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import sbt.internal.util.AttributeKey
+import sbt.internal.util.{ AttributeKey, IDSet }
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ Future as JFuture, RejectedExecutionException, CancellationException }
 import scala.collection.mutable
@@ -94,6 +94,12 @@ object ConcurrentRestrictions:
 
   /** A standard tag describing the total number of tasks. */
   val All = Tag("all")
+
+  /**
+   * Marker tag: keeps a task's tags held until it retires, spanning any flatMap continuation.
+   * Tasks inside the span must not carry tags conflicting with the held ones, or execution deadlocks.
+   */
+  val Span = Tag("span")
 
   type TagMap = Map[Tag, Int]
   val TagMap = Map.empty[Tag, Int]
@@ -224,6 +230,9 @@ object ConcurrentRestrictions:
        */
       private val pending = new LinkedList[Enqueue]
 
+      /** Span-tagged nodes whose tags remain held until Execute retires them. */
+      private val spanning = IDSet.create[TaskId[?]]
+
       private val sentinels: mutable.ListBuffer[JFuture[?]] = mutable.ListBuffer.empty
 
       def cancelSentinels(): Unit =
@@ -246,7 +255,7 @@ object ConcurrentRestrictions:
             submitValid(node, work)
             ()
           else
-            if running == 0 then errorAddingToIdle()
+            if running == 0 && spanning.isEmpty then errorAddingToIdle()
             pending.add(new Enqueue(node, work))
             ()
         ()
@@ -258,16 +267,25 @@ object ConcurrentRestrictions:
           finally cleanup(node)
         CompletionService.submitFuture(wrappedWork, jservice)
         ()
-      private def cleanup(node: TaskId[?]): Unit = synchronized {
-        running -= 1
+
+      private def removeTags(node: TaskId[?]): Unit =
         tagState = tags.remove(tagState, node)
         if !tags.valid(tagState) then
           warn(
             "Invalid restriction: removing a completed node from a valid system must result in a valid system."
           )
-          ()
+
+      private def cleanup(node: TaskId[?]): Unit = synchronized:
+        running -= 1
+        if node.tags.contains(Span) then spanning += node
+        else removeTags(node)
         submitValid(new LinkedList)
-      }
+
+      override def release(node: TaskId[?]): Unit = synchronized:
+        if spanning -= node then
+          removeTags(node)
+          submitValid(new LinkedList)
+
       private def errorAddingToIdle() =
         warn("Invalid restriction: adding a node to an idle system must be allowed.")
 
@@ -275,7 +293,7 @@ object ConcurrentRestrictions:
       @tailrec private def submitValid(tried: Queue[Enqueue]): Unit =
         if pending.isEmpty then
           if !tried.isEmpty then
-            if running == 0 then errorAddingToIdle()
+            if running == 0 && spanning.isEmpty then errorAddingToIdle()
             pending.addAll(tried)
             ()
         else

--- a/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
+++ b/tasks/src/main/scala/sbt/ConcurrentRestrictions.scala
@@ -42,6 +42,12 @@ trait ConcurrentRestrictions:
    *      valid(empty) 5. forall g: G, a: A, b: A; !valid(add(g,a)) => !valid(add(add(g,b), a))
    */
   def valid(g: G): Boolean
+
+  /** Like `remove`, but keeps `a`'s restriction in effect (see ConcurrentRestrictions.Span). */
+  def hold(g: G, a: TaskId[?]): G = remove(g, a)
+
+  /** Reverses what `hold` retained. The default is a no-op, matching the default `hold`. */
+  def unhold(g: G, a: TaskId[?]): G = g
 end ConcurrentRestrictions
 
 private[sbt] sealed trait CancelSentinels:
@@ -116,6 +122,10 @@ object ConcurrentRestrictions:
       def add(g: TagMap, a: TaskId[?]) = merge(g, a)(_ + _)
       def remove(g: TagMap, a: TaskId[?]) = merge(g, a)(_ - _)
       def valid(g: TagMap) = validF(g)
+      // Drop the execution-accounting bump (All/Untagged) but keep `a`'s own tags, so a held
+      // task no longer counts as running while its restriction is still enforced.
+      override def hold(g: TagMap, a: TaskId[?]): TagMap = merge(remove(g, a), a.tags)(_ + _)
+      override def unhold(g: TagMap, a: TaskId[?]): TagMap = merge(g, a.tags)(_ - _)
 
   private def merge(m: TagMap, a: TaskId[?])(
       f: (Int, Int) => Int
@@ -268,8 +278,8 @@ object ConcurrentRestrictions:
         CompletionService.submitFuture(wrappedWork, jservice)
         ()
 
-      private def removeTags(node: TaskId[?]): Unit =
-        tagState = tags.remove(tagState, node)
+      private def applyTags[A1](f: tags.G => tags.G): Unit =
+        tagState = f(tagState)
         if !tags.valid(tagState) then
           warn(
             "Invalid restriction: removing a completed node from a valid system must result in a valid system."
@@ -277,13 +287,15 @@ object ConcurrentRestrictions:
 
       private def cleanup(node: TaskId[?]): Unit = synchronized:
         running -= 1
-        if node.tags.contains(Span) then spanning += node
-        else removeTags(node)
+        if node.tags.contains(Span) then
+          applyTags(tags.hold(_, node))
+          spanning += node
+        else applyTags(tags.remove(_, node))
         submitValid(new LinkedList)
 
       override def release(node: TaskId[?]): Unit = synchronized:
         if spanning -= node then
-          removeTags(node)
+          applyTags(tags.unhold(_, node))
           submitValid(new LinkedList)
 
       private def errorAddingToIdle() =

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -154,15 +154,18 @@ private[sbt] final class Execute(
 
     results(node) = result
     state(node) = Done
-    if node.tags.contains(ConcurrentRestrictions.Span) then strategy.release(node)
     progress.afterCompleted(node, result)
     remove(reverse, node).foreach(dep => notifyDone(node, dep))
-    callers.remove(node).toList.flatten.foreach { c =>
-      retire(c, callerResult(c, result))
-    }
-    triggeredBy(node) foreach { t =>
+    if node.tags.contains(ConcurrentRestrictions.Span) then strategy.release(node)
+
+    callers
+      .remove(node)
+      .toList
+      .flatten
+      .foreach: c =>
+        retire(c, callerResult(c, result))
+    triggeredBy(node).foreach: t =>
       addChecked(t)
-    }
 
     post {
       assert(done(node))
@@ -173,6 +176,7 @@ private[sbt] final class Execute(
       assert(triggeredBy(node) forall added)
     }
   end retire
+
   def callerResult[A](node: TaskId[A], result: Result[A]): Result[A] =
     result match
       case _: Result.Value[A] => result

--- a/tasks/src/main/scala/sbt/Execute.scala
+++ b/tasks/src/main/scala/sbt/Execute.scala
@@ -154,6 +154,7 @@ private[sbt] final class Execute(
 
     results(node) = result
     state(node) = Done
+    if node.tags.contains(ConcurrentRestrictions.Span) then strategy.release(node)
     progress.afterCompleted(node, result)
     remove(reverse, node).foreach(dep => notifyDone(node, dep))
     callers.remove(node).toList.flatten.foreach { c =>


### PR DESCRIPTION
This is on top of https://github.com/sbt/sbt/pull/9665

## Problem
Tags are enforced per task node. This means that a chain like setup-test-cleanup would release the tags midway, and allow interleaving executions even for exclusive tests.

## Solution
This implements a special Span tag, which lets us keep the tags across the task chains.
Since this requires the flatMapped tasks to not carry their own tags to prevent a deadlock, the feature needs to be opt-in / internal implementation.
