### PR TITLE
[2.x] Fix diagnostics for task-local dependency references

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -867,6 +867,14 @@ lazy val sbtProj = (project in file("sbt-app"))
     Test / run / connectInput := true,
     Test / run / outputStrategy := Some(StdoutOutput),
     Test / run / fork := true,
+    Test / resourceGenerators += Def.task {
+      val converter = fileConverter.value
+      val classpath = (Compile / fullClasspathAsJars).value
+        .map(entry => converter.toPath(entry.data).toAbsolutePath.toString)
+      val resource = (Test / resourceManaged).value / "sbt-eval-classpath.txt"
+      IO.writeLines(resource, classpath)
+      Seq(resource)
+    }.taskValue,
     Test / testOptions ++= {
       val cp = (Test / fullClasspathAsJars).value.map(_.data).mkString(java.io.File.pathSeparator)
       val framework = TestFrameworks.ScalaTest

--- a/main-settings/src/main/scala/sbt/std/TaskMacro.scala
+++ b/main-settings/src/main/scala/sbt/std/TaskMacro.scala
@@ -15,6 +15,7 @@ import sbt.internal.util.appmacro.{ Cont, ContextUtil, ContextUtil0 }
 import sbt.internal.util.{ SourcePosition, SourcePositionImpl }
 
 import language.experimental.macros
+import scala.collection.mutable
 import scala.quoted.*
 import sbt.util.BuildWideCacheConfiguration
 import sjsonnew.JsonFormat
@@ -51,6 +52,60 @@ object TaskMacro:
 
   // import LinterDSL.{ Empty => EmptyLinter }
 
+  private def validateTaskReferences[C <: Quotes & Singleton](
+      convert: FullConvert[C],
+      expression: Expr[Any]
+  ): Unit =
+    import convert.qctx
+    import qctx.reflect.*
+    given qctx.type = qctx
+
+    val definitions = mutable.HashSet.empty[Symbol]
+    val inputs = mutable.ListBuffer.empty[Term]
+
+    def input(name: String, tpe: TypeRepr, argument: Term): Option[Term] = name match
+      case InputWrapper.WrapInitTaskName | InputWrapper.WrapPreviousName |
+          InputWrapper.WrapInitName | InputWrapper.WrapTaskName =>
+        Option.when(convert.asPredicate(name, tpe, argument))(argument)
+      case _ => None
+
+    def dependency(tree: Tree): Option[Term] = tree match
+      case Apply(TypeApply(Select(_, name), tpe :: Nil), argument :: Nil) =>
+        input(name, tpe.tpe, argument)
+      case Apply(TypeApply(Ident(name), tpe :: Nil), argument :: Nil) =>
+        input(name, tpe.tpe, argument)
+      case _ => None
+
+    object collect extends TreeTraverser:
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit =
+        dependency(tree) match
+          case Some(argument) => inputs += argument
+          case None           =>
+            tree match
+              case definition: Definition => definitions += definition.symbol
+              case binding: Bind          => definitions += binding.symbol
+              case _                      => ()
+            super.traverseTree(tree)(owner)
+    end collect
+
+    object check extends TreeTraverser:
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit =
+        tree match
+          case reference: Ident if definitions.contains(reference.symbol) =>
+            val name = reference.name
+            report.errorAndAbort(
+              s"Illegal dynamic reference: $name\n" +
+                "Task dependency expressions cannot reference values defined inside this task.\n" +
+                s"Move '$name' outside the task definition, or use Def.taskDyn to construct the dependent task.",
+              reference.pos
+            )
+          case _ => super.traverseTree(tree)(owner)
+    end check
+
+    collect.traverseTree(expression.asTerm)(Symbol.spliceOwner)
+    inputs.foreach(argument => check.traverseTree(argument)(Symbol.spliceOwner))
+  end validateTaskReferences
+
   def taskMacroImpl[A1: Type](t: Expr[A1], key: Expr[TaskKey[?]])(using
       qctx: Quotes
   ): Expr[Initialize[Task[A1]]] =
@@ -75,6 +130,7 @@ object TaskMacro:
       case '{ if $cond then $thenp else $elsep } => taskIfImpl[A1](t, cached)
       case _                                     =>
         val convert1 = new FullConvert(qctx, 0)
+        validateTaskReferences(convert1, t)
         if cached then
           convert1.contMapN[A1, F, Id](
             t,
@@ -95,6 +151,7 @@ object TaskMacro:
       case '{ if $cond then $thenp else $elsep } => taskIfImpl[A1](t, cached)
       case _                                     =>
         val convert1 = new FullConvert(qctx, 0)
+        validateTaskReferences(convert1, t)
         if cached then
           convert1.contMapN[A1, F, Id](
             t,
@@ -128,6 +185,7 @@ object TaskMacro:
       t: Expr[Initialize[Task[A1]]]
   )(using qctx: Quotes): Expr[Initialize[Task[A1]]] =
     val convert1 = new FullConvert(qctx, 1000)
+    validateTaskReferences(convert1, t)
     convert1.contFlatMap[A1, F, Id](t, convert1.appExpr, None)
 
   def previousImpl[A1: Type](t: Expr[TaskKey[A1]])(using qctx: Quotes): Expr[Option[A1]] =

--- a/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/api/src/main/scala/ApiSource.scala
+++ b/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/api/src/main/scala/ApiSource.scala
@@ -1,0 +1,3 @@
+object ApiSource:
+  val name = "api"
+end ApiSource

--- a/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/build.sbt
+++ b/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/build.sbt
@@ -1,0 +1,85 @@
+val selected = ScopeFilter(
+  inProjects(LocalProject("api"), LocalProject("engine")),
+  inConfigurations(Compile)
+)
+
+lazy val lazySelected = ScopeFilter(
+  inProjects(LocalProject("api"), LocalProject("engine")),
+  inConfigurations(Compile)
+)
+
+@transient val fromVal = taskKey[Seq[File]]("Collect sources with a val filter")
+@transient val fromLazyVal = taskKey[Seq[File]]("Collect sources with a lazy val filter")
+@transient val fromInline = taskKey[Seq[File]]("Collect sources with an inline filter")
+@transient val fromBlock = taskKey[Seq[File]]("Collect sources with an enclosing block filter")
+@transient val fromHelper = taskKey[Seq[File]]("Collect sources with a helper parameter")
+@transient val fromContainedBlock = taskKey[Seq[File]]("Collect sources with a contained filter")
+@transient val fromDynamic = taskKey[Seq[File]]("Collect sources with a dynamic task filter")
+@transient val fromPatternDynamic = taskKey[Seq[File]]("Collect sources with a pattern-bound dynamic filter")
+@transient val sequentialResult = taskKey[Int]("Run a sequential task inside a dynamic task")
+@transient val resultLocals = taskKey[Int]("Compute a task result using ordinary locals")
+@transient val check = taskKey[Unit]("Check the selected sources and nested task results")
+
+def collect(filter: ScopeFilter) = Def.task {
+  sources.all(filter).value.flatten
+}
+
+lazy val api = project
+lazy val engine = project
+
+lazy val root = project.in(file(".")).settings(
+  fromVal := sources.all(selected).value.flatten,
+  fromLazyVal := sources.all(lazySelected).value.flatten,
+  fromInline := sources.all(
+    ScopeFilter(inProjects(api, engine), inConfigurations(Compile))
+  ).value.flatten,
+  {
+    val filter = ScopeFilter(inProjects(api, engine), inConfigurations(Compile))
+    fromBlock := sources.all(filter).value.flatten
+  },
+  fromHelper := collect(selected).value,
+  fromContainedBlock := ({
+    val filter = ScopeFilter(inProjects(api, engine), inConfigurations(Compile))
+    sources.all(filter)
+  }).value.flatten,
+  fromDynamic := Def.taskDyn {
+    val filter = ScopeFilter(inProjects(api, engine), inConfigurations(Compile))
+    Def.task { sources.all(filter).value.flatten }
+  }.value,
+  fromPatternDynamic := Def.taskDyn {
+    Option(ScopeFilter(inProjects(api, engine), inConfigurations(Compile))) match {
+      case Some(filter) => Def.task { sources.all(filter).value.flatten }
+      case None => Def.task { Seq.empty[File] }
+    }
+  }.value,
+  sequentialResult := Def.taskDyn[Int] {
+    Def.unit(baseDirectory.value)
+    Def.sequential(Def.task(42))
+  }.value,
+  resultLocals := {
+    val collected = fromVal.value
+    val increment = 2
+    collected.size + increment
+  },
+  check := {
+    val expected = ((api / Compile / sources).value ++ (engine / Compile / sources).value).toSet
+    val rootSources = (Compile / sources).value
+    val actual = Seq(
+      "val" -> fromVal.value,
+      "lazy val" -> fromLazyVal.value,
+      "inline" -> fromInline.value,
+      "enclosing block" -> fromBlock.value,
+      "helper parameter" -> fromHelper.value,
+      "contained block" -> fromContainedBlock.value,
+      "dynamic capture" -> fromDynamic.value,
+      "dynamic pattern capture" -> fromPatternDynamic.value
+    )
+    assert(expected.map(_.getName) == Set("ApiSource.scala", "EngineSource.scala"))
+    assert(rootSources.map(_.getName).toSet == Set("ExcludedSource.scala"))
+    actual.foreach { case (form, collected) =>
+      assert(collected.toSet == expected, s"$form: expected $expected, got ${collected.toSet}")
+    }
+    assert(sequentialResult.value == 42)
+    assert(resultLocals.value == 4)
+  }
+)

--- a/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/engine/src/main/scala/EngineSource.scala
+++ b/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/engine/src/main/scala/EngineSource.scala
@@ -1,0 +1,3 @@
+object EngineSource:
+  val name = "engine"
+end EngineSource

--- a/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/test
+++ b/sbt-app/src/sbt-test/actions/i1095-dynamic-reference/test
@@ -1,0 +1,3 @@
+$ mkdir src/main/scala
+$ touch src/main/scala/ExcludedSource.scala
+> check

--- a/sbt-app/src/test/scala/sbt/IllegalDynamicReferenceSpec.scala
+++ b/sbt-app/src/test/scala/sbt/IllegalDynamicReferenceSpec.scala
@@ -1,0 +1,180 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.interfaces.Diagnostic.ERROR
+import dotty.tools.dotc.reporting.Diagnostic
+import hedgehog.Result
+import hedgehog.runner.*
+import java.nio.file.{ Path, Paths }
+import sbt.internal.{ Eval, EvalException, EvalImports, EvalReporter }
+import scala.io.Source
+import scala.util.Using
+
+object IllegalDynamicReferenceSpec extends Properties:
+  private val sourceName = "i1095-build.sbt"
+  private val imports = EvalImports(Seq("import sbt.*", "import sbt.given", "import sbt.Keys.*"))
+  private lazy val classpath: Seq[Path] =
+    val resource = Option(getClass.getResourceAsStream("/sbt-eval-classpath.txt"))
+      .getOrElse(sys.error("Missing generated sbt evaluator classpath"))
+    Using.resource(Source.fromInputStream(resource, "UTF-8")):
+      _.getLines().map(Paths.get(_)).toVector
+
+  private val filterExpression =
+    "ScopeFilter(inProjects(ThisProject), inConfigurations(Compile))"
+
+  private val validDefinitions = List(
+    "outer val" -> s"val filter = $filterExpression; sources := sources.all(filter).value.flatten",
+    "outer lazy val" -> s"lazy val filter = $filterExpression; sources := sources.all(filter).value.flatten",
+    "enclosing block" -> s"{ val filter = $filterExpression; sources := sources.all(filter).value.flatten }",
+    "helper parameter" -> s"def collect(filter: ScopeFilter) = Def.task { sources.all(filter).value.flatten }; sources := collect($filterExpression).value",
+    "dynamic parent local" -> s"sources := Def.taskDyn { val filter = $filterExpression; Def.task { sources.all(filter).value.flatten } }.value",
+    "dynamic parent pattern binder" -> s"Def.taskDyn { Option($filterExpression) match { case Some(filter) => Def.task { sources.all(filter).value.flatten }; case None => Def.task(Seq.empty[File]) } }",
+    "contained pattern binder" -> s"sources := (Option($filterExpression) match { case Some(filter) => sources.all(filter); case None => sources.all($filterExpression) }).value.flatten",
+    "result locals" -> "Def.task { val count = 2; val result = count + 1; result }",
+    "dependency result local" -> "Def.task { val base = baseDirectory.value; base.getName.length }",
+    "contained definition" -> s"sources := ({ val filter = $filterExpression; sources.all(filter) }).value.flatten",
+    "shadowed name" -> s"val filter = $filterExpression; sources := { val collected = sources.all(filter).value; val count = { val filter = 2; filter }; collected.flatten.take(count) }",
+    "lambda parameter" -> s"sources := List($filterExpression).map(filter => Def.task { sources.all(filter).value.flatten }).head.value",
+    "conditional task" -> "Def.task { if (baseDirectory.value.exists) Def.task(1).value else Def.task(2).value }",
+    "higher-kinded call" -> "class Box[A]; def build[F[_]](value: String): String = value; Def.task { build[Box](\"value\") }",
+    "higher-kinded call with dependency" -> "class Box[A]; object Builder { def apply[F[_]](value: String): String = value }; Def.cachedTask { Builder[Box](name.value) }",
+    "sequential task in dynamic task" -> "Def.taskDyn[Int] { Def.unit(baseDirectory.value); Def.sequential(Def.task(42)) }",
+  )
+
+  private val invalidDefinitions = List(
+    "task assignment" -> s"sources := { val filter = $filterExpression; sources.all(<filter>).value.flatten }",
+    "explicit task" -> s"Def.task { val filter = $filterExpression; sources.all(<filter>).value.flatten }",
+    "pattern-bound filter" -> s"""Def.task {
+      |  Option($filterExpression) match {
+      |    case Some(filter) => sources.all(<filter>).value.flatten
+      |    case None => Seq.empty[File]
+      |  }
+      |}""".stripMargin,
+    "two-project aggregation" -> """lazy val api = project
+      |lazy val engine = project
+      |sources := {
+      |  val filter = ScopeFilter(inProjects(api, engine), inConfigurations(Compile))
+      |  sources.all(<filter>).value.flatten
+      |}""".stripMargin,
+    "multiple inputs and renamed local" -> s"""Def.task {
+      |  val selected = $filterExpression
+      |  val base = baseDirectory.value
+      |  sources.all(<selected>).value.flatten.size + base.getName.length
+      |}""".stripMargin,
+    "cached task" -> s"Def.cachedTask { val filter = $filterExpression; sources.all(<filter>).value.size }",
+    "uncached task" -> s"Def.uncachedTask { val filter = $filterExpression; sources.all(<filter>).value.size }",
+    "dynamic task dependency" -> s"Def.taskDyn { val filter = $filterExpression; val collected = sources.all(<filter>).value; Def.task(collected.size) }",
+  )
+
+  override def tests: List[Test] = validDefinitions.map: (name, code) =>
+    example(
+      s"$name remains valid", {
+        val (compiled, diagnostics) = compile(code)
+        Result
+          .assert(compiled)
+          .and(Result.assert(diagnostics.isEmpty))
+          .log(diagnostics.mkString("\n"))
+      }
+    )
+  ++ invalidDefinitions.map: (name, markedCode) =>
+    example(
+      s"$name receives an actionable diagnostic at its use", {
+        val start = markedCode.indexOf('<')
+        val end = markedCode.indexOf('>', start)
+        val identifier = markedCode.substring(start + 1, end)
+        val prefix = markedCode.take(start)
+        val code = prefix + identifier + markedCode.drop(end + 1)
+        val line = prefix.count(_ == '\n')
+        val column = prefix.length - prefix.lastIndexOf('\n') - 1
+        val (compiled, diagnostics) = compile(code)
+        val expected =
+          s"Illegal dynamic reference: $identifier\n" +
+            "Task dependency expressions cannot reference values defined inside this task.\n" +
+            s"Move '$identifier' outside the task definition, or use Def.taskDyn to construct the dependent task."
+        Result
+          .assert(!compiled)
+          .and(Result.assert(diagnostics.size == 1))
+          .and(Result.assert(diagnostics.exists: diagnostic =>
+            diagnostic.level == ERROR && diagnostic.message == expected &&
+              diagnostic.location.contains((sourceName, line, column, identifier))))
+          .log(diagnostics.mkString("\n"))
+      }
+    )
+  ++ List(
+    example(
+      "an inline ScopeFilter compiles through the build evaluator", {
+        val (compiled, diagnostics) = compile(
+          "sources := sources.all(ScopeFilter(inProjects(ThisProject), inConfigurations(Compile))).value.flatten"
+        )
+        Result
+          .assert(compiled)
+          .and(Result.assert(diagnostics.isEmpty))
+          .log(diagnostics.mkString("\n"))
+      }
+    ),
+    example(
+      "a task-local ScopeFilter receives an actionable diagnostic at its use", {
+        val (compiled, diagnostics) = compile(
+          """sources := {
+          |  val filter = ScopeFilter(inProjects(ThisProject), inConfigurations(Compile))
+          |  sources.all(filter).value.flatten
+          |}""".stripMargin
+        )
+        val expected =
+          "Illegal dynamic reference: filter\n" +
+            "Task dependency expressions cannot reference values defined inside this task.\n" +
+            "Move 'filter' outside the task definition, or use Def.taskDyn to construct the dependent task."
+        Result
+          .assert(!compiled)
+          .and(Result.assert(diagnostics.size == 1))
+          .and(Result.assert(diagnostics.exists: diagnostic =>
+            diagnostic.level == ERROR && diagnostic.message == expected &&
+              diagnostic.location.contains((sourceName, 2, 14, "filter"))))
+          .log(diagnostics.mkString("\n"))
+      }
+    ),
+  )
+
+  private def compile(code: String): (Boolean, Vector[RecordedDiagnostic]) =
+    val reporter = RecordingReporter()
+    val evaluator = new Eval(Nil, classpath, backingDir = None, mkReporter = Some(() => reporter))
+    val compiled =
+      try
+        evaluator.eval(code, imports, None, sourceName, 1)
+        true
+      catch case _: EvalException => false
+    (compiled, reporter.diagnostics)
+
+  private final case class RecordedDiagnostic(
+      level: Int,
+      message: String,
+      location: Option[(String, Int, Int, String)]
+  )
+
+  private final class RecordingReporter extends EvalReporter:
+    var diagnostics = Vector.empty[RecordedDiagnostic]
+
+    override def doReport(diagnostic: Diagnostic)(using Context): Unit =
+      val position = diagnostic.pos
+      val location = Option.when(position.exists):
+        val source = position.source
+        val line = source.offsetToLine(position.start)
+        (
+          source.file.path,
+          line,
+          position.start - source.lineToOffset(line),
+          new String(source.content.slice(position.start, position.end))
+        )
+      diagnostics :+= RecordedDiagnostic(diagnostic.level, diagnostic.msg.message, location)
+
+    override def finalReport(sourceName: String): Unit = ()
+  end RecordingReporter
+end IllegalDynamicReferenceSpec


### PR DESCRIPTION
Task-local filters used in `sources.all(filter).value` currently produce generic Scala macro scope errors. Report one actionable diagnostic at the offending reference, explaining how to move the definition outside the task or use `Def.taskDyn`.

Covers ordinary and pattern-bound locals while preserving supported filter forms and dynamic-task captures.

Fixes #1095.
