### PR TITLE
[2.x] feat: Add LoggerContext.removeAppender for single appender removal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -350,7 +350,9 @@ lazy val utilLogging = project
     Test / fork := true,
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[MissingClassProblem]("com.github.ghik.silencer.silent")
+      ProblemFilters.exclude[MissingClassProblem]("com.github.ghik.silencer.silent"),
+      // LoggerContext is sealed, so it has no implementations outside of sbt
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("sbt.util.LoggerContext.removeAppender"),
     ),
   )
   .configure(addSbtIO)

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -19,8 +19,14 @@ sealed abstract class LogExchange:
   def logger(name: String): ManagedLogger = logger(name, None, None)
   def logger(name: String, channelName: Option[String], execId: Option[String]): ManagedLogger =
     LoggerContext.globalContext.logger(name, channelName, execId)
+
+  /** Removes and closes every appender bound to the logger, including ones bound by sbt itself. */
   def unbindLoggerAppenders(loggerName: String): Unit =
     LoggerContext.globalContext.clearAppenders(loggerName)
+
+  /** Removes and closes only the given appenders, leaving the rest of the logger's appenders. */
+  def unbindLoggerAppenders(loggerName: String, appenders: Seq[Appender]): Unit =
+    appenders.foreach(LoggerContext.globalContext.removeAppender(loggerName, _))
 
   def bindLoggerAppenders(
       loggerName: String,

--- a/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LoggerContext.scala
@@ -24,6 +24,12 @@ import java.util.concurrent.atomic.{ AtomicReference, AtomicBoolean }
 sealed trait LoggerContext extends AutoCloseable:
   def logger(name: String, channelName: Option[String], execId: Option[String]): ManagedLogger
   def clearAppenders(loggerName: String): Unit
+
+  /**
+   * Removes a single appender from the logger, leaving the other appenders in place, and closes it.
+   * Does nothing if the appender is not bound to the logger.
+   */
+  def removeAppender(loggerName: String, appender: Appender): Unit
   def addAppender(
       loggerName: String,
       appender: (Appender, Level.Value)
@@ -51,7 +57,11 @@ object LoggerContext:
       def clearAppenders(): Unit =
         consoleAppenders.get.foreach { case (a, _) => a.close() }
         consoleAppenders.set(Vector.empty)
+      def removeAppender(toRemove: Appender): Unit =
+        val previous = consoleAppenders.getAndUpdate(_.filterNot { (a, _) => a eq toRemove })
+        previous.foreach { (a, _) => if a eq toRemove then a.close() }
       def appenders: Seq[Appender] = consoleAppenders.get.map(_._1)
+    end Log
     private val loggers = new ConcurrentHashMap[String, Log]
     private val closed = new AtomicBoolean(false)
     override def logger(
@@ -68,6 +78,10 @@ object LoggerContext:
       loggers.get(loggerName) match
         case null =>
         case l    => l.clearAppenders()
+    override def removeAppender(loggerName: String, appender: Appender): Unit =
+      loggers.get(loggerName) match
+        case null =>
+        case l    => l.removeAppender(appender)
     override def addAppender(
         loggerName: String,
         appender: (Appender, Level.Value)

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -92,6 +92,21 @@ object ManagedLoggerSpec extends BasicTestSuite:
     pool.awaitTermination(30, TimeUnit.SECONDS)
     ()
 
+  test("LoggerContext should remove a single appender"):
+    val other: Appender = ConsoleAppender()
+    val log = newLogger("bar")
+    context.addAppender("bar", asyncStdout -> Level.Info)
+    context.addAppender("bar", other -> Level.Info)
+    context.removeAppender("bar", other)
+    assert(context.appenders("bar") == Seq(asyncStdout))
+    log.info("test_info")
+
+  test("LoggerContext should ignore removal of an unbound appender"):
+    newLogger("baz")
+    context.addAppender("baz", asyncStdout -> Level.Info)
+    context.removeAppender("baz", ConsoleAppender())
+    assert(context.appenders("baz") == Seq(asyncStdout))
+
   test("global logging should log immediately after initialization"):
     // this is passed into State normally
     val global0 = initialGlobalLogging


### PR DESCRIPTION
Fixes #9721.

LogExchange.unbindLoggerAppenders calls clearAppenders, which drops and closes every appender on the logger. So if you bind an appender to the global logger and then unbind it, sbt's own console and backing appenders go with it and nothing prints for the rest of the session.

LoggerContext now has removeAppender(loggerName, appender), which removes that one instance by identity and closes it. LogExchange gets an unbindLoggerAppenders(name, appenders) overload on top of it, so unbinding mirrors binding. The existing single-arg version behaves as before, it just says in the scaladoc what it does now.

Tests are in ManagedLoggerSpec. The Mima filter is safe because LoggerContext is sealed and its only implementation is private to sbt.
