### PR TITLE
[2.x] fix: Write the portfile again when a client deletes it

### DIFF
--- a/main-command/src/main/scala/sbt/internal/server/Server.scala
+++ b/main-command/src/main/scala/sbt/internal/server/Server.scala
@@ -12,6 +12,7 @@ package server
 
 import java.io.{ File, IOException }
 import java.net.{ InetAddress, ServerSocket, Socket, SocketException, SocketTimeoutException }
+import java.nio.file.FileAlreadyExistsException
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import java.security.SecureRandom
 import java.math.BigInteger
@@ -34,6 +35,7 @@ import xsbti.AppConfiguration
 private[sbt] sealed trait ServerInstance:
   def shutdown(): Unit
   def serverId: String
+  def writePortfileIfAbsent(): Unit
   def ready: Future[Unit]
   def authenticate(challenge: String): Boolean
 
@@ -100,7 +102,7 @@ private[sbt] object Server:
               serverSocket.setSoTimeout(5000)
               serverSocketHolder.set(serverSocket)
               log.debug(s"sbt server started at ${connection.shortName}")
-              writePortfile()
+              writePortfile(replace = true)
               if connection.bspEnabled then
                 log.debug("Writing bsp connection file")
                 BuildServerConnection.writeConnectionFile(
@@ -172,7 +174,9 @@ private[sbt] object Server:
         )
 
       // This file exists through the lifetime of the server.
-      private def writePortfile(): Unit =
+      override def writePortfileIfAbsent(): Unit = writePortfile(replace = false)
+
+      private def writePortfile(replace: Boolean): Unit =
         import JsonProtocol.given
 
         val uri = connection.shortName
@@ -189,7 +193,8 @@ private[sbt] object Server:
         // business taking down one whose options it never saw
         val sysPropsRecorded = Option(startedByThisBuild)
         val authOK = auth(ServerAuthentication.Token)
-        if authOK then writeTokenfile()
+        // the token is spent on first use, so a server keeps the one its clients hold
+        if authOK && (replace || !tokenfile.exists) then writeTokenfile()
         val p = PortFile(
           uri,
           if authOK then Some(tokenfile.toString) else None,
@@ -199,7 +204,11 @@ private[sbt] object Server:
           Some(serverId)
         )
         val json = Converter.toJson(p).get
-        IO.writeFileAtomically(portfile)(tmp => IO.write(tmp, CompactPrinter(json)))
+        def write(tmp: File): Unit = IO.write(tmp, CompactPrinter(json))
+        if replace then IO.writeFileAtomically(portfile)(write)
+        else
+          try IO.createFileAtomically(portfile, ownerOnly = false)(write)
+          catch case _: FileAlreadyExistsException => ()
       end writePortfile
 
       private[sbt] def prepareSocketfile(): Unit =

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -54,7 +54,6 @@ private[sbt] final class CommandExchange:
     sys.props get "sbt.server.autostart" forall (_.toLowerCase == "true")
   private var server: Option[ServerInstance] = None
   private val firstInstance: AtomicBoolean = new AtomicBoolean(true)
-  private val monitoringActiveJson: AtomicBoolean = new AtomicBoolean(false)
   private val watchedRepository = new AtomicReference[AnyRef]
   private val portfileWatch = AtomicCloseable[AutoCloseable]()
   private val commandQueue: LinkedBlockingQueue[Exec] = new LinkedBlockingQueue[Exec]
@@ -276,23 +275,6 @@ private[sbt] final class CommandExchange:
 
       s.get(Keys.bootServerSocket).foreach(_.close())
     end if
-    if server.isEmpty && !monitoringActiveJson.get then
-      s.get(sbt.nio.Keys.globalFileTreeRepository) match
-        case Some(r) =>
-          r.register(sbt.nio.file.Glob(portfile)) match
-            case Right(o) =>
-              o.addObserver { event =>
-                if !event.exists then
-                  firstInstance.set(true)
-                  monitoringActiveJson.set(false)
-                  // FailureWall is effectively a no-op command that will
-                  // cause shell to re-run which should start the server
-                  commandQueue.add(Exec(BasicCommandStrings.FailureWall, None))
-                  o.close()
-              }
-              monitoringActiveJson.set(true)
-            case _ =>
-        case _ =>
     server.foreach { instance =>
       s.get(sbt.nio.Keys.globalFileTreeRepository).foreach { repo =>
         if watchedRepository.get ne repo then watchPortfile(instance, portfile, repo)

--- a/main/src/main/scala/sbt/internal/CommandExchange.scala
+++ b/main/src/main/scala/sbt/internal/CommandExchange.scala
@@ -10,7 +10,7 @@ package sbt
 
 package internal
 
-import java.io.{ File, IOException }
+import java.io.{ File, FileNotFoundException, IOException }
 import java.net.Socket
 import java.util.concurrent.atomic.*
 import java.util.concurrent.{ LinkedBlockingQueue, TimeUnit }
@@ -294,6 +294,8 @@ private[sbt] final class CommandExchange:
       repo: FileTreeRepository[FileAttributes]
   ): Unit =
     def check(): Unit = Server.serverIdOf(portfile) match
+      case Failure(_: FileNotFoundException) =>
+        Util.ignoreTry(instance.writePortfileIfAbsent()) // a throw here would end the watch
       case Success(id) if !id.contains(instance.serverId) =>
         exitServer("another sbt server took over this build")
       case _ =>

--- a/server-test/src/server-test/client/build.sbt
+++ b/server-test/src/server-test/client/build.sbt
@@ -7,3 +7,10 @@ TaskKey[Unit]("willFail") := { throw new Exception("failed") }
 libraryDependencies += "org.scalameta" %% "munit" % "1.0.4" % Test
 
 TaskKey[Unit]("fooBar") := { () }
+
+commands += Command.command("slowTask") { state =>
+  Thread.sleep(10000)
+  state
+}
+
+TaskKey[Unit]("markLoaded") := IO.touch(baseDirectory.value / "loaded.txt")

--- a/server-test/src/test/scala/testpkg/PortfileBusyTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileBusyTest.scala
@@ -1,0 +1,38 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package testpkg
+
+import sbt.internal.langserver.SbtExecParams
+import sbt.internal.langserver.codec.JsonProtocol.given
+import sbt.io.IO
+import sbt.io.syntax.*
+import sbt.protocol.ExecStatusEvent
+import sbt.protocol.codec.JsonProtocol.given
+
+import scala.concurrent.duration.*
+
+/**
+ * A server that a second one displaces exits on its own, and a task in flight does not stop it
+ * seeing that: it exits once the task ends.
+ */
+class PortfileBusyTest extends AbstractServerTest:
+  override val testDirectory: String = "client"
+
+  private val settle = 30.seconds
+
+  test("a portfile that names another server, while a task runs") {
+    val slowId = svr.session.nextId()
+    svr.session.sendJsonRpc(slowId, "sbt/exec", SbtExecParams("slowTask")).get
+    Thread.sleep(1000)
+    val portfile = svr.baseDirectory / "project" / "target" / "active.json"
+    IO.write(portfile, """{"uri":"local:///displaced","serverId":"another-server"}""")
+    val done = svr.session.waitForResultInResponseMsg[ExecStatusEvent](settle, slowId).get
+    assert(done.status == "Done", s"the task finished: ${done.status}")
+    assert(waitUntil(settle)(!svr.isAlive), "the displaced server exits")
+  }

--- a/server-test/src/test/scala/testpkg/PortfileRestoreTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileRestoreTest.scala
@@ -1,0 +1,60 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package testpkg
+
+import java.io.File
+import java.nio.file.Files
+
+import sbt.io.IO
+import sbt.io.syntax.*
+
+import scala.concurrent.duration.*
+
+/**
+ * A server whose socket is gone keeps running and no client can reach it. A client that gives
+ * up deletes the portfile and starts a server of its own, and this covers what each of them
+ * does with that file.
+ */
+class PortfileRestoreTest extends AbstractServerTest:
+  override val testDirectory: String = "client"
+
+  private val settle = 30.seconds
+
+  private def portfile: File = svr.baseDirectory / "project" / "target" / "active.json"
+
+  /** The socket the portfile names. Deleting it leaves the server running and unreachable. */
+  private def socketfile: File =
+    val uri = """"uri":"local://([^"]+)"""".r
+      .findFirstMatchIn(IO.read(portfile))
+      .map(_.group(1))
+      .getOrElse(fail(s"the portfile must name a local socket: ${IO.read(portfile)}"))
+    new File(uri)
+
+  /** An sbt script that records being run instead of starting a server. */
+  private def scriptWriting(marker: File): String =
+    val f = Files.createTempFile("fake-sbt", ".sh")
+    Files.writeString(f, s"#!/usr/bin/env bash\ntouch ${marker.toString}\nsleep 600\n")
+    f.toFile.setExecutable(true)
+    f.toString
+
+  test("a client that cannot reach the server the portfile names") {
+    val marker = Files.createTempDirectory("started").toFile / "started.txt"
+    val script = scriptWriting(marker)
+    IO.delete(socketfile)
+    IO.delete(portfile)
+    assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+    /*
+     * The client fails either way, having spent its attempts on a server it cannot reach. What
+     * matters is that the restored file does not stop it starting a server of its own: it looks
+     * for that file before the server has written it back.
+     */
+    scala.util.Try(runBatchClient(s"--sbt-script=$script", "willSucceed"))
+    assert(marker.exists, "the client starts a server of its own")
+  }
+end PortfileRestoreTest

--- a/server-test/src/test/scala/testpkg/PortfileRestoreTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileRestoreTest.scala
@@ -48,7 +48,7 @@ class PortfileRestoreTest extends AbstractServerTest:
     val script = scriptWriting(marker)
     IO.delete(socketfile)
     IO.delete(portfile)
-    assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+    assert(waitUntil(settle)(portfile.exists), "the server writes its portfile again")
     /*
      * The client fails either way, having spent its attempts on a server it cannot reach. What
      * matters is that the restored file does not stop it starting a server of its own: it looks

--- a/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
@@ -1,0 +1,111 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package testpkg
+
+import java.io.File
+import java.lang.ProcessBuilder.Redirect
+
+import sbt.io.IO
+import sbt.io.syntax.*
+
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.Properties.isLinux
+
+import org.scalatest.Outcome
+
+/**
+ * An sbt server that finds another one serving the build keeps the build loaded and serves
+ * nothing. This covers what becomes of the portfile when a client deletes it while such a
+ * server is sitting there.
+ *
+ * A case leaves the build with no portfile, or with one that names the sbt server it forked,
+ * so each case gets a suite and a server of its own.
+ */
+trait AbstractTakeoverTest extends AbstractServerTest:
+  override val testDirectory: String = "client"
+
+  protected val settle: FiniteDuration = 90.seconds
+
+  protected def portfile: File = svr.baseDirectory / "project" / "target" / "active.json"
+  protected def marker: File = svr.baseDirectory / "loaded.txt"
+  private def logfile: File = svr.baseDirectory / "another-server.log"
+
+  /** The forked sbt server writes nowhere a failing run can reach, so hand its log over. */
+  override protected def withFixture(test: NoArgTest): Outcome =
+    val outcome = super.withFixture(test)
+    if !outcome.isSucceeded && logfile.exists then
+      System.err.println(IO.readLines(logfile).takeRight(40).mkString("\n"))
+    outcome
+
+  /**
+   * Another sbt server on this build. It finds the socket taken, and then waits in the shell
+   * with the build loaded.
+   */
+  protected def anotherServer(reloading: Boolean): Process =
+    val java = new File(new File(System.getProperty("java.home"), "bin"), "java").toString
+    val classpath = TestProperties.classpath
+    val jvm = List(java, "-Djline.terminal=none", "-Dsbt.io.virtual=false", "-Dsbt.banner=false")
+    val ivy = sys.props.get("sbt.ivy.home").map(h => s"-Dsbt.ivy.home=$h").toList
+    val main = List("-cp", classpath, "sbt.RunFromSourceMain")
+    val args = List(
+      svr.baseDirectory.toString,
+      TestProperties.scalaVersion,
+      TestProperties.version,
+      classpath,
+      "startServer",
+    ) ++ (if reloading then List("reload") else Nil) ++ List(
+      "markLoaded",
+      "shell",
+    )
+    val options = jvm ::: ivy ::: main ::: args
+    val builder = new ProcessBuilder(options.asJava)
+    /*
+     * Inherited, this tells the child a thin client started it, and such an sbt server shuts
+     * down as soon as it finds it serves nothing.
+     */
+    builder.environment.remove("SBT_TERMINAL_PROPS")
+    IO.delete(marker)
+    builder
+      .directory(svr.baseDirectory)
+      .redirectOutput(Redirect.to(logfile))
+      .redirectErrorStream(true)
+      .start()
+  end anotherServer
+end AbstractTakeoverTest
+
+/* Linux alone: forking a second sbt server is expensive, and this behaviour is the same
+ * everywhere. */
+class PortfileTakeoverAfterLoadTest extends AbstractTakeoverTest:
+  test("a portfile deleted while another sbt server is loaded") {
+    if isLinux then
+      val another = anotherServer(reloading = true)
+      try
+        assert(waitUntil(settle)(marker.exists), "another sbt server loads the build twice")
+        val owner = IO.read(portfile)
+        IO.delete(portfile)
+        assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+      finally another.destroy()
+  }
+end PortfileTakeoverAfterLoadTest
+
+/* Linux alone, for the same reason. */
+class PortfileTakeoverTest extends AbstractTakeoverTest:
+  test("a portfile deleted while another sbt server waits") {
+    if isLinux then
+      val another = anotherServer(reloading = false)
+      try
+        assert(waitUntil(settle)(marker.exists), "another sbt server loads the build")
+        val owner = IO.read(portfile)
+        IO.delete(portfile)
+        assert(waitUntil(settle)(portfile.exists), "a portfile appears again")
+        assert(IO.read(portfile) != owner, "it names the sbt server that was waiting")
+      finally another.destroy()
+  }
+end PortfileTakeoverTest

--- a/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
@@ -104,8 +104,7 @@ class PortfileTakeoverTest extends AbstractTakeoverTest:
         assert(waitUntil(settle)(marker.exists), "another sbt server loads the build")
         val owner = IO.read(portfile)
         IO.delete(portfile)
-        assert(waitUntil(settle)(portfile.exists), "a portfile appears again")
-        assert(IO.read(portfile) != owner, "it names the sbt server that was waiting")
+        assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
       finally another.destroy()
   }
 end PortfileTakeoverTest

--- a/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileTakeoverTest.scala
@@ -90,7 +90,8 @@ class PortfileTakeoverAfterLoadTest extends AbstractTakeoverTest:
         assert(waitUntil(settle)(marker.exists), "another sbt server loads the build twice")
         val owner = IO.read(portfile)
         IO.delete(portfile)
-        assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+        assert(waitUntil(settle)(portfile.exists), "the serving sbt server writes it again")
+        assert(IO.read(portfile) == owner, "the portfile still names the serving sbt server")
       finally another.destroy()
   }
 end PortfileTakeoverAfterLoadTest
@@ -104,7 +105,8 @@ class PortfileTakeoverTest extends AbstractTakeoverTest:
         assert(waitUntil(settle)(marker.exists), "another sbt server loads the build")
         val owner = IO.read(portfile)
         IO.delete(portfile)
-        assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+        assert(waitUntil(settle)(portfile.exists), "the serving sbt server writes it again")
+        assert(IO.read(portfile) == owner, "the portfile still names the serving sbt server")
       finally another.destroy()
   }
 end PortfileTakeoverTest

--- a/server-test/src/test/scala/testpkg/PortfileTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileTest.scala
@@ -32,11 +32,11 @@ class PortfileTest extends AbstractServerTest:
   test("a portfile deleted twice") {
     val published = IO.read(portfile)
     IO.delete(portfile)
-    assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
-    IO.write(portfile, published)
+    assert(waitUntil(settle)(portfile.exists), "the server writes its portfile again")
+    assert(IO.read(portfile) == published, "the portfile still names this server")
     Thread.sleep(1000)
     IO.delete(portfile)
-    assert(!waitUntil(settle)(portfile.exists), "it stays deleted the second time")
+    assert(waitUntil(settle)(portfile.exists), "it writes the portfile again the second time")
   }
 
   test("a portfile that names another server") {

--- a/server-test/src/test/scala/testpkg/PortfileTest.scala
+++ b/server-test/src/test/scala/testpkg/PortfileTest.scala
@@ -29,9 +29,20 @@ class PortfileTest extends AbstractServerTest:
     assert(id.exists(_.nonEmpty), s"the portfile names its writer: ${IO.read(portfile)}")
   }
 
+  test("a portfile deleted twice") {
+    val published = IO.read(portfile)
+    IO.delete(portfile)
+    assert(!waitUntil(settle)(portfile.exists), "the portfile stays deleted")
+    IO.write(portfile, published)
+    Thread.sleep(1000)
+    IO.delete(portfile)
+    assert(!waitUntil(settle)(portfile.exists), "it stays deleted the second time")
+  }
+
   test("a portfile that names another server") {
     val replacement = """{"uri":"local:///displaced","serverId":"another-server"}"""
     IO.write(portfile, replacement)
     assert(waitUntil(settle)(!svr.isAlive), "the displaced server exits")
     assert(IO.read(portfile) == replacement, "the displaced server does not delete the portfile")
   }
+end PortfileTest


### PR DESCRIPTION
A client that cannot reach the sbt server deletes the portfile and starts a server of its own. Nothing writes that file back, so the build is left with no portfile at all.

**What happens today**

Every later client finds no portfile, so each one starts yet another sbt server instead of connecting to the one that is already serving. A starting sbt server looks for another one only when a portfile exists, so the check that keeps a build to one server stops running too.

**The change**

The sbt server that holds the socket notices the file is gone and writes it back, naming itself and keeping the token file its clients already hold. It writes only if the file is still absent, so a server that has claimed the build in the meantime keeps it.

The first commit takes the portfile away from an sbt server that serves nothing. `sbt --server` on a build that already has a server keeps the build loaded and waits; today it claims the build when the portfile goes. That session belongs to whoever started it and ends when they stop it, so it is the wrong process to hand a build to.

**Scope**

The client that deleted the portfile is not rescued. It retries about two hundred milliseconds later, before the file comes back, and starts its own server exactly as it does today.

**Tests**

Three cases run a second sbt server against the suite's build: one that waits with the build loaded, one that has reloaded since, and one where the portfile is deleted twice. Each gets a server of its own, because each ends with a portfile that names a server the test started, or with none.

Those cases run on Linux only. On macOS the file watcher throws inside its own delete handling, so no observer is called after the first event and the tests would cover nothing.

*- Claude (on behalf of Albert)*
