### PR TITLE
Set sbt user agent in Coursier HTTP requests

### DIFF
--- a/lm-coursier/definitions/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/lm-coursier/definitions/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -73,4 +73,6 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
     localArtifactsShouldBeCached: Boolean = false,
     @since
     lockFile: Option[File] = None,
+    @since
+    userAgent: Option[String] = None,
 )

--- a/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -256,6 +256,9 @@ class CoursierDependencyResolution(
       .withCredentials(conf.credentials.map(ToCoursier.credentials))
       .withFollowHttpToHttpsRedirections(conf.followHttpToHttpsRedirections.getOrElse(true))
       .withLocalArtifactsShouldBeCached(conf.localArtifactsShouldBeCached)
+    val cache1 = conf.userAgent match
+      case Some(ua) => cache0.withUserAgent(ua)
+      case None     => cache0
 
     val excludeDependencies = conf.excludeDependencies.map { (strOrg, strName) =>
       (coursier.Organization(strOrg), coursier.ModuleName(strName))
@@ -275,7 +278,7 @@ class CoursierDependencyResolution(
       sbtClassifiers = conf.sbtClassifiers,
       projectName = projectName,
       loggerOpt = loggerOpt,
-      cache = cache0,
+      cache = cache1,
       parallel = conf.parallelDownloads,
       params = coursier.params
         .ResolutionParams()
@@ -306,7 +309,7 @@ class CoursierDependencyResolution(
         loggerOpt = loggerOpt,
         projectName = projectName,
         sbtClassifiers = conf.sbtClassifiers,
-        cache = cache0,
+        cache = cache1,
         parallel = conf.parallelDownloads,
         classpathOrder = conf.classpathOrder,
         missingOk = conf.missingOk
@@ -355,7 +358,7 @@ class CoursierDependencyResolution(
       )
       artifactResult0 <- lockDataOpt match
         case Some(lockData) =>
-          LockedArtifactsRun.fetchFromLockFile(lockData, cache0, verbosityLevel, log) match
+          LockedArtifactsRun.fetchFromLockFile(lockData, cache1, verbosityLevel, log) match
             case Right(arts) => Right(arts)
             case Left(err)   =>
               if verbosityLevel >= 1 then

--- a/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -256,9 +256,6 @@ class CoursierDependencyResolution(
       .withCredentials(conf.credentials.map(ToCoursier.credentials))
       .withFollowHttpToHttpsRedirections(conf.followHttpToHttpsRedirections.getOrElse(true))
       .withLocalArtifactsShouldBeCached(conf.localArtifactsShouldBeCached)
-    val cache1 = conf.userAgent match
-      case Some(ua) => cache0.withUserAgent(ua)
-      case None     => cache0
 
     val excludeDependencies = conf.excludeDependencies.map { (strOrg, strName) =>
       (coursier.Organization(strOrg), coursier.ModuleName(strName))
@@ -278,7 +275,7 @@ class CoursierDependencyResolution(
       sbtClassifiers = conf.sbtClassifiers,
       projectName = projectName,
       loggerOpt = loggerOpt,
-      cache = cache1,
+      cache = cache0,
       parallel = conf.parallelDownloads,
       params = coursier.params
         .ResolutionParams()
@@ -309,7 +306,7 @@ class CoursierDependencyResolution(
         loggerOpt = loggerOpt,
         projectName = projectName,
         sbtClassifiers = conf.sbtClassifiers,
-        cache = cache1,
+        cache = cache0,
         parallel = conf.parallelDownloads,
         classpathOrder = conf.classpathOrder,
         missingOk = conf.missingOk
@@ -358,7 +355,7 @@ class CoursierDependencyResolution(
       )
       artifactResult0 <- lockDataOpt match
         case Some(lockData) =>
-          LockedArtifactsRun.fetchFromLockFile(lockData, cache1, verbosityLevel, log) match
+          LockedArtifactsRun.fetchFromLockFile(lockData, cache0, verbosityLevel, log) match
             case Right(arts) => Right(arts)
             case Left(err)   =>
               if verbosityLevel >= 1 then

--- a/lm-coursier/src/main/scala/lmcoursier/syntax/package.scala
+++ b/lm-coursier/src/main/scala/lmcoursier/syntax/package.scala
@@ -79,6 +79,7 @@ package object syntax:
         sameVersions = Nil,
         localArtifactsShouldBeCached = false,
         lockFile = None,
+        userAgent = None,
       )
   end extension
 

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -113,6 +113,8 @@ object LMCoursier:
     val sbtBootJars = internalSbtScalaProvider.jars()
     val sbtScalaVersion = internalSbtScalaProvider.version()
     val sbtScalaOrganization = "org.scala-lang" // always assuming sbt uses mainline scala
+    val sbtVersion = appConfig.provider.id.version
+    val userAgent = Some(s"sbt/$sbtVersion (+https://www.scala-sbt.org/)")
     val userForceVersions = Inputs.forceVersions(depsOverrides, scalaVer, scalaBinaryVer)
     Classpaths.warnResolversConflict(rs, log)
     Classpaths.errorInsecureProtocol(rs, log)
@@ -144,6 +146,7 @@ object LMCoursier:
       .withSameVersions(sameVersions)
       .withLocalArtifactsShouldBeCached(localArtifactsShouldBeCached)
       .withLockFile(lockFile)
+      .withUserAgent(userAgent)
   end coursierConfiguration
 
   def coursierConfigurationTask: Def.Initialize[Task[CoursierConfiguration]] = Def.task {

--- a/main/src/main/scala/sbt/coursierint/LMCoursier.scala
+++ b/main/src/main/scala/sbt/coursierint/LMCoursier.scala
@@ -67,6 +67,13 @@ object LMCoursier:
   def relaxedForAllModules: Seq[(ModuleMatchers, Reconciliation)] =
     Vector((ModuleMatchers.all, Reconciliation.Relaxed))
 
+  private val coursierProductVersion = "2.1"
+
+  def userAgent(sbtVersion: String, httpAgentOverride: Option[String]): String =
+    httpAgentOverride.getOrElse(
+      s"Coursier/$coursierProductVersion (+https://github.com/coursier) sbt/$sbtVersion (+https://www.scala-sbt.org/)"
+    )
+
   def coursierConfiguration(
       rs: Seq[Resolver],
       interProjectDependencies: Seq[CProject],
@@ -114,7 +121,7 @@ object LMCoursier:
     val sbtScalaVersion = internalSbtScalaProvider.version()
     val sbtScalaOrganization = "org.scala-lang" // always assuming sbt uses mainline scala
     val sbtVersion = appConfig.provider.id.version
-    val userAgent = Some(s"sbt/$sbtVersion (+https://www.scala-sbt.org/)")
+    val resolvedUserAgent = Some(userAgent(sbtVersion, sys.props.get("coursier.http.agent")))
     val userForceVersions = Inputs.forceVersions(depsOverrides, scalaVer, scalaBinaryVer)
     Classpaths.warnResolversConflict(rs, log)
     Classpaths.errorInsecureProtocol(rs, log)
@@ -146,7 +153,7 @@ object LMCoursier:
       .withSameVersions(sameVersions)
       .withLocalArtifactsShouldBeCached(localArtifactsShouldBeCached)
       .withLockFile(lockFile)
-      .withUserAgent(userAgent)
+      .withUserAgent(resolvedUserAgent)
   end coursierConfiguration
 
   def coursierConfigurationTask: Def.Initialize[Task[CoursierConfiguration]] = Def.task {

--- a/main/src/main/scala/sbt/internal/Load.scala
+++ b/main/src/main/scala/sbt/internal/Load.scala
@@ -22,6 +22,7 @@ import sbt.internal.inc.classpath.ClasspathUtil
 import sbt.internal.inc.{ MappedFileConverter, ScalaInstance, ZincLmUtil, ZincUtil }
 import lmcoursier.{ CoursierConfiguration, CoursierDependencyResolution }
 import lmcoursier.syntax.*
+import sbt.coursierint.LMCoursier
 import sbt.internal.util.Attributed.data
 import sbt.internal.util.Types.const
 import sbt.internal.util.Attributed
@@ -106,6 +107,9 @@ private[sbt] object Load:
     val csrConfig = CoursierConfiguration()
       .withResolvers(Resolver.combineDefaultResolvers(Vector.empty).toVector)
       .withLog(log)
+      .withUserAgent(
+        Some(LMCoursier.userAgent(provider.id.version, sys.props.get("coursier.http.agent")))
+      )
     val dependencyResolution = CoursierDependencyResolution(csrConfig)
     val si = ScalaInstance(scalaProvider.version, scalaProvider.launcher)
     val zincDir = BuildPaths.getZincDirectory(state, globalBase)

--- a/main/src/test/scala/sbt/coursierint/LMCoursierUserAgentSpec.scala
+++ b/main/src/test/scala/sbt/coursierint/LMCoursierUserAgentSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * sbt
+ * Copyright 2023, Scala center
+ * Copyright 2011 - 2022, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ * Licensed under Apache License 2.0 (see LICENSE)
+ */
+
+package sbt
+package coursierint
+
+import java.io.File
+import java.util.concurrent.Callable
+
+import verify.BasicTestSuite
+import xsbti.{ Logger => _, _ }
+import sbt.util.Logger
+
+object LMCoursierUserAgentSpec extends BasicTestSuite:
+  private def unimplemented: Nothing = throw new NotImplementedError
+
+  private def appConfig(sbtVersion: String): AppConfiguration = new AppConfiguration:
+    def baseDirectory(): File = new File(".")
+    def arguments(): Array[String] = Array()
+    def provider(): AppProvider = new AppProvider:
+      def scalaProvider(): ScalaProvider = new ScalaProvider:
+        def launcher(): Launcher = new Launcher:
+          def getScala(version: String): ScalaProvider = unimplemented
+          def getScala(version: String, reason: String): ScalaProvider = unimplemented
+          def getScala(version: String, reason: String, scalaOrg: String): ScalaProvider =
+            unimplemented
+          def app(id: ApplicationID, version: String): AppProvider = unimplemented
+          def topLoader(): ClassLoader = getClass.getClassLoader
+          def globalLock(): GlobalLock = new GlobalLock:
+            def apply[T](lockFile: File, run: Callable[T]): T = run.call()
+          def bootDirectory(): File = new File(".")
+          def ivyRepositories(): Array[Repository] = Array()
+          def appRepositories(): Array[Repository] = Array()
+          def isOverrideRepositories: Boolean = false
+          def ivyHome(): File = new File(".")
+          def checksums(): Array[String] = Array()
+        def version(): String = "2.12.21"
+        def loader(): ClassLoader = getClass.getClassLoader
+        def jars(): Array[File] = Array()
+        def libraryJar(): File = new File("scala-library.jar")
+        def compilerJar(): File = new File("scala-compiler.jar")
+        def app(id: ApplicationID): AppProvider = unimplemented
+      def id(): ApplicationID = sbt.ApplicationID(
+        "org.scala-sbt",
+        "sbt",
+        sbtVersion,
+        "sbt.xMain",
+        components = Seq(),
+        crossVersionedValue = CrossValue.Disabled,
+        extra = Seq()
+      )
+      def loader(): ClassLoader = getClass.getClassLoader
+      def entryPoint(): Class[?] = unimplemented
+      def mainClass(): Class[? <: AppMain] = unimplemented
+      def newMain(): AppMain = unimplemented
+      def mainClasspath(): Array[File] = Array()
+      def components(): ComponentProvider = new ComponentProvider:
+        def componentLocation(id: String): File = unimplemented
+        def component(componentID: String): Array[File] = unimplemented
+        def defineComponent(componentID: String, components: Array[File]): Unit = unimplemented
+        def addToComponent(componentID: String, components: Array[File]): Boolean = unimplemented
+        def lockFile(): File = unimplemented
+
+  test("user agent names the Coursier product before sbt") {
+    val ua = LMCoursier.userAgent("2.0.8", None)
+    assert(
+      ua == "Coursier/2.1 (+https://github.com/coursier) sbt/2.0.8 (+https://www.scala-sbt.org/)",
+      ua
+    )
+    assert(ua.indexOf("Coursier/") < ua.indexOf("sbt/"), ua)
+  }
+
+  test("user agent honors the coursier.http.agent override") {
+    val ua = LMCoursier.userAgent("2.0.8", Some("MyTool/1.0"))
+    assert(ua == "MyTool/1.0", ua)
+  }
+
+  test("coursierConfiguration derives a Coursier-first user agent from the sbt version") {
+    val conf = LMCoursier.coursierConfiguration(
+      rs = Vector(),
+      interProjectDependencies = Vector(),
+      extraProjects = Vector(),
+      fallbackDeps = Vector(),
+      appConfig = appConfig("2.0.8"),
+      profiles = Set(),
+      scalaOrg = "org.scala-lang",
+      scalaVer = "2.12.21",
+      scalaBinaryVer = "2.12",
+      autoScalaLib = false,
+      scalaModInfo = None,
+      excludeDeps = Vector(),
+      credentials = Vector(),
+      createLogger = None,
+      cacheDirectory = new File("."),
+      reconciliation = Vector(),
+      ivyHome = None,
+      strict = None,
+      depsOverrides = Vector(),
+      updateConfig = None,
+      sameVersions = Vector(),
+      enableDependencyOverrides = None,
+      localArtifactsShouldBeCached = false,
+      lockFile = None,
+      log = Logger.Null
+    )
+    assert(
+      conf.userAgent == Some(
+        "Coursier/2.1 (+https://github.com/coursier) sbt/2.0.8 (+https://www.scala-sbt.org/)"
+      ),
+      conf.userAgent.toString
+    )
+  }
+end LMCoursierUserAgentSpec


### PR DESCRIPTION
## Summary

Set sbt user agent in Coursier HTTP requests to identify sbt traffic to repository operators.

## Problem

Repository operators rely on the `User-Agent` header to attribute traffic and identify which tool is making requests. Currently, sbt's Coursier-backed dependency resolution sends a generic Coursier user agent, making it indistinguishable from other Coursier-based tools (Mill, Scala CLI, etc).

From Sonatype: https://central.sonatype.org/faq/429-tooling-provider/

## Changes

1. **`CoursierConfiguration`**: Added `@since userAgent: Option[String] = None` field, plus the required explicit `userAgent = None` at the `lmcoursier.syntax` construction site (the generated `apply` carries no defaults)
2. **`LMCoursier`**: New pure `userAgent` helper building the header Coursier-first from the sbt version in `appConfig.provider.id.version`; a `coursier.http.agent` system property is honored as an outright override
3. **Tests**: Added `LMCoursierUserAgentSpec` pinning the exact header value, the product order, the override, and the `coursierConfiguration` wiring

The resulting HTTP requests will carry:

```
Coursier/2.1 (+https://github.com/coursier) sbt/2.0.8 (+https://www.scala-sbt.org/)
```

This follows RFC 9110 Section 10.1.5 (`product *( RWS ( comment ) ) `) and the format recommended in https://github.com/apache/spark/pull/58508.

## Notes

- The `@since` annotation maintains binary compatibility with existing plugins
- `FileCache.withUserAgent()` only exists on coursier main (coursier/coursier#3842) and is missing from the pinned 2.1.25-M26, so the `FileCache` wiring itself is intentionally left out of this revision; it can hook up `conf.userAgent` once coursier cuts a release with that API

## Related

Fixes #9732