### PR TITLE
[2.x] feat: Add initialProject to select the project at first load

### DIFF
--- a/main/src/main/scala/sbt/Defaults.scala
+++ b/main/src/main/scala/sbt/Defaults.scala
@@ -323,6 +323,7 @@ object Defaults extends BuildCommon with DefExtra {
       sbtVersion := appConfiguration.value.provider.id.version,
       sbtBinaryVersion := binarySbtVersion(sbtVersion.value),
       pluginCrossBuild / sbtVersion := sbtVersion.value,
+      initialProject :== None,
       onLoad := idFun[State],
       onUnload := idFun[State],
       onUnload := { s =>

--- a/main/src/main/scala/sbt/Keys.scala
+++ b/main/src/main/scala/sbt/Keys.scala
@@ -90,6 +90,8 @@ object Keys {
   val configuration = settingKey[Configuration]("Provides the current configuration of the referencing scope.").withRank(CSetting)
   val commands = settingKey[Seq[Command]]("Defines commands to be registered when this project or build is the current selected one.").withRank(CSetting)
   val initialize = settingKey[Unit]("A convenience setting for performing side-effects during initialization.").withRank(BSetting)
+  @transient
+  val initialProject = settingKey[Option[ProjectReference]]("Project to select when the build is first loaded. Must be in the root build. Defaults to the root project; not re-read on reload.").withRank(DSetting)
   val onLoad = settingKey[State => State]("Transformation to apply to the build state when the build is loaded.").withRank(DSetting)
   val onUnload = settingKey[State => State]("Transformation to apply to the build state when the build is unloaded.").withRank(DSetting)
   val onLoadMessage = settingKey[String]("Message to display when the project is loaded.").withRank(DSetting)

--- a/main/src/main/scala/sbt/internal/LintUnused.scala
+++ b/main/src/main/scala/sbt/internal/LintUnused.scala
@@ -38,6 +38,7 @@ object LintUnused {
       allowUnsafeScalaLibUpgrade,
       evictionWarningOptions,
       initialize,
+      initialProject,
       lintUnusedKeysOnLoad,
       localDigestCacheByteSize,
       onLoad,

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -38,6 +38,7 @@ import java.net.URI
 import java.nio.file.Path
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.util.{ Failure, Success, Try }
 import sbt.internal.util.Util
 
 /**
@@ -1587,7 +1588,9 @@ private[sbt] object Load {
 
   def initialSession(structure: BuildStructure, rootEval: () => Eval, s: State): SessionSettings = {
     val session = s.get(Keys.sessionSettings)
-    val currentProject = session map (_.currentProject) getOrElse Map.empty
+    val initial = if (session.isDefined) None else configuredInitialProject(structure, s.log)
+    val currentProject = session map (_.currentProject) getOrElse
+      initial.map(structure.root -> _).toMap
     val currentBuild = session
       .map(_.currentBuild)
       .filter(uri => structure.units.keys.exists(uri == _))
@@ -1600,6 +1603,42 @@ private[sbt] object Load {
       Nil,
       rootEval
     )
+  }
+
+  /**
+   * Resolves `initialProject` to a project id in the root build, on the first load.
+   * Warns and yields None rather than failing the load when it cannot be resolved.
+   *
+   * Read at the root project's scope so that a value set there, on `ThisBuild` or on
+   * `Global` is all honoured, since a project axis delegates to the build and to `Zero`.
+   * A value set on any other project is not read.
+   *
+   * The existence check is for the diagnostic: `projectMap` already falls back to the
+   * root project for an unknown id, so without it a typo would be silently ignored.
+   */
+  private def configuredInitialProject(
+      structure: BuildStructure,
+      log: Logger
+  ): Option[String] = {
+    val root = structure.root
+    def fallback(ref: ProjectReference, why: String): Option[String] = {
+      log.warn(s"initialProject is set to $ref, $why; using the root project")
+      None
+    }
+    val rootRef = ProjectRef(root, structure.rootProject(root))
+    (rootRef / Keys.initialProject).get(structure.data).flatten.flatMap { ref =>
+      Try(Scope.resolveProjectRef(root, structure.rootProject, ref)) match {
+        case Success(resolved) if resolved.build != root =>
+          fallback(ref, "which is in another build; only the root build is supported")
+        case Success(resolved) =>
+          if (structure.units.get(root).exists(_.defined.contains(resolved.project)))
+            Some(resolved.project)
+          else fallback(ref, "which is not a project in this build")
+        case Failure(e) =>
+          val cause = Option(e.getMessage).getOrElse(e.toString)
+          fallback(ref, s"which cannot be resolved ($cause)")
+      }
+    }
   }
 
   def initialSession(structure: BuildStructure, rootEval: () => Eval): SessionSettings =

--- a/notes/2.0.0/initial-project.md
+++ b/notes/2.0.0/initial-project.md
@@ -1,0 +1,52 @@
+## initialProject setting
+
+By default sbt selects the root project when a build is first loaded. In a
+multi-project build whose root is an empty aggregator, that means every session
+starts one `project`
+command away from where the work is. `initialProject` names the project to select
+instead.
+
+### Usage
+
+In `build.sbt`:
+
+```scala
+lazy val app = (project in file("app"))
+
+ThisBuild / initialProject := Some(app)
+```
+
+The value is a `ProjectReference`, so `LocalProject("app")` is also accepted.
+
+Two scopes are worth keeping apart:
+
+- **Where you set it.** The value is read at the root build's root project, which
+  delegates to `ThisBuild` and to `Global`, so all three spellings work — including a
+  bare `initialProject := Some(app)` at the top of `build.sbt`. A value set on any
+  other project is ignored. One set in a user global `.sbt` applies to every build
+  you open.
+- **What you may name.** The project must belong to the root build. A reference into
+  another build unit warns and falls back to the root project.
+
+This replaces the long-standing workaround:
+
+```scala
+Global / onLoad := (Global / onLoad).value.andThen(s => "project app" :: s)
+```
+
+which fires on *every* load and therefore re-selects the project after each
+`reload`, discarding wherever the user had navigated.
+
+### Details
+
+- Read only when the build is loaded with no existing session — that is, on startup
+  and on `reboot`, but **not** on `reload`. `reload` preserves the project you
+  navigated to, which is the behaviour the `onLoad` workaround got wrong.
+- Because of that, editing `initialProject` takes effect on the next start or
+  `reboot`, not on `reload`.
+- A reference that names no project in the build logs a warning and falls back to
+  the root project. It never fails the load.
+- Defaults to `None`, in which case the root project is selected exactly as before.
+- The selected project applies to non-interactive invocations too: with
+  `ThisBuild / initialProject := Some(app)`, `sbt test` runs `app`'s tests rather
+  than the root aggregate's, because commands run after the build is loaded.

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/build.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/build.sbt
@@ -1,0 +1,22 @@
+ThisBuild / autoScalaLibrary := false
+
+// initialProject is never set here. Each case copies a one-line ip.sbt into the
+// build root, which BuildPaths globs alongside this file, so the cases differ by
+// exactly one setting and this file never has to be duplicated into changes/.
+
+lazy val checkCurrent = inputKey[Unit]("Asserts which project is currently selected")
+
+lazy val checkSettings = Seq[Setting[?]](
+  checkCurrent := {
+    val expected = Def.spaceDelimited().parsed.head
+    val actual = thisProject.value.id
+    assert(actual == expected, s"expected current project $expected, got $actual")
+  },
+  checkCurrent / aggregate := false,
+)
+
+lazy val i1224Root = (project in file("."))
+  .aggregate(i1224SubA)
+  .settings(checkSettings)
+
+lazy val i1224SubA = project.settings(checkSettings)

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/aggregate.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/aggregate.sbt
@@ -1,0 +1,1 @@
+ThisBuild / initialProject := Some(LocalAggregate)

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/bare.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/bare.sbt
@@ -1,0 +1,1 @@
+initialProject := Some(LocalProject("i1224SubA"))

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/global.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/global.sbt
@@ -1,0 +1,1 @@
+Global / initialProject := Some(LocalProject("i1224SubA"))

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/local.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/local.sbt
@@ -1,0 +1,1 @@
+ThisBuild / initialProject := Some(LocalProject("nope"))

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/rooturi.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/rooturi.sbt
@@ -1,0 +1,1 @@
+ThisBuild / initialProject := Some(RootProject(file("nope")))

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/thisproject.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/thisproject.sbt
@@ -1,0 +1,1 @@
+ThisBuild / initialProject := Some(ThisProject)

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/unloadeduri.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/changes/unloadeduri.sbt
@@ -1,0 +1,1 @@
+ThisBuild / initialProject := Some(ProjectRef(file("nope").toURI, "i1224SubA"))

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/test
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project-invalid/test
@@ -1,0 +1,52 @@
+# An unresolvable initialProject must warn and fall back to the root project,
+# never fail the load. reboot re-reads the build from disk with no session, which
+# is the only state in which initialProject is consulted.
+> reboot
+> checkCurrent i1224Root
+
+# Resolves cleanly, then fails the existence check. Note this pins the WARNING, not
+# the fallback: projectMap already replaces an unknown id with the root project, so
+# the load would recover either way - silently, which is the point of the check.
+$ copy-file changes/local.sbt ip.sbt
+> reboot
+> checkCurrent i1224Root
+
+# The next three throw inside Scope.resolveProjectRef, before any existence check
+# can run. A fixture testing only the case above would pass with the Try wrapper
+# removed, which is what makes these three the point of this file.
+$ copy-file changes/rooturi.sbt ip.sbt
+> reboot
+> checkCurrent i1224Root
+
+$ copy-file changes/thisproject.sbt ip.sbt
+> reboot
+> checkCurrent i1224Root
+
+$ copy-file changes/aggregate.sbt ip.sbt
+> reboot
+> checkCurrent i1224Root
+
+# A reference into a build that was never loaded RESOLVES cleanly - resolveProjectRef
+# does not validate the URI - so it reaches the root-build guard, not the existence
+# check. This case discriminates only because it borrows an id that DOES exist in the
+# root build: drop the guard and the existence check passes, and sbt silently selects
+# the root build's project of that name. Keep the id in step with build.sbt.
+$ copy-file changes/unloadeduri.sbt ip.sbt
+> reboot
+> checkCurrent i1224Root
+
+# Criterion 4: Global works as well as ThisBuild. The read is at the root project's
+# scope, which delegates project -> build -> Zero, so it sees all three spellings.
+$ copy-file changes/global.sbt ip.sbt
+> reboot
+> checkCurrent i1224SubA
+
+# An unscoped setting lands at root-PROJECT scope. The read is at that scope
+# precisely so this spelling works; a build-scoped read would not see it, and the
+# excludeLintKeys entry means nothing would warn about it either.
+$ copy-file changes/bare.sbt ip.sbt
+> reboot
+> checkCurrent i1224SubA
+
+# Leave the shared batch session on the root project, as the sibling fixture does.
+> project i1224Root

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project/build.sbt
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project/build.sbt
@@ -1,0 +1,38 @@
+ThisBuild / autoScalaLibrary := false
+
+ThisBuild / initialProject := Some(i1224SubA)
+
+lazy val checkCurrent = inputKey[Unit]("Asserts which project is currently selected")
+
+@transient
+lazy val checkLint = taskKey[Unit]("Asserts initialProject does not trigger lintUnused")
+
+// Defined per project, never at Global: a Global-scoped definition loads fine but
+// reports the root project's id whatever is current, which would make every
+// assertion below silently vacuous. aggregate := false stops the root's
+// aggregation fanning an unscoped invocation out into the subprojects.
+lazy val checkSettings = Seq[Setting[?]](
+  checkCurrent := {
+    val expected = Def.spaceDelimited().parsed.head
+    val actual = thisProject.value.id
+    assert(actual == expected, s"expected current project $expected, got $actual")
+  },
+  checkCurrent / aggregate := false,
+  checkLint := Def.uncached {
+    val st = Keys.state.value
+    val includeKeys = (Global / lintIncludeFilter).value
+    val excludeKeys = (Global / lintExcludeFilter).value
+    val result = sbt.internal.LintUnused.lintUnused(st, includeKeys, excludeKeys)
+    val warned = result.filter { case (_, key, _) => key.contains("initialProject") }
+    assert(warned.isEmpty, s"initialProject should not be linted, found: ${warned.map(_._2).mkString(", ")}")
+  },
+  checkLint / aggregate := false,
+)
+
+lazy val i1224Root = (project in file("."))
+  .aggregate(i1224SubA, i1224SubB)
+  .settings(checkSettings)
+
+lazy val i1224SubA = project.settings(checkSettings)
+
+lazy val i1224SubB = project.settings(checkSettings)

--- a/sbt-app/src/sbt-test/project-load/i1224-initial-project/test
+++ b/sbt-app/src/sbt-test/project-load/i1224-initial-project/test
@@ -1,0 +1,21 @@
+# Force a genuinely session-free load. project-load/* runs as one batch and the
+# runner injects "reload;initialize" before every test but the first, so without
+# this the fixture would pass alone and fail in CI.
+> reboot
+
+# initialProject selects subA at the first load, instead of the root project.
+> checkCurrent i1224SubA
+
+# ...and must not fight the user afterwards: reload preserves navigation. This is
+# the half the Global / onLoad workaround gets wrong.
+> project i1224SubB
+> reload
+> checkCurrent i1224SubB
+> reload
+> checkCurrent i1224SubB
+
+# Nothing else in the settings graph depends on the key - it is read imperatively
+# during load - so lintUnused would report it as unused in any build that sets it.
+# That is what the excludeLintKeys entry suppresses.
+> project i1224Root
+> checkLint


### PR DESCRIPTION
**Problem**

sbt always selects the root project when a build is first loaded, so in a build whose root is an empty aggregator every session starts with a `project` command. The long-standing workaround, `Global / onLoad := (Global / onLoad).value.andThen(s => "project app" :: s)`, fires on every load, so it re-selects that project after each `reload` and discards wherever the user had navigated.

**Solution**

Add `initialProject`, read only when a build is loaded with no existing session, so `reload` keeps preserving navigation:

```scala
ThisBuild / initialProject := Some(app)
```

`Global /` and a bare `initialProject := ...` work too — the read is at the root build's root project, which delegates to both. The project must be in the root build; an unresolvable or out-of-build reference warns and falls back to the root project rather than failing the load. The key is lint-excluded like `onLoad`/`onUnload`, since nothing in the settings graph depends on it.

Two consequences: editing the setting takes effect on restart or `reboot`, not `reload`; and it applies to non-interactive runs, so `sbt test` runs the selected project's tests. Covered by two scripted tests under `project-load/`; documented in `notes/2.0.0/initial-project.md`.

Fixes sbt/sbt#1224
