### PR TITLE
[2.x] fix: Fail the build on bad resource generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1279,7 +1279,7 @@ lazy val lmCore = (project in file("lm-core"))
       .task(
         Utils.generateVersionFile(
           version.value,
-          resourceManaged.value,
+          (Compile / resourceManaged).value,
           streams.value,
           (Compile / compile).value.asInstanceOf[Analysis]
         )

--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -671,7 +671,18 @@ object Defaults extends BuildCommon with DefExtra {
     resourceGenerators += (Def.task {
       PluginDiscovery.writeDescriptors(discoveredSbtPlugins.value, resourceManaged.value)
     }).taskValue,
-    managedResources := generate(resourceGenerators).value,
+    managedResources := {
+      val files = generate(resourceGenerators).value
+      val dirs = managedResourceDirectories.value.map(_.toPath.toAbsolutePath.normalize)
+      files.foreach: f =>
+        val p = f.toPath.toAbsolutePath.normalize
+        if !dirs.exists(p.startsWith) then
+          sys.error(
+            s"resourceGenerators produced $f outside managedResourceDirectories (${dirs.mkString(", ")}); " +
+              "did you mean (Compile / resourceManaged).value instead of resourceManaged.value?"
+          )
+      files
+    },
     managedResourcesVF := Def.uncached {
       val conv = fileConverter.value
       managedResources.value.toVector.map: x =>

--- a/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/a/src/main/scala/pkg/A.scala
+++ b/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/a/src/main/scala/pkg/A.scala
@@ -1,0 +1,2 @@
+package pkg
+class A

--- a/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/build.sbt
+++ b/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/build.sbt
@@ -1,0 +1,31 @@
+ThisBuild / scalaVersion := "3.3.1"
+
+lazy val a = (project in file("a"))
+  .settings(
+    name := "a",
+    crossPaths := false,
+    // Intentionally uses bare `resourceManaged.value` instead of `(Compile / resourceManaged).value`.
+    // Referencing a key without an explicit configuration scope inside a Def.task block does not
+    // inherit the Compile scope from the `Compile / resourceGenerators` it's assigned to, so this
+    // writes into the wrong (globally-scoped) resource_managed directory. That file would previously
+    // be silently dropped from the packaged jar; managedResources should now fail the build instead.
+    Compile / resourceGenerators += Def.task {
+      val f = resourceManaged.value / "generated.txt"
+      IO.write(f, "should not be silently dropped")
+      Seq(f)
+    },
+  )
+
+TaskKey[Unit]("checkError") := Def.uncached {
+  (a / Compile / managedResources).result.value.toEither match {
+    case Right(_) =>
+      sys.error(
+        "Expected `a / Compile / managedResources` to fail because the generator writes " +
+          "outside managedResourceDirectories, but it succeeded"
+      )
+    case Left(inc) =>
+      val msg = inc.directCause.map(_.getMessage).getOrElse(inc.toString)
+      if (!msg.contains("outside managedResourceDirectories"))
+        sys.error(s"Expected error mentioning 'outside managedResourceDirectories', got:\n$msg")
+  }
+}

--- a/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/test
+++ b/sbt-app/src/sbt-test/package/resource-generator-wrong-scope/test
@@ -1,0 +1,5 @@
+# A resourceGenerators task that writes outside of managedResourceDirectories (e.g. because it
+# references an unscoped key like `resourceManaged.value` instead of `(Compile / resourceManaged).value`
+# inside a Def.task block) used to be silently dropped from the packaged jar. It should now fail
+# the build with a clear error instead.
+> checkError

--- a/sbt-app/src/sbt-test/package/resources/build.sbt
+++ b/sbt-app/src/sbt-test/package/resources/build.sbt
@@ -14,3 +14,19 @@ packageOptions := {
   }
   Package.JarManifest(manifestExtra) +: packageOptions.value
 }
+
+Compile / resourceGenerators += Def.task {
+  val file = (Compile / resourceManaged).value / "jartest" / "generated_resource_test"
+  IO.write(file, "This is a generated resource to test that sbt includes generated resources in the packaged jar.")
+  Seq(file)
+}
+
+TaskKey[Unit]("checkGeneratedResourceInJar") := {
+  val converter = fileConverter.value
+  val jarFile = converter.toPath((Compile / packageBin).value).toFile
+  val jar = new java.util.jar.JarFile(jarFile)
+  try {
+    if (jar.getJarEntry("jartest/generated_resource_test") == null)
+      sys.error(s"jartest/generated_resource_test not found in $jarFile")
+  } finally jar.close()
+}

--- a/sbt-app/src/sbt-test/package/resources/test
+++ b/sbt-app/src/sbt-test/package/resources/test
@@ -1,6 +1,7 @@
-#This test verifies two things:
+#This test verifies three things:
 # 1) That sbt properly puts resources from src/main/resources on the runtime classpath
 # 2) That sbt properly packages resources from src/main/resources into the jar
+# 3) That sbt properly packages generated resources (resourceGenerators) into the jar
 
 # This should fail because the Main object is in package jartest and the resource is directly
 # in src/main/resources
@@ -28,3 +29,6 @@ $ delete src/main/resources/main_resource_test
 
 # This should succeed because sbt should include the resource in the jar with the right directory structure
 $ exec java -jar ./target/out/jvm/u/main-resources-test/main-resources-test-0.1.jar
+
+# This should succeed because sbt should include generated resources in the packaged jar
+> checkGeneratedResourceInJar


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9734

## Problem
Currently bad resources are silently dropped.

## Solution
1. Fix a bad resource generator in the build.
2. Fail the build when bad resources are found.